### PR TITLE
Command rework

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,15 +15,6 @@ repos:
         pass_filenames: false
         types: [file, rust]
         language: system
-      - id: cargo-deny
-        name: check Cargo dependencies
-        description: check Cargo dependencies
-        entry: cargo deny
-        language: rust
-        types: [file, toml]
-        files: Cargo\.(toml|lock)
-        pass_filenames: false
-        args: ["--all-features", "check"]
   - repo: local
     hooks:
       - id: build-paper

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,15 @@ repos:
         pass_filenames: false
         types: [file, rust]
         language: system
+      - id: cargo-deny
+        name: check Cargo dependencies
+        description: check Cargo dependencies
+        entry: cargo deny
+        language: rust
+        types: [file, toml]
+        files: Cargo\.(toml|lock)
+        pass_filenames: false
+        args: ["--all-features", "check"]
   - repo: local
     hooks:
       - id: build-paper
@@ -24,4 +33,3 @@ repos:
         language: script
         pass_filenames: false
         files: ^paper/.*\.(md|bib|svg|dot)$
-

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -746,6 +746,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap-nested-commands"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3fe3d726076c1dbc46020fc2fbb653794d74bb720b6fb4e6fbfe1ea3f26c0b4"
+dependencies = [
+ "anyhow",
+ "paste",
+ "tokio",
+]
+
+[[package]]
 name = "clap_builder"
 version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1553,6 +1564,7 @@ dependencies = [
  "cargo-llvm-cov",
  "chrono",
  "clap",
+ "clap-nested-commands",
  "color-eyre",
  "convert_case",
  "crossterm",
@@ -5635,9 +5647,23 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ default = []
 cached = "0.55.1"
 chrono = "0.4.40"
 clap = { version = "4.5.32", features = ["derive"] }
+clap-nested-commands = "0.0.6"
 convert_case = "0.8.0"
 csv = "1.3.1"
 fallible-streaming-iterator = "0.1.9"

--- a/src/commands/cli_context.rs
+++ b/src/commands/cli_context.rs
@@ -1,0 +1,12 @@
+use crate::NewCli;
+
+#[derive(Debug)]
+pub struct CliContext {
+    pub db: Option<String>,
+}
+
+impl<'a> From<&'a NewCli> for CliContext {
+    fn from(cli: &'a NewCli) -> Self {
+        CliContext { db: cli.db.clone() }
+    }
+}

--- a/src/commands/cli_context.rs
+++ b/src/commands/cli_context.rs
@@ -1,12 +1,12 @@
-use crate::NewCli;
+use crate::commands::Cli;
 
 #[derive(Debug)]
 pub struct CliContext {
     pub db: Option<String>,
 }
 
-impl<'a> From<&'a NewCli> for CliContext {
-    fn from(cli: &'a NewCli) -> Self {
+impl<'a> From<&'a Cli> for CliContext {
+    fn from(cli: &'a Cli) -> Self {
         CliContext { db: cli.db.clone() }
     }
 }

--- a/src/commands/export/fasta.rs
+++ b/src/commands/export/fasta.rs
@@ -1,12 +1,11 @@
 use crate::commands::cli_context::CliContext;
-use crate::commands::get_db_for_command;
+use crate::commands::{get_db_for_command, get_default_collection};
 use crate::config::get_operation_connection;
 use crate::exports::fasta::export_fasta;
 use crate::get_connection;
 use crate::models::metadata;
 use crate::models::operations::setup_db;
 use clap::Args;
-use rusqlite::Connection;
 use std::path::PathBuf;
 
 /// Export a FASTA file
@@ -21,14 +20,6 @@ pub struct Command {
     /// The name of the sample for exporting
     #[arg(short, long)]
     sample: Option<String>,
-}
-
-fn get_default_collection(conn: &Connection) -> String {
-    let mut stmt = conn
-        .prepare("select collection_name from defaults where id = 1")
-        .unwrap();
-    stmt.query_row((), |row| row.get(0))
-        .unwrap_or("default".to_string())
 }
 
 pub fn execute(cli_context: &CliContext, cmd: Command) {

--- a/src/commands/export/genbank.rs
+++ b/src/commands/export/genbank.rs
@@ -1,12 +1,11 @@
 use crate::commands::cli_context::CliContext;
-use crate::commands::get_db_for_command;
+use crate::commands::{get_db_for_command, get_default_collection};
 use crate::config::get_operation_connection;
 use crate::exports::genbank::export_genbank;
 use crate::get_connection;
 use crate::models::metadata;
 use crate::models::operations::setup_db;
 use clap::Args;
-use rusqlite::Connection;
 use std::path::PathBuf;
 
 /// Export a GenBank file
@@ -21,14 +20,6 @@ pub struct Command {
     /// The name of the sample for exporting
     #[arg(short, long)]
     sample: Option<String>,
-}
-
-fn get_default_collection(conn: &Connection) -> String {
-    let mut stmt = conn
-        .prepare("select collection_name from defaults where id = 1")
-        .unwrap();
-    stmt.query_row((), |row| row.get(0))
-        .unwrap_or("default".to_string())
 }
 
 pub fn execute(cli_context: &CliContext, cmd: Command) {

--- a/src/commands/export/genbank.rs
+++ b/src/commands/export/genbank.rs
@@ -1,29 +1,24 @@
 use crate::commands::cli_context::CliContext;
 use crate::commands::get_db_for_command;
 use crate::config::get_operation_connection;
+use crate::exports::genbank::export_genbank;
 use crate::get_connection;
-use crate::imports::library::import_library;
 use crate::models::metadata;
 use crate::models::operations::setup_db;
 use clap::Args;
 use rusqlite::Connection;
+use std::path::PathBuf;
 
-/// Import Library files
+/// Export a GenBank file
 #[derive(Debug, Args)]
 pub struct Command {
-    /// The name of the region
+    /// GenBank file path
     #[clap(index = 1)]
-    region_name: String,
-    /// The path to the combinatorial library parts fasta file
-    #[clap(index = 2)]
-    parts: Option<String>,
-    /// The path to the combinatorial library csv file
-    #[clap(index = 3)]
-    library: Option<String>,
-    /// The name of the collection to store the entry under
+    pub path: String,
+    /// The name of the collection for exporting
     #[arg(short, long)]
     name: Option<String>,
-    /// A sample name to associate the library with
+    /// The name of the sample for exporting
     #[arg(short, long)]
     sample: Option<String>,
 }
@@ -37,8 +32,7 @@ fn get_default_collection(conn: &Connection) -> String {
 }
 
 pub fn execute(cli_context: &CliContext, cmd: Command) {
-    println!("Library import called");
-
+    println!("GFA export called");
     let operation_conn = get_operation_connection(None);
     let db = get_db_for_command(cli_context, &operation_conn);
     let conn = get_connection(&db);
@@ -53,18 +47,13 @@ pub fn execute(cli_context: &CliContext, cmd: Command) {
         .name
         .clone()
         .unwrap_or_else(|| get_default_collection(&operation_conn));
-    import_library(
+    export_genbank(
         &conn,
-        &operation_conn,
         name,
-        cmd.sample.as_deref(),
-        cmd.parts.as_deref().unwrap(),
-        cmd.library.as_deref().unwrap(),
-        &cmd.region_name,
-    )
-    .unwrap();
+        cmd.sample.clone().as_deref(),
+        &PathBuf::from(cmd.path),
+    );
 
-    println!("Library imported.");
-    conn.execute("END TRANSACTION;", []).unwrap();
-    operation_conn.execute("END TRANSACTION;", []).unwrap();
+    conn.execute("END TRANSACTION", []).unwrap();
+    operation_conn.execute("END TRANSACTION", []).unwrap();
 }

--- a/src/commands/export/gfa.rs
+++ b/src/commands/export/gfa.rs
@@ -1,12 +1,11 @@
 use crate::commands::cli_context::CliContext;
-use crate::commands::get_db_for_command;
+use crate::commands::{get_db_for_command, get_default_collection};
 use crate::config::get_operation_connection;
 use crate::exports::gfa::export_gfa;
 use crate::get_connection;
 use crate::models::metadata;
 use crate::models::operations::setup_db;
 use clap::Args;
-use rusqlite::Connection;
 use std::path::PathBuf;
 
 /// Export a GFA file
@@ -24,14 +23,6 @@ pub struct Command {
     /// The max sequence length per node
     #[arg(long)]
     node_max: Option<i64>,
-}
-
-fn get_default_collection(conn: &Connection) -> String {
-    let mut stmt = conn
-        .prepare("select collection_name from defaults where id = 1")
-        .unwrap();
-    stmt.query_row((), |row| row.get(0))
-        .unwrap_or("default".to_string())
 }
 
 pub fn execute(cli_context: &CliContext, cmd: Command) {

--- a/src/commands/export/gfa.rs
+++ b/src/commands/export/gfa.rs
@@ -1,31 +1,29 @@
 use crate::commands::cli_context::CliContext;
 use crate::commands::get_db_for_command;
 use crate::config::get_operation_connection;
+use crate::exports::gfa::export_gfa;
 use crate::get_connection;
-use crate::imports::library::import_library;
 use crate::models::metadata;
 use crate::models::operations::setup_db;
 use clap::Args;
 use rusqlite::Connection;
+use std::path::PathBuf;
 
-/// Import Library files
+/// Export a GFA file
 #[derive(Debug, Args)]
 pub struct Command {
-    /// The name of the region
+    /// GFA file path
     #[clap(index = 1)]
-    region_name: String,
-    /// The path to the combinatorial library parts fasta file
-    #[clap(index = 2)]
-    parts: Option<String>,
-    /// The path to the combinatorial library csv file
-    #[clap(index = 3)]
-    library: Option<String>,
-    /// The name of the collection to store the entry under
+    pub path: String,
+    /// The name of the collection for exporting
     #[arg(short, long)]
     name: Option<String>,
-    /// A sample name to associate the library with
+    /// The name of the sample for exporting
     #[arg(short, long)]
     sample: Option<String>,
+    /// The max sequence length per node
+    #[arg(long)]
+    node_max: Option<i64>,
 }
 
 fn get_default_collection(conn: &Connection) -> String {
@@ -37,8 +35,7 @@ fn get_default_collection(conn: &Connection) -> String {
 }
 
 pub fn execute(cli_context: &CliContext, cmd: Command) {
-    println!("Library import called");
-
+    println!("GFA export called");
     let operation_conn = get_operation_connection(None);
     let db = get_db_for_command(cli_context, &operation_conn);
     let conn = get_connection(&db);
@@ -53,18 +50,14 @@ pub fn execute(cli_context: &CliContext, cmd: Command) {
         .name
         .clone()
         .unwrap_or_else(|| get_default_collection(&operation_conn));
-    import_library(
+    export_gfa(
         &conn,
-        &operation_conn,
         name,
-        cmd.sample.as_deref(),
-        cmd.parts.as_deref().unwrap(),
-        cmd.library.as_deref().unwrap(),
-        &cmd.region_name,
-    )
-    .unwrap();
+        &PathBuf::from(cmd.path),
+        cmd.sample.clone(),
+        cmd.node_max,
+    );
 
-    println!("Library imported.");
-    conn.execute("END TRANSACTION;", []).unwrap();
-    operation_conn.execute("END TRANSACTION;", []).unwrap();
+    conn.execute("END TRANSACTION", []).unwrap();
+    operation_conn.execute("END TRANSACTION", []).unwrap();
 }

--- a/src/commands/export/mod.rs
+++ b/src/commands/export/mod.rs
@@ -5,13 +5,12 @@ use clap_nested_commands::generate_sync_commands;
 mod fasta;
 mod genbank;
 mod gfa;
-mod library;
 
-/// Import commands
+/// Export commands
 #[derive(Debug, Args)]
 pub struct Command {
     #[command(subcommand)]
     pub command: Commands,
 }
 
-generate_sync_commands!(fasta, genbank, gfa, library);
+generate_sync_commands!(fasta, genbank, gfa);

--- a/src/commands/import/fasta.rs
+++ b/src/commands/import/fasta.rs
@@ -1,0 +1,14 @@
+use crate::commands::cli_context::CliContext;
+use clap::Args;
+
+/// Import a fasta file
+#[derive(Debug, Args)]
+pub struct Command {
+    /// Fasta file path
+    #[arg(long)]
+    pub path: String,
+}
+
+pub fn execute(_cli_context: &CliContext, _cmd: Command) {
+    println!("Fasta import called");
+}

--- a/src/commands/import/fasta.rs
+++ b/src/commands/import/fasta.rs
@@ -77,7 +77,11 @@ pub fn execute(cli_context: &CliContext, cmd: Command) {
         &conn,
         &operation_conn,
     ) {
-        Ok(_) => println!("Fasta imported."),
+        Ok(_) => {
+            println!("Fasta imported.");
+            conn.execute("END TRANSACTION;", []).unwrap();
+            operation_conn.execute("END TRANSACTION;", []).unwrap();
+        }
         Err(FastaError::OperationError(OperationError::NoChanges)) => {
             conn.execute("ROLLBACK TRANSACTION;", []).unwrap();
             operation_conn.execute("ROLLBACK TRANSACTION;", []).unwrap();

--- a/src/commands/import/fasta.rs
+++ b/src/commands/import/fasta.rs
@@ -1,5 +1,5 @@
 use crate::commands::cli_context::CliContext;
-use crate::commands::get_db_for_command;
+use crate::commands::{get_db_for_command, get_default_collection};
 use crate::config::get_operation_connection;
 use crate::fasta::FastaError;
 use crate::get_connection;
@@ -8,7 +8,6 @@ use crate::models::metadata;
 use crate::models::operations::setup_db;
 use crate::operation_management::OperationError;
 use clap::Args;
-use rusqlite::Connection;
 
 /// Import a fasta file
 #[derive(Debug, Args)]
@@ -25,14 +24,6 @@ pub struct Command {
     /// A sample name to associate the fasta file with
     #[arg(short, long)]
     sample: Option<String>,
-}
-
-fn get_default_collection(conn: &Connection) -> String {
-    let mut stmt = conn
-        .prepare("select collection_name from defaults where id = 1")
-        .unwrap();
-    stmt.query_row((), |row| row.get(0))
-        .unwrap_or("default".to_string())
 }
 
 pub fn execute(cli_context: &CliContext, cmd: Command) {

--- a/src/commands/import/fasta.rs
+++ b/src/commands/import/fasta.rs
@@ -65,7 +65,8 @@ pub fn execute(cli_context: &CliContext, cmd: Command) {
     conn.execute("BEGIN TRANSACTION", []).unwrap();
     operation_conn.execute("BEGIN TRANSACTION", []).unwrap();
 
-    let name = &cmd.name
+    let name = &cmd
+        .name
         .clone()
         .unwrap_or_else(|| get_default_collection(&operation_conn));
     match import_fasta(

--- a/src/commands/import/genbank.rs
+++ b/src/commands/import/genbank.rs
@@ -1,13 +1,11 @@
-use crate::commands::get_db_for_command;
 use crate::commands::cli_context::CliContext;
+use crate::commands::get_db_for_command;
 use crate::config::get_operation_connection;
 use crate::get_connection;
 use crate::imports::genbank::import_genbank;
 use crate::models::file_types::FileTypes;
 use crate::models::metadata;
-use crate::models::operations::{
-    setup_db, OperationFile, OperationInfo
-};
+use crate::models::operations::{setup_db, OperationFile, OperationInfo};
 use clap::Args;
 use rusqlite::Connection;
 use std::fs::File;
@@ -47,7 +45,8 @@ pub fn execute(cli_context: &CliContext, cmd: Command) {
     conn.execute("BEGIN TRANSACTION", []).unwrap();
     operation_conn.execute("BEGIN TRANSACTION", []).unwrap();
 
-    let name = &cmd.name
+    let name = &cmd
+        .name
         .clone()
         .unwrap_or_else(|| get_default_collection(&operation_conn));
     let mut reader: Box<dyn std::io::Read> = if cmd.path.ends_with(".gz") {

--- a/src/commands/import/genbank.rs
+++ b/src/commands/import/genbank.rs
@@ -1,0 +1,80 @@
+use crate::commands::get_db_for_command;
+use crate::commands::cli_context::CliContext;
+use crate::config::get_operation_connection;
+use crate::get_connection;
+use crate::imports::genbank::import_genbank;
+use crate::models::file_types::FileTypes;
+use crate::models::metadata;
+use crate::models::operations::{
+    setup_db, OperationFile, OperationInfo
+};
+use clap::Args;
+use rusqlite::Connection;
+use std::fs::File;
+
+/// Import a Genbank file
+#[derive(Debug, Args)]
+pub struct Command {
+    /// Genbank file path
+    #[clap(index = 1)]
+    pub path: String,
+    /// The name of the collection to store the entry under
+    #[arg(short, long)]
+    name: Option<String>,
+    /// A sample name to associate the Genbank file with
+    #[arg(short, long)]
+    sample: Option<String>,
+}
+
+fn get_default_collection(conn: &Connection) -> String {
+    let mut stmt = conn
+        .prepare("select collection_name from defaults where id = 1")
+        .unwrap();
+    stmt.query_row((), |row| row.get(0))
+        .unwrap_or("default".to_string())
+}
+
+pub fn execute(cli_context: &CliContext, cmd: Command) {
+    println!("Genbank import called");
+
+    let operation_conn = get_operation_connection(None);
+    let db = get_db_for_command(cli_context, &operation_conn);
+    let conn = get_connection(&db);
+    let db_uuid = metadata::get_db_uuid(&conn);
+
+    // initialize the selected database if needed.
+    setup_db(&operation_conn, &db_uuid);
+    conn.execute("BEGIN TRANSACTION", []).unwrap();
+    operation_conn.execute("BEGIN TRANSACTION", []).unwrap();
+
+    let name = &cmd.name
+        .clone()
+        .unwrap_or_else(|| get_default_collection(&operation_conn));
+    let mut reader: Box<dyn std::io::Read> = if cmd.path.ends_with(".gz") {
+        let file = File::open(cmd.path.clone()).unwrap();
+        Box::new(flate2::read::GzDecoder::new(file))
+    } else {
+        Box::new(File::open(cmd.path.clone()).unwrap())
+    };
+    match import_genbank(
+        &conn,
+        &operation_conn,
+        &mut reader,
+        name.as_ref(),
+        cmd.sample.as_deref(),
+        OperationInfo {
+            files: vec![OperationFile {
+                file_path: cmd.path.clone(),
+                file_type: FileTypes::GenBank,
+            }],
+            description: "GenBank Import".to_string(),
+        },
+    ) {
+        Ok(_) => println!("GenBank Imported."),
+        Err(err) => {
+            conn.execute("ROLLBACK TRANSACTION;", []).unwrap();
+            operation_conn.execute("ROLLBACK TRANSACTION;", []).unwrap();
+            panic!("Import failed: {err:?}");
+        }
+    }
+}

--- a/src/commands/import/genbank.rs
+++ b/src/commands/import/genbank.rs
@@ -1,5 +1,5 @@
 use crate::commands::cli_context::CliContext;
-use crate::commands::get_db_for_command;
+use crate::commands::{get_db_for_command, get_default_collection};
 use crate::config::get_operation_connection;
 use crate::get_connection;
 use crate::imports::genbank::import_genbank;
@@ -7,7 +7,6 @@ use crate::models::file_types::FileTypes;
 use crate::models::metadata;
 use crate::models::operations::{setup_db, OperationFile, OperationInfo};
 use clap::Args;
-use rusqlite::Connection;
 use std::fs::File;
 
 /// Import a Genbank file
@@ -22,14 +21,6 @@ pub struct Command {
     /// A sample name to associate the Genbank file with
     #[arg(short, long)]
     sample: Option<String>,
-}
-
-fn get_default_collection(conn: &Connection) -> String {
-    let mut stmt = conn
-        .prepare("select collection_name from defaults where id = 1")
-        .unwrap();
-    stmt.query_row((), |row| row.get(0))
-        .unwrap_or("default".to_string())
 }
 
 pub fn execute(cli_context: &CliContext, cmd: Command) {

--- a/src/commands/import/genbank.rs
+++ b/src/commands/import/genbank.rs
@@ -69,7 +69,11 @@ pub fn execute(cli_context: &CliContext, cmd: Command) {
             description: "GenBank Import".to_string(),
         },
     ) {
-        Ok(_) => println!("GenBank Imported."),
+        Ok(_) => {
+            println!("GenBank imported.");
+            conn.execute("END TRANSACTION;", []).unwrap();
+            operation_conn.execute("END TRANSACTION;", []).unwrap();
+        }
         Err(err) => {
             conn.execute("ROLLBACK TRANSACTION;", []).unwrap();
             operation_conn.execute("ROLLBACK TRANSACTION;", []).unwrap();

--- a/src/commands/import/gfa.rs
+++ b/src/commands/import/gfa.rs
@@ -1,14 +1,14 @@
 use crate::commands::cli_context::CliContext;
 use crate::config::{get_gen_dir, get_operation_connection};
 use crate::get_connection;
-use crate::imports::gfa::{GFAImportError, import_gfa};
+use crate::imports::gfa::{import_gfa, GFAImportError};
 use crate::models::metadata;
 use crate::models::operations::setup_db;
 use crate::operation_management::OperationError;
 use clap::Args;
 use rusqlite::Connection;
 use std::path::PathBuf;
-    
+
 /// Import a GFA file
 #[derive(Debug, Args)]
 pub struct Command {
@@ -61,7 +61,8 @@ pub fn execute(cli_context: &CliContext, cmd: Command) {
     conn.execute("BEGIN TRANSACTION", []).unwrap();
     operation_conn.execute("BEGIN TRANSACTION", []).unwrap();
 
-    let name = &cmd.name
+    let name = &cmd
+        .name
         .clone()
         .unwrap_or_else(|| get_default_collection(&operation_conn));
     match import_gfa(

--- a/src/commands/import/gfa.rs
+++ b/src/commands/import/gfa.rs
@@ -1,5 +1,5 @@
 use crate::commands::cli_context::CliContext;
-use crate::commands::get_db_for_command;
+use crate::commands::{get_db_for_command, get_default_collection};
 use crate::config::get_operation_connection;
 use crate::get_connection;
 use crate::imports::gfa::{import_gfa, GFAImportError};
@@ -7,7 +7,6 @@ use crate::models::metadata;
 use crate::models::operations::setup_db;
 use crate::operation_management::OperationError;
 use clap::Args;
-use rusqlite::Connection;
 use std::path::PathBuf;
 
 /// Import a GFA file
@@ -22,14 +21,6 @@ pub struct Command {
     /// A sample name to associate the GFA file with
     #[arg(short, long)]
     sample: Option<String>,
-}
-
-fn get_default_collection(conn: &Connection) -> String {
-    let mut stmt = conn
-        .prepare("select collection_name from defaults where id = 1")
-        .unwrap();
-    stmt.query_row((), |row| row.get(0))
-        .unwrap_or("default".to_string())
 }
 
 pub fn execute(cli_context: &CliContext, cmd: Command) {

--- a/src/commands/import/library.rs
+++ b/src/commands/import/library.rs
@@ -1,12 +1,11 @@
 use crate::commands::cli_context::CliContext;
-use crate::commands::get_db_for_command;
+use crate::commands::{get_db_for_command, get_default_collection};
 use crate::config::get_operation_connection;
 use crate::get_connection;
 use crate::imports::library::import_library;
 use crate::models::metadata;
 use crate::models::operations::setup_db;
 use clap::Args;
-use rusqlite::Connection;
 
 /// Import Library files
 #[derive(Debug, Args)]
@@ -26,14 +25,6 @@ pub struct Command {
     /// A sample name to associate the library with
     #[arg(short, long)]
     sample: Option<String>,
-}
-
-fn get_default_collection(conn: &Connection) -> String {
-    let mut stmt = conn
-        .prepare("select collection_name from defaults where id = 1")
-        .unwrap();
-    stmt.query_row((), |row| row.get(0))
-        .unwrap_or("default".to_string())
 }
 
 pub fn execute(cli_context: &CliContext, cmd: Command) {

--- a/src/commands/import/library.rs
+++ b/src/commands/import/library.rs
@@ -1,5 +1,5 @@
-use crate::commands::get_db_for_command;
 use crate::commands::cli_context::CliContext;
+use crate::commands::get_db_for_command;
 use crate::config::get_operation_connection;
 use crate::get_connection;
 use crate::imports::library::import_library;
@@ -49,7 +49,8 @@ pub fn execute(cli_context: &CliContext, cmd: Command) {
     conn.execute("BEGIN TRANSACTION", []).unwrap();
     operation_conn.execute("BEGIN TRANSACTION", []).unwrap();
 
-    let name = &cmd.name
+    let name = &cmd
+        .name
         .clone()
         .unwrap_or_else(|| get_default_collection(&operation_conn));
     import_library(
@@ -61,5 +62,5 @@ pub fn execute(cli_context: &CliContext, cmd: Command) {
         cmd.library.as_deref().unwrap(),
         &cmd.region_name,
     )
-        .unwrap();
+    .unwrap();
 }

--- a/src/commands/import/library.rs
+++ b/src/commands/import/library.rs
@@ -1,0 +1,65 @@
+use crate::commands::get_db_for_command;
+use crate::commands::cli_context::CliContext;
+use crate::config::get_operation_connection;
+use crate::get_connection;
+use crate::imports::library::import_library;
+use crate::models::metadata;
+use crate::models::operations::setup_db;
+use clap::Args;
+use rusqlite::Connection;
+
+/// Import Library files
+#[derive(Debug, Args)]
+pub struct Command {
+    /// The name of the region
+    #[clap(index = 1)]
+    region_name: String,
+    /// The path to the combinatorial library parts fasta file
+    #[clap(index = 2)]
+    parts: Option<String>,
+    /// The path to the combinatorial library csv file
+    #[clap(index = 3)]
+    library: Option<String>,
+    /// The name of the collection to store the entry under
+    #[arg(short, long)]
+    name: Option<String>,
+    /// A sample name to associate the library with
+    #[arg(short, long)]
+    sample: Option<String>,
+}
+
+fn get_default_collection(conn: &Connection) -> String {
+    let mut stmt = conn
+        .prepare("select collection_name from defaults where id = 1")
+        .unwrap();
+    stmt.query_row((), |row| row.get(0))
+        .unwrap_or("default".to_string())
+}
+
+pub fn execute(cli_context: &CliContext, cmd: Command) {
+    println!("Library import called");
+
+    let operation_conn = get_operation_connection(None);
+    let db = get_db_for_command(cli_context, &operation_conn);
+    let conn = get_connection(&db);
+    let db_uuid = metadata::get_db_uuid(&conn);
+
+    // initialize the selected database if needed.
+    setup_db(&operation_conn, &db_uuid);
+    conn.execute("BEGIN TRANSACTION", []).unwrap();
+    operation_conn.execute("BEGIN TRANSACTION", []).unwrap();
+
+    let name = &cmd.name
+        .clone()
+        .unwrap_or_else(|| get_default_collection(&operation_conn));
+    import_library(
+        &conn,
+        &operation_conn,
+        name,
+        cmd.sample.as_deref(),
+        cmd.parts.as_deref().unwrap(),
+        cmd.library.as_deref().unwrap(),
+        &cmd.region_name,
+    )
+        .unwrap();
+}

--- a/src/commands/import/mod.rs
+++ b/src/commands/import/mod.rs
@@ -1,0 +1,186 @@
+use crate::commands::cli_context::CliContext;
+use clap::{Args, Subcommand};
+use clap_nested_commands::generate_sync_commands;
+
+mod fasta;
+
+/// Import commands
+#[derive(Debug, Args)]
+pub struct Command {
+    #[command(subcommand)]
+    pub command: Commands,
+}
+
+#[derive(Subcommand)]
+#[allow(clippy::large_enum_variant)]
+/// Import a new sequence collection.
+enum Import {
+    /// Import a fasta
+    #[command(arg_required_else_help(true))]
+    Fasta {
+        /// Fasta file path
+        #[clap(index = 1)]
+        fasta: String,
+        /// Don't store the sequence in the database, instead store the filename
+        #[arg(long, action)]
+        shallow: bool,
+        /// The name of the collection to store the entry under
+        #[arg(short, long)]
+        name: Option<String>,
+        /// A sample name to associate the fasta file with
+        #[arg(short, long)]
+        sample: Option<String>,
+    },
+    /// Import a genbank
+    #[command(arg_required_else_help(true))]
+    Genbank {
+        /// Genbank file path
+        #[clap(index = 1)]
+        gb: String,
+        /// The name of the collection to store the entry under
+        #[arg(short, long)]
+        name: Option<String>,
+        /// A sample name to associate the genbank file with
+        #[arg(short, long)]
+        sample: Option<String>,
+    },
+    /// Import a GFA
+    #[command(arg_required_else_help(true))]
+    Gfa {
+        /// GFA file path
+        #[clap(index = 1)]
+        gfa: String,
+        /// The name of the collection to store the entry under
+        #[arg(short, long)]
+        name: Option<String>,
+        /// A sample name to associate the GFA file with
+        #[arg(short, long)]
+        sample: Option<String>,
+    },
+    /// Import a library
+    #[command(arg_required_else_help(true))]
+    Library {
+        /// The name of the region
+        #[arg(long)]
+        region_name: Option<String>,
+        /// The path to the combinatorial library parts
+        #[arg(long)]
+        parts: Option<String>,
+        /// The path to the combinatorial library csv
+        #[arg(long)]
+        library: Option<String>,
+        /// The name of the collection to store the entry under
+        #[arg(short, long)]
+        name: Option<String>,
+        /// A sample name to associate the library with
+        #[arg(short, long)]
+        sample: Option<String>,
+    },
+}
+
+// fn blah() {
+//             Some(Commands::Import {
+//             fasta,
+//             gb,
+//             gfa,
+//             name,
+//             shallow,
+//             sample,
+//             region_name,
+//             parts,
+//             library,
+//         }) => {
+//             conn.execute("BEGIN TRANSACTION", []).unwrap();
+//             operation_conn.execute("BEGIN TRANSACTION", []).unwrap();
+//             let name = &name
+//                 .clone()
+//                 .unwrap_or_else(|| get_default_collection(&operation_conn));
+//             if fasta.is_some() {
+//                 match import_fasta(
+//                     &fasta.clone().unwrap(),
+//                     name,
+//                     sample.as_deref(),
+//                     *shallow,
+//                     &conn,
+//                     &operation_conn,
+//                 ) {
+//                     Ok(_) => println!("Fasta imported."),
+//                     Err(FastaError::OperationError(OperationError::NoChanges)) => {
+//                         println!("Fasta contents already exist.")
+//                     }
+//                     Err(_) => {
+//                         conn.execute("ROLLBACK TRANSACTION;", []).unwrap();
+//                         operation_conn.execute("ROLLBACK TRANSACTION;", []).unwrap();
+//                         panic!("Import failed.");
+//                     }
+//                 }
+//             } else if gfa.is_some() {
+//                 match import_gfa(
+//                     &PathBuf::from(gfa.clone().unwrap()),
+//                     name,
+//                     sample.as_deref(),
+//                     &conn,
+//                     &operation_conn,
+//                 ) {
+//                     Ok(_) => println!("GFA Imported."),
+//                     Err(GFAImportError::OperationError(OperationError::NoChanges)) => {
+//                         println!("GFA already exists.")
+//                     }
+//                     Err(_) => {
+//                         conn.execute("ROLLBACK TRANSACTION;", []).unwrap();
+//                         operation_conn.execute("ROLLBACK TRANSACTION;", []).unwrap();
+//                         panic!("Import failed.");
+//                     }
+//                 }
+//             } else if let Some(gb) = gb {
+//                 let mut reader: Box<dyn std::io::Read> = if gb.ends_with(".gz") {
+//                     let file = File::open(gb.clone()).unwrap();
+//                     Box::new(flate2::read::GzDecoder::new(file))
+//                 } else {
+//                     Box::new(File::open(gb.clone()).unwrap())
+//                 };
+//                 match import_genbank(
+//                     &conn,
+//                     &operation_conn,
+//                     &mut reader,
+//                     name.deref(),
+//                     sample.as_deref(),
+//                     OperationInfo {
+//                         files: vec![OperationFile {
+//                             file_path: gb.clone(),
+//                             file_type: FileTypes::GenBank,
+//                         }],
+//                         description: "GenBank Import".to_string(),
+//                     },
+//                 ) {
+//                     Ok(_) => println!("GenBank Imported."),
+//                     Err(err) => {
+//                         conn.execute("ROLLBACK TRANSACTION;", []).unwrap();
+//                         operation_conn.execute("ROLLBACK TRANSACTION;", []).unwrap();
+//                         panic!("Import failed: {err:?}");
+//                     }
+//                 }
+//             } else if region_name.is_some() && parts.is_some() && library.is_some() {
+//                 import_library(
+//                     &conn,
+//                     &operation_conn,
+//                     name,
+//                     sample.as_deref(),
+//                     parts.as_deref().unwrap(),
+//                     library.as_deref().unwrap(),
+//                     region_name.as_deref().unwrap(),
+//                 )
+//                 .unwrap();
+//             } else {
+//                 conn.execute("ROLLBACK TRANSACTION;", []).unwrap();
+//                 operation_conn.execute("ROLLBACK TRANSACTION;", []).unwrap();
+//                 panic!(
+//                     "ERROR: Import command attempted but no recognized file format was specified"
+//                 );
+//             }
+//             conn.execute("END TRANSACTION", []).unwrap();
+//             operation_conn.execute("END TRANSACTION", []).unwrap();
+//             }
+// }
+
+generate_sync_commands!(fasta);

--- a/src/commands/import/mod.rs
+++ b/src/commands/import/mod.rs
@@ -20,13 +20,7 @@ pub struct Command {
 enum Import {
     /// Import a library
     #[command(arg_required_else_help(true))]
-    Library {
-    },
+    Library {},
 }
 
-generate_sync_commands!(
-    fasta,
-    genbank,
-    gfa,
-    library
-);
+generate_sync_commands!(fasta, genbank, gfa, library);

--- a/src/commands/import/mod.rs
+++ b/src/commands/import/mod.rs
@@ -3,6 +3,9 @@ use clap::{Args, Subcommand};
 use clap_nested_commands::generate_sync_commands;
 
 mod fasta;
+mod genbank;
+mod gfa;
+mod library;
 
 /// Import commands
 #[derive(Debug, Args)]
@@ -15,172 +18,15 @@ pub struct Command {
 #[allow(clippy::large_enum_variant)]
 /// Import a new sequence collection.
 enum Import {
-    /// Import a fasta
-    #[command(arg_required_else_help(true))]
-    Fasta {
-        /// Fasta file path
-        #[clap(index = 1)]
-        fasta: String,
-        /// Don't store the sequence in the database, instead store the filename
-        #[arg(long, action)]
-        shallow: bool,
-        /// The name of the collection to store the entry under
-        #[arg(short, long)]
-        name: Option<String>,
-        /// A sample name to associate the fasta file with
-        #[arg(short, long)]
-        sample: Option<String>,
-    },
-    /// Import a genbank
-    #[command(arg_required_else_help(true))]
-    Genbank {
-        /// Genbank file path
-        #[clap(index = 1)]
-        gb: String,
-        /// The name of the collection to store the entry under
-        #[arg(short, long)]
-        name: Option<String>,
-        /// A sample name to associate the genbank file with
-        #[arg(short, long)]
-        sample: Option<String>,
-    },
-    /// Import a GFA
-    #[command(arg_required_else_help(true))]
-    Gfa {
-        /// GFA file path
-        #[clap(index = 1)]
-        gfa: String,
-        /// The name of the collection to store the entry under
-        #[arg(short, long)]
-        name: Option<String>,
-        /// A sample name to associate the GFA file with
-        #[arg(short, long)]
-        sample: Option<String>,
-    },
     /// Import a library
     #[command(arg_required_else_help(true))]
     Library {
-        /// The name of the region
-        #[arg(long)]
-        region_name: Option<String>,
-        /// The path to the combinatorial library parts
-        #[arg(long)]
-        parts: Option<String>,
-        /// The path to the combinatorial library csv
-        #[arg(long)]
-        library: Option<String>,
-        /// The name of the collection to store the entry under
-        #[arg(short, long)]
-        name: Option<String>,
-        /// A sample name to associate the library with
-        #[arg(short, long)]
-        sample: Option<String>,
     },
 }
 
-// fn blah() {
-//             Some(Commands::Import {
-//             fasta,
-//             gb,
-//             gfa,
-//             name,
-//             shallow,
-//             sample,
-//             region_name,
-//             parts,
-//             library,
-//         }) => {
-//             conn.execute("BEGIN TRANSACTION", []).unwrap();
-//             operation_conn.execute("BEGIN TRANSACTION", []).unwrap();
-//             let name = &name
-//                 .clone()
-//                 .unwrap_or_else(|| get_default_collection(&operation_conn));
-//             if fasta.is_some() {
-//                 match import_fasta(
-//                     &fasta.clone().unwrap(),
-//                     name,
-//                     sample.as_deref(),
-//                     *shallow,
-//                     &conn,
-//                     &operation_conn,
-//                 ) {
-//                     Ok(_) => println!("Fasta imported."),
-//                     Err(FastaError::OperationError(OperationError::NoChanges)) => {
-//                         println!("Fasta contents already exist.")
-//                     }
-//                     Err(_) => {
-//                         conn.execute("ROLLBACK TRANSACTION;", []).unwrap();
-//                         operation_conn.execute("ROLLBACK TRANSACTION;", []).unwrap();
-//                         panic!("Import failed.");
-//                     }
-//                 }
-//             } else if gfa.is_some() {
-//                 match import_gfa(
-//                     &PathBuf::from(gfa.clone().unwrap()),
-//                     name,
-//                     sample.as_deref(),
-//                     &conn,
-//                     &operation_conn,
-//                 ) {
-//                     Ok(_) => println!("GFA Imported."),
-//                     Err(GFAImportError::OperationError(OperationError::NoChanges)) => {
-//                         println!("GFA already exists.")
-//                     }
-//                     Err(_) => {
-//                         conn.execute("ROLLBACK TRANSACTION;", []).unwrap();
-//                         operation_conn.execute("ROLLBACK TRANSACTION;", []).unwrap();
-//                         panic!("Import failed.");
-//                     }
-//                 }
-//             } else if let Some(gb) = gb {
-//                 let mut reader: Box<dyn std::io::Read> = if gb.ends_with(".gz") {
-//                     let file = File::open(gb.clone()).unwrap();
-//                     Box::new(flate2::read::GzDecoder::new(file))
-//                 } else {
-//                     Box::new(File::open(gb.clone()).unwrap())
-//                 };
-//                 match import_genbank(
-//                     &conn,
-//                     &operation_conn,
-//                     &mut reader,
-//                     name.deref(),
-//                     sample.as_deref(),
-//                     OperationInfo {
-//                         files: vec![OperationFile {
-//                             file_path: gb.clone(),
-//                             file_type: FileTypes::GenBank,
-//                         }],
-//                         description: "GenBank Import".to_string(),
-//                     },
-//                 ) {
-//                     Ok(_) => println!("GenBank Imported."),
-//                     Err(err) => {
-//                         conn.execute("ROLLBACK TRANSACTION;", []).unwrap();
-//                         operation_conn.execute("ROLLBACK TRANSACTION;", []).unwrap();
-//                         panic!("Import failed: {err:?}");
-//                     }
-//                 }
-//             } else if region_name.is_some() && parts.is_some() && library.is_some() {
-//                 import_library(
-//                     &conn,
-//                     &operation_conn,
-//                     name,
-//                     sample.as_deref(),
-//                     parts.as_deref().unwrap(),
-//                     library.as_deref().unwrap(),
-//                     region_name.as_deref().unwrap(),
-//                 )
-//                 .unwrap();
-//             } else {
-//                 conn.execute("ROLLBACK TRANSACTION;", []).unwrap();
-//                 operation_conn.execute("ROLLBACK TRANSACTION;", []).unwrap();
-//                 panic!(
-//                     "ERROR: Import command attempted but no recognized file format was specified"
-//                 );
-//             }
-//             conn.execute("END TRANSACTION", []).unwrap();
-//             operation_conn.execute("END TRANSACTION", []).unwrap();
-//             }
-// }
-
-generate_sync_commands!(fasta);
+generate_sync_commands!(
+    fasta,
+    genbank,
+    gfa,
+    library
+);

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,0 +1,2 @@
+pub mod cli_context;
+pub mod import;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 pub mod cli_context;
 pub mod export;
 pub mod import;
+pub mod update;
 
 #[derive(Subcommand)]
 #[allow(clippy::large_enum_variant)]
@@ -14,6 +15,8 @@ pub enum Commands {
     Init {},
     /// Commands for importing
     Import(import::Command),
+    /// Commands for updating
+    Update(update::Command),
     /// Commands for exporting
     Export(export::Command),
     /// Commands for transforming file types for input to Gen.
@@ -39,61 +42,6 @@ pub enum Commands {
         #[arg(short, long)]
         sample: Option<String>,
     },
-    /// Update a sequence collection with new data
-    #[command(arg_required_else_help(true))]
-    Update {
-        /// The name of the collection to update
-        #[arg(short, long)]
-        name: Option<String>,
-        /// A fasta file to insert
-        #[arg(short, long)]
-        fasta: Option<String>,
-        /// A VCF file to incorporate
-        #[arg(short, long)]
-        vcf: Option<String>,
-        /// A GenBank file to update from
-        #[arg(long)]
-        gb: Option<String>,
-        /// If no genotype is provided, enter the genotype to assign variants
-        #[arg(short, long)]
-        genotype: Option<String>,
-        /// If no sample is provided, enter the sample to associate variants to
-        #[arg(short, long)]
-        sample: Option<String>,
-        /// New sample name if we are updating with intentional edits
-        #[arg(long)]
-        new_sample: Option<String>,
-        /// Use the given sample as the parent sample for changes.
-        #[arg(long, alias = "cf")]
-        coordinate_frame: Option<String>,
-        /// A CSV with combinatorial library information
-        #[arg(short, long)]
-        library: Option<String>,
-        /// A fasta with the combinatorial library parts
-        #[arg(long)]
-        parts: Option<String>,
-        /// The name of the path to add the library to
-        #[arg(short, long)]
-        path_name: Option<String>,
-        /// The name of the region to update (eg "chr1")
-        #[arg(long)]
-        region_name: Option<String>,
-        /// The start coordinate for the region to add the library to
-        #[arg(long)]
-        start: Option<i64>,
-        /// The end coordinate for the region to add the library to
-        #[arg(short, long)]
-        end: Option<i64>,
-        /// For fasta updates, do not update the sample's reference path if there is a single fasta entry
-        #[arg(long, action)]
-        no_reference_path_update: bool,
-        /// If a new entity is found, create it as a normal import
-        #[arg(long, action, alias = "cm")]
-        create_missing: bool,
-        /// A GFA file to update from
-        #[arg(long)]
-        gfa: Option<String>,
-    },
     /// Show a visual representation of a graph in the terminal
     #[command()]
     View {
@@ -109,25 +57,6 @@ pub enum Commands {
         /// Position as "node id:coordinate" to center the graph on
         #[arg(short, long)]
         position: Option<String>,
-    },
-    /// Update a sequence collecting using GAF results.
-    #[command(name = "update-gaf", arg_required_else_help(true))]
-    UpdateGaf {
-        /// The name of the collection to update
-        #[arg(short, long)]
-        name: Option<String>,
-        /// The GAF input
-        #[arg(short, long)]
-        gaf: String,
-        /// The csv describing changes to make
-        #[arg(short, long)]
-        csv: String,
-        /// The sample to update or create
-        #[arg(short, long)]
-        sample: String,
-        /// If specified, the newly created sample will inherit this sample's existing graph
-        #[arg(short, long)]
-        parent_sample: Option<String>,
     },
     /// Export a set of operations to a patch file
     #[command(name = "patch-create", arg_required_else_help(true))]

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -337,3 +337,11 @@ pub fn get_db_for_command(cli_context: &CliContext, operation_conn: &Connection)
     });
     binding
 }
+
+pub fn get_default_collection(conn: &Connection) -> String {
+    let mut stmt = conn
+        .prepare("select collection_name from defaults where id = 1")
+        .unwrap();
+    stmt.query_row((), |row| row.get(0))
+        .unwrap_or("default".to_string())
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -5,6 +5,7 @@ use rusqlite::Connection;
 use std::path::PathBuf;
 
 pub mod cli_context;
+pub mod export;
 pub mod import;
 
 #[derive(Subcommand)]
@@ -13,6 +14,8 @@ pub enum Commands {
     Init {},
     /// Commands for importing
     Import(import::Command),
+    /// Commands for exporting
+    Export(export::Command),
     /// Commands for transforming file types for input to Gen.
     #[command(arg_required_else_help(true))]
     Transform {
@@ -219,28 +222,6 @@ pub enum Commands {
         /// The operation hash to apply
         #[clap(index = 1)]
         hash: String,
-    },
-    /// Export sequence data
-    #[command(arg_required_else_help(true))]
-    Export {
-        /// The name of the collection to export
-        #[arg(short, long)]
-        name: Option<String>,
-        /// The name of the GFA file to export to
-        #[arg(short, long)]
-        gfa: Option<String>,
-        /// An optional sample name
-        #[arg(short, long)]
-        sample: Option<String>,
-        /// The name of the fasta file to export to
-        #[arg(short, long)]
-        fasta: Option<String>,
-        /// The name of the GenBank file to export to
-        #[arg(long)]
-        gb: Option<String>,
-        /// The max node size for gfa export
-        #[arg(long)]
-        node_max: Option<i64>,
     },
     /// Configure default options
     #[command(arg_required_else_help(true))]

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,6 +1,6 @@
-use clap::{Parser, Subcommand};
 use crate::commands::cli_context::CliContext;
 use crate::config::get_gen_dir;
+use clap::{Parser, Subcommand};
 use rusqlite::Connection;
 use std::path::PathBuf;
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,2 +1,429 @@
+use clap::{Parser, Subcommand};
+use crate::commands::cli_context::CliContext;
+use crate::config::get_gen_dir;
+use rusqlite::Connection;
+use std::path::PathBuf;
+
 pub mod cli_context;
 pub mod import;
+
+#[derive(Subcommand)]
+#[allow(clippy::large_enum_variant)]
+pub enum Commands {
+    Init {},
+    /// Commands for importing
+    Import(import::Command),
+    /// Commands for transforming file types for input to Gen.
+    #[command(arg_required_else_help(true))]
+    Transform {
+        /// For update-gaf, this transforms the csv to a fasta for use in alignments
+        #[arg(long)]
+        format_csv_for_gaf: Option<String>,
+    },
+    /// Translate coordinates of standard bioinformatic file formats.
+    #[command(arg_required_else_help(true))]
+    Translate {
+        /// Transform coordinates of a BED to graph nodes
+        #[arg(long)]
+        bed: Option<String>,
+        /// Transform coordinates of a GFF to graph nodes
+        #[arg(long)]
+        gff: Option<String>,
+        /// The name of the collection to map sequences against
+        #[arg(short, long)]
+        collection: Option<String>,
+        /// The sample name whose graph coordinates are mapped against
+        #[arg(short, long)]
+        sample: Option<String>,
+    },
+    /// Update a sequence collection with new data
+    #[command(arg_required_else_help(true))]
+    Update {
+        /// The name of the collection to update
+        #[arg(short, long)]
+        name: Option<String>,
+        /// A fasta file to insert
+        #[arg(short, long)]
+        fasta: Option<String>,
+        /// A VCF file to incorporate
+        #[arg(short, long)]
+        vcf: Option<String>,
+        /// A GenBank file to update from
+        #[arg(long)]
+        gb: Option<String>,
+        /// If no genotype is provided, enter the genotype to assign variants
+        #[arg(short, long)]
+        genotype: Option<String>,
+        /// If no sample is provided, enter the sample to associate variants to
+        #[arg(short, long)]
+        sample: Option<String>,
+        /// New sample name if we are updating with intentional edits
+        #[arg(long)]
+        new_sample: Option<String>,
+        /// Use the given sample as the parent sample for changes.
+        #[arg(long, alias = "cf")]
+        coordinate_frame: Option<String>,
+        /// A CSV with combinatorial library information
+        #[arg(short, long)]
+        library: Option<String>,
+        /// A fasta with the combinatorial library parts
+        #[arg(long)]
+        parts: Option<String>,
+        /// The name of the path to add the library to
+        #[arg(short, long)]
+        path_name: Option<String>,
+        /// The name of the region to update (eg "chr1")
+        #[arg(long)]
+        region_name: Option<String>,
+        /// The start coordinate for the region to add the library to
+        #[arg(long)]
+        start: Option<i64>,
+        /// The end coordinate for the region to add the library to
+        #[arg(short, long)]
+        end: Option<i64>,
+        /// For fasta updates, do not update the sample's reference path if there is a single fasta entry
+        #[arg(long, action)]
+        no_reference_path_update: bool,
+        /// If a new entity is found, create it as a normal import
+        #[arg(long, action, alias = "cm")]
+        create_missing: bool,
+        /// A GFA file to update from
+        #[arg(long)]
+        gfa: Option<String>,
+    },
+    /// Show a visual representation of a graph in the terminal
+    #[command()]
+    View {
+        /// The name of the graph to view
+        #[clap(index = 1)]
+        graph: Option<String>,
+        /// View the graph for a specific sample
+        #[arg(short, long)]
+        sample: Option<String>,
+        /// Look for the sample in a specific collection
+        #[arg(short, long)]
+        collection: Option<String>,
+        /// Position as "node id:coordinate" to center the graph on
+        #[arg(short, long)]
+        position: Option<String>,
+    },
+    /// Update a sequence collecting using GAF results.
+    #[command(name = "update-gaf", arg_required_else_help(true))]
+    UpdateGaf {
+        /// The name of the collection to update
+        #[arg(short, long)]
+        name: Option<String>,
+        /// The GAF input
+        #[arg(short, long)]
+        gaf: String,
+        /// The csv describing changes to make
+        #[arg(short, long)]
+        csv: String,
+        /// The sample to update or create
+        #[arg(short, long)]
+        sample: String,
+        /// If specified, the newly created sample will inherit this sample's existing graph
+        #[arg(short, long)]
+        parent_sample: Option<String>,
+    },
+    /// Export a set of operations to a patch file
+    #[command(name = "patch-create", arg_required_else_help(true))]
+    PatchCreate {
+        /// To create a patch against a non-checked out branch.
+        #[arg(short, long)]
+        branch: Option<String>,
+        /// The patch name
+        #[arg(short, long)]
+        name: String,
+        /// The operation(s) to create a patch from. For a range, use start..end and for multiple
+        /// or discontinuous ranges, use commas. HEAD and HEAD~<number> syntax is supported.
+        #[clap(index = 1)]
+        operation: String,
+    },
+    /// Apply changes from a patch file
+    #[command(name = "patch-apply", arg_required_else_help(true))]
+    PatchApply {
+        /// The patch file
+        #[clap(index = 1)]
+        patch: String,
+    },
+    /// View a patch in dot format
+    #[command(name = "patch-view", arg_required_else_help(true))]
+    PatchView {
+        /// The prefix to use in the output filenames. One dot file is created for each operation and graph,
+        /// following the pattern {prefix}_{operation}_{graph_id}.dot. Defaults to patch filename.
+        #[arg(long, short)]
+        prefix: Option<String>,
+        /// The patch file
+        #[clap(index = 1)]
+        patch: String,
+    },
+    /// Manage and create branches
+    #[command(arg_required_else_help(true))]
+    Branch {
+        /// Create a branch with the given name
+        #[arg(long, action)]
+        create: bool,
+        /// Delete a given branch
+        #[arg(short, long, action)]
+        delete: bool,
+        /// Checkout a given branch
+        #[arg(long, action)]
+        checkout: bool,
+        /// List all branches
+        #[arg(short, long, action)]
+        list: bool,
+        #[arg(short, long, action)]
+        merge: bool,
+        /// The branch name
+        #[clap(index = 1)]
+        branch_name: Option<String>,
+    },
+    /// Merge branches
+    #[command(arg_required_else_help(true))]
+    Merge {
+        /// The branch name to merge
+        #[clap(index = 1)]
+        branch_name: Option<String>,
+    },
+    /// Migrate a database to a given operation
+    #[command(arg_required_else_help(true))]
+    Checkout {
+        /// Create and checkout a new branch.
+        #[arg(short, long)]
+        branch: Option<String>,
+        /// The operation hash to move to
+        #[clap(index = 1)]
+        hash: Option<String>,
+    },
+    /// Reset a branch to a previous operation
+    #[command(arg_required_else_help(true))]
+    Reset {
+        /// The operation hash to reset to
+        #[clap(index = 1)]
+        hash: String,
+    },
+    /// View operations carried out against a database
+    #[command()]
+    Operations {
+        /// Edit operation messages
+        #[arg(short, long)]
+        interactive: bool,
+        /// The branch to list operations for
+        #[arg(short, long)]
+        branch: Option<String>,
+    },
+    /// Apply an operation to a branch
+    #[command(arg_required_else_help(true))]
+    Apply {
+        /// The operation hash to apply
+        #[clap(index = 1)]
+        hash: String,
+    },
+    /// Export sequence data
+    #[command(arg_required_else_help(true))]
+    Export {
+        /// The name of the collection to export
+        #[arg(short, long)]
+        name: Option<String>,
+        /// The name of the GFA file to export to
+        #[arg(short, long)]
+        gfa: Option<String>,
+        /// An optional sample name
+        #[arg(short, long)]
+        sample: Option<String>,
+        /// The name of the fasta file to export to
+        #[arg(short, long)]
+        fasta: Option<String>,
+        /// The name of the GenBank file to export to
+        #[arg(long)]
+        gb: Option<String>,
+        /// The max node size for gfa export
+        #[arg(long)]
+        node_max: Option<i64>,
+    },
+    /// Configure default options
+    #[command(arg_required_else_help(true))]
+    Defaults {
+        /// The default database to use
+        #[arg(short, long)]
+        database: Option<String>,
+        /// The default collection to use
+        #[arg(short, long)]
+        collection: Option<String>,
+    },
+    /// Set the remote URL for this repo
+    #[command(arg_required_else_help(true))]
+    SetRemote {
+        /// The remote URL to set
+        #[arg(short, long)]
+        remote: String,
+    },
+    /// Push the local repo to the remote
+    #[command()]
+    Push {},
+    #[command()]
+    Pull {},
+    /// Convert annotation coordinates between two samples
+    #[command(arg_required_else_help(true))]
+    PropagateAnnotations {
+        /// The name of the collection to annotate
+        #[arg(short, long)]
+        name: Option<String>,
+        /// The name of the sample the annotations are referenced to (if not provided, the default)
+        #[arg(short, long)]
+        from_sample: Option<String>,
+        /// The name of the sample to annotate
+        #[arg(short, long)]
+        to_sample: String,
+        /// The name of the annotation file to propagate
+        #[arg(short, long)]
+        gff: String,
+        /// The name of the output file
+        #[arg(short, long)]
+        output_gff: String,
+    },
+    /// List all samples in the current collection
+    ListSamples {},
+    #[command()]
+    /// List all regions/contigs in the current collection and given sample
+    ListGraphs {
+        /// The name of the collection to list graphs for
+        #[arg(short, long)]
+        name: Option<String>,
+        /// The name of the sample to list graphs for
+        #[arg(short, long)]
+        sample: Option<String>,
+    },
+    /// Extract a sequence from a graph
+    #[command(arg_required_else_help(true))]
+    GetSequence {
+        /// The name of the collection containing the sequence
+        #[arg(short, long)]
+        name: Option<String>,
+        /// The name of the sample containing the sequence
+        #[arg(short, long)]
+        sample: Option<String>,
+        /// The name of the graph to get the sequence for
+        #[arg(short, long)]
+        graph: Option<String>,
+        /// The start coordinate of the sequence
+        #[arg(long)]
+        start: Option<i64>,
+        /// The end coordinate of the sequence
+        #[arg(long)]
+        end: Option<i64>,
+        /// The region (name:start-end format) of the sequence
+        #[arg(long)]
+        region: Option<String>,
+    },
+    /// Output a file representing the "diff" between two samples
+    Diff {
+        /// The name of the collection to diff
+        #[arg(short, long)]
+        name: Option<String>,
+        /// The name of the first sample to diff
+        #[arg(long)]
+        sample1: Option<String>,
+        /// The name of the second sample to diff
+        #[arg(long)]
+        sample2: Option<String>,
+        /// The name of the output GFA file
+        #[arg(long)]
+        gfa: String,
+    },
+    /// Replace a sequence graph with a subgraph in the range of the specified coordinates
+    DeriveSubgraph {
+        /// The name of the collection to derive the subgraph from
+        #[arg(short, long)]
+        name: Option<String>,
+        /// The name of the parent sample
+        #[arg(short, long)]
+        sample: Option<String>,
+        /// The name of the new sample
+        #[arg(long)]
+        new_sample: String,
+        /// The name of the region to derive the subgraph from
+        #[arg(short, long)]
+        region: String,
+        /// Name of alternate path (not current) to use
+        #[arg(long)]
+        backbone: Option<String>,
+    },
+    /// Replace a sequence graph with subgraphs in the ranges of the specified coordinates
+    DeriveChunks {
+        /// The name of the collection to derive the subgraph from
+        #[arg(short, long)]
+        name: Option<String>,
+        /// The name of the parent sample
+        #[arg(short, long)]
+        sample: Option<String>,
+        /// The name of the new sample
+        #[arg(long)]
+        new_sample: String,
+        /// The name of the region to derive the subgraph from
+        #[arg(short, long)]
+        region: String,
+        /// Name of alternate path (not current) to use
+        #[arg(long)]
+        backbone: Option<String>,
+        /// Breakpoints to derive chunks from
+        #[arg(long)]
+        breakpoints: Option<String>,
+        /// The size of the chunks to derive
+        #[arg(long)]
+        chunk_size: Option<i64>,
+    },
+    #[command(
+        verbatim_doc_comment,
+        long_about = "Combine multiple sequence graphs into one. Example:
+    gen make-stitch --sample parent_sample --new-sample my_child_sample --regions chr1.2,chr1.3 --new-region spliced_chr1"
+    )]
+    MakeStitch {
+        /// The name of the collection to derive the subgraph from
+        #[arg(short, long)]
+        name: Option<String>,
+        /// The name of the parent sample
+        #[arg(short, long)]
+        sample: Option<String>,
+        /// The name of the new sample
+        #[arg(long)]
+        new_sample: String,
+        /// The names of the regions to combine
+        #[arg(long)]
+        regions: String,
+        /// The name of the new region
+        #[arg(long)]
+        new_region: String,
+    },
+}
+
+#[derive(Parser)]
+#[command(version, about, long_about = None, arg_required_else_help(true))]
+pub struct Cli {
+    /// The path to the database you wish to utilize
+    #[arg(short, long)]
+    pub db: Option<String>,
+    #[command(subcommand)]
+    pub command: Option<Commands>,
+}
+
+pub fn get_db_for_command(cli_context: &CliContext, operation_conn: &Connection) -> String {
+    let binding = cli_context.db.clone().unwrap_or_else(|| {
+        let mut stmt = operation_conn
+            .prepare("select db_name from defaults where id = 1;")
+            .unwrap();
+        let row: Option<String> = stmt.query_row((), |row| row.get(0)).unwrap();
+        row.unwrap_or_else(|| match get_gen_dir() {
+            Some(dir) => PathBuf::from(dir)
+                .join("default.db")
+                .to_str()
+                .unwrap()
+                .to_string(),
+            None => {
+                panic!("No .gen directory found. Please run 'gen init' first.")
+            }
+        })
+    });
+    binding
+}

--- a/src/commands/update/fasta.rs
+++ b/src/commands/update/fasta.rs
@@ -1,30 +1,40 @@
 use crate::commands::cli_context::CliContext;
 use crate::commands::get_db_for_command;
 use crate::config::get_operation_connection;
-use crate::fasta::FastaError;
 use crate::get_connection;
-use crate::imports::fasta::import_fasta;
 use crate::models::metadata;
 use crate::models::operations::setup_db;
-use crate::operation_management::OperationError;
+use crate::updates::fasta::update_with_fasta;
 use clap::Args;
 use rusqlite::Connection;
 
-/// Import a fasta file
+/// Update with a fasta file
 #[derive(Debug, Args)]
 pub struct Command {
     /// Fasta file path
     #[clap(index = 1)]
     pub path: String,
-    /// Don't store the sequence in the database, instead store the filename
-    #[arg(long, action)]
-    shallow: bool,
-    /// The name of the collection to store the entry under
+    /// The name of the collection to update
     #[arg(short, long)]
     name: Option<String>,
-    /// A sample name to associate the fasta file with
+    /// The name of the sample to update
     #[arg(short, long)]
     sample: Option<String>,
+    /// A new sample name to associate with the update
+    #[arg(long)]
+    new_sample: String,
+    /// The name of the region to update (eg "chr1")
+    #[arg(long)]
+    region_name: String,
+    /// The start coordinate for the region to add the library to
+    #[arg(long)]
+    start: i64,
+    /// The end coordinate for the region to add the library to
+    #[arg(short, long)]
+    end: i64,
+    /// Do not update the sample's reference path if there is a single fasta entry
+    #[arg(long, action)]
+    no_reference_path_update: bool,
 }
 
 fn get_default_collection(conn: &Connection) -> String {
@@ -36,7 +46,7 @@ fn get_default_collection(conn: &Connection) -> String {
 }
 
 pub fn execute(cli_context: &CliContext, cmd: Command) {
-    println!("Fasta import called");
+    println!("Update with fasta called");
 
     let operation_conn = get_operation_connection(None);
     let db = get_db_for_command(cli_context, &operation_conn);
@@ -52,28 +62,21 @@ pub fn execute(cli_context: &CliContext, cmd: Command) {
         .name
         .clone()
         .unwrap_or_else(|| get_default_collection(&operation_conn));
-    match import_fasta(
-        &cmd.path.clone(),
-        name,
-        cmd.sample.as_deref(),
-        cmd.shallow,
+
+    update_with_fasta(
         &conn,
         &operation_conn,
-    ) {
-        Ok(_) => {
-            println!("Fasta imported.");
-            conn.execute("END TRANSACTION;", []).unwrap();
-            operation_conn.execute("END TRANSACTION;", []).unwrap();
-        }
-        Err(FastaError::OperationError(OperationError::NoChanges)) => {
-            conn.execute("ROLLBACK TRANSACTION;", []).unwrap();
-            operation_conn.execute("ROLLBACK TRANSACTION;", []).unwrap();
-            println!("Fasta contents already exist.")
-        }
-        Err(_) => {
-            conn.execute("ROLLBACK TRANSACTION;", []).unwrap();
-            operation_conn.execute("ROLLBACK TRANSACTION;", []).unwrap();
-            panic!("Import failed.");
-        }
-    }
+        name,
+        cmd.sample.clone().as_deref(),
+        &cmd.new_sample,
+        &cmd.region_name,
+        cmd.start,
+        cmd.end,
+        &cmd.path,
+        cmd.no_reference_path_update,
+    )
+    .unwrap();
+
+    conn.execute("END TRANSACTION;", []).unwrap();
+    operation_conn.execute("END TRANSACTION;", []).unwrap();
 }

--- a/src/commands/update/fasta.rs
+++ b/src/commands/update/fasta.rs
@@ -1,12 +1,11 @@
 use crate::commands::cli_context::CliContext;
-use crate::commands::get_db_for_command;
+use crate::commands::{get_db_for_command, get_default_collection};
 use crate::config::get_operation_connection;
 use crate::get_connection;
 use crate::models::metadata;
 use crate::models::operations::setup_db;
 use crate::updates::fasta::update_with_fasta;
 use clap::Args;
-use rusqlite::Connection;
 
 /// Update with a fasta file
 #[derive(Debug, Args)]
@@ -35,14 +34,6 @@ pub struct Command {
     /// Do not update the sample's reference path if there is a single fasta entry
     #[arg(long, action)]
     no_reference_path_update: bool,
-}
-
-fn get_default_collection(conn: &Connection) -> String {
-    let mut stmt = conn
-        .prepare("select collection_name from defaults where id = 1")
-        .unwrap();
-    stmt.query_row((), |row| row.get(0))
-        .unwrap_or("default".to_string())
 }
 
 pub fn execute(cli_context: &CliContext, cmd: Command) {

--- a/src/commands/update/gaf.rs
+++ b/src/commands/update/gaf.rs
@@ -1,30 +1,31 @@
 use crate::commands::cli_context::CliContext;
 use crate::commands::get_db_for_command;
 use crate::config::get_operation_connection;
-use crate::fasta::FastaError;
 use crate::get_connection;
-use crate::imports::fasta::import_fasta;
 use crate::models::metadata;
 use crate::models::operations::setup_db;
-use crate::operation_management::OperationError;
+use crate::updates::gaf::update_with_gaf;
 use clap::Args;
 use rusqlite::Connection;
 
-/// Import a fasta file
+/// Update with a GAF file
 #[derive(Debug, Args)]
 pub struct Command {
-    /// Fasta file path
+    /// GAF file path
     #[clap(index = 1)]
     pub path: String,
-    /// Don't store the sequence in the database, instead store the filename
-    #[arg(long, action)]
-    shallow: bool,
-    /// The name of the collection to store the entry under
+    /// The name of the collection to update
     #[arg(short, long)]
     name: Option<String>,
-    /// A sample name to associate the fasta file with
+    /// The name of the sample to update
     #[arg(short, long)]
     sample: Option<String>,
+    /// The csv describing changes to make
+    #[arg(short, long)]
+    csv: String,
+    /// If specified, the newly created sample will inherit this sample's existing graph
+    #[arg(short, long)]
+    parent_sample: Option<String>,
 }
 
 fn get_default_collection(conn: &Connection) -> String {
@@ -36,7 +37,7 @@ fn get_default_collection(conn: &Connection) -> String {
 }
 
 pub fn execute(cli_context: &CliContext, cmd: Command) {
-    println!("Fasta import called");
+    println!("Update with GAF called");
 
     let operation_conn = get_operation_connection(None);
     let db = get_db_for_command(cli_context, &operation_conn);
@@ -52,28 +53,17 @@ pub fn execute(cli_context: &CliContext, cmd: Command) {
         .name
         .clone()
         .unwrap_or_else(|| get_default_collection(&operation_conn));
-    match import_fasta(
-        &cmd.path.clone(),
-        name,
-        cmd.sample.as_deref(),
-        cmd.shallow,
+
+    update_with_gaf(
         &conn,
         &operation_conn,
-    ) {
-        Ok(_) => {
-            println!("Fasta imported.");
-            conn.execute("END TRANSACTION;", []).unwrap();
-            operation_conn.execute("END TRANSACTION;", []).unwrap();
-        }
-        Err(FastaError::OperationError(OperationError::NoChanges)) => {
-            conn.execute("ROLLBACK TRANSACTION;", []).unwrap();
-            operation_conn.execute("ROLLBACK TRANSACTION;", []).unwrap();
-            println!("Fasta contents already exist.")
-        }
-        Err(_) => {
-            conn.execute("ROLLBACK TRANSACTION;", []).unwrap();
-            operation_conn.execute("ROLLBACK TRANSACTION;", []).unwrap();
-            panic!("Import failed.");
-        }
-    }
+        &cmd.path,
+        &cmd.csv,
+        name,
+        cmd.sample.as_deref(),
+        cmd.parent_sample.as_deref(),
+    );
+
+    conn.execute("END TRANSACTION;", []).unwrap();
+    operation_conn.execute("END TRANSACTION;", []).unwrap();
 }

--- a/src/commands/update/gaf.rs
+++ b/src/commands/update/gaf.rs
@@ -1,12 +1,11 @@
 use crate::commands::cli_context::CliContext;
-use crate::commands::get_db_for_command;
+use crate::commands::{get_db_for_command, get_default_collection};
 use crate::config::get_operation_connection;
 use crate::get_connection;
 use crate::models::metadata;
 use crate::models::operations::setup_db;
 use crate::updates::gaf::update_with_gaf;
 use clap::Args;
-use rusqlite::Connection;
 
 /// Update with a GAF file
 #[derive(Debug, Args)]
@@ -26,14 +25,6 @@ pub struct Command {
     /// If specified, the newly created sample will inherit this sample's existing graph
     #[arg(short, long)]
     parent_sample: Option<String>,
-}
-
-fn get_default_collection(conn: &Connection) -> String {
-    let mut stmt = conn
-        .prepare("select collection_name from defaults where id = 1")
-        .unwrap();
-    stmt.query_row((), |row| row.get(0))
-        .unwrap_or("default".to_string())
 }
 
 pub fn execute(cli_context: &CliContext, cmd: Command) {

--- a/src/commands/update/genbank.rs
+++ b/src/commands/update/genbank.rs
@@ -1,5 +1,5 @@
 use crate::commands::cli_context::CliContext;
-use crate::commands::get_db_for_command;
+use crate::commands::{get_db_for_command, get_default_collection};
 use crate::config::get_operation_connection;
 use crate::get_connection;
 use crate::models::file_types::FileTypes;
@@ -7,7 +7,6 @@ use crate::models::metadata;
 use crate::models::operations::{setup_db, OperationFile, OperationInfo};
 use crate::updates::genbank::update_with_genbank;
 use clap::Args;
-use rusqlite::Connection;
 use std::fs::File;
 
 /// Update with a GenBank file
@@ -22,14 +21,6 @@ pub struct Command {
     /// If a new entity is found, create it as a normal import
     #[arg(long, action, alias = "cm")]
     create_missing: bool,
-}
-
-fn get_default_collection(conn: &Connection) -> String {
-    let mut stmt = conn
-        .prepare("select collection_name from defaults where id = 1")
-        .unwrap();
-    stmt.query_row((), |row| row.get(0))
-        .unwrap_or("default".to_string())
 }
 
 pub fn execute(cli_context: &CliContext, cmd: Command) {

--- a/src/commands/update/genbank.rs
+++ b/src/commands/update/genbank.rs
@@ -1,30 +1,27 @@
 use crate::commands::cli_context::CliContext;
 use crate::commands::get_db_for_command;
 use crate::config::get_operation_connection;
-use crate::fasta::FastaError;
 use crate::get_connection;
-use crate::imports::fasta::import_fasta;
+use crate::models::file_types::FileTypes;
 use crate::models::metadata;
-use crate::models::operations::setup_db;
-use crate::operation_management::OperationError;
+use crate::models::operations::{setup_db, OperationFile, OperationInfo};
+use crate::updates::genbank::update_with_genbank;
 use clap::Args;
 use rusqlite::Connection;
+use std::fs::File;
 
-/// Import a fasta file
+/// Update with a GenBank file
 #[derive(Debug, Args)]
 pub struct Command {
-    /// Fasta file path
+    /// GenBank file path
     #[clap(index = 1)]
     pub path: String,
-    /// Don't store the sequence in the database, instead store the filename
-    #[arg(long, action)]
-    shallow: bool,
-    /// The name of the collection to store the entry under
+    /// The name of the collection to update
     #[arg(short, long)]
     name: Option<String>,
-    /// A sample name to associate the fasta file with
-    #[arg(short, long)]
-    sample: Option<String>,
+    /// If a new entity is found, create it as a normal import
+    #[arg(long, action, alias = "cm")]
+    create_missing: bool,
 }
 
 fn get_default_collection(conn: &Connection) -> String {
@@ -36,7 +33,7 @@ fn get_default_collection(conn: &Connection) -> String {
 }
 
 pub fn execute(cli_context: &CliContext, cmd: Command) {
-    println!("Fasta import called");
+    println!("Update with GenBank called");
 
     let operation_conn = get_operation_connection(None);
     let db = get_db_for_command(cli_context, &operation_conn);
@@ -52,28 +49,30 @@ pub fn execute(cli_context: &CliContext, cmd: Command) {
         .name
         .clone()
         .unwrap_or_else(|| get_default_collection(&operation_conn));
-    match import_fasta(
-        &cmd.path.clone(),
-        name,
-        cmd.sample.as_deref(),
-        cmd.shallow,
+
+    let f = File::open(&cmd.path).unwrap();
+    match update_with_genbank(
         &conn,
         &operation_conn,
+        &f,
+        name.as_ref(),
+        cmd.create_missing,
+        &OperationInfo {
+            files: vec![OperationFile {
+                file_path: cmd.path.clone(),
+                file_type: FileTypes::GenBank,
+            }],
+            description: "Update from GenBank".to_string(),
+        },
     ) {
         Ok(_) => {
-            println!("Fasta imported.");
             conn.execute("END TRANSACTION;", []).unwrap();
             operation_conn.execute("END TRANSACTION;", []).unwrap();
         }
-        Err(FastaError::OperationError(OperationError::NoChanges)) => {
+        Err(e) => {
             conn.execute("ROLLBACK TRANSACTION;", []).unwrap();
             operation_conn.execute("ROLLBACK TRANSACTION;", []).unwrap();
-            println!("Fasta contents already exist.")
-        }
-        Err(_) => {
-            conn.execute("ROLLBACK TRANSACTION;", []).unwrap();
-            operation_conn.execute("ROLLBACK TRANSACTION;", []).unwrap();
-            panic!("Import failed.");
+            panic!("Failed to update. Error is: {e}");
         }
     }
 }

--- a/src/commands/update/gfa.rs
+++ b/src/commands/update/gfa.rs
@@ -1,12 +1,11 @@
 use crate::commands::cli_context::CliContext;
-use crate::commands::get_db_for_command;
+use crate::commands::{get_db_for_command, get_default_collection};
 use crate::config::get_operation_connection;
 use crate::get_connection;
 use crate::models::metadata;
 use crate::models::operations::setup_db;
 use crate::updates::gfa::update_with_gfa;
 use clap::Args;
-use rusqlite::Connection;
 
 /// Update with a GFA file
 #[derive(Debug, Args)]
@@ -23,14 +22,6 @@ pub struct Command {
     /// A new sample name to associate with the update
     #[arg(long)]
     new_sample: String,
-}
-
-fn get_default_collection(conn: &Connection) -> String {
-    let mut stmt = conn
-        .prepare("select collection_name from defaults where id = 1")
-        .unwrap();
-    stmt.query_row((), |row| row.get(0))
-        .unwrap_or("default".to_string())
 }
 
 pub fn execute(cli_context: &CliContext, cmd: Command) {

--- a/src/commands/update/gfa.rs
+++ b/src/commands/update/gfa.rs
@@ -1,30 +1,28 @@
 use crate::commands::cli_context::CliContext;
 use crate::commands::get_db_for_command;
 use crate::config::get_operation_connection;
-use crate::fasta::FastaError;
 use crate::get_connection;
-use crate::imports::fasta::import_fasta;
 use crate::models::metadata;
 use crate::models::operations::setup_db;
-use crate::operation_management::OperationError;
+use crate::updates::gfa::update_with_gfa;
 use clap::Args;
 use rusqlite::Connection;
 
-/// Import a fasta file
+/// Update with a GFA file
 #[derive(Debug, Args)]
 pub struct Command {
-    /// Fasta file path
+    /// GFA file path
     #[clap(index = 1)]
     pub path: String,
-    /// Don't store the sequence in the database, instead store the filename
-    #[arg(long, action)]
-    shallow: bool,
-    /// The name of the collection to store the entry under
+    /// The name of the collection to update
     #[arg(short, long)]
     name: Option<String>,
-    /// A sample name to associate the fasta file with
+    /// The name of the sample to update
     #[arg(short, long)]
     sample: Option<String>,
+    /// A new sample name to associate with the update
+    #[arg(long)]
+    new_sample: String,
 }
 
 fn get_default_collection(conn: &Connection) -> String {
@@ -36,7 +34,7 @@ fn get_default_collection(conn: &Connection) -> String {
 }
 
 pub fn execute(cli_context: &CliContext, cmd: Command) {
-    println!("Fasta import called");
+    println!("Update with GFA called");
 
     let operation_conn = get_operation_connection(None);
     let db = get_db_for_command(cli_context, &operation_conn);
@@ -52,28 +50,23 @@ pub fn execute(cli_context: &CliContext, cmd: Command) {
         .name
         .clone()
         .unwrap_or_else(|| get_default_collection(&operation_conn));
-    match import_fasta(
-        &cmd.path.clone(),
-        name,
-        cmd.sample.as_deref(),
-        cmd.shallow,
+
+    match update_with_gfa(
         &conn,
         &operation_conn,
+        name,
+        cmd.sample.clone().as_deref(),
+        &cmd.new_sample,
+        &cmd.path,
     ) {
         Ok(_) => {
-            println!("Fasta imported.");
             conn.execute("END TRANSACTION;", []).unwrap();
             operation_conn.execute("END TRANSACTION;", []).unwrap();
         }
-        Err(FastaError::OperationError(OperationError::NoChanges)) => {
+        Err(e) => {
             conn.execute("ROLLBACK TRANSACTION;", []).unwrap();
             operation_conn.execute("ROLLBACK TRANSACTION;", []).unwrap();
-            println!("Fasta contents already exist.")
-        }
-        Err(_) => {
-            conn.execute("ROLLBACK TRANSACTION;", []).unwrap();
-            operation_conn.execute("ROLLBACK TRANSACTION;", []).unwrap();
-            panic!("Import failed.");
+            panic!("Failed to update. Error is: {e}");
         }
     }
 }

--- a/src/commands/update/library.rs
+++ b/src/commands/update/library.rs
@@ -1,12 +1,11 @@
 use crate::commands::cli_context::CliContext;
-use crate::commands::get_db_for_command;
+use crate::commands::{get_db_for_command, get_default_collection};
 use crate::config::get_operation_connection;
 use crate::get_connection;
 use crate::models::metadata;
 use crate::models::operations::setup_db;
 use crate::updates::library::update_with_library;
 use clap::Args;
-use rusqlite::Connection;
 
 /// Update with library files
 #[derive(Debug, Args)]
@@ -35,14 +34,6 @@ pub struct Command {
     /// A fasta with the combinatorial library parts
     #[arg(long)]
     parts: String,
-}
-
-fn get_default_collection(conn: &Connection) -> String {
-    let mut stmt = conn
-        .prepare("select collection_name from defaults where id = 1")
-        .unwrap();
-    stmt.query_row((), |row| row.get(0))
-        .unwrap_or("default".to_string())
 }
 
 pub fn execute(cli_context: &CliContext, cmd: Command) {

--- a/src/commands/update/mod.rs
+++ b/src/commands/update/mod.rs
@@ -1,0 +1,19 @@
+use crate::commands::cli_context::CliContext;
+use clap::{Args, Subcommand};
+use clap_nested_commands::generate_sync_commands;
+
+mod fasta;
+mod gaf;
+mod genbank;
+mod gfa;
+mod library;
+mod vcf;
+
+/// Import commands
+#[derive(Debug, Args)]
+pub struct Command {
+    #[command(subcommand)]
+    pub command: Commands,
+}
+
+generate_sync_commands!(fasta, gaf, genbank, gfa, library, vcf);

--- a/src/commands/update/vcf.rs
+++ b/src/commands/update/vcf.rs
@@ -1,5 +1,5 @@
 use crate::commands::cli_context::CliContext;
-use crate::commands::get_db_for_command;
+use crate::commands::{get_db_for_command, get_default_collection};
 use crate::config::get_operation_connection;
 use crate::get_connection;
 use crate::models::metadata;
@@ -7,7 +7,6 @@ use crate::models::operations::setup_db;
 use crate::operation_management::OperationError;
 use crate::updates::vcf::{update_with_vcf, VcfError};
 use clap::Args;
-use rusqlite::Connection;
 
 /// Update with a VCF file
 #[derive(Debug, Args)]
@@ -27,14 +26,6 @@ pub struct Command {
     /// Use the given sample as the parent sample for changes.
     #[arg(long, alias = "cf")]
     coordinate_frame: Option<String>,
-}
-
-fn get_default_collection(conn: &Connection) -> String {
-    let mut stmt = conn
-        .prepare("select collection_name from defaults where id = 1")
-        .unwrap();
-    stmt.query_row((), |row| row.get(0))
-        .unwrap_or("default".to_string())
 }
 
 pub fn execute(cli_context: &CliContext, cmd: Command) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,10 @@
+use clap::{Parser, Subcommand};
 use std::fs::File;
 use std::io::BufRead;
 use std::path::Path;
 use std::{io, str};
 pub mod annotations;
+pub mod commands;
 pub mod config;
 pub mod diffs;
 pub mod exports;
@@ -111,6 +113,23 @@ where
 
 pub fn normalize_string(s: &str) -> String {
     s.chars().filter(|c| !c.is_whitespace()).collect()
+}
+
+#[derive(Subcommand)]
+#[allow(clippy::large_enum_variant)]
+pub enum Commands {
+    /// Commands for importing
+    Import(commands::import::Command),
+}
+
+#[derive(Parser)]
+#[command(version, about, long_about = None, arg_required_else_help(true))]
+pub struct NewCli {
+    /// The path to the database you wish to utilize
+    #[arg(short, long)]
+    pub db: Option<String>,
+    #[command(subcommand)]
+    pub command: Option<Commands>,
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-use clap::{Parser, Subcommand};
 use std::fs::File;
 use std::io::BufRead;
 use std::path::Path;
@@ -113,23 +112,6 @@ where
 
 pub fn normalize_string(s: &str) -> String {
     s.chars().filter(|c| !c.is_whitespace()).collect()
-}
-
-#[derive(Subcommand)]
-#[allow(clippy::large_enum_variant)]
-pub enum Commands {
-    /// Commands for importing
-    Import(commands::import::Command),
-}
-
-#[derive(Parser)]
-#[command(version, about, long_about = None, arg_required_else_help(true))]
-pub struct NewCli {
-    /// The path to the database you wish to utilize
-    #[arg(short, long)]
-    pub db: Option<String>,
-    #[command(subcommand)]
-    pub command: Option<Commands>,
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,9 @@
 #![allow(warnings)]
 use clap::{Parser, Subcommand};
 use core::ops::Range;
+use gen::commands::{Cli, Commands};
 use gen::config;
 use gen::config::{get_gen_dir, get_operation_connection};
-use gen::commands::Commands;
-use gen::commands::Cli;
 use rusqlite::params;
 
 use gen::annotations::gff::propagate_gff;
@@ -140,13 +139,13 @@ fn main() {
     setup_db(&operation_conn, &db_uuid);
 
     match cli.command {
-	Some(Commands::Init {}) => {
+        Some(Commands::Init {}) => {
             config::get_or_create_gen_dir();
             println!("Gen repository initialized.");
-	}
+        }
         Some(Commands::Import(cmd)) => {
-	    gen::commands::import::execute(&cli_context, cmd);
-	}
+            gen::commands::import::execute(&cli_context, cmd);
+        }
         Some(Commands::View {
             graph,
             sample,

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,8 +3,8 @@ use clap::{Parser, Subcommand};
 use core::ops::Range;
 use gen::config;
 use gen::config::{get_gen_dir, get_operation_connection};
-use gen::Commands;
-use gen::NewCli;
+use gen::commands::Commands;
+use gen::commands::Cli;
 use rusqlite::params;
 
 use gen::annotations::gff::propagate_gff;
@@ -17,7 +17,6 @@ use gen::fasta::FastaError;
 use gen::genbank::GenBankError;
 use gen::get_connection;
 use gen::graph_operators::{derive_chunks, get_path, make_stitch};
-use gen::imports::fasta::import_fasta;
 use gen::imports::genbank::import_genbank;
 use gen::imports::gfa::{import_gfa, GFAImportError};
 use gen::imports::library::import_library;
@@ -53,16 +52,6 @@ use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::{io, str};
 
-#[derive(Parser)]
-#[command(version, about, long_about = None, arg_required_else_help(true))]
-pub struct Cli {
-    /// The path to the database you wish to utilize
-    #[arg(short, long)]
-    pub db: Option<String>,
-    #[command(subcommand)]
-    pub command: Option<OldCommands>,
-}
-
 fn get_default_collection(conn: &Connection) -> String {
     let mut stmt = conn
         .prepare("select collection_name from defaults where id = 1")
@@ -71,424 +60,22 @@ fn get_default_collection(conn: &Connection) -> String {
         .unwrap_or("default".to_string())
 }
 
-#[derive(Subcommand)]
-#[allow(clippy::large_enum_variant)]
-enum OldCommands {
-    /// Commands for transforming file types for input to Gen.
-    #[command(arg_required_else_help(true))]
-    Transform {
-        /// For update-gaf, this transforms the csv to a fasta for use in alignments
-        #[arg(long)]
-        format_csv_for_gaf: Option<String>,
-    },
-    /// Translate coordinates of standard bioinformatic file formats.
-    #[command(arg_required_else_help(true))]
-    Translate {
-        /// Transform coordinates of a BED to graph nodes
-        #[arg(long)]
-        bed: Option<String>,
-        /// Transform coordinates of a GFF to graph nodes
-        #[arg(long)]
-        gff: Option<String>,
-        /// The name of the collection to map sequences against
-        #[arg(short, long)]
-        collection: Option<String>,
-        /// The sample name whose graph coordinates are mapped against
-        #[arg(short, long)]
-        sample: Option<String>,
-    },
-    /// Update a sequence collection with new data
-    #[command(arg_required_else_help(true))]
-    Update {
-        /// The name of the collection to update
-        #[arg(short, long)]
-        name: Option<String>,
-        /// A fasta file to insert
-        #[arg(short, long)]
-        fasta: Option<String>,
-        /// A VCF file to incorporate
-        #[arg(short, long)]
-        vcf: Option<String>,
-        /// A GenBank file to update from
-        #[arg(long)]
-        gb: Option<String>,
-        /// If no genotype is provided, enter the genotype to assign variants
-        #[arg(short, long)]
-        genotype: Option<String>,
-        /// If no sample is provided, enter the sample to associate variants to
-        #[arg(short, long)]
-        sample: Option<String>,
-        /// New sample name if we are updating with intentional edits
-        #[arg(long)]
-        new_sample: Option<String>,
-        /// Use the given sample as the parent sample for changes.
-        #[arg(long, alias = "cf")]
-        coordinate_frame: Option<String>,
-        /// A CSV with combinatorial library information
-        #[arg(short, long)]
-        library: Option<String>,
-        /// A fasta with the combinatorial library parts
-        #[arg(long)]
-        parts: Option<String>,
-        /// The name of the path to add the library to
-        #[arg(short, long)]
-        path_name: Option<String>,
-        /// The name of the region to update (eg "chr1")
-        #[arg(long)]
-        region_name: Option<String>,
-        /// The start coordinate for the region to add the library to
-        #[arg(long)]
-        start: Option<i64>,
-        /// The end coordinate for the region to add the library to
-        #[arg(short, long)]
-        end: Option<i64>,
-        /// For fasta updates, do not update the sample's reference path if there is a single fasta entry
-        #[arg(long, action)]
-        no_reference_path_update: bool,
-        /// If a new entity is found, create it as a normal import
-        #[arg(long, action, alias = "cm")]
-        create_missing: bool,
-        /// A GFA file to update from
-        #[arg(long)]
-        gfa: Option<String>,
-    },
-    /// Show a visual representation of a graph in the terminal
-    #[command()]
-    View {
-        /// The name of the graph to view
-        #[clap(index = 1)]
-        graph: Option<String>,
-        /// View the graph for a specific sample
-        #[arg(short, long)]
-        sample: Option<String>,
-        /// Look for the sample in a specific collection
-        #[arg(short, long)]
-        collection: Option<String>,
-        /// Position as "node id:coordinate" to center the graph on
-        #[arg(short, long)]
-        position: Option<String>,
-    },
-    /// Update a sequence collecting using GAF results.
-    #[command(name = "update-gaf", arg_required_else_help(true))]
-    UpdateGaf {
-        /// The name of the collection to update
-        #[arg(short, long)]
-        name: Option<String>,
-        /// The GAF input
-        #[arg(short, long)]
-        gaf: String,
-        /// The csv describing changes to make
-        #[arg(short, long)]
-        csv: String,
-        /// The sample to update or create
-        #[arg(short, long)]
-        sample: String,
-        /// If specified, the newly created sample will inherit this sample's existing graph
-        #[arg(short, long)]
-        parent_sample: Option<String>,
-    },
-    /// Export a set of operations to a patch file
-    #[command(name = "patch-create", arg_required_else_help(true))]
-    PatchCreate {
-        /// To create a patch against a non-checked out branch.
-        #[arg(short, long)]
-        branch: Option<String>,
-        /// The patch name
-        #[arg(short, long)]
-        name: String,
-        /// The operation(s) to create a patch from. For a range, use start..end and for multiple
-        /// or discontinuous ranges, use commas. HEAD and HEAD~<number> syntax is supported.
-        #[clap(index = 1)]
-        operation: String,
-    },
-    /// Apply changes from a patch file
-    #[command(name = "patch-apply", arg_required_else_help(true))]
-    PatchApply {
-        /// The patch file
-        #[clap(index = 1)]
-        patch: String,
-    },
-    /// View a patch in dot format
-    #[command(name = "patch-view", arg_required_else_help(true))]
-    PatchView {
-        /// The prefix to use in the output filenames. One dot file is created for each operation and graph,
-        /// following the pattern {prefix}_{operation}_{graph_id}.dot. Defaults to patch filename.
-        #[arg(long, short)]
-        prefix: Option<String>,
-        /// The patch file
-        #[clap(index = 1)]
-        patch: String,
-    },
-    /// Initialize a gen repository
-    Init {},
-    /// Manage and create branches
-    #[command(arg_required_else_help(true))]
-    Branch {
-        /// Create a branch with the given name
-        #[arg(long, action)]
-        create: bool,
-        /// Delete a given branch
-        #[arg(short, long, action)]
-        delete: bool,
-        /// Checkout a given branch
-        #[arg(long, action)]
-        checkout: bool,
-        /// List all branches
-        #[arg(short, long, action)]
-        list: bool,
-        #[arg(short, long, action)]
-        merge: bool,
-        /// The branch name
-        #[clap(index = 1)]
-        branch_name: Option<String>,
-    },
-    /// Merge branches
-    #[command(arg_required_else_help(true))]
-    Merge {
-        /// The branch name to merge
-        #[clap(index = 1)]
-        branch_name: Option<String>,
-    },
-    /// Migrate a database to a given operation
-    #[command(arg_required_else_help(true))]
-    Checkout {
-        /// Create and checkout a new branch.
-        #[arg(short, long)]
-        branch: Option<String>,
-        /// The operation hash to move to
-        #[clap(index = 1)]
-        hash: Option<String>,
-    },
-    /// Reset a branch to a previous operation
-    #[command(arg_required_else_help(true))]
-    Reset {
-        /// The operation hash to reset to
-        #[clap(index = 1)]
-        hash: String,
-    },
-    /// View operations carried out against a database
-    #[command()]
-    Operations {
-        /// Edit operation messages
-        #[arg(short, long)]
-        interactive: bool,
-        /// The branch to list operations for
-        #[arg(short, long)]
-        branch: Option<String>,
-    },
-    /// Apply an operation to a branch
-    #[command(arg_required_else_help(true))]
-    Apply {
-        /// The operation hash to apply
-        #[clap(index = 1)]
-        hash: String,
-    },
-    /// Export sequence data
-    #[command(arg_required_else_help(true))]
-    Export {
-        /// The name of the collection to export
-        #[arg(short, long)]
-        name: Option<String>,
-        /// The name of the GFA file to export to
-        #[arg(short, long)]
-        gfa: Option<String>,
-        /// An optional sample name
-        #[arg(short, long)]
-        sample: Option<String>,
-        /// The name of the fasta file to export to
-        #[arg(short, long)]
-        fasta: Option<String>,
-        /// The name of the GenBank file to export to
-        #[arg(long)]
-        gb: Option<String>,
-        /// The max node size for gfa export
-        #[arg(long)]
-        node_max: Option<i64>,
-    },
-    /// Configure default options
-    #[command(arg_required_else_help(true))]
-    Defaults {
-        /// The default database to use
-        #[arg(short, long)]
-        database: Option<String>,
-        /// The default collection to use
-        #[arg(short, long)]
-        collection: Option<String>,
-    },
-    /// Set the remote URL for this repo
-    #[command(arg_required_else_help(true))]
-    SetRemote {
-        /// The remote URL to set
-        #[arg(short, long)]
-        remote: String,
-    },
-    /// Push the local repo to the remote
-    #[command()]
-    Push {},
-    #[command()]
-    Pull {},
-    /// Convert annotation coordinates between two samples
-    #[command(arg_required_else_help(true))]
-    PropagateAnnotations {
-        /// The name of the collection to annotate
-        #[arg(short, long)]
-        name: Option<String>,
-        /// The name of the sample the annotations are referenced to (if not provided, the default)
-        #[arg(short, long)]
-        from_sample: Option<String>,
-        /// The name of the sample to annotate
-        #[arg(short, long)]
-        to_sample: String,
-        /// The name of the annotation file to propagate
-        #[arg(short, long)]
-        gff: String,
-        /// The name of the output file
-        #[arg(short, long)]
-        output_gff: String,
-    },
-    /// List all samples in the current collection
-    ListSamples {},
-    #[command()]
-    /// List all regions/contigs in the current collection and given sample
-    ListGraphs {
-        /// The name of the collection to list graphs for
-        #[arg(short, long)]
-        name: Option<String>,
-        /// The name of the sample to list graphs for
-        #[arg(short, long)]
-        sample: Option<String>,
-    },
-    /// Extract a sequence from a graph
-    #[command(arg_required_else_help(true))]
-    GetSequence {
-        /// The name of the collection containing the sequence
-        #[arg(short, long)]
-        name: Option<String>,
-        /// The name of the sample containing the sequence
-        #[arg(short, long)]
-        sample: Option<String>,
-        /// The name of the graph to get the sequence for
-        #[arg(short, long)]
-        graph: Option<String>,
-        /// The start coordinate of the sequence
-        #[arg(long)]
-        start: Option<i64>,
-        /// The end coordinate of the sequence
-        #[arg(long)]
-        end: Option<i64>,
-        /// The region (name:start-end format) of the sequence
-        #[arg(long)]
-        region: Option<String>,
-    },
-    /// Output a file representing the "diff" between two samples
-    Diff {
-        /// The name of the collection to diff
-        #[arg(short, long)]
-        name: Option<String>,
-        /// The name of the first sample to diff
-        #[arg(long)]
-        sample1: Option<String>,
-        /// The name of the second sample to diff
-        #[arg(long)]
-        sample2: Option<String>,
-        /// The name of the output GFA file
-        #[arg(long)]
-        gfa: String,
-    },
-    /// Replace a sequence graph with a subgraph in the range of the specified coordinates
-    DeriveSubgraph {
-        /// The name of the collection to derive the subgraph from
-        #[arg(short, long)]
-        name: Option<String>,
-        /// The name of the parent sample
-        #[arg(short, long)]
-        sample: Option<String>,
-        /// The name of the new sample
-        #[arg(long)]
-        new_sample: String,
-        /// The name of the region to derive the subgraph from
-        #[arg(short, long)]
-        region: String,
-        /// Name of alternate path (not current) to use
-        #[arg(long)]
-        backbone: Option<String>,
-    },
-    /// Replace a sequence graph with subgraphs in the ranges of the specified coordinates
-    DeriveChunks {
-        /// The name of the collection to derive the subgraph from
-        #[arg(short, long)]
-        name: Option<String>,
-        /// The name of the parent sample
-        #[arg(short, long)]
-        sample: Option<String>,
-        /// The name of the new sample
-        #[arg(long)]
-        new_sample: String,
-        /// The name of the region to derive the subgraph from
-        #[arg(short, long)]
-        region: String,
-        /// Name of alternate path (not current) to use
-        #[arg(long)]
-        backbone: Option<String>,
-        /// Breakpoints to derive chunks from
-        #[arg(long)]
-        breakpoints: Option<String>,
-        /// The size of the chunks to derive
-        #[arg(long)]
-        chunk_size: Option<i64>,
-    },
-    #[command(
-        verbatim_doc_comment,
-        long_about = "Combine multiple sequence graphs into one. Example:
-    gen make-stitch --sample parent_sample --new-sample my_child_sample --regions chr1.2,chr1.3 --new-region spliced_chr1"
-    )]
-    MakeStitch {
-        /// The name of the collection to derive the subgraph from
-        #[arg(short, long)]
-        name: Option<String>,
-        /// The name of the parent sample
-        #[arg(short, long)]
-        sample: Option<String>,
-        /// The name of the new sample
-        #[arg(long)]
-        new_sample: String,
-        /// The names of the regions to combine
-        #[arg(long)]
-        regions: String,
-        /// The name of the new region
-        #[arg(long)]
-        new_region: String,
-    },
-}
-
 fn main() {
     // Start logger (gets log level from RUST_LOG environment variable, sends output to stderr)
     env_logger::init();
 
-    let cli = NewCli::parse();
+    let cli = Cli::parse();
     let cli_context = CliContext::from(&cli);
 
-    match cli.command {
-        Some(Commands::Import(cmd)) => gen::commands::import::execute(&cli_context, cmd),
-        None => println!("No command provided."),
-    }
-}
-
-fn main2() {
-    // Start logger (gets log level from RUST_LOG environment variable, sends output to stderr)
-    env_logger::init();
-
-    let cli = Cli::parse();
-
     // commands not requiring a db connection are handled here
-    if let Some(OldCommands::Init {}) = &cli.command {
+    if let Some(Commands::Init {}) = &cli.command {
         config::get_or_create_gen_dir();
         println!("Gen repository initialized.");
         return;
     }
 
     let operation_conn = get_operation_connection(None);
-    if let Some(OldCommands::Defaults {
+    if let Some(Commands::Defaults {
         database,
         collection,
     }) = &cli.command
@@ -510,7 +97,7 @@ fn main2() {
         }
         return;
     }
-    if let Some(OldCommands::SetRemote { remote }) = &cli.command {
+    if let Some(Commands::SetRemote { remote }) = &cli.command {
         operation_conn
             .execute("update defaults set remote_url=?1 where id = 1", (remote,))
             .unwrap();
@@ -518,7 +105,7 @@ fn main2() {
         return;
     }
 
-    if let Some(OldCommands::Transform { format_csv_for_gaf }) = &cli.command {
+    if let Some(Commands::Transform { format_csv_for_gaf }) = &cli.command {
         let csv = format_csv_for_gaf
             .clone()
             .expect("csv for transformation not provided.");
@@ -552,8 +139,15 @@ fn main2() {
     // initialize the selected database if needed.
     setup_db(&operation_conn, &db_uuid);
 
-    match &cli.command {
-        Some(OldCommands::View {
+    match cli.command {
+	Some(Commands::Init {}) => {
+            config::get_or_create_gen_dir();
+            println!("Gen repository initialized.");
+	}
+        Some(Commands::Import(cmd)) => {
+	    gen::commands::import::execute(&cli_context, cmd);
+	}
+        Some(Commands::View {
             graph,
             sample,
             collection,
@@ -572,7 +166,7 @@ fn main2() {
                 position.clone(),
             );
         }
-        Some(OldCommands::Update {
+        Some(Commands::Update {
             name,
             fasta,
             vcf,
@@ -607,7 +201,7 @@ fn main2() {
                     start.unwrap(),
                     end.unwrap(),
                     &parts.clone().unwrap(),
-                    library_path,
+                    &library_path,
                 )
                 .unwrap();
             } else if let Some(fasta_path) = fasta {
@@ -624,13 +218,13 @@ fn main2() {
                     &region_name.clone().expect("region-name must be provided."),
                     start.expect("start flag must be provided."),
                     end.expect("end flag must be provided."),
-                    fasta_path,
-                    *no_reference_path_update,
+                    &fasta_path,
+                    no_reference_path_update,
                 )
                 .unwrap();
             } else if let Some(vcf_path) = vcf {
                 match update_with_vcf(
-                    vcf_path,
+                    &vcf_path,
                     name,
                     genotype.clone().unwrap_or("".to_string()),
                     sample.clone().unwrap_or("".to_string()),
@@ -643,13 +237,13 @@ fn main2() {
                     Err(e) => panic!("Error updating with vcf: {e}"),
                 }
             } else if let Some(gb_path) = gb {
-                let f = File::open(gb_path).unwrap();
+                let f = File::open(&gb_path).unwrap();
                 match update_with_genbank(
                     &conn,
                     &operation_conn,
                     &f,
                     name.deref(),
-                    *create_missing,
+                    create_missing,
                     &OperationInfo {
                         files: vec![OperationFile {
                             file_path: gb_path.clone(),
@@ -668,7 +262,7 @@ fn main2() {
                     name,
                     sample.clone().as_deref(),
                     &new_sample.clone().unwrap(),
-                    gfa_path,
+                    &gfa_path,
                 ) {
                     Ok(_) => {}
                     Err(e) => panic!("Failed to update. Error is: {e}"),
@@ -680,7 +274,7 @@ fn main2() {
             conn.execute("END TRANSACTION", []).unwrap();
             operation_conn.execute("END TRANSACTION", []).unwrap();
         }
-        Some(OldCommands::UpdateGaf {
+        Some(Commands::UpdateGaf {
             name,
             gaf,
             csv,
@@ -704,7 +298,7 @@ fn main2() {
             conn.execute("END TRANSACTION", []).unwrap();
             operation_conn.execute("END TRANSACTION", []).unwrap();
         }
-        Some(OldCommands::Translate {
+        Some(Commands::Translate {
             bed,
             gff,
             collection,
@@ -747,7 +341,7 @@ fn main2() {
                 }
             }
         }
-        Some(OldCommands::Operations {
+        Some(Commands::Operations {
             interactive,
             branch,
         }) => {
@@ -767,7 +361,7 @@ fn main2() {
                         .unwrap_or_else(|| panic!("No branch named {branch_name}."))
                         .id,
                 );
-                if *interactive {
+                if interactive {
                     view_operations(&conn, &operation_conn, &operations);
                 } else {
                     let mut indicator = "";
@@ -793,7 +387,7 @@ fn main2() {
                 println!("No operations found.");
             }
         }
-        Some(OldCommands::Branch {
+        Some(Commands::Branch {
             create,
             delete,
             checkout,
@@ -801,7 +395,7 @@ fn main2() {
             merge,
             branch_name,
         }) => {
-            if *create {
+            if create {
                 Branch::create(
                     &operation_conn,
                     &db_uuid,
@@ -809,7 +403,7 @@ fn main2() {
                         .clone()
                         .expect("Must provide a branch name to create."),
                 );
-            } else if *delete {
+            } else if delete {
                 Branch::delete(
                     &operation_conn,
                     &db_uuid,
@@ -817,7 +411,7 @@ fn main2() {
                         .clone()
                         .expect("Must provide a branch name to delete."),
                 );
-            } else if *checkout {
+            } else if checkout {
                 operation_management::checkout(
                     &conn,
                     &operation_conn,
@@ -830,7 +424,7 @@ fn main2() {
                     ),
                     None,
                 );
-            } else if *list {
+            } else if list {
                 let current_branch = OperationState::get_current_branch(&operation_conn, &db_uuid);
                 let mut indicator = "";
                 println!(
@@ -861,7 +455,7 @@ fn main2() {
                             .unwrap_or(String::new())
                     );
                 }
-            } else if *merge {
+            } else if merge {
                 let branch_name = branch_name.clone().expect("Branch name must be provided.");
                 let other_branch = Branch::get_by_name(&operation_conn, &db_uuid, &branch_name)
                     .unwrap_or_else(|| panic!("Unable to find branch {branch_name}."));
@@ -890,7 +484,7 @@ fn main2() {
                 println!("No options selected.");
             }
         }
-        Some(OldCommands::Merge { branch_name }) => {
+        Some(Commands::Merge { branch_name }) => {
             let branch_name = branch_name.clone().expect("Branch name must be provided.");
             let other_branch = Branch::get_by_name(&operation_conn, &db_uuid, &branch_name)
                 .unwrap_or_else(|| panic!("Unable to find branch {branch_name}."));
@@ -916,10 +510,10 @@ fn main2() {
             conn.execute("END TRANSACTION", []).unwrap();
             operation_conn.execute("END TRANSACTION", []).unwrap();
         }
-        Some(OldCommands::Apply { hash }) => {
+        Some(Commands::Apply { hash }) => {
             conn.execute("BEGIN TRANSACTION", []).unwrap();
             operation_conn.execute("BEGIN TRANSACTION", []).unwrap();
-            match operation_management::apply(&conn, &operation_conn, hash, None) {
+            match operation_management::apply(&conn, &operation_conn, &hash, None) {
                 Ok(_) => println!("Operation applied"),
                 Err(_) => {
                     conn.execute("ROLLBACK TRANSACTION;", []).unwrap();
@@ -930,7 +524,7 @@ fn main2() {
             conn.execute("END TRANSACTION", []).unwrap();
             operation_conn.execute("END TRANSACTION", []).unwrap();
         }
-        Some(OldCommands::Checkout { branch, hash }) => {
+        Some(Commands::Checkout { branch, hash }) => {
             if let Some(name) = branch.clone() {
                 if Branch::get_by_name(&operation_conn, &db_uuid, &name).is_none() {
                     Branch::create(&operation_conn, &db_uuid, &name);
@@ -963,10 +557,10 @@ fn main2() {
                 println!("No branch or hash to checkout provided.");
             }
         }
-        Some(OldCommands::Reset { hash }) => {
-            operation_management::reset(&conn, &operation_conn, &db_uuid, hash);
+        Some(Commands::Reset { hash }) => {
+            operation_management::reset(&conn, &operation_conn, &db_uuid, &hash);
         }
-        Some(OldCommands::Export {
+        Some(Commands::Export {
             name,
             gb,
             gfa,
@@ -985,7 +579,7 @@ fn main2() {
                     name,
                     &PathBuf::from(gfa_path),
                     sample.clone(),
-                    *node_max,
+                    node_max,
                 );
             } else if let Some(fasta_path) = fasta {
                 export_fasta(
@@ -1007,13 +601,13 @@ fn main2() {
             conn.execute("END TRANSACTION", []).unwrap();
             operation_conn.execute("END TRANSACTION", []).unwrap();
         }
-        Some(OldCommands::PatchCreate {
+        Some(Commands::PatchCreate {
             name,
             operation,
             branch,
         }) => {
             let branch = if let Some(branch_name) = branch {
-                Branch::get_by_name(&operation_conn, &db_uuid, branch_name)
+                Branch::get_by_name(&operation_conn, &db_uuid, &branch_name)
                     .unwrap_or_else(|| panic!("No branch with name {branch_name} found."))
             } else {
                 let current_branch_id =
@@ -1025,24 +619,24 @@ fn main2() {
             let operations = parse_patch_operations(
                 &branch_ops,
                 &branch.current_operation_hash.unwrap(),
-                operation,
+                &operation,
             );
             let mut f = File::create(format!("{name}.gz")).unwrap();
             patch::create_patch(&operation_conn, &operations, &mut f);
         }
-        Some(OldCommands::PatchApply { patch }) => {
+        Some(Commands::PatchApply { patch }) => {
             let mut f = File::open(patch).unwrap();
             let patches = patch::load_patches(&mut f);
             patch::apply_patches(&conn, &operation_conn, &patches);
         }
-        Some(OldCommands::PatchView { prefix, patch }) => {
-            let patch_path = Path::new(patch);
+        Some(Commands::PatchView { prefix, patch }) => {
+            let patch_path = Path::new(&patch);
             let mut f = File::open(patch_path).unwrap();
             let patches = patch::load_patches(&mut f);
             let diagrams = view_patches(&patches);
             for (patch_hash, patch_diagrams) in diagrams.iter() {
                 for (bg_id, dot) in patch_diagrams.iter() {
-                    let path = if let Some(p) = prefix {
+                    let path = if let Some(ref p) = prefix {
                         format!("{p}_{patch_hash:.7}_{bg_id}.dot")
                     } else {
                         format!(
@@ -1063,17 +657,17 @@ fn main2() {
         }
         None => {}
         // these will never be handled by this method as we search for them earlier.
-        Some(OldCommands::Init {}) => {
+        Some(Commands::Init {}) => {
             config::get_or_create_gen_dir();
             println!("Gen repository initialized.");
         }
-        Some(OldCommands::Defaults {
+        Some(Commands::Defaults {
             database,
             collection,
         }) => {}
-        Some(OldCommands::SetRemote { remote }) => {}
-        Some(OldCommands::Transform { format_csv_for_gaf }) => {}
-        Some(OldCommands::PropagateAnnotations {
+        Some(Commands::SetRemote { remote }) => {}
+        Some(Commands::Transform { format_csv_for_gaf }) => {}
+        Some(Commands::PropagateAnnotations {
             name,
             from_sample,
             to_sample,
@@ -1092,15 +686,15 @@ fn main2() {
                 &conn,
                 name,
                 from_sample_name.as_deref(),
-                to_sample,
-                gff,
-                output_gff,
+                &to_sample,
+                &gff,
+                &output_gff,
             );
 
             conn.execute("END TRANSACTION", []).unwrap();
             operation_conn.execute("END TRANSACTION", []).unwrap();
         }
-        Some(OldCommands::ListSamples {}) => {
+        Some(Commands::ListSamples {}) => {
             let sample_names = Sample::get_all_names(&conn);
             // Null sample
             println!();
@@ -1108,7 +702,7 @@ fn main2() {
                 println!("{}", sample_name);
             }
         }
-        Some(OldCommands::ListGraphs { name, sample }) => {
+        Some(Commands::ListGraphs { name, sample }) => {
             let name = &name
                 .clone()
                 .unwrap_or_else(|| get_default_collection(&operation_conn));
@@ -1117,7 +711,7 @@ fn main2() {
                 println!("{}", block_group.name);
             }
         }
-        Some(OldCommands::GetSequence {
+        Some(Commands::GetSequence {
             name,
             sample,
             graph,
@@ -1164,7 +758,7 @@ fn main2() {
                 &sequence[start_coordinate as usize..end_coordinate as usize]
             );
         }
-        Some(OldCommands::Diff {
+        Some(Commands::Diff {
             name,
             sample1,
             sample2,
@@ -1181,7 +775,7 @@ fn main2() {
                 sample2.as_deref(),
             );
         }
-        Some(OldCommands::DeriveSubgraph {
+        Some(Commands::DeriveSubgraph {
             name,
             sample,
             new_sample,
@@ -1218,7 +812,7 @@ fn main2() {
             conn.execute("END TRANSACTION", []).unwrap();
             operation_conn.execute("END TRANSACTION", []).unwrap();
         }
-        Some(OldCommands::DeriveChunks {
+        Some(Commands::DeriveChunks {
             name,
             sample,
             new_sample,
@@ -1301,7 +895,7 @@ fn main2() {
             conn.execute("END TRANSACTION", []).unwrap();
             operation_conn.execute("END TRANSACTION", []).unwrap();
         }
-        Some(OldCommands::MakeStitch {
+        Some(Commands::MakeStitch {
             name,
             sample,
             new_sample,
@@ -1325,7 +919,7 @@ fn main2() {
                 sample_name.as_deref(),
                 &new_sample_name,
                 &region_names,
-                new_region,
+                &new_region,
             ) {
                 Ok(_) => {}
                 Err(e) => panic!("Error stitching subgraphs: {e}"),
@@ -1333,7 +927,7 @@ fn main2() {
             conn.execute("END TRANSACTION", []).unwrap();
             operation_conn.execute("END TRANSACTION", []).unwrap();
         }
-        Some(OldCommands::Push {}) => match push(&operation_conn, &db_uuid) {
+        Some(Commands::Push {}) => match push(&operation_conn, &db_uuid) {
             Ok(_) => {
                 println!("Push succeeded.");
             }
@@ -1341,6 +935,6 @@ fn main2() {
                 println!("Push failed: {e}");
             }
         },
-        Some(OldCommands::Pull {}) => {}
+        Some(Commands::Pull {}) => {}
     }
 }


### PR DESCRIPTION
Adds nested commands so that for instance,

```
gen import --fasta simple.fa
gen update --fasta aa.fa --region m123:5-10
```

becomes

```
gen import fasta simple.fa
gen update fasta --region m123:5-10 aa.fa
```

Bob requested this, but I think it's worth it to refactor each command and its possible flags into a separate place.