### PR TITLE
Ensure Mac OS builds are signed/verified with Apple

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
         security unlock-keychain -p "$MACOS_CI_KEYCHAIN_PWD" build.keychain
         security import certificate.p12 -k build.keychain -P "$MACOS_CERTIFICATE_PWD" -T /usr/bin/codesign
         security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$MACOS_CI_KEYCHAIN_PWD" build.keychain
-      productsign --sign "MACOS_CERTIFICATE_NAME" gen-unsigned.pkg gen.macos.pkg
+        productsign --sign "MACOS_CERTIFICATE_NAME" gen-unsigned.pkg gen.macos.pkg
     - name: Notarize package file
       env:
         PROD_MACOS_NOTARIZATION_APPLE_ID: ${{ secrets.PROD_MACOS_NOTARIZATION_APPLE_ID }}


### PR DESCRIPTION
This ensures that someone who downloads the mac build can run it and not get a popup saying "this was downloaded from the internet, do you trust it?"

Secrets (which are not viewable by anyone) are listed here: https://github.com/genhub-bio/gen/settings/secrets/actions

Note that I'm using a mac program called lipo to consolidate the x86 and arm builds into one binary