### PR TITLE
Path parent

### DIFF
--- a/gen-models/migrations/core/04-block-group-lineage/down.sql
+++ b/gen-models/migrations/core/04-block-group-lineage/down.sql
@@ -1,0 +1,25 @@
+PRAGMA foreign_keys = OFF;
+
+DROP INDEX IF EXISTS block_group_lineage_uidx;
+DROP INDEX IF EXISTS block_group_root_uidx;
+DROP INDEX IF EXISTS block_groups_parent_idx;
+
+CREATE TABLE block_groups_rollback (
+  id BLOB PRIMARY KEY NOT NULL,
+  collection_name TEXT NOT NULL,
+  sample_name TEXT NOT NULL,
+  name TEXT NOT NULL,
+  created_on INTEGER NOT NULL,
+  FOREIGN KEY(collection_name) REFERENCES collections(name),
+  FOREIGN KEY(sample_name) REFERENCES samples(name)
+) STRICT;
+
+INSERT INTO block_groups_rollback (id, collection_name, sample_name, name, created_on)
+SELECT id, collection_name, sample_name, name, created_on
+FROM block_groups;
+
+DROP TABLE block_groups;
+ALTER TABLE block_groups_rollback RENAME TO block_groups;
+CREATE UNIQUE INDEX block_group_uidx ON block_groups(collection_name, sample_name, name);
+
+PRAGMA foreign_keys = ON;

--- a/gen-models/migrations/core/04-block-group-lineage/up.sql
+++ b/gen-models/migrations/core/04-block-group-lineage/up.sql
@@ -1,0 +1,13 @@
+ALTER TABLE block_groups ADD COLUMN parent_block_group_id BLOB REFERENCES block_groups(id);
+
+CREATE INDEX block_groups_parent_idx ON block_groups(parent_block_group_id);
+
+DROP INDEX IF EXISTS block_group_uidx;
+
+CREATE UNIQUE INDEX block_group_root_uidx
+ON block_groups(collection_name, sample_name, name)
+WHERE parent_block_group_id IS NULL;
+
+CREATE UNIQUE INDEX block_group_lineage_uidx
+ON block_groups(collection_name, sample_name, name, parent_block_group_id)
+WHERE parent_block_group_id IS NOT NULL;

--- a/gen-models/src/block_group.rs
+++ b/gen-models/src/block_group.rs
@@ -1396,6 +1396,11 @@ mod tests {
             .collect::<HashSet<_>>();
 
         assert_eq!(merged_node_ids, HashSet::from([node_a, node_b]));
+        let all_sequences = BlockGroup::get_all_sequences(conn, &merged_bg_id, false);
+        assert_eq!(
+            all_sequences,
+            HashSet::from_iter(vec!["AAAA".to_string(), "CCCC".to_string()])
+        );
     }
 
     #[test]

--- a/gen-models/src/block_group.rs
+++ b/gen-models/src/block_group.rs
@@ -120,12 +120,8 @@ impl<'a> PathCache<'a> {
             path.clone()
         } else {
             let conn = path_cache.conn;
-            let new_path = Path::query(
-                conn,
-                "select * from paths where block_group_id = ?1 AND name = ?2",
-                params![block_group_id, name],
-            )[0]
-            .clone();
+            let new_path = BlockGroup::get_path_by_name(conn, block_group_id, &name)
+                .expect("path should exist for cached lookup");
 
             path_cache.cache.insert(path_key, new_path.clone());
             let tree = new_path.intervaltree(conn);
@@ -215,7 +211,7 @@ impl BlockGroup {
     ) {
         let existing_paths = Path::query(
             conn,
-            "SELECT * from paths where block_group_id = ?1;",
+            "SELECT * from paths where block_group_id = ?1 ORDER BY name, created_on DESC;",
             params![self.id],
         );
 
@@ -942,19 +938,13 @@ impl BlockGroup {
         block_group_id: &HashId,
         path_name: &str,
     ) -> Option<Path> {
-        let paths = Path::query(
+        Path::query(
             conn,
-            "SELECT * FROM paths WHERE block_group_id = ?1 ORDER BY created_on DESC",
-            params![block_group_id],
-        );
-
-        for path in &paths {
-            if path.name == path_name {
-                return Some(path.clone());
-            }
-        }
-
-        None
+            "select * from paths where block_group_id = ?1 and name = ?2 order by created_on desc",
+            params![block_group_id, path_name],
+        )
+        .into_iter()
+        .next()
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/gen-models/src/changesets.rs
+++ b/gen-models/src/changesets.rs
@@ -758,6 +758,12 @@ pub fn process_changesetiter(
         }
     }
 
+    for path in Path::query_by_ids(conn, &previous_paths.iter().copied().collect::<Vec<_>>()) {
+        if !created_block_groups_set.contains(&path.block_group_id) {
+            previous_block_groups.insert(path.block_group_id);
+        }
+    }
+
     // Process additional dependencies for edges
     let existing_edges = Edge::query_by_ids(
         conn,
@@ -851,7 +857,7 @@ pub fn apply_changeset(
             .collect::<Vec<_>>(),
     );
 
-    for path in dependencies.paths.iter() {
+    for path in &dependencies.paths {
         Path::create(conn, &path.name, &path.block_group_id, &[]);
     }
 


### PR DESCRIPTION
Keeps a pointer to path parentage for use when cloning paths from parents. A new field, is_default, is present as well so users can define which parent path to default to for coordinates. This would be used in the cases when a multi-parent sample is created where the parents have different reference genomes for a given path (such as 2 strains of yeast being crossed and each strain may have a different reference chr1/etc.)