### PR TITLE
Blockgroup lineage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,9 +424,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-llvm-cov"
-version = "0.6.24"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e7b0ac0ba19c67fe7d8c999c82a00a93f852f53c3f05f76f96ebb09827de3c5"
+checksum = "e40b72db9c18b7e128730f67135c065d73d014c34d59e107351b98214eca1034"
 dependencies = [
  "anyhow",
  "camino",
@@ -518,6 +518,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "chrono"
@@ -732,6 +743,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -1457,18 +1477,14 @@ dependencies = [
 
 [[package]]
 name = "gb-io"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae0f0a179902bdc33891eef7b8bb85b496550a3b6238837314db2c8b860f0771"
+checksum = "98e6430fd1aab1f2586f8ad0ef27151bee96d5adcda39b39054fc4ce9c72d08a"
 dependencies = [
  "circular",
  "itertools 0.14.0",
  "log",
  "nom 8.0.0",
- "serde",
- "serde_bytes",
- "string_cache",
- "string_cache_codegen",
  "thiserror 2.0.18",
 ]
 
@@ -1512,7 +1528,7 @@ dependencies = [
  "noodles",
  "once_cell",
  "petgraph 0.6.5",
- "rand 0.9.2",
+ "rand 0.10.1",
  "rat-cursor",
  "rat-text",
  "ratatui",
@@ -1564,7 +1580,7 @@ dependencies = [
  "noodles",
  "pyo3",
  "pyo3-macros",
- "rand 0.9.2",
+ "rand 0.10.1",
  "rusqlite",
  "serde",
  "sha2",
@@ -1617,7 +1633,7 @@ dependencies = [
  "itertools 0.14.0",
  "noodles",
  "petgraph 0.6.5",
- "rand 0.9.2",
+ "rand 0.10.1",
  "rusqlite",
  "rusqlite_migration",
  "serde",
@@ -1653,7 +1669,7 @@ dependencies = [
  "log",
  "more-asserts",
  "petgraph 0.6.5",
- "rand 0.9.2",
+ "rand 0.10.1",
  "ratatui",
  "rstar",
  "rusqlite",
@@ -1712,6 +1728,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -3507,12 +3524,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
-name = "new_debug_unreachable"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
-
-[[package]]
 name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4139,12 +4150,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "precomputed-hash"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
-
-[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4351,6 +4356,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4374,6 +4390,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rat-cursor"
@@ -4905,9 +4927,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -5076,16 +5098,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_bytes"
-version = "0.11.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
-dependencies = [
- "serde",
- "serde_core",
-]
-
-[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5216,7 +5228,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -5237,7 +5249,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -5398,31 +5410,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d08889ec5408683408db66ad89e0e1f93dff55c73a4ccc71c427d5b277ee47e6"
 
 [[package]]
-name = "string_cache"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
-dependencies = [
- "new_debug_unreachable",
- "parking_lot",
- "phf_shared",
- "precomputed-hash",
- "serde",
-]
-
-[[package]]
-name = "string_cache_codegen"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
-dependencies = [
- "phf_generator",
- "phf_shared",
- "proc-macro2",
- "quote",
-]
-
-[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5547,9 +5534,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
 dependencies = [
  "filetime",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/main.rs"
 
 [workspace]
 members = [".", "gen-core", "gen-models", "gen-graph", "gen-diff", "gen-tui", "gen-sugiyama", "gen-annotations", "gen-capnp-schemas"]
-default-members = [".", "gen-core", "gen-models", "gen-graph", "gen-diff", "gen-capnp-schemas"]
+default-members = [".", "gen-core", "gen-models", "gen-graph", "gen-diff", "gen-capnp-schemas", "gen-annotations"]
 exclude = ["gen-python"]
 
 [features]
@@ -57,7 +57,7 @@ tempfile = "3.20.0"
 interavl = "0.3.0"
 regex = "1.11.1"
 flate2 = "1.1.0"
-gb-io = "0.8.0"
+gb-io = "0.9.0"
 thiserror = "2.0.12"
 indicatif = "0.18.3"
 html-escape = "0.2.13"
@@ -75,7 +75,7 @@ serde_with = "3.0"
 once_cell = "1.21.3"
 webbrowser = "1.0.5"
 reqwest = { version = "0.12.23", default-features = false,features = ["blocking", "json", "multipart", "stream", "rustls-tls"] }
-rand = "0.9.2"
+rand = "0.10.1"
 base64 = "0.22.1"
 getrandom = "0.3.3"
 directories = "6.0.0"
@@ -85,7 +85,7 @@ indexmap = "2.11.3"
 anyhow = { version = "1.0.100", features = ["backtrace"] }
 
 [dev-dependencies]
-cargo-llvm-cov = "0.6.16"
+cargo-llvm-cov = "0.8.5"
 cargo-deny = "0.19.0"
 more-asserts = "0.3.1"
 

--- a/gen-annotations/src/gff.rs
+++ b/gen-annotations/src/gff.rs
@@ -118,7 +118,7 @@ mod tests {
         HashId, NO_CHROMOSOME_INDEX, PATH_END_NODE_ID, PATH_START_NODE_ID, PathBlock, Strand,
     };
     use gen_models::{
-        block_group::{BlockGroup, PathChange},
+        block_group::{BlockGroup, NewBlockGroup, PathChange},
         block_group_edge::{BlockGroupEdge, BlockGroupEdgeData},
         collection::Collection,
         db::GraphConnection,
@@ -152,7 +152,16 @@ mod tests {
                 hash = reference_sequence.hash
             )),
         );
-        let block_group = BlockGroup::create(conn, &collection.name, Sample::DEFAULT_NAME, "m123");
+        let block_group = BlockGroup::create(
+            conn,
+            NewBlockGroup {
+                collection_name: &collection.name,
+                sample_name: Sample::DEFAULT_NAME,
+                name: "m123",
+                parent_block_group_id: None,
+                is_default: false,
+            },
+        );
 
         let edge_into = Edge::create(
             conn,
@@ -206,14 +215,15 @@ mod tests {
             vec![Sample::DEFAULT_NAME.to_string()],
         );
 
-        let sample_bg_id = BlockGroup::get_or_create_sample_block_group(
+        let sample_bg_id = BlockGroup::get_or_create_sample_block_groups(
             conn,
             "test",
             "child sample",
             "m123",
             vec![Sample::DEFAULT_NAME.to_string()],
         )
-        .expect("should create child block group");
+        .expect("should create child block group")[0]
+            .id;
         let sample_path = BlockGroup::get_current_path(conn, &sample_bg_id);
         let tree = sample_path.intervaltree(conn);
         let replacement_sequence = "AA";

--- a/gen-annotations/src/test_helpers.rs
+++ b/gen-annotations/src/test_helpers.rs
@@ -1,6 +1,6 @@
 use gen_core::{HashId, PATH_END_NODE_ID, PATH_START_NODE_ID, PathBlock, Strand};
 use gen_models::{
-    block_group::{BlockGroup, PathChange},
+    block_group::{BlockGroup, NewBlockGroup, PathChange},
     block_group_edge::{BlockGroupEdge, BlockGroupEdgeData},
     collection::Collection,
     db::GraphConnection,
@@ -49,7 +49,16 @@ pub fn setup_test_data(conn: &GraphConnection) {
             hash = seq2.hash
         )),
     );
-    let block_group = BlockGroup::create(conn, &collection.name, Sample::DEFAULT_NAME, "m123");
+    let block_group = BlockGroup::create(
+        conn,
+        NewBlockGroup {
+            collection_name: &collection.name,
+            sample_name: Sample::DEFAULT_NAME,
+            name: "m123",
+            parent_block_group_id: None,
+            is_default: false,
+        },
+    );
 
     let edge_into = Edge::create(
         conn,
@@ -112,14 +121,15 @@ pub fn setup_test_data(conn: &GraphConnection) {
     let _ =
         Sample::get_or_create_child(conn, "test", "foo", vec![Sample::DEFAULT_NAME.to_string()]);
 
-    let sample_bg_id = BlockGroup::get_or_create_sample_block_group(
+    let sample_bg_id = BlockGroup::get_or_create_sample_block_groups(
         conn,
         "test",
         "foo",
         "m123",
         vec![Sample::DEFAULT_NAME.to_string()],
     )
-    .expect("should create child block group");
+    .expect("should create child block group")[0]
+        .id;
     let sample_path = BlockGroup::get_current_path(conn, &sample_bg_id);
     let tree = sample_path.intervaltree(conn);
 

--- a/gen-capnp-schemas/gen-models.capnp
+++ b/gen-capnp-schemas/gen-models.capnp
@@ -69,6 +69,11 @@ struct BlockGroup {
   sampleName @2 :Text;
   name @3 :Text;
   createdOn @4 :Int64;
+  parentBlockGroupId :union {
+    none @5 :Void;
+    some @6 :List(UInt8);
+  }
+  isDefault @7 :Bool;
 }
 
 struct BlockGroupEdge {

--- a/gen-core/Cargo.toml
+++ b/gen-core/Cargo.toml
@@ -21,7 +21,7 @@ serde = {  version = "1.0.219", features = ["derive"] }
 thiserror = "1.0"
 sha2 = "0.10.9"
 hex = "0.4.3"
-rand = "0.9.2"
+rand = "0.10.1"
 uuid = { version = "1.18.1", features = ["v7"] }
 pyo3 = { version = "0.25.1", optional = true }
 pyo3-macros = { version = "0.25.1", optional = true }

--- a/gen-core/src/lib.rs
+++ b/gen-core/src/lib.rs
@@ -1,7 +1,7 @@
 use std::{convert::TryFrom, fmt, hash::Hash};
 
 use hex::FromHex;
-use rand::RngCore;
+use rand::Rng;
 use sha2::{Digest, Sha256};
 
 pub mod config;

--- a/gen-diff/src/graph.rs
+++ b/gen-diff/src/graph.rs
@@ -349,6 +349,8 @@ mod tests {
             sample_name: "sample".to_string(),
             name: "bg".to_string(),
             created_on: 0,
+            parent_block_group_id: None,
+            is_default: false,
         };
         let seq = NewSequence::new()
             .sequence_type("dna")

--- a/gen-diff/src/operations.rs
+++ b/gen-diff/src/operations.rs
@@ -411,6 +411,8 @@ mod tests {
             sample_name: "s".to_string(),
             name: "bg".to_string(),
             created_on: 0,
+            parent_block_group_id: None,
+            is_default: false,
         };
 
         let head = Operation::create(op_conn, "add", &HashId::pad_str(2)).expect("create op");
@@ -461,6 +463,8 @@ mod tests {
             sample_name: "s".to_string(),
             name: "bg".to_string(),
             created_on: 0,
+            parent_block_group_id: None,
+            is_default: false,
         };
 
         let head = Operation::create(op_conn, "add", &HashId::pad_str(2)).expect("create op");
@@ -504,6 +508,8 @@ mod tests {
             sample_name: "s".to_string(),
             name: "bg1".to_string(),
             created_on: 0,
+            parent_block_group_id: None,
+            is_default: false,
         };
         let seq_one = NewSequence::new()
             .sequence_type("dna")
@@ -533,6 +539,8 @@ mod tests {
             sample_name: "s".to_string(),
             name: "bg2".to_string(),
             created_on: 0,
+            parent_block_group_id: None,
+            is_default: false,
         };
         let seq_two = NewSequence::new()
             .sequence_type("dna")
@@ -591,6 +599,8 @@ mod tests {
             sample_name: "s".to_string(),
             name: "main".to_string(),
             created_on: 0,
+            parent_block_group_id: None,
+            is_default: false,
         };
         let main_seq = NewSequence::new()
             .sequence_type("dna")
@@ -629,6 +639,8 @@ mod tests {
             sample_name: "s".to_string(),
             name: "feature".to_string(),
             created_on: 0,
+            parent_block_group_id: None,
+            is_default: false,
         };
         let feature_seq = NewSequence::new()
             .sequence_type("dna")
@@ -691,6 +703,8 @@ mod tests {
             sample_name: "s".to_string(),
             name: "db-one".to_string(),
             created_on: 0,
+            parent_block_group_id: None,
+            is_default: false,
         };
         let seq_one = NewSequence::new()
             .sequence_type("dna")
@@ -725,6 +739,8 @@ mod tests {
             sample_name: "s".to_string(),
             name: "db-two".to_string(),
             created_on: 0,
+            parent_block_group_id: None,
+            is_default: false,
         };
         let seq_two = NewSequence::new()
             .sequence_type("dna")

--- a/gen-models/Cargo.toml
+++ b/gen-models/Cargo.toml
@@ -12,7 +12,7 @@ include = ["src", "migrations"]
 benchmark = []
 
 [dev-dependencies]
-rand = "0.9.2"
+rand = "0.10.1"
 tempfile = "3.20.0"
 
 [dependencies]

--- a/gen-models/migrations/core/04-block-group-lineage/down.sql
+++ b/gen-models/migrations/core/04-block-group-lineage/down.sql
@@ -1,0 +1,7 @@
+DROP INDEX IF EXISTS block_group_parent_idx;
+DROP INDEX IF EXISTS block_group_uidx;
+
+CREATE UNIQUE INDEX block_group_uidx ON block_groups(collection_name, sample_name, name);
+
+ALTER TABLE block_groups DROP COLUMN is_default;
+ALTER TABLE block_groups DROP COLUMN parent_block_group_id;

--- a/gen-models/migrations/core/04-block-group-lineage/down.sql
+++ b/gen-models/migrations/core/04-block-group-lineage/down.sql
@@ -1,4 +1,5 @@
 DROP INDEX IF EXISTS block_group_parent_idx;
+DROP INDEX IF EXISTS block_group_default_uidx;
 DROP INDEX IF EXISTS block_group_uidx;
 
 CREATE UNIQUE INDEX block_group_uidx ON block_groups(collection_name, sample_name, name);

--- a/gen-models/migrations/core/04-block-group-lineage/up.sql
+++ b/gen-models/migrations/core/04-block-group-lineage/up.sql
@@ -14,4 +14,8 @@ ON block_groups(
   IFNULL(hex(parent_block_group_id), '')
 );
 
+CREATE UNIQUE INDEX block_group_default_uidx
+ON block_groups(collection_name, sample_name, name)
+WHERE is_default = 1;
+
 CREATE INDEX block_group_parent_idx ON block_groups(parent_block_group_id);

--- a/gen-models/migrations/core/04-block-group-lineage/up.sql
+++ b/gen-models/migrations/core/04-block-group-lineage/up.sql
@@ -1,0 +1,17 @@
+ALTER TABLE block_groups
+ADD COLUMN parent_block_group_id BLOB REFERENCES block_groups(id);
+
+ALTER TABLE block_groups
+ADD COLUMN is_default INTEGER NOT NULL DEFAULT 0 CHECK (is_default IN (0, 1));
+
+DROP INDEX IF EXISTS block_group_uidx;
+
+CREATE UNIQUE INDEX block_group_uidx
+ON block_groups(
+  collection_name,
+  sample_name,
+  name,
+  IFNULL(hex(parent_block_group_id), '')
+);
+
+CREATE INDEX block_group_parent_idx ON block_groups(parent_block_group_id);

--- a/gen-models/src/block_group.rs
+++ b/gen-models/src/block_group.rs
@@ -79,17 +79,25 @@ impl<'a> Capnp<'a> for BlockGroup {
         let sample_name = reader.get_sample_name().unwrap().to_string().unwrap();
         let name = reader.get_name().unwrap().to_string().unwrap();
         let created_on = reader.get_created_on();
-        let parent_block_group_id = match reader.get_parent_block_group_id().which().unwrap() {
-            block_group::parent_block_group_id::None(()) => None,
-            block_group::parent_block_group_id::Some(parent_block_group_id) => Some(
-                parent_block_group_id
-                    .unwrap()
-                    .as_slice()
-                    .unwrap()
-                    .try_into()
-                    .unwrap(),
-            ),
-        };
+        let parent_block_group_id =
+            reader
+                .get_parent_block_group_id()
+                .which()
+                .ok()
+                .and_then(|parent_block_group_id| match parent_block_group_id {
+                    block_group::parent_block_group_id::None(()) => None,
+                    block_group::parent_block_group_id::Some(parent_block_group_id) => {
+                        if let Ok(parent_block_group_id) = parent_block_group_id {
+                            if let Some(parent_block_group_id) = parent_block_group_id.as_slice() {
+                                parent_block_group_id.try_into().ok()
+                            } else {
+                                None
+                            }
+                        } else {
+                            None
+                        }
+                    }
+                });
         let is_default = reader.get_is_default();
 
         BlockGroup {
@@ -1314,6 +1322,23 @@ mod tests {
     }
 
     #[test]
+    fn test_capnp_deserialization_defaults_missing_parent_to_none() {
+        let created_on = Utc::now().timestamp_nanos_opt().unwrap();
+
+        let mut message = TypedBuilder::<block_group::Owned>::new_default();
+        let mut root = message.init_root();
+        root.set_id(&HashId::pad_str(42).0).unwrap();
+        root.set_collection_name("test_collection");
+        root.set_sample_name("test_sample");
+        root.set_name("test_block_group");
+        root.set_created_on(created_on);
+
+        let deserialized = BlockGroup::read_capnp(root.into_reader());
+        assert_eq!(deserialized.parent_block_group_id, None);
+        assert!(!deserialized.is_default);
+    }
+
+    #[test]
     fn test_blockgroup_create() {
         let conn = &get_connection(None).unwrap();
         Collection::create(conn, "test");
@@ -1519,7 +1544,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_or_create_sample_block_groups_creates_root_block_group() {
+    fn test_get_or_create_sample_block_groups_creates_root_block_group_if_no_parents() {
         let conn = &get_connection(None).unwrap();
         Collection::create(conn, "test");
         Sample::get_or_create(conn, "root_sample");

--- a/gen-models/src/block_group.rs
+++ b/gen-models/src/block_group.rs
@@ -10,8 +10,8 @@ use gen_core::{
     calculate_hash, is_end_node, is_start_node, is_terminal, traits::Capnp,
 };
 use gen_graph::{
-    GenGraph, GraphNode, MergeGraph as _, all_intermediate_edges, all_reachable_nodes,
-    all_simple_paths, flatten_to_interval_tree,
+    GenGraph, GraphNode, all_intermediate_edges, all_reachable_nodes, all_simple_paths,
+    flatten_to_interval_tree,
 };
 use intervaltree::IntervalTree;
 use rusqlite::{Row, params, types::Value as SQLValue};
@@ -38,6 +38,8 @@ pub struct BlockGroup {
     pub sample_name: String,
     pub name: String,
     pub created_on: i64,
+    pub parent_block_group_id: Option<HashId>,
+    pub is_default: bool,
 }
 
 impl<'a> Capnp<'a> for BlockGroup {
@@ -50,6 +52,19 @@ impl<'a> Capnp<'a> for BlockGroup {
         builder.set_sample_name(&self.sample_name);
         builder.set_name(&self.name);
         builder.set_created_on(self.created_on);
+        match &self.parent_block_group_id {
+            None => {
+                builder.reborrow().get_parent_block_group_id().set_none(());
+            }
+            Some(parent_block_group_id) => {
+                builder
+                    .reborrow()
+                    .get_parent_block_group_id()
+                    .set_some(&parent_block_group_id.0)
+                    .unwrap();
+            }
+        }
+        builder.set_is_default(self.is_default);
     }
 
     fn read_capnp(reader: Self::Reader) -> Self {
@@ -64,6 +79,18 @@ impl<'a> Capnp<'a> for BlockGroup {
         let sample_name = reader.get_sample_name().unwrap().to_string().unwrap();
         let name = reader.get_name().unwrap().to_string().unwrap();
         let created_on = reader.get_created_on();
+        let parent_block_group_id = match reader.get_parent_block_group_id().which().unwrap() {
+            block_group::parent_block_group_id::None(()) => None,
+            block_group::parent_block_group_id::Some(parent_block_group_id) => Some(
+                parent_block_group_id
+                    .unwrap()
+                    .as_slice()
+                    .unwrap()
+                    .try_into()
+                    .unwrap(),
+            ),
+        };
+        let is_default = reader.get_is_default();
 
         BlockGroup {
             id,
@@ -71,6 +98,8 @@ impl<'a> Capnp<'a> for BlockGroup {
             sample_name,
             name,
             created_on,
+            parent_block_group_id,
+            is_default,
         }
     }
 }
@@ -80,6 +109,15 @@ pub struct BlockGroupData<'a> {
     pub collection_name: &'a str,
     pub sample_name: &'a str,
     pub name: String,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct NewBlockGroup<'a> {
+    pub collection_name: &'a str,
+    pub sample_name: &'a str,
+    pub name: &'a str,
+    pub parent_block_group_id: Option<&'a HashId>,
+    pub is_default: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -148,27 +186,43 @@ impl<'a> PathCache<'a> {
 }
 
 impl BlockGroup {
-    pub fn create(
-        conn: &GraphConnection,
-        collection_name: &str,
-        sample_name: &str,
-        name: &str,
-    ) -> BlockGroup {
-        Sample::get_or_create(conn, sample_name);
-        let hash = HashId(calculate_hash(&format!(
-            "{collection_name}:{sample_name}:{name}"
-        )));
+    pub fn create(conn: &GraphConnection, new_block_group: NewBlockGroup<'_>) -> BlockGroup {
+        Sample::get_or_create(conn, new_block_group.sample_name);
+        let hash = BlockGroup::get_id(
+            new_block_group.collection_name,
+            new_block_group.sample_name,
+            new_block_group.name,
+            new_block_group.parent_block_group_id,
+        );
         let timestamp = chrono::Utc::now().timestamp_nanos_opt().unwrap();
-        let query = "INSERT INTO block_groups (id, collection_name, sample_name, name, created_on) VALUES (?1, ?2, ?3, ?4, ?5);";
+        let query = "INSERT INTO block_groups (
+                id,
+                collection_name,
+                sample_name,
+                name,
+                created_on,
+                parent_block_group_id,
+                is_default
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7);";
         let mut stmt = conn.prepare(query).unwrap();
         let bg = BlockGroup {
             id: hash,
-            collection_name: collection_name.to_string(),
-            sample_name: sample_name.to_string(),
-            name: name.to_string(),
+            collection_name: new_block_group.collection_name.to_string(),
+            sample_name: new_block_group.sample_name.to_string(),
+            name: new_block_group.name.to_string(),
             created_on: timestamp,
+            parent_block_group_id: new_block_group.parent_block_group_id.copied(),
+            is_default: new_block_group.is_default,
         };
-        match stmt.execute((hash, collection_name, sample_name, name, timestamp)) {
+        match stmt.execute(params![
+            hash,
+            new_block_group.collection_name,
+            new_block_group.sample_name,
+            new_block_group.name,
+            timestamp,
+            new_block_group.parent_block_group_id,
+            new_block_group.is_default,
+        ]) {
             Ok(_) => bg,
             Err(rusqlite::Error::SqliteFailure(err, _details)) => {
                 if err.code == rusqlite::ErrorCode::ConstraintViolation {
@@ -259,68 +313,87 @@ impl BlockGroup {
         }
     }
 
-    pub fn get_or_create_sample_block_group(
+    pub fn get_or_create_sample_block_groups(
         conn: &GraphConnection,
         collection_name: &str,
         sample_name: &str,
         group_name: &str,
         parent_samples: Vec<String>,
-    ) -> Result<HashId, QueryError> {
-        let binding = BlockGroup::query(
+    ) -> Result<Vec<BlockGroup>, QueryError> {
+        let existing_block_groups = BlockGroup::query(
             conn,
-            "select * from block_groups where collection_name = ?1 AND sample_name = ?2 AND name = ?3",
+            "select * from block_groups
+             where collection_name = ?1 AND sample_name = ?2 AND name = ?3
+             order by created_on, id",
             params![collection_name, sample_name, group_name],
         );
-        let initial_query_result = binding.first();
 
-        if let Some(block_group) = initial_query_result {
-            return Ok(block_group.id);
+        if !existing_block_groups.is_empty() {
+            return Ok(existing_block_groups);
         }
 
         let parent_block_groups = BlockGroup::find_parent_block_groups(
             conn,
             collection_name,
+            sample_name,
             group_name,
             &parent_samples,
         );
 
-        if let Some(parent_block_group) = parent_block_groups.first() {
-            let new_block_group =
-                BlockGroup::create(conn, collection_name, sample_name, group_name);
-            let mut merged_graph = GenGraph::new();
-
-            new_block_group.merge_from(conn, parent_block_group, &mut merged_graph);
-            for parent_block_group in parent_block_groups.iter().skip(1) {
-                new_block_group.merge_from(conn, parent_block_group, &mut merged_graph);
-            }
-
-            Ok(new_block_group.id)
-        } else {
-            let error_message = if parent_samples.is_empty() {
-                format!("Block group {group_name} not found for sample ({sample_name})")
-            } else {
-                format!(
-                    "Block group not found for either new sample ({sample_name}) or parent samples ({})",
-                    parent_samples.join(", ")
-                )
-            };
-            Err(QueryError::ResultsNotFound(error_message))
+        if parent_block_groups.is_empty() {
+            return Ok(vec![BlockGroup::create(
+                conn,
+                NewBlockGroup {
+                    collection_name,
+                    sample_name,
+                    name: group_name,
+                    ..Default::default()
+                },
+            )]);
         }
+
+        let new_block_groups = parent_block_groups
+            .iter()
+            .map(|parent_block_group| {
+                let new_block_group = BlockGroup::create(
+                    conn,
+                    NewBlockGroup {
+                        collection_name,
+                        sample_name,
+                        name: group_name,
+                        parent_block_group_id: Some(&parent_block_group.id),
+                        ..Default::default()
+                    },
+                );
+                new_block_group.copy_contents_from(conn, parent_block_group);
+                new_block_group
+            })
+            .collect::<Vec<_>>();
+
+        Ok(new_block_groups)
     }
 
     pub fn find_parent_block_groups(
         conn: &GraphConnection,
         collection_name: &str,
+        sample_name: &str,
         group_name: &str,
         parent_samples: &[String],
     ) -> Vec<BlockGroup> {
+        let parent_samples = if parent_samples.is_empty() {
+            Sample::get_parent_names(conn, sample_name)
+        } else {
+            parent_samples.to_vec()
+        };
         if parent_samples.is_empty() {
             return vec![];
         }
 
         BlockGroup::query(
             conn,
-            "select * from block_groups where collection_name = ?1 AND sample_name IN rarray(?2) AND name = ?3 order by collection_name, sample_name, name",
+            "select * from block_groups
+             where collection_name = ?1 AND sample_name IN rarray(?2) AND name = ?3
+             order by sample_name, created_on, id",
             params![
                 collection_name,
                 Rc::new(
@@ -335,15 +408,7 @@ impl BlockGroup {
         )
     }
 
-    fn merge_from(
-        &self,
-        conn: &GraphConnection,
-        source_block_group: &BlockGroup,
-        merged_graph: &mut GenGraph,
-    ) {
-        let source_graph = BlockGroup::get_graph(conn, &source_block_group.id);
-        merged_graph.merge_graph(&source_graph);
-
+    fn copy_contents_from(&self, conn: &GraphConnection, source_block_group: &BlockGroup) {
         let new_block_group_edges =
             BlockGroupEdge::edges_for_block_group(conn, &source_block_group.id)
                 .into_iter()
@@ -358,9 +423,17 @@ impl BlockGroup {
         source_block_group.copy_paths_and_accessions_into(conn, &self.id);
     }
 
-    pub fn get_id(collection_name: &str, sample_name: &str, group_name: &str) -> HashId {
+    pub fn get_id(
+        collection_name: &str,
+        sample_name: &str,
+        group_name: &str,
+        parent_block_group_id: Option<&HashId>,
+    ) -> HashId {
+        let lineage_key = parent_block_group_id
+            .map(ToString::to_string)
+            .unwrap_or_default();
         HashId(calculate_hash(&format!(
-            "{collection_name}:{sample_name}:{group_name}"
+            "{collection_name}:{sample_name}:{group_name}:{lineage_key}"
         )))
     }
 
@@ -1175,6 +1248,8 @@ impl Query for BlockGroup {
             sample_name: row.get(2).unwrap(),
             name: row.get(3).unwrap(),
             created_on: row.get(4).unwrap(),
+            parent_block_group_id: row.get(5).unwrap(),
+            is_default: row.get(6).unwrap(),
         }
     }
 }
@@ -1194,8 +1269,29 @@ mod tests {
         node::Node,
         sample::Sample,
         sequence::Sequence,
-        test_helpers::{get_connection, interval_tree_verify, setup_block_group},
+        test_helpers::{create_bg, get_connection, interval_tree_verify, setup_block_group},
     };
+
+    fn get_single_bg_id(
+        conn: &GraphConnection,
+        collection_name: &str,
+        sample_name: &str,
+        group_name: &str,
+        parent_samples: Vec<String>,
+    ) -> HashId {
+        BlockGroup::get_or_create_sample_block_groups(
+            conn,
+            collection_name,
+            sample_name,
+            group_name,
+            parent_samples,
+        )
+        .unwrap()
+        .into_iter()
+        .next()
+        .unwrap()
+        .id
+    }
 
     #[test]
     fn test_capnp_serialization() {
@@ -1205,6 +1301,8 @@ mod tests {
             sample_name: "test_sample".to_string(),
             name: "test_block_group".to_string(),
             created_on: Utc::now().timestamp_nanos_opt().unwrap(),
+            parent_block_group_id: None,
+            is_default: false,
         };
 
         let mut message = TypedBuilder::<block_group::Owned>::new_default();
@@ -1220,11 +1318,11 @@ mod tests {
         let conn = &get_connection(None).unwrap();
         Collection::create(conn, "test");
         Sample::get_or_create(conn, Sample::DEFAULT_NAME);
-        let bg1 = BlockGroup::create(conn, "test", Sample::DEFAULT_NAME, "hg19");
+        let bg1 = create_bg(conn, "test", Sample::DEFAULT_NAME, "hg19");
         assert_eq!(bg1.collection_name, "test");
         assert_eq!(bg1.name, "hg19");
         Sample::get_or_create(conn, "sample");
-        let bg2 = BlockGroup::create(conn, "test", "sample", "hg19");
+        let bg2 = create_bg(conn, "test", "sample", "hg19");
         assert_eq!(bg2.collection_name, "test");
         assert_eq!(bg2.name, "hg19");
         assert_eq!(bg2.sample_name, "sample".to_string());
@@ -1237,8 +1335,8 @@ mod tests {
         Collection::create(conn, "test");
         Sample::get_or_create(conn, "sample1");
         Sample::get_or_create(conn, "sample2");
-        let bg1 = BlockGroup::create(conn, "test", "sample1", "hg19");
-        let bg2 = BlockGroup::create(conn, "test", "sample2", "hg19");
+        let bg1 = create_bg(conn, "test", "sample1", "hg19");
+        let bg2 = create_bg(conn, "test", "sample2", "hg19");
 
         BlockGroup::delete(conn, "test", &bg1.sample_name, &bg1.name);
 
@@ -1252,18 +1350,17 @@ mod tests {
         let conn = &get_connection(None).unwrap();
         Collection::create(conn, "test");
         Sample::get_or_create(conn, Sample::DEFAULT_NAME);
-        let bg1 = BlockGroup::create(conn, "test", Sample::DEFAULT_NAME, "hg19");
+        let bg1 = create_bg(conn, "test", Sample::DEFAULT_NAME, "hg19");
         assert_eq!(bg1.collection_name, "test");
         assert_eq!(bg1.name, "hg19");
         Sample::get_or_create(conn, "sample");
-        let bg2 = BlockGroup::get_or_create_sample_block_group(
+        let bg2 = get_single_bg_id(
             conn,
             "test",
             "sample",
             "hg19",
             vec![Sample::DEFAULT_NAME.to_string()],
-        )
-        .unwrap();
+        );
         assert_eq!(
             BlockGroupEdge::edges_for_block_group(conn, &bg1.id),
             BlockGroupEdge::edges_for_block_group(conn, &bg2)
@@ -1271,15 +1368,15 @@ mod tests {
     }
 
     #[test]
-    fn test_blockgroup_merge_from_multiple_parents() {
+    fn test_blockgroup_copies_immediate_parent_block_groups() {
         let conn = &get_connection(None).unwrap();
         Collection::create(conn, "test");
         Sample::get_or_create(conn, "parent_a");
         Sample::get_or_create(conn, "parent_b");
         Sample::get_or_create(conn, "child");
 
-        let parent_a_bg = BlockGroup::create(conn, "test", "parent_a", "chr1");
-        let parent_b_bg = BlockGroup::create(conn, "test", "parent_b", "chr1");
+        let parent_a_bg = create_bg(conn, "test", "parent_a", "chr1");
+        let parent_b_bg = create_bg(conn, "test", "parent_b", "chr1");
 
         let seq_a = Sequence::new()
             .sequence_type("DNA")
@@ -1358,7 +1455,7 @@ mod tests {
                 .collect::<Vec<_>>(),
         );
 
-        let merged_bg_id = BlockGroup::get_or_create_sample_block_group(
+        let child_block_groups = BlockGroup::get_or_create_sample_block_groups(
             conn,
             "test",
             "child",
@@ -1366,41 +1463,105 @@ mod tests {
             vec!["parent_a".to_string(), "parent_b".to_string()],
         )
         .unwrap();
+        assert_eq!(child_block_groups.len(), 2);
 
-        let merged_block_group_edges = BlockGroupEdge::query(
+        let child_by_parent = child_block_groups
+            .iter()
+            .map(|block_group| (block_group.parent_block_group_id.unwrap(), block_group))
+            .collect::<HashMap<_, _>>();
+
+        let child_a = child_by_parent.get(&parent_a_bg.id).unwrap();
+        let child_b = child_by_parent.get(&parent_b_bg.id).unwrap();
+
+        let child_a_edges = BlockGroupEdge::query(
             conn,
             "select * from block_group_edges where block_group_id = ?1",
-            params![merged_bg_id],
+            params![child_a.id],
+        );
+        let child_b_edges = BlockGroupEdge::query(
+            conn,
+            "select * from block_group_edges where block_group_id = ?1",
+            params![child_b.id],
         );
         assert_eq!(
-            merged_block_group_edges.len(),
-            parent_a_edges.len() + parent_b_edges.len()
-        );
-        assert_eq!(
-            merged_block_group_edges
+            child_a_edges
                 .iter()
                 .map(|edge| edge.edge_id)
                 .collect::<HashSet<_>>(),
             parent_a_edges
                 .iter()
-                .chain(parent_b_edges.iter())
+                .map(|edge| edge.id)
+                .collect::<HashSet<_>>()
+        );
+        assert_eq!(
+            child_b_edges
+                .iter()
+                .map(|edge| edge.edge_id)
+                .collect::<HashSet<_>>(),
+            parent_b_edges
+                .iter()
                 .map(|edge| edge.id)
                 .collect::<HashSet<_>>()
         );
 
-        let merged_graph = BlockGroup::get_graph(conn, &merged_bg_id);
-        let merged_node_ids = merged_graph
-            .nodes()
-            .filter(|node| !is_terminal(node.node_id))
-            .map(|node| node.node_id)
-            .collect::<HashSet<_>>();
-
-        assert_eq!(merged_node_ids, HashSet::from([node_a, node_b]));
-        let all_sequences = BlockGroup::get_all_sequences(conn, &merged_bg_id, false);
         assert_eq!(
-            all_sequences,
+            BlockGroup::get_all_sequences(conn, &child_a.id, false),
+            HashSet::from_iter(vec!["AAAA".to_string()])
+        );
+        assert_eq!(
+            BlockGroup::get_all_sequences(conn, &child_b.id, false),
+            HashSet::from_iter(vec!["CCCC".to_string()])
+        );
+        assert_eq!(
+            Sample::get_all_sequences(conn, "test", "child", false),
             HashSet::from_iter(vec!["AAAA".to_string(), "CCCC".to_string()])
         );
+    }
+
+    #[test]
+    fn test_get_or_create_sample_block_groups_creates_root_block_group() {
+        let conn = &get_connection(None).unwrap();
+        Collection::create(conn, "test");
+        Sample::get_or_create(conn, "root_sample");
+
+        let block_groups = BlockGroup::get_or_create_sample_block_groups(
+            conn,
+            "test",
+            "root_sample",
+            "chr1",
+            vec![],
+        )
+        .unwrap();
+
+        assert_eq!(block_groups.len(), 1);
+        assert_eq!(block_groups[0].collection_name, "test");
+        assert_eq!(block_groups[0].sample_name, "root_sample");
+        assert_eq!(block_groups[0].name, "chr1");
+        assert!(block_groups[0].parent_block_group_id.is_none());
+    }
+
+    #[test]
+    fn test_get_or_create_sample_block_groups_seeds_from_parents_without_block_groups() {
+        let conn = &get_connection(None).unwrap();
+        Collection::create(conn, "test");
+        Sample::get_or_create(conn, "parent_sample");
+        Sample::get_or_create(conn, "child_sample");
+
+        let block_groups = BlockGroup::get_or_create_sample_block_groups(
+            conn,
+            "test",
+            "child_sample",
+            "chr1",
+            vec!["parent_sample".to_string()],
+        )
+        .unwrap();
+
+        assert_eq!(block_groups.len(), 1);
+        assert_eq!(block_groups[0].collection_name, "test");
+        assert_eq!(block_groups[0].sample_name, "child_sample");
+        assert_eq!(block_groups[0].name, "chr1");
+        assert!(block_groups[0].parent_block_group_id.is_none());
+        assert!(BlockGroupEdge::edges_for_block_group(conn, &block_groups[0].id).is_empty());
     }
 
     #[test]
@@ -1411,8 +1572,8 @@ mod tests {
         Sample::get_or_create(conn, "parent_b");
         Sample::get_or_create(conn, "child");
 
-        let parent_a_bg = BlockGroup::create(conn, "test", "parent_a", "chr1");
-        let parent_b_bg = BlockGroup::create(conn, "test", "parent_b", "chr1");
+        let parent_a_bg = create_bg(conn, "test", "parent_a", "chr1");
+        let parent_b_bg = create_bg(conn, "test", "parent_b", "chr1");
 
         let seq_a = Sequence::new()
             .sequence_type("DNA")
@@ -1548,7 +1709,7 @@ mod tests {
             &mut path_cache,
         );
 
-        let merged_bg_id = BlockGroup::get_or_create_sample_block_group(
+        let child_block_groups = BlockGroup::get_or_create_sample_block_groups(
             conn,
             "test",
             "child",
@@ -1556,31 +1717,63 @@ mod tests {
             vec!["parent_a".to_string(), "parent_b".to_string()],
         )
         .unwrap();
+        let child_by_parent = child_block_groups
+            .iter()
+            .map(|block_group| (block_group.parent_block_group_id.unwrap(), block_group))
+            .collect::<HashMap<_, _>>();
+        let child_a = child_by_parent.get(&parent_a_bg.id).unwrap();
+        let child_b = child_by_parent.get(&parent_b_bg.id).unwrap();
 
-        let merged_paths = Path::query(
+        let child_a_paths = Path::query(
             conn,
             "select * from paths where block_group_id = ?1 order by name",
-            params![merged_bg_id],
+            params![child_a.id],
         );
         assert_eq!(
-            merged_paths
+            child_a_paths
+                .iter()
+                .map(|path| path.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["chr1"]
+        );
+
+        let child_b_paths = Path::query(
+            conn,
+            "select * from paths where block_group_id = ?1 order by name",
+            params![child_b.id],
+        );
+        assert_eq!(
+            child_b_paths
                 .iter()
                 .map(|path| path.name.as_str())
                 .collect::<Vec<_>>(),
             vec!["chr1", "chr1-alt"]
         );
 
-        let merged_accessions = Accession::query(
+        let child_a_accessions = Accession::query(
             conn,
             "select accessions.* from accessions join paths on accessions.path_id = paths.id where paths.block_group_id = ?1 order by accessions.name",
-            params![merged_bg_id],
+            params![child_a.id],
         );
         assert_eq!(
-            merged_accessions
+            child_a_accessions
                 .iter()
                 .map(|accession| accession.name.as_str())
                 .collect::<Vec<_>>(),
-            vec!["parent-a-acc", "parent-b-acc", "parent-b-alt-acc"]
+            vec!["parent-a-acc"]
+        );
+
+        let child_b_accessions = Accession::query(
+            conn,
+            "select accessions.* from accessions join paths on accessions.path_id = paths.id where paths.block_group_id = ?1 order by accessions.name",
+            params![child_b.id],
+        );
+        assert_eq!(
+            child_b_accessions
+                .iter()
+                .map(|accession| accession.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["parent-b-acc", "parent-b-alt-acc"]
         );
     }
 
@@ -1605,14 +1798,7 @@ mod tests {
         );
 
         Sample::get_or_create(conn, "sample2");
-        let _bg2 = BlockGroup::get_or_create_sample_block_group(
-            conn,
-            "test",
-            "sample2",
-            "chr1",
-            vec!["test".to_string()],
-        )
-        .unwrap();
+        let _bg2 = get_single_bg_id(conn, "test", "sample2", "chr1", vec!["test".to_string()]);
         assert_eq!(
             Accession::query(
                 conn,
@@ -2577,14 +2763,7 @@ mod tests {
         let conn = &get_connection(None).unwrap();
         let (block_group_id, path) = setup_block_group(conn);
         let _new_sample = Sample::get_or_create(conn, "child");
-        let new_bg_id = BlockGroup::get_or_create_sample_block_group(
-            conn,
-            "test",
-            "child",
-            "chr1",
-            vec!["test".to_string()],
-        )
-        .unwrap();
+        let new_bg_id = get_single_bg_id(conn, "test", "child", "chr1", vec!["test".to_string()]);
         let new_path = Path::query(
             conn,
             "select * from paths where block_group_id = ?1",
@@ -2754,14 +2933,7 @@ mod tests {
         let conn = &get_connection(None).unwrap();
         let (_block_group_id, _path) = setup_block_group(conn);
         let _new_sample = Sample::get_or_create(conn, "child");
-        let new_bg_id = BlockGroup::get_or_create_sample_block_group(
-            conn,
-            "test",
-            "child",
-            "chr1",
-            vec!["test".to_string()],
-        )
-        .unwrap();
+        let new_bg_id = get_single_bg_id(conn, "test", "child", "chr1", vec!["test".to_string()]);
         let new_path = Path::query(
             conn,
             "select * from paths where block_group_id = ?1",
@@ -2803,14 +2975,13 @@ mod tests {
 
         // Now, we make a change against another descendant
         let _new_sample = Sample::get_or_create(conn, "grandchild");
-        let gc_bg_id = BlockGroup::get_or_create_sample_block_group(
+        let gc_bg_id = get_single_bg_id(
             conn,
             "test",
             "grandchild",
             "chr1",
             vec!["child".to_string()],
-        )
-        .unwrap();
+        );
         let new_path = Path::query(
             conn,
             "select * from paths where block_group_id = ?1",
@@ -2854,14 +3025,7 @@ mod tests {
         let conn = &get_connection(None).unwrap();
         let (_block_group_id, _path) = setup_block_group(conn);
         let _new_sample = Sample::get_or_create(conn, "child");
-        let new_bg_id = BlockGroup::get_or_create_sample_block_group(
-            conn,
-            "test",
-            "child",
-            "chr1",
-            vec!["test".to_string()],
-        )
-        .unwrap();
+        let new_bg_id = get_single_bg_id(conn, "test", "child", "chr1", vec!["test".to_string()]);
         let new_path = Path::query(
             conn,
             "select * from paths where block_group_id = ?1",
@@ -2906,14 +3070,13 @@ mod tests {
 
         // Now, we make a change against another descendant
         let _new_sample = Sample::get_or_create(conn, "grandchild");
-        let gc_bg_id = BlockGroup::get_or_create_sample_block_group(
+        let gc_bg_id = get_single_bg_id(
             conn,
             "test",
             "grandchild",
             "chr1",
             vec!["child".to_string()],
-        )
-        .unwrap();
+        );
         let new_path = Path::query(
             conn,
             "select * from paths where block_group_id = ?1",
@@ -2972,14 +3135,7 @@ mod tests {
         let conn = &get_connection(None).unwrap();
         let (_block_group_id, _path) = setup_block_group(conn);
         let _new_sample = Sample::get_or_create(conn, "child");
-        let new_bg_id = BlockGroup::get_or_create_sample_block_group(
-            conn,
-            "test",
-            "child",
-            "chr1",
-            vec!["test".to_string()],
-        )
-        .unwrap();
+        let new_bg_id = get_single_bg_id(conn, "test", "child", "chr1", vec!["test".to_string()]);
         let new_path = Path::query(
             conn,
             "select * from paths where block_group_id = ?1",
@@ -3026,14 +3182,13 @@ mod tests {
 
         // Now, we make a change against another descendant and get an error
         let _new_sample = Sample::get_or_create(conn, "grandchild");
-        let gc_bg_id = BlockGroup::get_or_create_sample_block_group(
+        let gc_bg_id = get_single_bg_id(
             conn,
             "test",
             "grandchild",
             "chr1",
             vec!["child".to_string()],
-        )
-        .unwrap();
+        );
         let new_path = Path::query(
             conn,
             "select * from paths where block_group_id = ?1",
@@ -3191,7 +3346,7 @@ mod tests {
             let end_block = blocks[blocks.len() - 1];
             let end_node_coordinate = 25 - end_block.start + end_block.sequence_start;
 
-            let block_group2 = BlockGroup::create(conn, "test", "test", "chr1.1");
+            let block_group2 = create_bg(conn, "test", "test", "chr1.1");
             BlockGroup::derive_subgraph(
                 conn,
                 "test",
@@ -3398,7 +3553,7 @@ mod tests {
             let end_block = blocks[blocks.len() - 1];
             let end_node_coordinate = 36 - end_block.start + end_block.sequence_start;
 
-            let block_group2 = BlockGroup::create(conn, "test", "test", "chr1.1");
+            let block_group2 = create_bg(conn, "test", "test", "chr1.1");
             BlockGroup::derive_subgraph(
                 conn,
                 "test",
@@ -3662,7 +3817,7 @@ mod tests {
             let end_block = blocks[blocks.len() - 1];
             let end_node_coordinate = 36 - end_block.start + end_block.sequence_start;
 
-            let block_group2 = BlockGroup::create(conn, "test", "test", "chr1.1");
+            let block_group2 = create_bg(conn, "test", "test", "chr1.1");
             BlockGroup::derive_subgraph(
                 conn,
                 "test",

--- a/gen-models/src/block_group_lineage.rs
+++ b/gen-models/src/block_group_lineage.rs
@@ -1,0 +1,99 @@
+use gen_core::HashId;
+use rusqlite::{Row, params};
+
+use crate::{block_group::BlockGroup, db::GraphConnection, lineage::SqlLineage, traits::Query};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BlockGroupLineage {
+    pub parent_block_group_id: HashId,
+    pub child_block_group_id: HashId,
+}
+
+impl Query for BlockGroupLineage {
+    type Model = BlockGroupLineage;
+
+    const PRIMARY_KEY: &'static str = "id";
+    const TABLE_NAME: &'static str = "block_groups";
+
+    fn process_row(row: &Row) -> Self::Model {
+        BlockGroupLineage {
+            parent_block_group_id: row.get(0).unwrap(),
+            child_block_group_id: row.get(1).unwrap(),
+        }
+    }
+}
+
+impl SqlLineage for BlockGroupLineage {
+    type Id = HashId;
+
+    const CHILD_COLUMN: &'static str = "id";
+    const CHILD_ID_COLUMN: &'static str = "id";
+    const CHILD_TABLE_NAME: &'static str = "block_groups";
+    const PARENT_COLUMN: &'static str = "parent_block_group_id";
+    const PARENT_ID_COLUMN: &'static str = "id";
+    const PARENT_TABLE_NAME: &'static str = "block_groups";
+
+    fn parent_id(&self) -> &Self::Id {
+        &self.parent_block_group_id
+    }
+
+    fn child_id(&self) -> &Self::Id {
+        &self.child_block_group_id
+    }
+}
+
+impl BlockGroupLineage {
+    pub fn get_parents(conn: &GraphConnection, child_block_group_id: &HashId) -> Vec<HashId> {
+        BlockGroupLineage::query(
+            conn,
+            "SELECT parent_block_group_id, id
+             FROM block_groups
+             WHERE id = ?1 AND parent_block_group_id IS NOT NULL;",
+            params![child_block_group_id],
+        )
+        .into_iter()
+        .map(|lineage| lineage.parent_block_group_id)
+        .collect()
+    }
+
+    pub fn get_children(conn: &GraphConnection, parent_block_group_id: &HashId) -> Vec<HashId> {
+        BlockGroupLineage::query(
+            conn,
+            "SELECT parent_block_group_id, id
+             FROM block_groups
+             WHERE parent_block_group_id = ?1
+             ORDER BY created_on, id;",
+            params![parent_block_group_id],
+        )
+        .into_iter()
+        .map(|lineage| lineage.child_block_group_id)
+        .collect()
+    }
+
+    pub fn get_parent_block_groups(
+        conn: &GraphConnection,
+        child_block_group_id: &HashId,
+    ) -> Vec<BlockGroup> {
+        let parent_ids = BlockGroupLineage::get_parents(conn, child_block_group_id);
+        BlockGroup::query_by_ids(conn, &parent_ids)
+    }
+
+    pub fn get_ancestor_block_groups(
+        conn: &GraphConnection,
+        child_block_group_id: &HashId,
+        max_depth: Option<usize>,
+    ) -> Vec<BlockGroup> {
+        let ancestor_ids = BlockGroupLineage::get_ancestors(conn, child_block_group_id, max_depth);
+        BlockGroup::query_by_ids(conn, &ancestor_ids)
+    }
+
+    pub fn get_descendant_block_groups(
+        conn: &GraphConnection,
+        parent_block_group_id: &HashId,
+        max_depth: Option<usize>,
+    ) -> Vec<BlockGroup> {
+        let descendant_ids =
+            BlockGroupLineage::get_descendants(conn, parent_block_group_id, max_depth);
+        BlockGroup::query_by_ids(conn, &descendant_ids)
+    }
+}

--- a/gen-models/src/changesets.rs
+++ b/gen-models/src/changesets.rs
@@ -20,7 +20,7 @@ use crate::{
     annotations::{
         Annotation, AnnotationError, AnnotationGroup, AnnotationGroupError, AnnotationGroupSample,
     },
-    block_group::BlockGroup,
+    block_group::{BlockGroup, NewBlockGroup},
     block_group_edge::{BlockGroupEdge, BlockGroupEdgeData},
     collection::Collection,
     db::GraphConnection,
@@ -521,6 +521,8 @@ pub fn process_changesetiter(
                         sample_name: sample_name.clone(),
                         name,
                         created_on,
+                        parent_block_group_id: parse_maybe_hashid(item, 5),
+                        is_default: parse_number(item, 6) != 0,
                     });
 
                     created_block_groups_set.insert(bg_pk);
@@ -835,7 +837,16 @@ pub fn apply_changeset(
     }
 
     for bg in dependencies.block_group.iter() {
-        BlockGroup::create(conn, &bg.collection_name, &bg.sample_name, &bg.name);
+        BlockGroup::create(
+            conn,
+            NewBlockGroup {
+                collection_name: &bg.collection_name,
+                sample_name: &bg.sample_name,
+                name: &bg.name,
+                parent_block_group_id: bg.parent_block_group_id.as_ref(),
+                is_default: bg.is_default,
+            },
+        );
     }
 
     for node in dependencies.nodes.iter() {
@@ -890,7 +901,16 @@ pub fn apply_changeset(
         NewSequence::from(sequence).save(conn);
     }
     for bg in &changeset.block_groups {
-        BlockGroup::create(conn, &bg.collection_name, &bg.sample_name, &bg.name);
+        BlockGroup::create(
+            conn,
+            NewBlockGroup {
+                collection_name: &bg.collection_name,
+                sample_name: &bg.sample_name,
+                name: &bg.name,
+                parent_block_group_id: bg.parent_block_group_id.as_ref(),
+                is_default: bg.is_default,
+            },
+        );
     }
 
     for node in &changeset.nodes {
@@ -1214,6 +1234,8 @@ mod tests {
                 sample_name: "test_sample".to_string(),
                 name: "test_bg".to_string(),
                 created_on: Utc::now().timestamp_nanos_opt().unwrap(),
+                parent_block_group_id: None,
+                is_default: false,
             }],
             nodes: vec![
                 Node {
@@ -1377,6 +1399,8 @@ mod tests {
                 sample_name: "test_sample".to_string(),
                 name: "test_bg".to_string(),
                 created_on: Utc::now().timestamp_nanos_opt().unwrap(),
+                parent_block_group_id: None,
+                is_default: false,
             }],
             nodes: vec![
                 Node {
@@ -1580,7 +1604,15 @@ mod tests {
             let mut session = start_operation(conn);
             // make a blockgroup with an edge from our parent blockgroup
             let _ = Sample::create(conn, "new").unwrap();
-            let new_bg = BlockGroup::create(conn, "test", "new", "new-bg");
+            let new_bg = BlockGroup::create(
+                conn,
+                NewBlockGroup {
+                    collection_name: "test",
+                    sample_name: "new",
+                    name: "new-bg",
+                    ..Default::default()
+                },
+            );
             let shared_edge = old_edges[0].edge.clone();
             BlockGroupEdge::bulk_create(
                 conn,

--- a/gen-models/src/changesets.rs
+++ b/gen-models/src/changesets.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashSet,
+    collections::{HashMap, HashSet},
     convert::TryInto,
     fs,
     io::Read,
@@ -514,6 +514,7 @@ pub fn process_changesetiter(
                     let sample_name = parse_string(item, 2);
                     let name = parse_string(item, 3);
                     let created_on = parse_number(item, 4);
+                    let parent_block_group_id = parse_maybe_hashid(item, 5);
 
                     created_block_groups.push(BlockGroup {
                         id: bg_pk,
@@ -521,11 +522,16 @@ pub fn process_changesetiter(
                         sample_name: sample_name.clone(),
                         name,
                         created_on,
-                        parent_block_group_id: parse_maybe_hashid(item, 5),
+                        parent_block_group_id,
                         is_default: parse_number(item, 6) != 0,
                     });
 
                     created_block_groups_set.insert(bg_pk);
+                    if let Some(parent_block_group_id) = parent_block_group_id
+                        && !created_block_groups_set.contains(&parent_block_group_id)
+                    {
+                        previous_block_groups.insert(parent_block_group_id);
+                    }
                     if !created_collections_set.contains(&collection) {
                         previous_collections.insert(collection);
                     }
@@ -836,7 +842,13 @@ pub fn apply_changeset(
         }
     }
 
-    for bg in dependencies.block_group.iter() {
+    let block_groups = dependencies
+        .block_group
+        .iter()
+        .chain(changeset.block_groups.iter())
+        .cloned()
+        .collect::<Vec<_>>();
+    for bg in block_groups_parent_first(&block_groups) {
         BlockGroup::create(
             conn,
             NewBlockGroup {
@@ -900,19 +912,6 @@ pub fn apply_changeset(
     for sequence in &changeset.sequences {
         NewSequence::from(sequence).save(conn);
     }
-    for bg in &changeset.block_groups {
-        BlockGroup::create(
-            conn,
-            NewBlockGroup {
-                collection_name: &bg.collection_name,
-                sample_name: &bg.sample_name,
-                name: &bg.name,
-                parent_block_group_id: bg.parent_block_group_id.as_ref(),
-                is_default: bg.is_default,
-            },
-        );
-    }
-
     for node in &changeset.nodes {
         Node::create(conn, &node.sequence_hash, &node.id);
     }
@@ -1162,6 +1161,71 @@ pub fn get_changeset_dependencies_from_path(path: PathBuf) -> DependencyModels {
         .get_root::<crate::gen_models_capnp::dependency_models::Reader>()
         .unwrap();
     DependencyModels::read_capnp(root)
+}
+
+fn block_groups_parent_first(block_groups: &[BlockGroup]) -> Vec<&BlockGroup> {
+    let by_id = block_groups
+        .iter()
+        .map(|block_group| (block_group.id, block_group))
+        .collect::<HashMap<_, _>>();
+    let mut children_by_parent: HashMap<Option<HashId>, Vec<&BlockGroup>> = HashMap::new();
+    let mut roots = Vec::new();
+    for block_group in block_groups {
+        if let Some(parent_id) = block_group.parent_block_group_id
+            && by_id.contains_key(&parent_id)
+        {
+            children_by_parent
+                .entry(Some(parent_id))
+                .or_default()
+                .push(block_group);
+            continue;
+        }
+        roots.push(block_group);
+    }
+
+    fn walk<'a>(
+        parent_id: Option<HashId>,
+        children_by_parent: &HashMap<Option<HashId>, Vec<&'a BlockGroup>>,
+        visited: &mut HashSet<HashId>,
+        ordered: &mut Vec<&'a BlockGroup>,
+    ) {
+        if let Some(children) = children_by_parent.get(&parent_id) {
+            for block_group in children {
+                if visited.insert(block_group.id) {
+                    ordered.push(block_group);
+                    walk(Some(block_group.id), children_by_parent, visited, ordered);
+                }
+            }
+        }
+    }
+
+    let mut ordered = Vec::new();
+    let mut visited = HashSet::new();
+    for root in roots {
+        if visited.insert(root.id) {
+            ordered.push(root);
+            walk(
+                Some(root.id),
+                &children_by_parent,
+                &mut visited,
+                &mut ordered,
+            );
+        }
+    }
+
+    for block_group in block_groups {
+        if visited.insert(block_group.id) {
+            ordered.push(block_group);
+            walk(
+                Some(block_group.id),
+                &children_by_parent,
+                &mut visited,
+                &mut ordered,
+            );
+        }
+    }
+
+    ordered
 }
 
 pub fn write_changeset(
@@ -1582,6 +1646,32 @@ mod tests {
         let dependencies = operation.get_changeset_dependencies(context.workspace());
         assert_eq!(dependencies.samples.len(), 1);
         assert_eq!(dependencies.samples[0].name, "parent");
+    }
+
+    #[test]
+    fn test_block_groups_parent_first() {
+        let parent = BlockGroup {
+            id: HashId::pad_str(1),
+            collection_name: "test".to_string(),
+            sample_name: "parent".to_string(),
+            name: "bg".to_string(),
+            created_on: Utc::now().timestamp_nanos_opt().unwrap(),
+            parent_block_group_id: None,
+            is_default: false,
+        };
+        let child = BlockGroup {
+            id: HashId::pad_str(2),
+            collection_name: "test".to_string(),
+            sample_name: "child".to_string(),
+            name: "bg".to_string(),
+            created_on: Utc::now().timestamp_nanos_opt().unwrap(),
+            parent_block_group_id: Some(parent.id),
+            is_default: false,
+        };
+
+        let block_groups = [child.clone(), parent.clone()];
+        let ordered = block_groups_parent_first(&block_groups);
+        assert_eq!(ordered, vec![&parent, &child]);
     }
 
     #[cfg(test)]

--- a/gen-models/src/changesets.rs
+++ b/gen-models/src/changesets.rs
@@ -842,13 +842,7 @@ pub fn apply_changeset(
         }
     }
 
-    let block_groups = dependencies
-        .block_group
-        .iter()
-        .chain(changeset.block_groups.iter())
-        .cloned()
-        .collect::<Vec<_>>();
-    for bg in block_groups_parent_first(&block_groups) {
+    for bg in block_groups_parent_first(&dependencies.block_group) {
         BlockGroup::create(
             conn,
             NewBlockGroup {
@@ -911,6 +905,18 @@ pub fn apply_changeset(
     }
     for sequence in &changeset.sequences {
         NewSequence::from(sequence).save(conn);
+    }
+    for bg in block_groups_parent_first(&changeset.block_groups) {
+        BlockGroup::create(
+            conn,
+            NewBlockGroup {
+                collection_name: &bg.collection_name,
+                sample_name: &bg.sample_name,
+                name: &bg.name,
+                parent_block_group_id: bg.parent_block_group_id.as_ref(),
+                is_default: bg.is_default,
+            },
+        );
     }
     for node in &changeset.nodes {
         Node::create(conn, &node.sequence_hash, &node.id);
@@ -1163,66 +1169,48 @@ pub fn get_changeset_dependencies_from_path(path: PathBuf) -> DependencyModels {
     DependencyModels::read_capnp(root)
 }
 
+// This sorts parents first so when creating blockgroups, we don't have foreign key issues when a child is made before a parent.
 fn block_groups_parent_first(block_groups: &[BlockGroup]) -> Vec<&BlockGroup> {
     let by_id = block_groups
         .iter()
         .map(|block_group| (block_group.id, block_group))
         .collect::<HashMap<_, _>>();
-    let mut children_by_parent: HashMap<Option<HashId>, Vec<&BlockGroup>> = HashMap::new();
-    let mut roots = Vec::new();
-    for block_group in block_groups {
-        if let Some(parent_id) = block_group.parent_block_group_id
-            && by_id.contains_key(&parent_id)
-        {
-            children_by_parent
-                .entry(Some(parent_id))
-                .or_default()
-                .push(block_group);
-            continue;
-        }
-        roots.push(block_group);
-    }
 
     fn walk<'a>(
-        parent_id: Option<HashId>,
-        children_by_parent: &HashMap<Option<HashId>, Vec<&'a BlockGroup>>,
+        block_group_id: HashId,
+        by_id: &HashMap<HashId, &'a BlockGroup>,
+        visiting: &mut HashSet<HashId>,
         visited: &mut HashSet<HashId>,
         ordered: &mut Vec<&'a BlockGroup>,
     ) {
-        if let Some(children) = children_by_parent.get(&parent_id) {
-            for block_group in children {
-                if visited.insert(block_group.id) {
-                    ordered.push(block_group);
-                    walk(Some(block_group.id), children_by_parent, visited, ordered);
-                }
-            }
+        if visited.contains(&block_group_id) || !visiting.insert(block_group_id) {
+            return;
+        }
+
+        let block_group = by_id[&block_group_id];
+        if let Some(parent_id) = block_group.parent_block_group_id
+            && by_id.contains_key(&parent_id)
+        {
+            walk(parent_id, by_id, visiting, visited, ordered);
+        }
+
+        visiting.remove(&block_group_id);
+        if visited.insert(block_group_id) {
+            ordered.push(block_group);
         }
     }
 
     let mut ordered = Vec::new();
+    let mut visiting = HashSet::new();
     let mut visited = HashSet::new();
-    for root in roots {
-        if visited.insert(root.id) {
-            ordered.push(root);
-            walk(
-                Some(root.id),
-                &children_by_parent,
-                &mut visited,
-                &mut ordered,
-            );
-        }
-    }
-
     for block_group in block_groups {
-        if visited.insert(block_group.id) {
-            ordered.push(block_group);
-            walk(
-                Some(block_group.id),
-                &children_by_parent,
-                &mut visited,
-                &mut ordered,
-            );
-        }
+        walk(
+            block_group.id,
+            &by_id,
+            &mut visiting,
+            &mut visited,
+            &mut ordered,
+        );
     }
 
     ordered
@@ -1672,6 +1660,68 @@ mod tests {
         let block_groups = [child.clone(), parent.clone()];
         let ordered = block_groups_parent_first(&block_groups);
         assert_eq!(ordered, vec![&parent, &child]);
+    }
+
+    #[test]
+    fn test_block_groups_parent_first_with_three_level_lineage() {
+        let parent = BlockGroup {
+            id: HashId::pad_str(1),
+            collection_name: "test".to_string(),
+            sample_name: "parent".to_string(),
+            name: "bg".to_string(),
+            created_on: Utc::now().timestamp_nanos_opt().unwrap(),
+            parent_block_group_id: None,
+            is_default: false,
+        };
+        let child = BlockGroup {
+            id: HashId::pad_str(2),
+            collection_name: "test".to_string(),
+            sample_name: "child".to_string(),
+            name: "bg".to_string(),
+            created_on: Utc::now().timestamp_nanos_opt().unwrap(),
+            parent_block_group_id: Some(parent.id),
+            is_default: false,
+        };
+        let grandchild = BlockGroup {
+            id: HashId::pad_str(3),
+            collection_name: "test".to_string(),
+            sample_name: "grandchild".to_string(),
+            name: "bg".to_string(),
+            created_on: Utc::now().timestamp_nanos_opt().unwrap(),
+            parent_block_group_id: Some(child.id),
+            is_default: false,
+        };
+
+        let block_groups = [grandchild.clone(), child.clone(), parent.clone()];
+        let ordered = block_groups_parent_first(&block_groups);
+        assert_eq!(ordered, vec![&parent, &child, &grandchild]);
+    }
+
+    #[test]
+    fn test_block_groups_parent_first_when_every_entry_has_a_parent() {
+        let root_id = HashId::pad_str(1);
+        let child = BlockGroup {
+            id: HashId::pad_str(2),
+            collection_name: "test".to_string(),
+            sample_name: "child".to_string(),
+            name: "bg".to_string(),
+            created_on: Utc::now().timestamp_nanos_opt().unwrap(),
+            parent_block_group_id: Some(root_id),
+            is_default: false,
+        };
+        let grandchild = BlockGroup {
+            id: HashId::pad_str(3),
+            collection_name: "test".to_string(),
+            sample_name: "grandchild".to_string(),
+            name: "bg".to_string(),
+            created_on: Utc::now().timestamp_nanos_opt().unwrap(),
+            parent_block_group_id: Some(child.id),
+            is_default: false,
+        };
+
+        let block_groups = [grandchild.clone(), child.clone()];
+        let ordered = block_groups_parent_first(&block_groups);
+        assert_eq!(ordered, vec![&child, &grandchild]);
     }
 
     #[cfg(test)]

--- a/gen-models/src/lib.rs
+++ b/gen-models/src/lib.rs
@@ -2,6 +2,7 @@ pub mod accession;
 pub mod annotations;
 pub mod block_group;
 pub mod block_group_edge;
+pub mod block_group_lineage;
 pub mod changesets;
 pub mod collection;
 pub mod db;

--- a/gen-models/src/path.rs
+++ b/gen-models/src/path.rs
@@ -846,9 +846,23 @@ mod tests {
 
     use super::*;
     use crate::{
-        block_group::BlockGroup, block_group_edge::BlockGroupEdgeData, collection::Collection,
+        block_group::{BlockGroup, NewBlockGroup},
+        block_group_edge::BlockGroupEdgeData,
+        collection::Collection,
         test_helpers::get_connection,
     };
+
+    fn create_test_block_group(conn: &GraphConnection) -> BlockGroup {
+        BlockGroup::create(
+            conn,
+            NewBlockGroup {
+                collection_name: "test collection",
+                sample_name: "test-sample",
+                name: "test block group",
+                ..Default::default()
+            },
+        )
+    }
 
     #[test]
     fn test_path_capnp_serialization() {
@@ -871,8 +885,7 @@ mod tests {
     fn test_path_delete() {
         let conn = &get_connection(None).unwrap();
         Collection::create(conn, "test collection");
-        let block_group =
-            BlockGroup::create(conn, "test collection", "test-sample", "test block group");
+        let block_group = create_test_block_group(conn);
 
         // Create first path
         let sequence1 = Sequence::new()
@@ -966,8 +979,7 @@ mod tests {
     fn test_gets_sequence() {
         let conn = &get_connection(None).unwrap();
         Collection::create(conn, "test collection");
-        let block_group =
-            BlockGroup::create(conn, "test collection", "test-sample", "test block group");
+        let block_group = create_test_block_group(conn);
         let sequence1 = Sequence::new()
             .sequence_type("DNA")
             .sequence("ATCGATCG")
@@ -1054,8 +1066,7 @@ mod tests {
     fn test_gets_sequence_with_rc() {
         let conn = &get_connection(None).unwrap();
         Collection::create(conn, "test collection");
-        let block_group =
-            BlockGroup::create(conn, "test collection", "test-sample", "test block group");
+        let block_group = create_test_block_group(conn);
         let sequence1 = Sequence::new()
             .sequence_type("DNA")
             .sequence("ATCGATCG")
@@ -1149,8 +1160,7 @@ mod tests {
     fn test_intervaltree() {
         let conn = &get_connection(None).unwrap();
         Collection::create(conn, "test collection");
-        let block_group =
-            BlockGroup::create(conn, "test collection", "test-sample", "test block group");
+        let block_group = create_test_block_group(conn);
         let sequence1 = Sequence::new()
             .sequence_type("DNA")
             .sequence("ATCGATCG")
@@ -1269,8 +1279,7 @@ mod tests {
         // sequence is correctly generated
         let conn = &get_connection(None).unwrap();
         Collection::create(conn, "test collection");
-        let block_group =
-            BlockGroup::create(conn, "test collection", "test-sample", "test block group");
+        let block_group = create_test_block_group(conn);
         let sequence1 = Sequence::new()
             .sequence_type("DNA")
             .sequence("ATCGATCG")
@@ -1395,8 +1404,7 @@ mod tests {
         */
         let conn = &get_connection(None).unwrap();
         Collection::create(conn, "test collection");
-        let block_group =
-            BlockGroup::create(conn, "test collection", "test-sample", "test block group");
+        let block_group = create_test_block_group(conn);
         let sequence1 = Sequence::new()
             .sequence_type("DNA")
             .sequence("ATCGATCG")
@@ -1458,8 +1466,7 @@ mod tests {
         */
         let conn = &get_connection(None).unwrap();
         Collection::create(conn, "test collection");
-        let block_group =
-            BlockGroup::create(conn, "test collection", "test-sample", "test block group");
+        let block_group = create_test_block_group(conn);
         let sequence1 = Sequence::new()
             .sequence_type("DNA")
             .sequence("ATCGATCG")
@@ -1556,8 +1563,7 @@ mod tests {
         */
         let conn = &get_connection(None).unwrap();
         Collection::create(conn, "test collection");
-        let block_group =
-            BlockGroup::create(conn, "test collection", "test-sample", "test block group");
+        let block_group = create_test_block_group(conn);
         let sequence1 = Sequence::new()
             .sequence_type("DNA")
             .sequence("ATCGATCG")
@@ -1672,8 +1678,7 @@ mod tests {
         */
         let conn = &get_connection(None).unwrap();
         Collection::create(conn, "test collection");
-        let block_group =
-            BlockGroup::create(conn, "test collection", "test-sample", "test block group");
+        let block_group = create_test_block_group(conn);
         let sequence1 = Sequence::new()
             .sequence_type("DNA")
             .sequence("ATCGATCG")
@@ -1790,8 +1795,7 @@ mod tests {
         */
         let conn = &get_connection(None).unwrap();
         Collection::create(conn, "test collection");
-        let block_group =
-            BlockGroup::create(conn, "test collection", "test-sample", "test block group");
+        let block_group = create_test_block_group(conn);
         let sequence1 = Sequence::new()
             .sequence_type("DNA")
             .sequence("ATCGATCG")
@@ -1907,8 +1911,7 @@ mod tests {
         */
         let conn = &get_connection(None).unwrap();
         Collection::create(conn, "test collection");
-        let block_group =
-            BlockGroup::create(conn, "test collection", "test-sample", "test block group");
+        let block_group = create_test_block_group(conn);
         let sequence1 = Sequence::new()
             .sequence_type("DNA")
             .sequence("ATCGATCG")
@@ -2012,8 +2015,7 @@ mod tests {
         */
         let conn = &get_connection(None).unwrap();
         Collection::create(conn, "test collection");
-        let block_group =
-            BlockGroup::create(conn, "test collection", "test-sample", "test block group");
+        let block_group = create_test_block_group(conn);
         let sequence1 = Sequence::new()
             .sequence_type("DNA")
             .sequence("ATCGATCG")
@@ -2145,8 +2147,7 @@ mod tests {
         */
         let conn = &get_connection(None).unwrap();
         Collection::create(conn, "test collection");
-        let block_group =
-            BlockGroup::create(conn, "test collection", "test-sample", "test block group");
+        let block_group = create_test_block_group(conn);
         let sequence1 = Sequence::new()
             .sequence_type("DNA")
             .sequence("ATCGATCG")
@@ -2277,8 +2278,7 @@ mod tests {
         */
         let conn = &get_connection(None).unwrap();
         Collection::create(conn, "test collection");
-        let block_group =
-            BlockGroup::create(conn, "test collection", "test-sample", "test block group");
+        let block_group = create_test_block_group(conn);
         let sequence1 = Sequence::new()
             .sequence_type("DNA")
             .sequence("ATCGATCG")
@@ -2389,8 +2389,7 @@ mod tests {
         */
         let conn = &get_connection(None).unwrap();
         Collection::create(conn, "test collection");
-        let block_group =
-            BlockGroup::create(conn, "test collection", "test-sample", "test block group");
+        let block_group = create_test_block_group(conn);
         let sequence1 = Sequence::new()
             .sequence_type("DNA")
             .sequence("ATCGATCG")
@@ -2455,8 +2454,7 @@ mod tests {
         */
         let conn = &get_connection(None).unwrap();
         Collection::create(conn, "test collection");
-        let block_group =
-            BlockGroup::create(conn, "test collection", "test-sample", "test block group");
+        let block_group = create_test_block_group(conn);
         let sequence1 = Sequence::new()
             .sequence_type("DNA")
             .sequence("ATCGATCG")
@@ -2559,8 +2557,7 @@ mod tests {
         */
         let conn = &get_connection(None).unwrap();
         Collection::create(conn, "test collection");
-        let block_group =
-            BlockGroup::create(conn, "test collection", "test-sample", "test block group");
+        let block_group = create_test_block_group(conn);
         let sequence1 = Sequence::new()
             .sequence_type("DNA")
             .sequence("ATCGATCG")
@@ -2678,8 +2675,7 @@ mod tests {
         */
         let conn = &get_connection(None).unwrap();
         Collection::create(conn, "test collection");
-        let block_group =
-            BlockGroup::create(conn, "test collection", "test-sample", "test block group");
+        let block_group = create_test_block_group(conn);
         let sequence1 = Sequence::new()
             .sequence_type("DNA")
             .sequence("ATCGATCG")
@@ -2797,8 +2793,7 @@ mod tests {
         */
         let conn = &get_connection(None).unwrap();
         Collection::create(conn, "test collection");
-        let block_group =
-            BlockGroup::create(conn, "test collection", "test-sample", "test block group");
+        let block_group = create_test_block_group(conn);
         let sequence1 = Sequence::new()
             .sequence_type("DNA")
             .sequence("ATCGATCG")
@@ -2916,8 +2911,7 @@ mod tests {
         */
         let conn = &get_connection(None).unwrap();
         Collection::create(conn, "test collection");
-        let block_group =
-            BlockGroup::create(conn, "test collection", "test-sample", "test block group");
+        let block_group = create_test_block_group(conn);
         let sequence1 = Sequence::new()
             .sequence_type("DNA")
             .sequence("ATCGATCG")
@@ -3049,8 +3043,7 @@ mod tests {
         */
         let conn = &get_connection(None).unwrap();
         Collection::create(conn, "test collection");
-        let block_group =
-            BlockGroup::create(conn, "test collection", "test-sample", "test block group");
+        let block_group = create_test_block_group(conn);
         let sequence1 = Sequence::new()
             .sequence_type("DNA")
             .sequence("ATCGATCG")
@@ -3154,8 +3147,7 @@ mod tests {
     fn test_new_path_with() {
         let conn = &get_connection(None).unwrap();
         Collection::create(conn, "test collection");
-        let block_group =
-            BlockGroup::create(conn, "test collection", "test-sample", "test block group");
+        let block_group = create_test_block_group(conn);
         let sequence1 = Sequence::new()
             .sequence_type("DNA")
             .sequence("ATCGATCG")
@@ -3287,8 +3279,7 @@ mod tests {
     fn test_new_path_with_deletion() {
         let conn = &get_connection(None).unwrap();
         Collection::create(conn, "test collection");
-        let block_group =
-            BlockGroup::create(conn, "test collection", "test-sample", "test block group");
+        let block_group = create_test_block_group(conn);
         let sequence1 = Sequence::new()
             .sequence_type("DNA")
             .sequence("ATCGATCG")
@@ -3369,8 +3360,7 @@ mod tests {
     fn test_duplicate_edge_warning() {
         let conn = &get_connection(None).unwrap();
         Collection::create(conn, "test collection");
-        let block_group =
-            BlockGroup::create(conn, "test collection", "test-sample", "test block group");
+        let block_group = create_test_block_group(conn);
         let sequence1 = Sequence::new()
             .sequence_type("DNA")
             .sequence("ATCGATCG")
@@ -3416,8 +3406,7 @@ mod tests {
     fn test_edges_must_be_in_path_block_group() {
         let conn = &get_connection(None).unwrap();
         Collection::create(conn, "test collection");
-        let block_group =
-            BlockGroup::create(conn, "test collection", "test-sample", "test block group");
+        let block_group = create_test_block_group(conn);
         let sequence1 = Sequence::new()
             .sequence_type("DNA")
             .sequence("ATCGATCG")
@@ -3452,8 +3441,7 @@ mod tests {
     fn test_consecutive_edges_must_share_a_node() {
         let conn = &get_connection(None).unwrap();
         Collection::create(conn, "test collection");
-        let block_group =
-            BlockGroup::create(conn, "test collection", "test-sample", "test block group");
+        let block_group = create_test_block_group(conn);
         let sequence1 = Sequence::new()
             .sequence_type("DNA")
             .sequence("ATCGATCG")
@@ -3510,8 +3498,7 @@ mod tests {
     fn test_consecutive_edges_must_share_the_same_strand() {
         let conn = &get_connection(None).unwrap();
         Collection::create(conn, "test collection");
-        let block_group =
-            BlockGroup::create(conn, "test collection", "test-sample", "test block group");
+        let block_group = create_test_block_group(conn);
         let sequence1 = Sequence::new()
             .sequence_type("DNA")
             .sequence("ATCGATCG")
@@ -3563,8 +3550,7 @@ mod tests {
     fn test_consecutive_edges_must_have_different_coordinates_on_a_node() {
         let conn = &get_connection(None).unwrap();
         Collection::create(conn, "test collection");
-        let block_group =
-            BlockGroup::create(conn, "test collection", "test-sample", "test block group");
+        let block_group = create_test_block_group(conn);
         let sequence1 = Sequence::new()
             .sequence_type("DNA")
             .sequence("ATCGATCG")
@@ -3614,8 +3600,7 @@ mod tests {
     fn test_node_blocks_for_range() {
         let conn = &get_connection(None).unwrap();
         Collection::create(conn, "test collection");
-        let block_group =
-            BlockGroup::create(conn, "test collection", "test-sample", "test block group");
+        let block_group = create_test_block_group(conn);
         let sequence1 = Sequence::new()
             .sequence_type("DNA")
             .sequence("ATCGATCG")
@@ -3751,8 +3736,7 @@ mod tests {
     fn test_node_blocks_for_range_with_node_parts() {
         let conn = &get_connection(None).unwrap();
         Collection::create(conn, "test collection");
-        let block_group =
-            BlockGroup::create(conn, "test collection", "test-sample", "test block group");
+        let block_group = create_test_block_group(conn);
         let sequence1 = Sequence::new()
             .sequence_type("DNA")
             .sequence("AAAAAAAA")

--- a/gen-models/src/sample.rs
+++ b/gen-models/src/sample.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, rc::Rc};
+use std::{collections::HashSet, rc::Rc};
 
 use gen_core::traits::Capnp;
 use gen_graph::GenGraph;
@@ -99,6 +99,18 @@ impl Sample {
         sample_graph
     }
 
+    pub fn get_all_sequences(
+        conn: &GraphConnection,
+        collection_name: &str,
+        sample_name: &str,
+        prune: bool,
+    ) -> HashSet<String> {
+        Sample::get_block_groups(conn, collection_name, sample_name)
+            .into_iter()
+            .flat_map(|block_group| BlockGroup::get_all_sequences(conn, &block_group.id, prune))
+            .collect()
+    }
+
     pub fn get_or_create_child(
         conn: &GraphConnection,
         collection_name: &str,
@@ -110,7 +122,9 @@ impl Sample {
                 if !parent_samples.is_empty() {
                     let parent_block_groups = BlockGroup::query(
                         conn,
-                        "select * from block_groups where collection_name = ?1 AND sample_name IN rarray(?2) ORDER BY name, sample_name",
+                        "select * from block_groups
+                         where collection_name = ?1 AND sample_name IN rarray(?2)
+                         ORDER BY name, sample_name, created_on, id",
                         params![
                             collection_name,
                             Rc::new(
@@ -122,21 +136,18 @@ impl Sample {
                             ),
                         ],
                     );
-                    let mut parent_samples_by_group_name = BTreeMap::<String, Vec<String>>::new();
-                    for parent_block_group in parent_block_groups {
-                        parent_samples_by_group_name
-                            .entry(parent_block_group.name)
-                            .or_default()
-                            .push(parent_block_group.sample_name);
-                    }
+                    let group_names = parent_block_groups
+                        .into_iter()
+                        .map(|parent_block_group| parent_block_group.name)
+                        .collect::<HashSet<_>>();
 
-                    for (group_name, group_parent_samples) in parent_samples_by_group_name {
-                        BlockGroup::get_or_create_sample_block_group(
+                    for group_name in group_names {
+                        BlockGroup::get_or_create_sample_block_groups(
                             conn,
                             collection_name,
                             &new_sample.name,
                             &group_name,
-                            group_parent_samples,
+                            parent_samples.clone(),
                         )
                         .map_err(SampleError::from)?;
                     }
@@ -195,7 +206,11 @@ mod tests {
     use capnp::message::TypedBuilder;
 
     use super::*;
-    use crate::{collection::Collection, errors::SampleError, test_helpers::get_connection};
+    use crate::{
+        collection::Collection,
+        errors::SampleError,
+        test_helpers::{create_bg, get_connection},
+    };
 
     #[test]
     fn test_capnp_serialization() {
@@ -257,10 +272,10 @@ mod tests {
         let conn = &get_connection(None).unwrap();
         Collection::create(conn, "test");
 
-        BlockGroup::create(conn, "test", "parent_a", "chr1");
-        BlockGroup::create(conn, "test", "parent_a", "chr2");
-        BlockGroup::create(conn, "test", "parent_b", "chr2");
-        BlockGroup::create(conn, "test", "parent_c", "chr3");
+        create_bg(conn, "test", "parent_a", "chr1");
+        create_bg(conn, "test", "parent_a", "chr2");
+        create_bg(conn, "test", "parent_b", "chr2");
+        create_bg(conn, "test", "parent_c", "chr3");
 
         let child = Sample::get_or_create_child(
             conn,
@@ -279,7 +294,7 @@ mod tests {
             .map(|block_group| block_group.name)
             .collect::<Vec<_>>();
         block_group_names.sort();
-        assert_eq!(block_group_names, vec!["chr1", "chr2", "chr3"]);
+        assert_eq!(block_group_names, vec!["chr1", "chr2", "chr2", "chr3"]);
         assert_eq!(
             SampleLineage::get_parents(conn, &child.name),
             vec![

--- a/gen-models/src/sequence.rs
+++ b/gen-models/src/sequence.rs
@@ -394,7 +394,7 @@ mod tests {
     use std::time;
     use std::{fs::OpenOptions, io::Write};
 
-    use rand::{self, Rng};
+    use rand::{self, RngExt};
 
     use super::*;
     use crate::test_helpers::get_connection;

--- a/gen-models/src/session_operations.rs
+++ b/gen-models/src/session_operations.rs
@@ -374,6 +374,8 @@ mod tests {
                 sample_name: "test_sample".to_string(),
                 name: "test_bg".to_string(),
                 created_on: 0,
+                parent_block_group_id: None,
+                is_default: false,
             }],
             nodes: vec![Node {
                 id: HashId::convert_str("node_hash"),

--- a/gen-models/src/test_helpers.rs
+++ b/gen-models/src/test_helpers.rs
@@ -9,7 +9,7 @@ use rusqlite::Connection;
 use tempfile::tempdir;
 
 use crate::{
-    block_group::BlockGroup,
+    block_group::{BlockGroup, NewBlockGroup},
     block_group_edge::{BlockGroupEdge, BlockGroupEdgeData},
     collection::Collection,
     db::{DbContext, GraphConnection, OperationsConnection},
@@ -23,6 +23,23 @@ use crate::{
     sequence::Sequence,
     session_operations::{end_operation, start_operation},
 };
+
+pub fn create_bg(
+    conn: &GraphConnection,
+    collection_name: &str,
+    sample_name: &str,
+    name: &str,
+) -> BlockGroup {
+    BlockGroup::create(
+        conn,
+        NewBlockGroup {
+            collection_name,
+            sample_name,
+            name,
+            ..Default::default()
+        },
+    )
+}
 
 pub fn get_connection<'a>(
     db_path: impl Into<Option<&'a str>>,
@@ -92,7 +109,7 @@ pub fn setup_block_group(conn: &GraphConnection) -> (HashId, Path) {
     let g_node_id = Node::create(conn, &g_seq.hash, &HashId::convert_str("test-g-node"));
     let _collection = Collection::create(conn, "test");
     Sample::get_or_create(conn, "test");
-    let block_group = BlockGroup::create(conn, "test", "test", "chr1");
+    let block_group = create_bg(conn, "test", "test", "chr1");
     let edge0 = Edge::create(
         conn,
         PATH_START_NODE_ID,

--- a/gen-python/Cargo.lock
+++ b/gen-python/Cargo.lock
@@ -373,6 +373,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -543,6 +554,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -1116,18 +1136,14 @@ dependencies = [
 
 [[package]]
 name = "gb-io"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae0f0a179902bdc33891eef7b8bb85b496550a3b6238837314db2c8b860f0771"
+checksum = "98e6430fd1aab1f2586f8ad0ef27151bee96d5adcda39b39054fc4ce9c72d08a"
 dependencies = [
  "circular",
  "itertools 0.14.0",
  "log",
  "nom 8.0.0",
- "serde",
- "serde_bytes",
- "string_cache",
- "string_cache_codegen",
  "thiserror 2.0.18",
 ]
 
@@ -1168,7 +1184,7 @@ dependencies = [
  "noodles",
  "once_cell",
  "petgraph",
- "rand 0.9.2",
+ "rand 0.10.1",
  "rat-cursor",
  "rat-text",
  "ratatui",
@@ -1218,7 +1234,7 @@ dependencies = [
  "noodles",
  "pyo3",
  "pyo3-macros",
- "rand 0.9.2",
+ "rand 0.10.1",
  "rusqlite",
  "serde",
  "sha2",
@@ -1315,7 +1331,7 @@ dependencies = [
  "itertools 0.14.0",
  "log",
  "petgraph",
- "rand 0.9.2",
+ "rand 0.10.1",
  "ratatui",
  "rstar",
  "rusqlite",
@@ -1372,6 +1388,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -2212,12 +2229,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
-name = "new_debug_unreachable"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
-
-[[package]]
 name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2773,12 +2784,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "precomputed-hash"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
-
-[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2970,6 +2975,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2993,6 +3009,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rat-cursor"
@@ -3482,16 +3504,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_bytes"
-version = "0.11.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
-dependencies = [
- "serde",
- "serde_core",
-]
-
-[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3587,7 +3599,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -3679,31 +3691,6 @@ name = "str_indices"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d08889ec5408683408db66ad89e0e1f93dff55c73a4ccc71c427d5b277ee47e6"
-
-[[package]]
-name = "string_cache"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
-dependencies = [
- "new_debug_unreachable",
- "parking_lot",
- "phf_shared",
- "precomputed-hash",
- "serde",
-]
-
-[[package]]
-name = "string_cache_codegen"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
-dependencies = [
- "phf_generator",
- "phf_shared",
- "proc-macro2",
- "quote",
-]
 
 [[package]]
 name = "strsim"

--- a/gen-python/src/python_api/repository.rs
+++ b/gen-python/src/python_api/repository.rs
@@ -2,7 +2,12 @@ use std::{path::PathBuf, sync::Mutex};
 
 use r#gen::{core::HashId, get_connection};
 use gen_core::config::Workspace;
-use gen_models::{block_group::BlockGroup, db::GraphConnection, node::Node, traits::Query};
+use gen_models::{
+    block_group::{BlockGroup, NewBlockGroup},
+    db::GraphConnection,
+    node::Node,
+    traits::Query,
+};
 use pyo3::{prelude::*, types::PyModule};
 
 use super::{
@@ -249,7 +254,15 @@ impl PyRepository {
         sample_name: String,
     ) -> PyResult<PyBlockGroup> {
         self.with_connection(|conn| {
-            let block_group = BlockGroup::create(conn, &collection_name, &sample_name, &name);
+            let block_group = BlockGroup::create(
+                conn,
+                NewBlockGroup {
+                    collection_name: &collection_name,
+                    sample_name: &sample_name,
+                    name: &name,
+                    ..Default::default()
+                },
+            );
 
             Ok(PyBlockGroup {
                 id: block_group.id,

--- a/gen-tui/Cargo.toml
+++ b/gen-tui/Cargo.toml
@@ -22,7 +22,7 @@ ratatui = { version = "0.30.0", features = ["unstable-rendered-line-info"] }
 crossterm = "0.29.0"
 rstar = { version = "0.12.2", features = ["serde"] }
 ftree = "1.2.0"
-rand = { version = "0.9.1", features = ["std"] }
+rand = { version = "0.10.1", features = ["std"] }
 tachyonfx = "0.23.0"
 tokio = { version = "1.45.0", features = [
   "rt",

--- a/src/commands/import/fasta.rs
+++ b/src/commands/import/fasta.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use clap::Args;
-use gen_models::errors::OperationError;
+use gen_models::{errors::OperationError, sample::Sample};
 
 use crate::{
     commands::{cli_context::CliContext, get_default_collection},
@@ -21,7 +21,7 @@ pub struct Command {
     #[arg(short, long)]
     name: Option<String>,
     /// A sample name to associate the fasta file with
-    #[arg(short, long, default_value = "reference")]
+    #[arg(short, long, default_value_t = Sample::DEFAULT_NAME.to_string())]
     sample: String,
 }
 

--- a/src/commands/import/fasta.rs
+++ b/src/commands/import/fasta.rs
@@ -21,7 +21,7 @@ pub struct Command {
     #[arg(short, long)]
     name: Option<String>,
     /// A sample name to associate the fasta file with
-    #[arg(short, long)]
+    #[arg(short, long, default_value = "reference")]
     sample: String,
 }
 

--- a/src/commands/import/genbank.rs
+++ b/src/commands/import/genbank.rs
@@ -5,6 +5,7 @@ use clap::Args;
 use gen_models::{
     file_types::FileTypes,
     operations::{OperationFile, OperationInfo},
+    sample::Sample,
 };
 
 use crate::{
@@ -22,7 +23,7 @@ pub struct Command {
     #[arg(short, long)]
     name: Option<String>,
     /// A sample name to associate the Genbank file with
-    #[arg(short, long, default_value = "reference")]
+    #[arg(short, long, default_value_t = Sample::DEFAULT_NAME.to_string())]
     sample: String,
 }
 

--- a/src/commands/import/genbank.rs
+++ b/src/commands/import/genbank.rs
@@ -22,7 +22,7 @@ pub struct Command {
     #[arg(short, long)]
     name: Option<String>,
     /// A sample name to associate the Genbank file with
-    #[arg(short, long)]
+    #[arg(short, long, default_value = "reference")]
     sample: String,
 }
 

--- a/src/commands/import/gfa.rs
+++ b/src/commands/import/gfa.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use anyhow::Result;
 use clap::Args;
-use gen_models::errors::OperationError;
+use gen_models::{errors::OperationError, sample::Sample};
 
 use crate::{
     commands::{cli_context::CliContext, get_default_collection},
@@ -19,7 +19,7 @@ pub struct Command {
     #[arg(short, long)]
     name: Option<String>,
     /// A sample name to associate the GFA file with
-    #[arg(short, long, default_value = "reference")]
+    #[arg(short, long, default_value_t = Sample::DEFAULT_NAME.to_string())]
     sample: String,
 }
 

--- a/src/commands/import/gfa.rs
+++ b/src/commands/import/gfa.rs
@@ -19,7 +19,7 @@ pub struct Command {
     #[arg(short, long)]
     name: Option<String>,
     /// A sample name to associate the GFA file with
-    #[arg(short, long)]
+    #[arg(short, long, default_value = "reference")]
     sample: String,
 }
 

--- a/src/commands/import/library.rs
+++ b/src/commands/import/library.rs
@@ -23,7 +23,7 @@ pub struct Command {
     #[arg(short, long)]
     name: Option<String>,
     /// A sample name to associate the library with
-    #[arg(short, long)]
+    #[arg(short, long, default_value = "reference")]
     sample: String,
 }
 

--- a/src/commands/import/library.rs
+++ b/src/commands/import/library.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use clap::Args;
-use gen_models::errors::OperationError;
+use gen_models::{errors::OperationError, sample::Sample};
 
 use crate::{
     commands::{cli_context::CliContext, get_default_collection},
@@ -23,7 +23,7 @@ pub struct Command {
     #[arg(short, long)]
     name: Option<String>,
     /// A sample name to associate the library with
-    #[arg(short, long, default_value = "reference")]
+    #[arg(short, long, default_value_t = Sample::DEFAULT_NAME.to_string())]
     sample: String,
 }
 

--- a/src/commands/update/fasta.rs
+++ b/src/commands/update/fasta.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use clap::Args;
+use gen_models::sample::Sample;
 
 use crate::{
     commands::{cli_context::CliContext, get_default_collection},
@@ -16,7 +17,7 @@ pub struct Command {
     #[arg(short, long)]
     name: Option<String>,
     /// The name of the sample to update
-    #[arg(short, long, default_value = "reference")]
+    #[arg(short, long, default_value_t = Sample::DEFAULT_NAME.to_string())]
     sample: String,
     /// A new sample name to associate with the update
     #[arg(long)]

--- a/src/commands/update/fasta.rs
+++ b/src/commands/update/fasta.rs
@@ -16,7 +16,7 @@ pub struct Command {
     #[arg(short, long)]
     name: Option<String>,
     /// The name of the sample to update
-    #[arg(short, long)]
+    #[arg(short, long, default_value = "reference")]
     sample: String,
     /// A new sample name to associate with the update
     #[arg(long)]

--- a/src/commands/update/gaf.rs
+++ b/src/commands/update/gaf.rs
@@ -16,14 +16,14 @@ pub struct Command {
     #[arg(short, long)]
     name: Option<String>,
     /// The name of the sample to update
-    #[arg(short, long)]
+    #[arg(short, long, default_value = "reference")]
     sample: String,
     /// The csv describing changes to make
     #[arg(short, long)]
     csv: String,
     /// If specified, the newly created sample will inherit this sample's existing graph
-    #[arg(short, long)]
-    parent_sample: Option<String>,
+    #[arg(short, long, default_value = "reference")]
+    parent_sample: String,
 }
 
 pub fn execute(cli_context: &CliContext, cmd: Command) -> Result<()> {
@@ -47,7 +47,7 @@ pub fn execute(cli_context: &CliContext, cmd: Command) -> Result<()> {
         &cmd.csv,
         name,
         cmd.sample.as_str(),
-        cmd.parent_sample.as_deref(),
+        Some(cmd.parent_sample.as_str()),
     ) {
         conn.execute("ROLLBACK TRANSACTION;", [])?;
         operation_conn.execute("ROLLBACK TRANSACTION;", [])?;

--- a/src/commands/update/gaf.rs
+++ b/src/commands/update/gaf.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use clap::Args;
+use gen_models::sample::Sample;
 
 use crate::{
     commands::{cli_context::CliContext, get_default_collection},
@@ -16,13 +17,13 @@ pub struct Command {
     #[arg(short, long)]
     name: Option<String>,
     /// The name of the sample to update
-    #[arg(short, long, default_value = "reference")]
+    #[arg(short, long, default_value_t = Sample::DEFAULT_NAME.to_string())]
     sample: String,
     /// The csv describing changes to make
     #[arg(short, long)]
     csv: String,
     /// If specified, the newly created sample will inherit this sample's existing graph
-    #[arg(short, long, default_value = "reference")]
+    #[arg(short, long, default_value_t = Sample::DEFAULT_NAME.to_string())]
     parent_sample: String,
 }
 

--- a/src/commands/update/genbank.rs
+++ b/src/commands/update/genbank.rs
@@ -5,6 +5,7 @@ use clap::Args;
 use gen_models::{
     file_types::FileTypes,
     operations::{OperationFile, OperationInfo},
+    sample::Sample,
 };
 
 use crate::{
@@ -22,7 +23,7 @@ pub struct Command {
     #[arg(short, long)]
     name: Option<String>,
     /// The name of the sample to update
-    #[arg(short, long, default_value = "reference")]
+    #[arg(short, long, default_value_t = Sample::DEFAULT_NAME.to_string())]
     sample: String,
     /// If a new entity is found, create it as a normal import
     #[arg(long, action, alias = "cm")]

--- a/src/commands/update/genbank.rs
+++ b/src/commands/update/genbank.rs
@@ -22,7 +22,7 @@ pub struct Command {
     #[arg(short, long)]
     name: Option<String>,
     /// The name of the sample to update
-    #[arg(short, long)]
+    #[arg(short, long, default_value = "reference")]
     sample: String,
     /// If a new entity is found, create it as a normal import
     #[arg(long, action, alias = "cm")]

--- a/src/commands/update/gfa.rs
+++ b/src/commands/update/gfa.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use clap::Args;
+use gen_models::sample::Sample;
 
 use crate::{
     commands::{cli_context::CliContext, get_default_collection},
@@ -16,7 +17,7 @@ pub struct Command {
     #[arg(short, long)]
     name: Option<String>,
     /// The name of the sample to update
-    #[arg(short, long, default_value = "reference")]
+    #[arg(short, long, default_value_t = Sample::DEFAULT_NAME.to_string())]
     sample: String,
     /// A new sample name to associate with the update
     #[arg(long)]

--- a/src/commands/update/gfa.rs
+++ b/src/commands/update/gfa.rs
@@ -16,7 +16,7 @@ pub struct Command {
     #[arg(short, long)]
     name: Option<String>,
     /// The name of the sample to update
-    #[arg(short, long)]
+    #[arg(short, long, default_value = "reference")]
     sample: String,
     /// A new sample name to associate with the update
     #[arg(long)]

--- a/src/commands/update/library.rs
+++ b/src/commands/update/library.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use clap::Args;
+use gen_models::sample::Sample;
 
 use crate::{
     commands::{cli_context::CliContext, get_default_collection},
@@ -13,7 +14,7 @@ pub struct Command {
     #[arg(short, long)]
     name: Option<String>,
     /// The name of the sample to update
-    #[arg(short, long, default_value = "reference")]
+    #[arg(short, long, default_value_t = Sample::DEFAULT_NAME.to_string())]
     sample: String,
     /// A new sample name to associate with the update
     #[arg(long)]

--- a/src/commands/update/library.rs
+++ b/src/commands/update/library.rs
@@ -13,7 +13,7 @@ pub struct Command {
     #[arg(short, long)]
     name: Option<String>,
     /// The name of the sample to update
-    #[arg(short, long)]
+    #[arg(short, long, default_value = "reference")]
     sample: String,
     /// A new sample name to associate with the update
     #[arg(long)]

--- a/src/commands/update/sequence.rs
+++ b/src/commands/update/sequence.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use clap::Args;
+use gen_models::sample::Sample;
 
 use crate::{
     commands::{cli_context::CliContext, get_default_collection},
@@ -16,7 +17,7 @@ pub struct Command {
     #[arg(short, long)]
     name: Option<String>,
     /// The name of the sample to update
-    #[arg(short, long, default_value = "reference")]
+    #[arg(short, long, default_value_t = Sample::DEFAULT_NAME.to_string())]
     sample: String,
     /// A new sample name to associate with the update
     #[arg(long)]

--- a/src/commands/update/sequence.rs
+++ b/src/commands/update/sequence.rs
@@ -16,7 +16,7 @@ pub struct Command {
     #[arg(short, long)]
     name: Option<String>,
     /// The name of the sample to update
-    #[arg(short, long)]
+    #[arg(short, long, default_value = "reference")]
     sample: String,
     /// A new sample name to associate with the update
     #[arg(long)]

--- a/src/commands/update/vcf.rs
+++ b/src/commands/update/vcf.rs
@@ -23,7 +23,12 @@ pub struct Command {
     #[arg(short, long)]
     sample: Option<String>,
     /// Use the given samples as the parent samples for changes. Repeat the flag or use commas.
-    #[arg(long = "parent-samples", aliases = ["parent-sample", "ps"], value_delimiter = ',')]
+    #[arg(
+        long = "parent-samples",
+        aliases = ["parent-sample", "ps"],
+        value_delimiter = ',',
+        default_value = "reference"
+    )]
     parent_samples: Vec<String>,
     /// Apply edits in-place instead of using parent sample's reference coordinates
     #[arg(long = "inplace")]

--- a/src/commands/update/vcf.rs
+++ b/src/commands/update/vcf.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use clap::Args;
-use gen_models::errors::OperationError;
+use gen_models::{errors::OperationError, sample::Sample};
 
 use crate::{
     commands::{cli_context::CliContext, get_default_collection},
@@ -27,7 +27,7 @@ pub struct Command {
         long = "parent-samples",
         aliases = ["parent-sample", "ps"],
         value_delimiter = ',',
-        default_value = "reference"
+        default_values_t = [Sample::DEFAULT_NAME.to_string()]
     )]
     parent_samples: Vec<String>,
     /// Apply edits in-place instead of using parent sample's reference coordinates

--- a/src/diffs/gfa.rs
+++ b/src/diffs/gfa.rs
@@ -254,7 +254,11 @@ mod tests {
     use tempfile::tempdir;
 
     use super::*;
-    use crate::{imports::gfa::import_gfa, test_helpers::setup_gen, track_database};
+    use crate::{
+        imports::gfa::import_gfa,
+        test_helpers::{create_bg, setup_gen},
+        track_database,
+    };
 
     #[test]
     fn test_gfa_diff() {
@@ -267,7 +271,7 @@ mod tests {
 
         let collection_name = "test collection";
         Collection::create(conn, collection_name);
-        let block_group = BlockGroup::create(
+        let block_group = create_bg(
             conn,
             collection_name,
             Sample::DEFAULT_NAME,
@@ -529,8 +533,7 @@ mod tests {
         let collection_name = "test collection";
         Collection::create(conn, collection_name);
         let _sample = Sample::get_or_create(conn, "test sample");
-        let block_group =
-            BlockGroup::create(conn, collection_name, "test sample", "test block group");
+        let block_group = create_bg(conn, collection_name, "test sample", "test block group");
         let sequence1 = Sequence::new()
             .sequence_type("DNA")
             .sequence("AAAAAAAA")
@@ -628,8 +631,7 @@ mod tests {
         let collection_name = "test collection";
         Collection::create(conn, collection_name);
         let _sample = Sample::get_or_create(conn, "test sample");
-        let block_group =
-            BlockGroup::create(conn, collection_name, "test sample", "test block group");
+        let block_group = create_bg(conn, collection_name, "test sample", "test block group");
         let sequence1 = Sequence::new()
             .sequence_type("DNA")
             .sequence("AAAAAAAA")
@@ -727,7 +729,7 @@ mod tests {
         let collection_name = "test collection";
         Collection::create(conn, collection_name);
         let _sample1 = Sample::get_or_create(conn, "sample1");
-        let block_group = BlockGroup::create(conn, collection_name, "sample1", "test block group");
+        let block_group = create_bg(conn, collection_name, "sample1", "test block group");
         let sequence1 = Sequence::new()
             .sequence_type("DNA")
             .sequence("AAAAAAAA")
@@ -782,8 +784,7 @@ mod tests {
         let _path1 = Path::create(conn, "parent", &block_group.id, &edge_ids);
 
         let _sample2 = Sample::get_or_create(conn, "sample2");
-        let block_group2 =
-            BlockGroup::create(conn, collection_name, "sample2", "test block group 2");
+        let block_group2 = create_bg(conn, collection_name, "sample2", "test block group 2");
         let sequence3 = Sequence::new()
             .sequence_type("DNA")
             .sequence("GGGGGGGG")
@@ -875,7 +876,7 @@ mod tests {
         let collection_name = "test collection";
         Collection::create(conn, collection_name);
         let _sample1 = Sample::get_or_create(conn, "sample1");
-        let block_group = BlockGroup::create(conn, collection_name, "sample1", "test block group");
+        let block_group = create_bg(conn, collection_name, "sample1", "test block group");
         let sequence1 = Sequence::new()
             .sequence_type("DNA")
             .sequence("AAAAAAAA")
@@ -930,7 +931,7 @@ mod tests {
         let _path1 = Path::create(conn, "parent", &block_group.id, &edge_ids);
 
         let _sample2 = Sample::get_or_create(conn, "sample2");
-        let block_group2 = BlockGroup::create(conn, collection_name, "sample2", "test block group");
+        let block_group2 = create_bg(conn, collection_name, "sample2", "test block group");
         let sequence3 = Sequence::new()
             .sequence_type("DNA")
             .sequence("GGGGGGGG")
@@ -1022,7 +1023,7 @@ mod tests {
 
         let collection_name = "test collection";
         Collection::create(conn, collection_name);
-        let block_group = BlockGroup::create(
+        let block_group = create_bg(
             conn,
             collection_name,
             Sample::DEFAULT_NAME,

--- a/src/exports/genbank.rs
+++ b/src/exports/genbank.rs
@@ -1,7 +1,7 @@
 #![allow(warnings)]
-use std::{collections::HashSet, fs::File, hash::Hash, iter::zip, path::PathBuf, str};
+use std::{borrow::Cow, collections::HashSet, fs::File, hash::Hash, iter::zip, path::PathBuf, str};
 
-use gb_io::{self, QualifierKey, seq::Location};
+use gb_io::{self, seq::Location};
 use gen_core::{is_terminal, path::PathBlock};
 use gen_graph::{GenGraph, GraphEdge, GraphNode, all_simple_paths};
 use gen_models::{block_group::BlockGroup, db::GraphConnection, node::Node, sample::Sample};
@@ -228,10 +228,10 @@ pub fn export_genbank(
                                     .splice(upos..upos, sequence.into_bytes())
                                     .collect::<Vec<_>>();
                                 qualifiers.push((
-                                    QualifierKey::from("note"),
+                                    Cow::Borrowed("note"),
                                     Some("Geneious type: Editing History Insertion".to_string()),
                                 ));
-                                qualifiers.push((QualifierKey::from("Original_Bases"), None));
+                                qualifiers.push((Cow::Borrowed("Original_Bases"), None));
                             } else {
                                 let end_pos = upos + next_node.length() as usize;
                                 offset += sequence.len() as i64 - next_node.length();
@@ -240,11 +240,11 @@ pub fn export_genbank(
                                     .splice(upos..end_pos, sequence.into_bytes())
                                     .collect::<Vec<u8>>();
                                 qualifiers.push((
-                                    QualifierKey::from("note"),
+                                    Cow::Borrowed("note"),
                                     Some("Geneious type: Editing History Replacement".to_string()),
                                 ));
                                 qualifiers.push((
-                                    QualifierKey::from("Original_Bases"),
+                                    Cow::Borrowed("Original_Bases"),
                                     Some(str::from_utf8(&original_bases).unwrap().to_string()),
                                 ));
                             }
@@ -271,17 +271,17 @@ pub fn export_genbank(
                             .unwrap();
                         location = Some(Location::Between(ls - 1, le - 1));
                         qualifiers.push((
-                            QualifierKey::from("note"),
+                            Cow::Borrowed("note"),
                             Some("Geneious type: Editing History Deletion".to_string()),
                         ));
                         qualifiers.push((
-                            QualifierKey::from("Original_Bases"),
+                            Cow::Borrowed("Original_Bases"),
                             Some(str::from_utf8(&original_bases).unwrap().to_string()),
                         ));
                     }
                     if let Some(l) = location {
                         seq.features.push(gb_io::seq::Feature {
-                            kind: gb_io::seq::FeatureKind::from("misc_feature"),
+                            kind: Cow::Borrowed("misc_feature"),
                             location: l,
                             qualifiers,
                         });

--- a/src/exports/gfa.rs
+++ b/src/exports/gfa.rs
@@ -318,9 +318,12 @@ mod tests {
         Collection::create(conn, collection_name);
         let block_group = BlockGroup::create(
             conn,
-            collection_name,
-            Sample::DEFAULT_NAME,
-            "test block group",
+            gen_models::block_group::NewBlockGroup {
+                collection_name,
+                sample_name: Sample::DEFAULT_NAME,
+                name: "test block group",
+                ..Default::default()
+            },
         );
         let sequence1 = Sequence::new()
             .sequence_type("DNA")
@@ -473,8 +476,8 @@ mod tests {
         assert!(matches!(
             result,
             Err(GfaExportError::MissingBlockGroups {
-                collection_name,
-                sample_name,
+                collection_name: _,
+                sample_name: _,
             })
         ));
     }
@@ -544,7 +547,7 @@ mod tests {
 
         let _ = import_gfa(&context, &gfa_path, &collection_name, Sample::DEFAULT_NAME);
 
-        let block_group_id = BlockGroup::get_id(&collection_name, Sample::DEFAULT_NAME, "");
+        let block_group_id = BlockGroup::get_id(&collection_name, Sample::DEFAULT_NAME, "", None);
         let all_sequences = BlockGroup::get_all_sequences(conn, &block_group_id, false);
 
         let temp_dir = tempdir().expect("Couldn't get handle to temp directory");
@@ -587,7 +590,7 @@ mod tests {
 
         let _ = import_gfa(&context, &gfa_path, &collection_name, Sample::DEFAULT_NAME);
 
-        let block_group_id = BlockGroup::get_id(&collection_name, Sample::DEFAULT_NAME, "");
+        let block_group_id = BlockGroup::get_id(&collection_name, Sample::DEFAULT_NAME, "", None);
         let all_sequences = BlockGroup::get_all_sequences(conn, &block_group_id, false);
 
         let temp_dir = tempdir().expect("Couldn't get handle to temp directory");
@@ -630,7 +633,7 @@ mod tests {
 
         let _ = import_gfa(&context, &gfa_path, &collection_name, Sample::DEFAULT_NAME);
 
-        let block_group_id = BlockGroup::get_id(&collection_name, Sample::DEFAULT_NAME, "");
+        let block_group_id = BlockGroup::get_id(&collection_name, Sample::DEFAULT_NAME, "", None);
         let all_sequences = BlockGroup::get_all_sequences(conn, &block_group_id, false);
 
         let temp_dir = tempdir().expect("Couldn't get handle to temp directory");

--- a/src/graphs/combinatorial_library.rs
+++ b/src/graphs/combinatorial_library.rs
@@ -278,7 +278,10 @@ pub fn create_library(
 
 #[cfg(test)]
 mod tests {
-    use gen_models::{block_group::BlockGroup, sample::Sample};
+    use gen_models::{
+        block_group::{BlockGroup, NewBlockGroup},
+        sample::Sample,
+    };
 
     use super::*;
     use crate::{test_helpers::setup_gen, track_database};
@@ -293,7 +296,15 @@ mod tests {
         let collection = "test";
         let sample_name = "test-sample";
         let _sample = Sample::get_or_create(conn, sample_name);
-        let block_group = BlockGroup::create(conn, collection, sample_name, "test-block-group");
+        let block_group = BlockGroup::create(
+            conn,
+            NewBlockGroup {
+                collection_name: collection,
+                sample_name,
+                name: "test-block-group",
+                ..Default::default()
+            },
+        );
 
         match create_library(conn, block_group.id, "library", vec![], false) {
             Ok(_) => {

--- a/src/graphs/operators.rs
+++ b/src/graphs/operators.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 
 use gen_core::{HashId, PATH_END_NODE_ID, PATH_START_NODE_ID, Strand, is_end_node, is_start_node};
 use gen_models::{
-    block_group::BlockGroup,
+    block_group::{BlockGroup, NewBlockGroup},
     block_group_edge::{BlockGroupEdge, BlockGroupEdgeData},
     db::{DbContext, GraphConnection},
     edge::Edge,
@@ -107,9 +107,13 @@ pub fn derive_chunks(
 
             let child_block_group = BlockGroup::create(
                 conn,
-                collection_name,
-                new_sample_name,
-                child_block_group_name.as_str(),
+                NewBlockGroup {
+                    collection_name,
+                    sample_name: new_sample_name,
+                    name: child_block_group_name.as_str(),
+                    parent_block_group_id: Some(&parent_block_group_id),
+                    ..Default::default()
+                },
             );
             child_block_group.id
         };
@@ -303,8 +307,15 @@ pub fn make_stitch(
 
     let _new_sample = Sample::get_or_create(conn, new_sample_name);
 
-    let child_block_group =
-        BlockGroup::create(conn, collection_name, new_sample_name, new_region_name);
+    let child_block_group = BlockGroup::create(
+        conn,
+        NewBlockGroup {
+            collection_name,
+            sample_name: new_sample_name,
+            name: new_region_name,
+            ..Default::default()
+        },
+    );
 
     let mut block_group_chunks = vec![];
 

--- a/src/imports/fasta.rs
+++ b/src/imports/fasta.rs
@@ -8,7 +8,7 @@ use std::{
 use flate2::read::MultiGzDecoder;
 use gen_core::{HashId, PATH_END_NODE_ID, PATH_START_NODE_ID, Strand};
 use gen_models::{
-    block_group::BlockGroup,
+    block_group::{BlockGroup, NewBlockGroup},
     block_group_edge::{BlockGroupEdge, BlockGroupEdgeData},
     collection::Collection,
     db::DbContext,
@@ -91,7 +91,15 @@ pub fn import_fasta(
                 hash = seq.hash
             )),
         );
-        let block_group = BlockGroup::create(conn, &collection.name, sample, &name);
+        let block_group = BlockGroup::create(
+            conn,
+            NewBlockGroup {
+                collection_name: &collection.name,
+                sample_name: sample,
+                name: &name,
+                ..Default::default()
+            },
+        );
         let edge_into = Edge::create(
             conn,
             PATH_START_NODE_ID,
@@ -189,7 +197,7 @@ mod tests {
             false,
         )
         .unwrap();
-        let block_group_id = BlockGroup::get_id("test", Sample::DEFAULT_NAME, "m123");
+        let block_group_id = BlockGroup::get_id("test", Sample::DEFAULT_NAME, "m123", None);
         assert_eq!(
             BlockGroup::get_all_sequences(conn, &block_group_id, false),
             HashSet::from_iter(vec!["ATCGATCGATCGATCGATCGGGAACACACAGAGA".to_string()])
@@ -220,7 +228,7 @@ mod tests {
             false,
         )
         .unwrap();
-        let block_group_id = BlockGroup::get_id("test", Sample::DEFAULT_NAME, "m123");
+        let block_group_id = BlockGroup::get_id("test", Sample::DEFAULT_NAME, "m123", None);
         assert_eq!(
             BlockGroup::get_all_sequences(conn, &block_group_id, false),
             HashSet::from_iter(vec!["ATCGATCGATCGATCGATCGGGAACACACAGAGA".to_string()])
@@ -244,7 +252,7 @@ mod tests {
             false,
         )
         .unwrap();
-        let block_group_id = BlockGroup::get_id("test", Sample::DEFAULT_NAME, "chr22");
+        let block_group_id = BlockGroup::get_id("test", Sample::DEFAULT_NAME, "chr22", None);
         let sequences = Sequence::query_by_blockgroup(conn, &block_group_id);
         let dna = sequences
             .iter()
@@ -271,7 +279,7 @@ mod tests {
             false,
         )
         .unwrap();
-        let block_group_id = BlockGroup::get_id("test", Sample::DEFAULT_NAME, "m123");
+        let block_group_id = BlockGroup::get_id("test", Sample::DEFAULT_NAME, "m123", None);
         assert_eq!(
             BlockGroup::get_all_sequences(conn, &block_group_id, false),
             HashSet::from_iter(vec!["ATCGATCGATCGATCGATCGGGAACACACAGAGA".to_string()])
@@ -296,7 +304,7 @@ mod tests {
             false,
         )
         .unwrap();
-        let block_group_id = BlockGroup::get_id("test", "new-sample", "m123");
+        let block_group_id = BlockGroup::get_id("test", "new-sample", "m123", None);
         assert_eq!(
             BlockGroup::get_all_sequences(conn, &block_group_id, false),
             HashSet::from_iter(vec!["ATCGATCGATCGATCGATCGGGAACACACAGAGA".to_string()])
@@ -331,7 +339,7 @@ mod tests {
             true,
         )
         .unwrap();
-        let block_group_id = BlockGroup::get_id("test", Sample::DEFAULT_NAME, "m123");
+        let block_group_id = BlockGroup::get_id("test", Sample::DEFAULT_NAME, "m123", None);
         assert_eq!(
             BlockGroup::get_all_sequences(conn, &block_group_id, false),
             HashSet::from_iter(vec!["ATCGATCGATCGATCGATCGGGAACACACAGAGA".to_string()])

--- a/src/imports/genbank.rs
+++ b/src/imports/genbank.rs
@@ -3,7 +3,7 @@ use std::{io::Read, str};
 use gb_io::reader;
 use gen_core::{HashId, PATH_END_NODE_ID, PATH_START_NODE_ID, PathBlock, Strand};
 use gen_models::{
-    block_group::{BlockGroup, PathChange},
+    block_group::{BlockGroup, NewBlockGroup, PathChange},
     block_group_edge::{BlockGroupEdge, BlockGroupEdgeData},
     collection::Collection,
     db::DbContext,
@@ -65,7 +65,15 @@ where
                     )),
                 );
 
-                let block_group = BlockGroup::create(conn, &collection.name, sample, &locus.name);
+                let block_group = BlockGroup::create(
+                    conn,
+                    NewBlockGroup {
+                        collection_name: &collection.name,
+                        sample_name: sample,
+                        name: &locus.name,
+                        ..Default::default()
+                    },
+                );
                 let edge_into = Edge::create(
                     conn,
                     PATH_START_NODE_ID,
@@ -342,7 +350,7 @@ mod tests {
             );
             let f = reader::parse_file(&path).unwrap();
             let seq = str::from_utf8(&f[0].seq).unwrap().to_string();
-            let block_group_id = BlockGroup::get_id("", Sample::DEFAULT_NAME, "insertion");
+            let block_group_id = BlockGroup::get_id("", Sample::DEFAULT_NAME, "insertion", None);
             let seqs = BlockGroup::get_all_sequences(conn, &block_group_id, false);
             assert_eq!(
                 seqs,
@@ -393,7 +401,7 @@ mod tests {
         GCTGAACGGTCTGGTTATAGGTACATTGAGCAACTGACTGAAATGCCTCAAAATGTTCTTTAC
         GATGCCATTGGGATATATCAACGGTGGTATATCCAGTGATTTTTTTCTCCAT",
             );
-            let block_group_id = BlockGroup::get_id("", Sample::DEFAULT_NAME, "deletion");
+            let block_group_id = BlockGroup::get_id("", Sample::DEFAULT_NAME, "deletion", None);
             let seqs = BlockGroup::get_all_sequences(conn, &block_group_id, false);
             assert_eq!(
                 seqs,
@@ -451,7 +459,7 @@ mod tests {
             );
             let seqs = BlockGroup::get_all_sequences(
                 conn,
-                &BlockGroup::get_id("", Sample::DEFAULT_NAME, "deletion_and_insertion"),
+                &BlockGroup::get_id("", Sample::DEFAULT_NAME, "deletion_and_insertion", None),
                 false,
             );
             assert_eq!(
@@ -512,7 +520,7 @@ mod tests {
             );
             let seqs = BlockGroup::get_all_sequences(
                 conn,
-                &BlockGroup::get_id("", Sample::DEFAULT_NAME, "substitution"),
+                &BlockGroup::get_id("", Sample::DEFAULT_NAME, "substitution", None),
                 false,
             );
             assert_eq!(
@@ -558,7 +566,7 @@ mod tests {
             let mod_seq = str::from_utf8(&f[0].seq).unwrap().to_string();
             let sequences: HashSet<String> = BlockGroup::get_all_sequences(
                 conn,
-                &BlockGroup::get_id("", Sample::DEFAULT_NAME, "insertion"),
+                &BlockGroup::get_id("", Sample::DEFAULT_NAME, "insertion", None),
                 false,
             )
             .iter()

--- a/src/imports/gfa.rs
+++ b/src/imports/gfa.rs
@@ -6,7 +6,7 @@ use gen_core::{
 };
 use gen_graph::{GraphEdge, GraphNode};
 use gen_models::{
-    block_group::BlockGroup,
+    block_group::{BlockGroup, NewBlockGroup},
     block_group_edge::{BlockGroupEdge, BlockGroupEdgeData},
     collection::Collection,
     db::DbContext,
@@ -49,7 +49,15 @@ pub fn import_gfa(
     let mut session = start_operation(conn);
     Collection::create(conn, collection_name);
     Sample::get_or_create(conn, sample_name);
-    let block_group = BlockGroup::create(conn, collection_name, sample_name, "");
+    let block_group = BlockGroup::create(
+        conn,
+        NewBlockGroup {
+            collection_name,
+            sample_name,
+            name: "",
+            ..Default::default()
+        },
+    );
     let bar = progress_bar.add(get_time_elapsed_bar());
     bar.set_message("Parsing GFA");
     let gfa: Gfa<String, (), ()> = Gfa::parse_gfa_file(gfa_path.to_str().unwrap());
@@ -471,7 +479,7 @@ mod tests {
         track_database(conn, context.operations().conn()).unwrap();
         let _ = import_gfa(&context, &gfa_path, &collection_name, Sample::DEFAULT_NAME);
 
-        let block_group_id = BlockGroup::get_id(&collection_name, Sample::DEFAULT_NAME, "");
+        let block_group_id = BlockGroup::get_id(&collection_name, Sample::DEFAULT_NAME, "", None);
         let path = Path::query(
             conn,
             "select * from paths where block_group_id = ?1 AND name = ?2",
@@ -513,7 +521,7 @@ mod tests {
         track_database(conn, context.operations().conn()).unwrap();
         let _ = import_gfa(&context, &gfa_path, &collection_name, Sample::DEFAULT_NAME);
 
-        let block_group_id = BlockGroup::get_id(&collection_name, Sample::DEFAULT_NAME, "");
+        let block_group_id = BlockGroup::get_id(&collection_name, Sample::DEFAULT_NAME, "", None);
         let all_sequences = BlockGroup::get_all_sequences(conn, &block_group_id, false);
         assert_eq!(
             all_sequences,
@@ -535,7 +543,7 @@ mod tests {
         track_database(conn, context.operations().conn()).unwrap();
         let _ = import_gfa(&context, &gfa_path, &collection_name, Sample::DEFAULT_NAME);
 
-        let block_group_id = BlockGroup::get_id(&collection_name, Sample::DEFAULT_NAME, "");
+        let block_group_id = BlockGroup::get_id(&collection_name, Sample::DEFAULT_NAME, "", None);
         let path = Path::query(
             conn,
             "select * from paths where block_group_id = ?1 AND name = ?2",
@@ -561,7 +569,7 @@ mod tests {
         track_database(conn, context.operations().conn()).unwrap();
         let _ = import_gfa(&context, &gfa_path, &collection_name, Sample::DEFAULT_NAME);
 
-        let block_group_id = BlockGroup::get_id(&collection_name, Sample::DEFAULT_NAME, "");
+        let block_group_id = BlockGroup::get_id(&collection_name, Sample::DEFAULT_NAME, "", None);
         let path = Path::query(
             conn,
             "select * from paths where block_group_id = ?1 AND name = ?2",
@@ -591,7 +599,7 @@ mod tests {
         let paths = Path::query_for_collection(conn, &collection_name);
         assert_eq!(paths.len(), 20);
 
-        let block_group_id = BlockGroup::get_id(&collection_name, Sample::DEFAULT_NAME, "");
+        let block_group_id = BlockGroup::get_id(&collection_name, Sample::DEFAULT_NAME, "", None);
         let path = Path::query(
             conn,
             "select * from paths where block_group_id = ?1 AND name = ?2",
@@ -694,7 +702,7 @@ mod tests {
         track_database(conn, op_conn).unwrap();
         let _ = import_gfa(&context, &gfa_path, &collection_name, Sample::DEFAULT_NAME);
 
-        let block_group_id = BlockGroup::get_id(&collection_name, Sample::DEFAULT_NAME, "");
+        let block_group_id = BlockGroup::get_id(&collection_name, Sample::DEFAULT_NAME, "", None);
         let path = Path::query(
             conn,
             "select * from paths where block_group_id = ?1 AND name = ?2",
@@ -724,7 +732,7 @@ mod tests {
         track_database(conn, op_conn).unwrap();
         let _ = import_gfa(&context, &gfa_path, &collection_name, Sample::DEFAULT_NAME);
 
-        let block_group_id = BlockGroup::get_id(&collection_name, Sample::DEFAULT_NAME, "");
+        let block_group_id = BlockGroup::get_id(&collection_name, Sample::DEFAULT_NAME, "", None);
 
         let all_sequences = BlockGroup::get_all_sequences(conn, &block_group_id, false);
         assert_eq!(
@@ -747,7 +755,7 @@ mod tests {
         track_database(conn, op_conn).unwrap();
         let _ = import_gfa(&context, &gfa_path, &collection_name, Sample::DEFAULT_NAME);
 
-        let block_group_id = BlockGroup::get_id(&collection_name, Sample::DEFAULT_NAME, "");
+        let block_group_id = BlockGroup::get_id(&collection_name, Sample::DEFAULT_NAME, "", None);
 
         let all_sequences = BlockGroup::get_all_sequences(conn, &block_group_id, false);
         assert_eq!(

--- a/src/imports/library.rs
+++ b/src/imports/library.rs
@@ -2,7 +2,7 @@ use std::str;
 
 use anyhow::Result;
 use gen_models::{
-    block_group::BlockGroup,
+    block_group::{BlockGroup, NewBlockGroup},
     collection::Collection,
     db::DbContext,
     errors::OperationError,
@@ -59,7 +59,15 @@ pub fn import_library(
     }
 
     Sample::get_or_create(conn, sample);
-    let new_block_group = BlockGroup::create(conn, collection_name, sample, library_name);
+    let new_block_group = BlockGroup::create(
+        conn,
+        NewBlockGroup {
+            collection_name,
+            sample_name: sample,
+            name: library_name,
+            ..Default::default()
+        },
+    );
 
     let parts_list = parse_library(parts_file_path, library_file_path)?;
     let _block_group_boundaries =

--- a/src/operation_management.rs
+++ b/src/operation_management.rs
@@ -1818,7 +1818,8 @@ mod tests {
         )
         .unwrap();
 
-        let foo_bg_id = BlockGroup::get_id(&collection, "foo", "m123", None);
+        let default_bg = BlockGroup::get_id(&collection, Sample::DEFAULT_NAME, "m123", None);
+        let foo_bg_id = BlockGroup::get_id(&collection, "foo", "m123", Some(&default_bg));
         let patch_1_seqs =
             HashSet::from_iter(vec!["ATCATCGATCGATCGATCGGGAACACACAGAGA".to_string()]);
 
@@ -1850,7 +1851,7 @@ mod tests {
             false,
         );
 
-        let foo_bg_id = BlockGroup::get_id(&collection, "foo", "m123", None);
+        let foo_bg_id = BlockGroup::get_id(&collection, "foo", "m123", Some(&default_bg));
         let patch_2_seqs = HashSet::from_iter(vec!["ATCGATCGATCGAGATCGGGAACACACAGAGA".to_string()]);
         assert_eq!(
             BlockGroup::get_all_sequences(conn, &foo_bg_id, false),
@@ -1868,7 +1869,7 @@ mod tests {
         // apply changes from branch-1, it will be operation id 2
         apply(&context, &op_2.hash, None, false).unwrap();
 
-        let foo_bg_id = BlockGroup::get_id(&collection, "foo", "m123", None);
+        let foo_bg_id = BlockGroup::get_id(&collection, "foo", "m123", Some(&default_bg));
         let patch_2_seqs = HashSet::from_iter(vec!["ATCATCGATCGAGATCGGGAACACACAGAGA".to_string()]);
         assert_eq!(
             BlockGroup::get_all_sequences(conn, &foo_bg_id, false),
@@ -1887,7 +1888,7 @@ mod tests {
             ])
         );
 
-        let unknown_bg_id = BlockGroup::get_id(&collection, "unknown", "m123", None);
+        let unknown_bg_id = BlockGroup::get_id(&collection, "unknown", "m123", Some(&default_bg));
         let unknown_seqs =
             HashSet::from_iter(vec!["ATCATCGATAGACGATCGATCGGGAACACACAGAGA".to_string()]);
         assert_eq!(

--- a/src/operation_management.rs
+++ b/src/operation_management.rs
@@ -1818,7 +1818,7 @@ mod tests {
         )
         .unwrap();
 
-        let foo_bg_id = BlockGroup::get_id(&collection, "foo", "m123");
+        let foo_bg_id = BlockGroup::get_id(&collection, "foo", "m123", None);
         let patch_1_seqs =
             HashSet::from_iter(vec!["ATCATCGATCGATCGATCGGGAACACACAGAGA".to_string()]);
 
@@ -1850,7 +1850,7 @@ mod tests {
             false,
         );
 
-        let foo_bg_id = BlockGroup::get_id(&collection, "foo", "m123");
+        let foo_bg_id = BlockGroup::get_id(&collection, "foo", "m123", None);
         let patch_2_seqs = HashSet::from_iter(vec!["ATCGATCGATCGAGATCGGGAACACACAGAGA".to_string()]);
         assert_eq!(
             BlockGroup::get_all_sequences(conn, &foo_bg_id, false),
@@ -1868,7 +1868,7 @@ mod tests {
         // apply changes from branch-1, it will be operation id 2
         apply(&context, &op_2.hash, None, false).unwrap();
 
-        let foo_bg_id = BlockGroup::get_id(&collection, "foo", "m123");
+        let foo_bg_id = BlockGroup::get_id(&collection, "foo", "m123", None);
         let patch_2_seqs = HashSet::from_iter(vec!["ATCATCGATCGAGATCGGGAACACACAGAGA".to_string()]);
         assert_eq!(
             BlockGroup::get_all_sequences(conn, &foo_bg_id, false),
@@ -1887,7 +1887,7 @@ mod tests {
             ])
         );
 
-        let unknown_bg_id = BlockGroup::get_id(&collection, "unknown", "m123");
+        let unknown_bg_id = BlockGroup::get_id(&collection, "unknown", "m123", None);
         let unknown_seqs =
             HashSet::from_iter(vec!["ATCATCGATAGACGATCGATCGGGAACACACAGAGA".to_string()]);
         assert_eq!(

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -6,7 +6,7 @@ use gen_core::{
 };
 use gen_graph::GenGraph;
 use gen_models::{
-    block_group::BlockGroup,
+    block_group::{BlockGroup, NewBlockGroup},
     block_group_edge::{BlockGroupEdge, BlockGroupEdgeData},
     collection::Collection,
     db::{DbContext, GraphConnection, OperationsConnection},
@@ -20,6 +20,23 @@ use gen_models::{
     sequence::Sequence,
     session_operations::{end_operation, start_operation},
 };
+
+pub fn create_bg(
+    conn: &GraphConnection,
+    collection_name: &str,
+    sample_name: &str,
+    name: &str,
+) -> BlockGroup {
+    BlockGroup::create(
+        conn,
+        NewBlockGroup {
+            collection_name,
+            sample_name,
+            name,
+            ..Default::default()
+        },
+    )
+}
 use intervaltree::IntervalTree;
 use rusqlite::Connection;
 use tempfile::tempdir;
@@ -127,7 +144,7 @@ pub fn setup_block_group(conn: &GraphConnection) -> (HashId, Path) {
     );
     let _collection = Collection::create(conn, "test");
     Sample::get_or_create(conn, "test");
-    let block_group = BlockGroup::create(conn, "test", "test", "chr1");
+    let block_group = create_bg(conn, "test", "test", "chr1");
     let edge0 = Edge::create(
         conn,
         PATH_START_NODE_ID,

--- a/src/updates/fasta.rs
+++ b/src/updates/fasta.rs
@@ -37,9 +37,9 @@ pub fn update_with_fasta(
     let _new_sample = Sample::get_or_create(conn, new_sample_name);
     let block_groups = Sample::get_block_groups(conn, collection_name, parent_sample_name);
 
-    let mut found_bg_id = None;
+    let mut target_block_groups = vec![];
     for block_group in block_groups {
-        let new_bg_id = BlockGroup::get_or_create_sample_block_group(
+        let new_block_groups = BlockGroup::get_or_create_sample_block_groups(
             conn,
             collection_name,
             new_sample_name,
@@ -48,138 +48,149 @@ pub fn update_with_fasta(
         )?;
 
         if block_group.name == region_name {
-            found_bg_id = Some(new_bg_id);
+            target_block_groups = new_block_groups;
         }
     }
 
-    let new_block_group_id = if let Some(x) = found_bg_id {
-        x
-    } else {
+    if target_block_groups.is_empty() {
         panic!("No region found with name: {region_name}");
-    };
+    }
 
-    let path = BlockGroup::get_current_path(conn, &new_block_group_id);
-    let interval_tree = path.intervaltree(conn);
+    struct TargetBlockGroupState {
+        block_group_id: HashId,
+        path: gen_models::path::Path,
+        interval_tree: intervaltree::IntervalTree<i64, gen_core::NodeIntervalBlock>,
+        first_node: Option<HashId>,
+    }
 
-    // Assuming just one entry in the fasta file
-    let mut first_node = None;
+    let mut target_states = target_block_groups
+        .iter()
+        .map(|target_block_group| {
+            let path = BlockGroup::get_current_path(conn, &target_block_group.id);
+            let interval_tree = path.intervaltree(conn);
+            TargetBlockGroupState {
+                block_group_id: target_block_group.id,
+                path,
+                interval_tree,
+                first_node: None,
+            }
+        })
+        .collect::<Vec<_>>();
+
     let mut change_count = 0;
     for (index, result) in fasta_reader.records().enumerate() {
         let record = result?;
+        let sequence = str::from_utf8(record.sequence().as_ref()).unwrap();
 
-        let sequence = str::from_utf8(record.sequence().as_ref())
-            .unwrap()
-            .to_string();
-        if sequence.is_empty() {
-            // We assume this is a deletion.
-            let node_id = HashId::convert_str("");
-            // This path block represents a deletion, so will not actually be
-            // used to create a new node.  So the node ID can be anything, which
-            // is why we're setting it to the HashId of the empty string.  The
-            // important part is that sequence_start == sequence_end (the 0
-            // values for them are arbitrary), which flags that it's a deletion
-            // to the logic in BlockGroup::insert_change.
-            let path_block = PathBlock {
-                node_id,
-                block_sequence: sequence,
-                sequence_start: 0,
-                sequence_end: 0,
-                path_start: start_coordinate,
-                path_end: end_coordinate,
-                strand: Strand::Forward,
-            };
+        for state in &mut target_states {
+            if sequence.is_empty() {
+                let node_id = HashId::convert_str("");
+                let path_block = PathBlock {
+                    node_id,
+                    block_sequence: sequence.to_string(),
+                    sequence_start: 0,
+                    sequence_end: 0,
+                    path_start: start_coordinate,
+                    path_end: end_coordinate,
+                    strand: Strand::Forward,
+                };
 
-            let path_change = PathChange {
-                block_group_id: new_block_group_id,
-                path: path.clone(),
-                path_accession: None,
-                start: start_coordinate,
-                end: end_coordinate,
-                block: path_block,
-                chromosome_index: NO_CHROMOSOME_INDEX,
-                phased: 0,
-                preserve_edge: true,
-            };
+                let path_change = PathChange {
+                    block_group_id: state.block_group_id,
+                    path: state.path.clone(),
+                    path_accession: None,
+                    start: start_coordinate,
+                    end: end_coordinate,
+                    block: path_block,
+                    chromosome_index: NO_CHROMOSOME_INDEX,
+                    phased: 0,
+                    preserve_edge: true,
+                };
 
-            BlockGroup::insert_change(conn, &path_change, &interval_tree).unwrap();
-            if index == 0 {
-                first_node = Some(node_id);
-            } else if first_node.is_some() {
-                first_node = None;
+                BlockGroup::insert_change(conn, &path_change, &state.interval_tree).unwrap();
+                if index == 0 {
+                    state.first_node = Some(node_id);
+                } else if state.first_node.is_some() {
+                    state.first_node = None;
+                }
+            } else {
+                let seq = Sequence::new()
+                    .sequence_type("DNA")
+                    .sequence(sequence)
+                    .save(conn);
+                let node_id = Node::create(
+                    conn,
+                    &seq.hash,
+                    &HashId::convert_str(&format!(
+                        "{path_id}:{ref_start}-{ref_end}->{sequence_hash}",
+                        path_id = state.path.id,
+                        ref_start = 0,
+                        ref_end = seq.length,
+                        sequence_hash = seq.hash
+                    )),
+                );
+
+                let path_block = PathBlock {
+                    node_id,
+                    block_sequence: sequence.to_string(),
+                    sequence_start: 0,
+                    sequence_end: seq.length,
+                    path_start: start_coordinate,
+                    path_end: end_coordinate,
+                    strand: Strand::Forward,
+                };
+
+                let path_change = PathChange {
+                    block_group_id: state.block_group_id,
+                    path: state.path.clone(),
+                    path_accession: None,
+                    start: start_coordinate,
+                    end: end_coordinate,
+                    block: path_block,
+                    chromosome_index: NO_CHROMOSOME_INDEX,
+                    phased: 0,
+                    preserve_edge: true,
+                };
+
+                BlockGroup::insert_change(conn, &path_change, &state.interval_tree).unwrap();
+                if index == 0 {
+                    state.first_node = Some(node_id);
+                } else if state.first_node.is_some() {
+                    state.first_node = None;
+                }
             }
-        } else {
-            let seq = Sequence::new()
-                .sequence_type("DNA")
-                .sequence(&sequence)
-                .save(conn);
-            let node_id = Node::create(
-                conn,
-                &seq.hash,
-                &HashId::convert_str(&format!(
-                    "{path_id}:{ref_start}-{ref_end}->{sequence_hash}",
-                    path_id = path.id,
-                    ref_start = 0,
-                    ref_end = seq.length,
-                    sequence_hash = seq.hash
-                )),
-            );
 
-            let path_block = PathBlock {
-                node_id,
-                block_sequence: sequence,
-                sequence_start: 0,
-                sequence_end: seq.length,
-                path_start: start_coordinate,
-                path_end: end_coordinate,
-                strand: Strand::Forward,
-            };
-
-            let path_change = PathChange {
-                block_group_id: new_block_group_id,
-                path: path.clone(),
-                path_accession: None,
-                start: start_coordinate,
-                end: end_coordinate,
-                block: path_block,
-                chromosome_index: NO_CHROMOSOME_INDEX,
-                phased: 0,
-                preserve_edge: true,
-            };
-
-            BlockGroup::insert_change(conn, &path_change, &interval_tree).unwrap();
-            if index == 0 {
-                first_node = Some(node_id);
-            } else if first_node.is_some() {
-                first_node = None;
-            }
+            change_count += 1;
         }
-
-        change_count += 1;
     }
 
-    if !disable_reference_path_update && let Some(node_id) = first_node {
-        if node_id == HashId::convert_str("") {
-            let _ = path.new_path_with_deletion(conn, start_coordinate, end_coordinate);
-        } else {
-            let edge_to_new_node = Edge::query(
-                conn,
-                "select * from edges where target_node_id = ?1",
-                rusqlite::params![node_id],
-            )[0]
-            .clone();
-            let edge_from_new_node = Edge::query(
-                conn,
-                "select * from edges where source_node_id = ?1",
-                rusqlite::params!(SQLValue::from(node_id)),
-            )[0]
-            .clone();
-            path.new_path_with(
-                conn,
-                start_coordinate,
-                end_coordinate,
-                &edge_to_new_node,
-                &edge_from_new_node,
-            );
+    for state in target_states {
+        if !disable_reference_path_update && let Some(node_id) = state.first_node {
+            if node_id == HashId::convert_str("") {
+                let _ = state
+                    .path
+                    .new_path_with_deletion(conn, start_coordinate, end_coordinate);
+            } else {
+                let edge_to_new_node = Edge::query(
+                    conn,
+                    "select * from edges where target_node_id = ?1",
+                    rusqlite::params![node_id],
+                )[0]
+                .clone();
+                let edge_from_new_node = Edge::query(
+                    conn,
+                    "select * from edges where source_node_id = ?1",
+                    rusqlite::params!(SQLValue::from(node_id)),
+                )[0]
+                .clone();
+                state.path.new_path_with(
+                    conn,
+                    start_coordinate,
+                    end_coordinate,
+                    &edge_to_new_node,
+                    &edge_from_new_node,
+                );
+            }
         }
     }
 

--- a/src/updates/genbank.rs
+++ b/src/updates/genbank.rs
@@ -3,7 +3,7 @@ use std::{io::Read, str};
 use gb_io::reader;
 use gen_core::{HashId, PATH_END_NODE_ID, PATH_START_NODE_ID, PathBlock, Strand};
 use gen_models::{
-    block_group::{BlockGroup, PathChange},
+    block_group::{BlockGroup, NewBlockGroup, PathChange},
     block_group_edge::{BlockGroupEdge, BlockGroupEdgeData},
     collection::Collection,
     db::DbContext,
@@ -76,7 +76,15 @@ where
                             contig = &locus.name
                         )));
                     }
-                    BlockGroup::create(conn, &collection.name, sample_name, &locus.name)
+                    BlockGroup::create(
+                        conn,
+                        NewBlockGroup {
+                            collection_name: &collection.name,
+                            sample_name,
+                            name: &locus.name,
+                            ..Default::default()
+                        },
+                    )
                 };
                 let paths = Path::query(
                     conn,
@@ -353,7 +361,7 @@ mod tests {
 
             let f = reader::parse_file(&path).unwrap();
             let mod_seq = str::from_utf8(&f[0].seq).unwrap().to_string();
-            let block_group_id = BlockGroup::get_id("", Sample::DEFAULT_NAME, "insertion");
+            let block_group_id = BlockGroup::get_id("", Sample::DEFAULT_NAME, "insertion", None);
             let sequences: HashSet<String> =
                 BlockGroup::get_all_sequences(conn, &block_group_id, false)
                     .iter()
@@ -409,7 +417,7 @@ mod tests {
             );
 
             let f = reader::parse_file(&path).unwrap();
-            let block_group_id = BlockGroup::get_id("", Sample::DEFAULT_NAME, "insertion");
+            let block_group_id = BlockGroup::get_id("", Sample::DEFAULT_NAME, "insertion", None);
             let sequences: HashSet<String> =
                 BlockGroup::get_all_sequences(conn, &block_group_id, false)
                     .iter()
@@ -422,7 +430,7 @@ mod tests {
 
             // we have a new blockgroup called deletion that uses the same base sequence but
             // has a deletion in it.
-            let block_group_id = BlockGroup::get_id("", Sample::DEFAULT_NAME, "deletion");
+            let block_group_id = BlockGroup::get_id("", Sample::DEFAULT_NAME, "deletion", None);
             let sequences: HashSet<String> =
                 BlockGroup::get_all_sequences(conn, &block_group_id, false)
                     .iter()

--- a/src/updates/library.rs
+++ b/src/updates/library.rs
@@ -2,7 +2,7 @@ use core::ops::Range;
 use std::str;
 
 use gen_models::{
-    block_group::BlockGroup,
+    block_group::{BlockGroup, NewBlockGroup},
     db::DbContext,
     file_types::FileTypes,
     operations::{OperationFile, OperationInfo},
@@ -87,8 +87,15 @@ pub fn update_with_library(
         });
     }
 
-    let child_block_group =
-        BlockGroup::create(conn, collection_name, new_sample_name, new_sample_name);
+    let child_block_group = BlockGroup::create(
+        conn,
+        NewBlockGroup {
+            collection_name,
+            sample_name: new_sample_name,
+            name: new_sample_name,
+            ..Default::default()
+        },
+    );
 
     let derived_block_group_chunks = derive_chunks(
         context,

--- a/src/updates/sequence.rs
+++ b/src/updates/sequence.rs
@@ -33,9 +33,9 @@ pub fn update_with_sequence(
     let _new_sample = Sample::get_or_create(conn, new_sample_name);
     let block_groups = Sample::get_block_groups(conn, collection_name, parent_sample_name);
 
-    let mut found_bg_id = None;
+    let mut target_block_groups = vec![];
     for block_group in block_groups {
-        let new_bg_id = BlockGroup::get_or_create_sample_block_group(
+        let new_block_groups = BlockGroup::get_or_create_sample_block_groups(
             conn,
             collection_name,
             new_sample_name,
@@ -44,117 +44,110 @@ pub fn update_with_sequence(
         )?;
 
         if block_group.name == region_name {
-            found_bg_id = Some(new_bg_id);
+            target_block_groups = new_block_groups;
         }
     }
 
-    let new_block_group_id = if let Some(x) = found_bg_id {
-        x
-    } else {
+    if target_block_groups.is_empty() {
         panic!("No region found with name: {region_name}");
-    };
+    }
 
-    let path = BlockGroup::get_current_path(conn, &new_block_group_id);
-    let interval_tree = path.intervaltree(conn);
-    let node_id = if sequence.is_empty() {
-        // We assume this is a deletion.
-        let node_id = HashId::convert_str("");
-        // This path block represents a deletion, so will not actually be
-        // used to create a new node.  So the node ID can be anything, which
-        // is why we're setting it to the HashId of the empty string.  The
-        // important part is that sequence_start == sequence_end (the 0
-        // values for them are arbitrary), which flags that it's a deletion
-        // to the logic in BlockGroup::insert_change.
-        let path_block = PathBlock {
-            node_id,
-            block_sequence: sequence.to_string(),
-            sequence_start: 0,
-            sequence_end: 0,
-            path_start: start_coordinate,
-            path_end: end_coordinate,
-            strand: Strand::Forward,
-        };
+    for target_block_group in &target_block_groups {
+        let path = BlockGroup::get_current_path(conn, &target_block_group.id);
+        let interval_tree = path.intervaltree(conn);
+        let node_id = if sequence.is_empty() {
+            let node_id = HashId::convert_str("");
+            let path_block = PathBlock {
+                node_id,
+                block_sequence: sequence.to_string(),
+                sequence_start: 0,
+                sequence_end: 0,
+                path_start: start_coordinate,
+                path_end: end_coordinate,
+                strand: Strand::Forward,
+            };
 
-        let path_change = PathChange {
-            block_group_id: new_block_group_id,
-            path: path.clone(),
-            path_accession: None,
-            start: start_coordinate,
-            end: end_coordinate,
-            block: path_block,
-            chromosome_index: NO_CHROMOSOME_INDEX,
-            phased: 0,
-            preserve_edge: true,
-        };
+            let path_change = PathChange {
+                block_group_id: target_block_group.id,
+                path: path.clone(),
+                path_accession: None,
+                start: start_coordinate,
+                end: end_coordinate,
+                block: path_block,
+                chromosome_index: NO_CHROMOSOME_INDEX,
+                phased: 0,
+                preserve_edge: true,
+            };
 
-        BlockGroup::insert_change(conn, &path_change, &interval_tree).unwrap();
-        node_id
-    } else {
-        let seq = Sequence::new()
-            .sequence_type("DNA")
-            .sequence(sequence)
-            .save(conn);
-        let node_id = Node::create(
-            conn,
-            &seq.hash,
-            &HashId::convert_str(&format!(
-                "{path_id}:{ref_start}-{ref_end}->{sequence_hash}",
-                path_id = path.id,
-                ref_start = 0,
-                ref_end = seq.length,
-                sequence_hash = seq.hash
-            )),
-        );
-
-        let path_block = PathBlock {
-            node_id,
-            block_sequence: sequence.to_string(),
-            sequence_start: 0,
-            sequence_end: seq.length,
-            path_start: start_coordinate,
-            path_end: end_coordinate,
-            strand: Strand::Forward,
-        };
-
-        let path_change = PathChange {
-            block_group_id: new_block_group_id,
-            path: path.clone(),
-            path_accession: None,
-            start: start_coordinate,
-            end: end_coordinate,
-            block: path_block,
-            chromosome_index: NO_CHROMOSOME_INDEX,
-            phased: 0,
-            preserve_edge: true,
-        };
-
-        BlockGroup::insert_change(conn, &path_change, &interval_tree).unwrap();
-        node_id
-    };
-
-    if !disable_reference_path_update {
-        if node_id == HashId::convert_str("") {
-            let _ = path.new_path_with_deletion(conn, start_coordinate, end_coordinate);
+            BlockGroup::insert_change(conn, &path_change, &interval_tree).unwrap();
+            node_id
         } else {
-            let edge_to_new_node = Edge::query(
+            let seq = Sequence::new()
+                .sequence_type("DNA")
+                .sequence(sequence)
+                .save(conn);
+            let node_id = Node::create(
                 conn,
-                "select * from edges where target_node_id = ?1",
-                params![node_id],
-            )[0]
-            .clone();
-            let edge_from_new_node = Edge::query(
-                conn,
-                "select * from edges where source_node_id = ?1",
-                params![node_id],
-            )[0]
-            .clone();
-            path.new_path_with(
-                conn,
-                start_coordinate,
-                end_coordinate,
-                &edge_to_new_node,
-                &edge_from_new_node,
+                &seq.hash,
+                &HashId::convert_str(&format!(
+                    "{path_id}:{ref_start}-{ref_end}->{sequence_hash}",
+                    path_id = path.id,
+                    ref_start = 0,
+                    ref_end = seq.length,
+                    sequence_hash = seq.hash
+                )),
             );
+
+            let path_block = PathBlock {
+                node_id,
+                block_sequence: sequence.to_string(),
+                sequence_start: 0,
+                sequence_end: seq.length,
+                path_start: start_coordinate,
+                path_end: end_coordinate,
+                strand: Strand::Forward,
+            };
+
+            let path_change = PathChange {
+                block_group_id: target_block_group.id,
+                path: path.clone(),
+                path_accession: None,
+                start: start_coordinate,
+                end: end_coordinate,
+                block: path_block,
+                chromosome_index: NO_CHROMOSOME_INDEX,
+                phased: 0,
+                preserve_edge: true,
+            };
+
+            BlockGroup::insert_change(conn, &path_change, &interval_tree).unwrap();
+            node_id
+        };
+
+        if !disable_reference_path_update {
+            if node_id == HashId::convert_str("") {
+                let _ = path.new_path_with_deletion(conn, start_coordinate, end_coordinate);
+            } else {
+                let edge_to_new_node = Edge::query(
+                    conn,
+                    "select * from edges where target_node_id = ?1",
+                    params![node_id],
+                )[0]
+                .clone();
+                let edge_from_new_node = Edge::query(
+                    conn,
+                    "select * from edges where source_node_id = ?1",
+                    params![node_id],
+                )[0]
+                .clone();
+                path.new_path_with(
+                    conn,
+                    start_coordinate,
+                    end_coordinate,
+                    &edge_to_new_node,
+                    &edge_from_new_node,
+                );
+            }
         }
     }
 

--- a/src/updates/vcf.rs
+++ b/src/updates/vcf.rs
@@ -41,14 +41,14 @@ use crate::{
 
 #[derive(Debug)]
 struct BlockGroupCache<'a> {
-    pub cache: HashMap<BlockGroupData<'a>, HashId>,
+    pub cache: HashMap<BlockGroupData<'a>, Vec<HashId>>,
     pub conn: &'a GraphConnection,
 }
 
 impl<'a> BlockGroupCache<'_> {
     pub fn new(conn: &GraphConnection) -> BlockGroupCache<'_> {
         BlockGroupCache {
-            cache: HashMap::<BlockGroupData, HashId>::new(),
+            cache: HashMap::<BlockGroupData, Vec<HashId>>::new(),
             conn,
         }
     }
@@ -59,7 +59,7 @@ impl<'a> BlockGroupCache<'_> {
         sample_name: &'a str,
         name: String,
         parent_samples: &[String],
-    ) -> Result<HashId, QueryError> {
+    ) -> Result<Vec<HashId>, QueryError> {
         let block_group_key = BlockGroupData {
             collection_name,
             sample_name,
@@ -67,16 +67,21 @@ impl<'a> BlockGroupCache<'_> {
         };
         let block_group_lookup = block_group_cache.cache.get(&block_group_key);
         if let Some(block_group_id) = block_group_lookup {
-            Ok(*block_group_id)
+            Ok(block_group_id.clone())
         } else {
-            let result = BlockGroup::get_or_create_sample_block_group(
+            let result = BlockGroup::get_or_create_sample_block_groups(
                 block_group_cache.conn,
                 collection_name,
                 sample_name,
                 &name,
                 parent_samples.to_vec(),
-            )?;
-            block_group_cache.cache.insert(block_group_key, result);
+            )?
+            .into_iter()
+            .map(|block_group| block_group.id)
+            .collect::<Vec<_>>();
+            block_group_cache
+                .cache
+                .insert(block_group_key, result.clone());
             Ok(result)
         }
     }
@@ -290,7 +295,7 @@ pub fn update_with_vcf(
                 )?;
                 created_samples.insert(fixed_sample);
             }
-            let sample_bg_id = BlockGroupCache::lookup(
+            let sample_bg_ids = BlockGroupCache::lookup(
                 &mut block_group_cache,
                 collection_name,
                 fixed_sample,
@@ -340,38 +345,42 @@ pub fn update_with_vcf(
                             Phasing::Phased => 1,
                             Phasing::Unphased => 0,
                         };
-                        let sample_path =
-                            PathCache::lookup(&mut path_cache, &sample_bg_id, seq_name.clone());
-                        let path_length = path_lengths
-                            .entry(sample_path.id)
-                            .or_insert_with(|| sample_path.length(conn));
+                        for sample_bg_id in &sample_bg_ids {
+                            let sample_path =
+                                PathCache::lookup(&mut path_cache, sample_bg_id, seq_name.clone());
+                            let path_length = path_lengths
+                                .entry(sample_path.id)
+                                .or_insert_with(|| sample_path.length(conn));
 
-                        if ref_start > *path_length {
-                            return Err(VcfError::InvalidRecord(format!(
-                                "Invalid position found. Path {0} has length of {path_length}, change is in position {ref_start}.",
-                                sample_path.name
-                            )));
+                            if ref_start > *path_length {
+                                return Err(VcfError::InvalidRecord(format!(
+                                    "Invalid position found. Path {0} has length of {path_length}, change is in position {ref_start}.",
+                                    sample_path.name
+                                )));
+                            }
+                            vcf_entries.push(VcfEntry {
+                                ids: allele_accession.clone(),
+                                ref_start,
+                                block_group_id: *sample_bg_id,
+                                path: sample_path.clone(),
+                                sample_name: fixed_sample.to_string(),
+                                alt_seq: alt_seq.clone(),
+                                chromosome_index: chromosome_index as i64,
+                                phased,
+                                preserve_reference: has_ref,
+                            });
                         }
-                        vcf_entries.push(VcfEntry {
-                            ids: allele_accession,
-                            ref_start,
-                            block_group_id: sample_bg_id,
-                            path: sample_path.clone(),
-                            sample_name: fixed_sample.to_string(),
-                            alt_seq,
-                            chromosome_index: chromosome_index as i64,
-                            phased,
-                            preserve_reference: has_ref,
-                        });
                     } else if let Some(ref_accession) = allele_accession {
-                        let sample_path =
-                            PathCache::lookup(&mut path_cache, &sample_bg_id, seq_name.clone());
+                        for sample_bg_id in &sample_bg_ids {
+                            let sample_path =
+                                PathCache::lookup(&mut path_cache, sample_bg_id, seq_name.clone());
 
-                        let key = (sample_path, ref_accession.clone());
+                            let key = (sample_path, ref_accession.clone());
 
-                        accession_cache.entry(key).or_insert_with(|| {
-                            (ref_start, ref_start + record.reference_bases().len() as i64)
-                        });
+                            accession_cache.entry(key).or_insert_with(|| {
+                                (ref_start, ref_start + record.reference_bases().len() as i64)
+                            });
+                        }
                     }
                 }
             }
@@ -393,7 +402,7 @@ pub fn update_with_vcf(
                     )?;
                     created_samples.insert(sample_name);
                 }
-                let sample_bg_id = BlockGroupCache::lookup(
+                let sample_bg_ids = BlockGroupCache::lookup(
                     &mut block_group_cache,
                     collection_name,
                     sample_name,
@@ -448,53 +457,57 @@ pub fn update_with_vcf(
                                             alt_seq = alt_seq[1..].to_string();
                                         }
                                     }
-                                    let sample_path = PathCache::lookup(
-                                        &mut path_cache,
-                                        &sample_bg_id,
-                                        seq_name.clone(),
-                                    );
-                                    let path_length =
-                                        if let Some(l) = path_lengths.get(&sample_path.id) {
-                                            l
-                                        } else {
-                                            let l = sample_path.sequence(conn).len();
-                                            path_lengths.insert(sample_path.id, l as i64);
-                                            &path_lengths[&sample_path.id]
-                                        };
+                                    for sample_bg_id in &sample_bg_ids {
+                                        let sample_path = PathCache::lookup(
+                                            &mut path_cache,
+                                            sample_bg_id,
+                                            seq_name.clone(),
+                                        );
+                                        let path_length =
+                                            if let Some(l) = path_lengths.get(&sample_path.id) {
+                                                l
+                                            } else {
+                                                let l = sample_path.sequence(conn).len();
+                                                path_lengths.insert(sample_path.id, l as i64);
+                                                &path_lengths[&sample_path.id]
+                                            };
 
-                                    if ref_start > *path_length {
-                                        return Err(VcfError::InvalidRecord(format!(
-                                            "Invalid position found. Path {0} has length of {path_length}, change is in position {ref_start}.",
-                                            sample_path.name
-                                        )));
-                                    }
+                                        if ref_start > *path_length {
+                                            return Err(VcfError::InvalidRecord(format!(
+                                                "Invalid position found. Path {0} has length of {path_length}, change is in position {ref_start}.",
+                                                sample_path.name
+                                            )));
+                                        }
 
-                                    vcf_entries.push(VcfEntry {
-                                        ids: allele_accession,
-                                        block_group_id: sample_bg_id,
-                                        ref_start,
-                                        path: sample_path.clone(),
-                                        sample_name: sample_name.to_string(),
-                                        alt_seq,
-                                        chromosome_index: chromosome_index as i64,
-                                        phased,
-                                        preserve_reference: has_ref,
-                                    });
-                                } else if let Some(ref_accession) = allele_accession {
-                                    let sample_path = PathCache::lookup(
-                                        &mut path_cache,
-                                        &sample_bg_id,
-                                        seq_name.clone(),
-                                    );
-
-                                    let key = (sample_path, ref_accession.clone());
-
-                                    accession_cache.entry(key).or_insert_with(|| {
-                                        (
+                                        vcf_entries.push(VcfEntry {
+                                            ids: allele_accession.clone(),
+                                            block_group_id: *sample_bg_id,
                                             ref_start,
-                                            ref_start + record.reference_bases().len() as i64,
-                                        )
-                                    });
+                                            path: sample_path.clone(),
+                                            sample_name: sample_name.to_string(),
+                                            alt_seq: alt_seq.clone(),
+                                            chromosome_index: chromosome_index as i64,
+                                            phased,
+                                            preserve_reference: has_ref,
+                                        });
+                                    }
+                                } else if let Some(ref_accession) = allele_accession {
+                                    for sample_bg_id in &sample_bg_ids {
+                                        let sample_path = PathCache::lookup(
+                                            &mut path_cache,
+                                            sample_bg_id,
+                                            seq_name.clone(),
+                                        );
+
+                                        let key = (sample_path, ref_accession.clone());
+
+                                        accession_cache.entry(key).or_insert_with(|| {
+                                            (
+                                                ref_start,
+                                                ref_start + record.reference_bases().len() as i64,
+                                            )
+                                        });
+                                    }
                                 }
                             }
                         }
@@ -516,23 +529,11 @@ pub fn update_with_vcf(
             let source_path_id = node_source_paths
                 .entry(vcf_entry.path.id)
                 .or_insert_with(|| {
-                    let sample_parent_samples = resolved_parent_samples
-                        .get(&vcf_entry.sample_name)
-                        .cloned()
-                        .unwrap_or_default();
-                    let parent_block_groups = BlockGroup::find_parent_block_groups(
-                        conn,
-                        collection_name,
-                        &vcf_entry.path.name,
-                        &sample_parent_samples,
-                    );
-
-                    if let Some(parent_block_group) = parent_block_groups.first() {
-                        // TODO: Use the default parent path here once multi-parent samples have
-                        // default paths.
+                    let block_group = BlockGroup::get_by_id(conn, &vcf_entry.block_group_id);
+                    if let Some(parent_block_group_id) = block_group.parent_block_group_id {
                         let parent_path = PathCache::lookup(
                             &mut path_cache,
-                            &parent_block_group.id,
+                            &parent_block_group_id,
                             vcf_entry.path.name.clone(),
                         );
                         parent_path.id

--- a/src/views.rs
+++ b/src/views.rs
@@ -14,6 +14,7 @@ pub mod messages;
 pub mod operations;
 pub mod panels;
 pub mod patch;
+pub mod samples;
 pub mod tui_runtime;
 
 #[cfg(test)]

--- a/src/views/block_group.rs
+++ b/src/views/block_group.rs
@@ -202,7 +202,7 @@ pub fn view_block_group(
         CollectionExplorer::new(conn, op_conn, sample_name.as_deref(), collection_name);
     let mut explorer_state = CollectionExplorerState::new();
     if let Some(ref s) = sample_name {
-        explorer_state.toggle_sample(s);
+        explorer_state.set_sample_expanded(s, true);
     }
 
     let mut block_graph;

--- a/src/views/collection.rs
+++ b/src/views/collection.rs
@@ -10,6 +10,7 @@ use gen_models::{
     db::{GraphConnection, OperationsConnection},
     file_types::FileTypes,
     sample::Sample,
+    sample_lineage::SampleLineage,
     traits::Query,
 };
 use ratatui::{
@@ -27,6 +28,7 @@ use crate::{
     views::{
         annotation_files::{AnnotationFileEntry, load_annotation_file_entries},
         annotation_groups::{AnnotationGroupEntry, load_annotation_group_entries},
+        samples::{SampleTree, SampleTreeEntry},
     },
 };
 
@@ -116,6 +118,12 @@ pub struct CollectionExplorerData {
     pub reference_block_groups: Vec<(gen_core::HashId, String)>,
     /// The samples in the entire collection
     pub collection_samples: Vec<String>,
+    /// Root samples for the lineage tree.
+    pub sample_roots: Vec<String>,
+    /// Direct child samples for each sample.
+    pub sample_children: HashMap<String, Vec<String>>,
+    /// Direct parent samples for each sample.
+    pub sample_parents: HashMap<String, Vec<String>>,
     /// The block groups for each sample
     pub sample_block_groups: HashMap<String, Vec<(gen_core::HashId, String)>>,
     /// Immediate sub-collections ("direct children") one level deeper
@@ -145,6 +153,34 @@ pub fn gather_collection_explorer_data(
         all_blocks.iter().map(|bg| bg.sample_name.clone()).collect();
     let mut collection_samples: Vec<String> = sample_names.drain().collect();
     collection_samples.sort();
+
+    let collection_sample_set: HashSet<String> = collection_samples.iter().cloned().collect();
+    let mut sample_children = HashMap::new();
+    let mut sample_parents = HashMap::new();
+    let mut sample_roots = Vec::new();
+    for sample in &collection_samples {
+        let mut parents = SampleLineage::get_parents(conn, sample)
+            .into_iter()
+            .filter(|parent| collection_sample_set.contains(parent))
+            .collect::<Vec<_>>();
+        parents.sort();
+        parents.dedup();
+
+        let mut children = SampleLineage::get_children(conn, sample)
+            .into_iter()
+            .filter(|child| collection_sample_set.contains(child))
+            .collect::<Vec<_>>();
+        children.sort();
+        children.dedup();
+
+        if parents.is_empty() {
+            sample_roots.push(sample.clone());
+        }
+
+        sample_parents.insert(sample.clone(), parents);
+        sample_children.insert(sample.clone(), children);
+    }
+    sample_roots.sort();
 
     // 4) For each sample, retrieve block groups
     let mut sample_block_groups = HashMap::new();
@@ -186,6 +222,9 @@ pub fn gather_collection_explorer_data(
         current_collection,
         reference_block_groups,
         collection_samples,
+        sample_roots,
+        sample_children,
+        sample_parents,
         sample_block_groups,
         nested_collections,
         annotation_files,
@@ -203,10 +242,13 @@ pub enum ExplorerItem {
     BlockGroup {
         id: HashId,
         name: String,
+        depth: usize,
     },
     Sample {
         name: String,
         expanded: bool,
+        depth: usize,
+        has_children: bool,
     },
     Header {
         text: String,
@@ -256,6 +298,8 @@ pub struct CollectionExplorerState {
     pub annotation_file_toggle_requested: Option<HashId>,
     /// Pending annotation group toggle request
     pub annotation_group_toggle_requested: Option<String>,
+    /// Horizontal scroll offset for the sample lineage tree.
+    pub sample_tree_scroll: u16,
 }
 
 impl CollectionExplorerState {
@@ -275,6 +319,7 @@ impl CollectionExplorerState {
             active_annotation_groups: HashSet::new(),
             annotation_file_toggle_requested: None,
             annotation_group_toggle_requested: None,
+            sample_tree_scroll: 0,
         }
     }
 
@@ -381,7 +426,10 @@ impl CollectionExplorer {
             gather_collection_explorer_data(conn, op_conn, sample_name, full_collection_name);
         let changed = self.data.reference_block_groups.len()
             != new_data.reference_block_groups.len()
-            || self.data.sample_block_groups != new_data.sample_block_groups;
+            || self.data.sample_block_groups != new_data.sample_block_groups
+            || self.data.sample_roots != new_data.sample_roots
+            || self.data.sample_children != new_data.sample_children
+            || self.data.sample_parents != new_data.sample_parents;
         self.data = new_data;
         changed
     }
@@ -480,6 +528,47 @@ impl CollectionExplorer {
         match key.code {
             KeyCode::Up => self.previous(state),
             KeyCode::Down => self.next(state),
+            KeyCode::Left => {
+                if let Some(selected_idx) = state.list_state.selected {
+                    let items = self.get_display_items(state);
+                    if let Some(ExplorerItem::Sample { name, expanded, .. }) =
+                        items.get(selected_idx)
+                    {
+                        if *expanded {
+                            state.toggle_sample(name);
+                        } else if let Some(parent_name) = self
+                            .data
+                            .sample_parents
+                            .get(name)
+                            .and_then(|parents| parents.first())
+                        {
+                            state.list_state.selected =
+                                items.iter().enumerate().find_map(|(idx, item)| match item {
+                                    ExplorerItem::Sample {
+                                        name: item_name, ..
+                                    } if item_name == parent_name => Some(idx),
+                                    _ => None,
+                                });
+                        }
+                    }
+                }
+            }
+            KeyCode::Right => {
+                if let Some(selected_idx) = state.list_state.selected {
+                    let items = self.get_display_items(state);
+                    if let Some(ExplorerItem::Sample {
+                        name,
+                        expanded,
+                        has_children,
+                        ..
+                    }) = items.get(selected_idx)
+                        && *has_children
+                        && !*expanded
+                    {
+                        state.toggle_sample(name);
+                    }
+                }
+            }
             KeyCode::Enter | KeyCode::Char(' ') => {
                 if let Some(selected_idx) = state.list_state.selected {
                     let items = self.get_display_items(state);
@@ -508,12 +597,14 @@ impl CollectionExplorer {
     }
 
     pub fn get_status_line() -> String {
-        "*▼ ▲* navigate | *return* select | *space* toggle".to_string()
+        "*▼ ▲* navigate | *return/space* toggle | *←/→* tree".to_string()
     }
 
     /// Get all items to display, taking into account the current state
     fn get_display_items(&self, state: &CollectionExplorerState) -> Vec<ExplorerItem> {
         let mut items = Vec::new();
+        let sample_tree = SampleTree::new(&self.data);
+        let sample_entries = sample_tree.build_entries(state);
 
         // Current collection name
         items.push(ExplorerItem::Collection {
@@ -536,6 +627,7 @@ impl CollectionExplorer {
             items.push(ExplorerItem::BlockGroup {
                 id: *id,
                 name: name.clone(),
+                depth: 0,
             });
         }
 
@@ -546,24 +638,24 @@ impl CollectionExplorer {
 
         // Samples section
         items.push(ExplorerItem::Header {
-            text: "Sample graphs:".to_string(),
+            text: "Sample lineages:".to_string(),
         });
 
-        // Samples and their block groups
-        for sample in &self.data.collection_samples {
-            items.push(ExplorerItem::Sample {
-                name: sample.clone(),
-                expanded: state.is_sample_expanded(sample),
-            });
-
-            if state.is_sample_expanded(sample)
-                && let Some(block_groups) = self.data.sample_block_groups.get(sample)
-            {
-                for (id, name) in block_groups {
-                    items.push(ExplorerItem::BlockGroup {
-                        id: *id,
-                        name: name.clone(),
-                    });
+        for entry in sample_entries {
+            match entry {
+                SampleTreeEntry::Sample {
+                    name,
+                    expanded,
+                    depth,
+                    has_children,
+                } => items.push(ExplorerItem::Sample {
+                    name,
+                    expanded,
+                    depth,
+                    has_children,
+                }),
+                SampleTreeEntry::BlockGroup { id, name, depth } => {
+                    items.push(ExplorerItem::BlockGroup { id, name, depth })
                 }
             }
         }
@@ -651,6 +743,17 @@ impl StatefulWidget for &CollectionExplorer {
 
     fn render(self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
         let items = self.get_display_items(state);
+        state.sample_tree_scroll = state
+            .list_state
+            .selected
+            .and_then(|idx| items.get(idx))
+            .map(|item| match item {
+                ExplorerItem::Sample { depth, .. } | ExplorerItem::BlockGroup { depth, .. } => {
+                    (*depth as u16).saturating_mul(2)
+                }
+                _ => 0,
+            })
+            .unwrap_or(0);
         let mut display_items = Vec::new();
 
         // Convert ExplorerItems to display items
@@ -674,7 +777,7 @@ impl StatefulWidget for &CollectionExplorer {
                             .wrap(Wrap { trim: false })
                     }
                 }
-                ExplorerItem::BlockGroup { id, name, .. } => {
+                ExplorerItem::BlockGroup { id, name, depth } => {
                     // Check if this block group is one of the sample_name = NULL reference block groups
                     // This influences the indentation
                     let is_reference = self
@@ -682,20 +785,45 @@ impl StatefulWidget for &CollectionExplorer {
                         .reference_block_groups
                         .iter()
                         .any(|(ref_id, _)| ref_id == id);
+                    let scroll = if *depth > 0 {
+                        state.sample_tree_scroll
+                    } else {
+                        0
+                    };
 
                     if is_reference {
                         Paragraph::new(Line::from(vec![Span::raw(format!("   • {}", name))]))
                             .wrap(Wrap { trim: false })
                     } else {
-                        Paragraph::new(Line::from(vec![Span::raw(format!("     • {}", name))]))
-                            .wrap(Wrap { trim: false })
+                        Paragraph::new(Line::from(vec![Span::raw(format!(
+                            "{}• {}",
+                            "  ".repeat(*depth),
+                            name
+                        ))]))
+                        .scroll((0, scroll))
+                        .wrap(Wrap { trim: false })
                     }
                 }
-                ExplorerItem::Sample { name, expanded } => Paragraph::new(Line::from(vec![
-                    Span::raw(if *expanded { "   ▼ " } else { "   ▶ " }),
-                    Span::styled(name, Style::default()),
-                ]))
-                .wrap(Wrap { trim: false }),
+                ExplorerItem::Sample {
+                    name,
+                    expanded,
+                    depth,
+                    has_children,
+                } => {
+                    let marker = if *has_children {
+                        if *expanded { "▼" } else { "▶" }
+                    } else {
+                        "•"
+                    };
+                    Paragraph::new(Line::from(vec![Span::raw(format!(
+                        "{}{} {}",
+                        "  ".repeat(*depth),
+                        marker,
+                        name
+                    ))]))
+                    .scroll((0, state.sample_tree_scroll))
+                    .wrap(Wrap { trim: false })
+                }
                 ExplorerItem::Header { text } => Paragraph::new(Line::from(vec![
                     Span::raw("  "),
                     Span::styled(text, Style::default().add_modifier(Modifier::UNDERLINED)),

--- a/src/views/collection.rs
+++ b/src/views/collection.rs
@@ -286,8 +286,8 @@ pub struct CollectionExplorerState {
     pub has_focus: bool,
     /// The currently selected block group
     pub selected_block_group_id: Option<HashId>,
-    /// Tracks which samples are expanded/collapsed
-    expanded_samples: HashSet<String>,
+    /// Explicit sample expansion overrides, separate from the default auto-open tree.
+    sample_expansion_overrides: HashMap<String, bool>,
     /// Indicates which focus zone should receive focus (if any)
     pub focus_change_requested: Option<FocusZone>,
     /// Active annotation files
@@ -313,7 +313,7 @@ impl CollectionExplorerState {
             total_items: 0,
             has_focus: false,
             selected_block_group_id: block_group_id,
-            expanded_samples: HashSet::new(),
+            sample_expansion_overrides: HashMap::new(),
             focus_change_requested: None,
             active_annotation_files: HashSet::new(),
             active_annotation_groups: HashSet::new(),
@@ -324,17 +324,24 @@ impl CollectionExplorerState {
     }
 
     /// Toggle expansion state of a sample
-    pub fn toggle_sample(&mut self, sample_name: &str) {
-        if self.expanded_samples.contains(sample_name) {
-            self.expanded_samples.remove(sample_name);
-        } else {
-            self.expanded_samples.insert(sample_name.to_string());
-        }
+    pub fn toggle_sample(&mut self, sample_name: &str, currently_expanded: bool) {
+        let next = !currently_expanded;
+        self.sample_expansion_overrides
+            .insert(sample_name.to_string(), next);
     }
 
     /// Check if a sample is expanded
-    pub fn is_sample_expanded(&self, sample_name: &str) -> bool {
-        self.expanded_samples.contains(sample_name)
+    pub fn is_sample_expanded(&self, sample_name: &str, default_expanded: bool) -> bool {
+        self.sample_expansion_overrides
+            .get(sample_name)
+            .copied()
+            .unwrap_or(default_expanded)
+    }
+
+    /// Force a sample to a specific expansion state.
+    pub fn set_sample_expanded(&mut self, sample_name: &str, expanded: bool) {
+        self.sample_expansion_overrides
+            .insert(sample_name.to_string(), expanded);
     }
 
     /// Toggle an annotation file on/off
@@ -535,7 +542,7 @@ impl CollectionExplorer {
                         items.get(selected_idx)
                     {
                         if *expanded {
-                            state.toggle_sample(name);
+                            state.toggle_sample(name, *expanded);
                         } else if let Some(parent_name) = self
                             .data
                             .sample_parents
@@ -565,7 +572,7 @@ impl CollectionExplorer {
                         && *has_children
                         && !*expanded
                     {
-                        state.toggle_sample(name);
+                        state.toggle_sample(name, *expanded);
                     }
                 }
             }
@@ -731,8 +738,8 @@ impl CollectionExplorer {
     pub fn toggle_sample_expansion(&self, state: &mut CollectionExplorerState) {
         if let Some(selected_idx) = state.list_state.selected {
             let items = self.get_display_items(state);
-            if let Some(ExplorerItem::Sample { name, .. }) = items.get(selected_idx) {
-                state.toggle_sample(name);
+            if let Some(ExplorerItem::Sample { name, expanded, .. }) = items.get(selected_idx) {
+                state.toggle_sample(name, *expanded);
             }
         }
     }
@@ -792,11 +799,11 @@ impl StatefulWidget for &CollectionExplorer {
                     };
 
                     if is_reference {
-                        Paragraph::new(Line::from(vec![Span::raw(format!("   • {}", name))]))
+                        Paragraph::new(Line::from(vec![Span::raw(format!("  • {}", name))]))
                             .wrap(Wrap { trim: false })
                     } else {
                         Paragraph::new(Line::from(vec![Span::raw(format!(
-                            "{}• {}",
+                            "  {}• {}",
                             "  ".repeat(*depth),
                             name
                         ))]))
@@ -816,7 +823,7 @@ impl StatefulWidget for &CollectionExplorer {
                         "•"
                     };
                     Paragraph::new(Line::from(vec![Span::raw(format!(
-                        "{}{} {}",
+                        "  {}{} {}",
                         "  ".repeat(*depth),
                         marker,
                         name

--- a/src/views/collection.rs
+++ b/src/views/collection.rs
@@ -813,10 +813,42 @@ mod tests {
         let sample_beta = Sample::get_or_create(conn, "SampleBeta");
 
         // Create block groups for three explicit samples
-        BlockGroup::create(conn, "/foo/bar", &sample_reference.name, "BG_ReferenceA");
-        BlockGroup::create(conn, "/foo/bar", &sample_reference.name, "BG_ReferenceB");
-        BlockGroup::create(conn, "/foo/bar", &sample_alpha.name, "BG_Alpha1");
-        BlockGroup::create(conn, "/foo/bar", &sample_beta.name, "BG_Beta1");
+        BlockGroup::create(
+            conn,
+            gen_models::block_group::NewBlockGroup {
+                collection_name: "/foo/bar",
+                sample_name: &sample_reference.name,
+                name: "BG_ReferenceA",
+                ..Default::default()
+            },
+        );
+        BlockGroup::create(
+            conn,
+            gen_models::block_group::NewBlockGroup {
+                collection_name: "/foo/bar",
+                sample_name: &sample_reference.name,
+                name: "BG_ReferenceB",
+                ..Default::default()
+            },
+        );
+        BlockGroup::create(
+            conn,
+            gen_models::block_group::NewBlockGroup {
+                collection_name: "/foo/bar",
+                sample_name: &sample_alpha.name,
+                name: "BG_Alpha1",
+                ..Default::default()
+            },
+        );
+        BlockGroup::create(
+            conn,
+            gen_models::block_group::NewBlockGroup {
+                collection_name: "/foo/bar",
+                sample_name: &sample_beta.name,
+                name: "BG_Beta1",
+                ..Default::default()
+            },
+        );
 
         // Call the function under test—notice we pass the full path
         let op_conn = context.operations().conn();

--- a/src/views/samples.rs
+++ b/src/views/samples.rs
@@ -2,7 +2,8 @@ use std::collections::HashSet;
 
 use crate::views::collection::{CollectionExplorerData, CollectionExplorerState};
 
-const AUTO_UNFURL_LINES: usize = 10;
+const AUTO_EXPAND_ROOTS: usize = 5;
+const AUTO_EXPAND_DEPTH: usize = 3;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum SampleTreeEntry {
@@ -40,34 +41,21 @@ impl<'a> SampleTree<'a> {
     pub fn build_entries(&self, state: &CollectionExplorerState) -> Vec<SampleTreeEntry> {
         let mut entries = Vec::new();
         let mut visited = HashSet::new();
-        let mut remaining = AUTO_UNFURL_LINES;
 
         let mut roots = self.data.sample_roots.clone();
         if roots.is_empty() {
             roots = self.data.collection_samples.clone();
         }
 
-        for root in roots {
-            self.push_sample(&root, 0, &mut visited, state, &mut entries, &mut remaining);
-            if remaining == 0 {
-                break;
-            }
-        }
-
-        for sample_name in &self.data.collection_samples {
-            if !visited.contains(sample_name) {
-                self.push_sample(
-                    sample_name,
-                    0,
-                    &mut visited,
-                    state,
-                    &mut entries,
-                    &mut remaining,
-                );
-                if remaining == 0 {
-                    break;
-                }
-            }
+        for (index, root) in roots.iter().enumerate() {
+            self.push_sample(
+                root,
+                0,
+                index < AUTO_EXPAND_ROOTS,
+                &mut visited,
+                state,
+                &mut entries,
+            );
         }
 
         entries
@@ -105,14 +93,11 @@ impl<'a> SampleTree<'a> {
         &self,
         sample_name: &str,
         depth: usize,
+        auto_expand: bool,
         visited: &mut HashSet<String>,
         state: &CollectionExplorerState,
         entries: &mut Vec<SampleTreeEntry>,
-        remaining: &mut usize,
     ) {
-        if *remaining == 0 {
-            return;
-        }
         if !visited.insert(sample_name.to_string()) {
             return;
         }
@@ -129,7 +114,8 @@ impl<'a> SampleTree<'a> {
             .get(sample_name)
             .cloned()
             .unwrap_or_default();
-        let expanded = state.is_sample_expanded(sample_name) || *remaining > 0;
+        let expanded =
+            state.is_sample_expanded(sample_name, auto_expand && depth < AUTO_EXPAND_DEPTH);
 
         entries.push(SampleTreeEntry::Sample {
             name: sample_name.to_string(),
@@ -137,29 +123,21 @@ impl<'a> SampleTree<'a> {
             depth,
             has_children: !children.is_empty() || !block_groups.is_empty(),
         });
-        *remaining = remaining.saturating_sub(1);
 
-        if !expanded || *remaining == 0 {
+        if !expanded {
             return;
         }
 
         for (id, name) in block_groups {
-            if *remaining == 0 {
-                return;
-            }
             entries.push(SampleTreeEntry::BlockGroup {
                 id,
                 name,
                 depth: depth + 1,
             });
-            *remaining = remaining.saturating_sub(1);
         }
 
         for child in children {
-            if *remaining == 0 {
-                return;
-            }
-            self.push_sample(&child, depth + 1, visited, state, entries, remaining);
+            self.push_sample(&child, depth + 1, auto_expand, visited, state, entries);
         }
     }
 }

--- a/src/views/samples.rs
+++ b/src/views/samples.rs
@@ -1,0 +1,165 @@
+use std::collections::HashSet;
+
+use crate::views::collection::{CollectionExplorerData, CollectionExplorerState};
+
+const AUTO_UNFURL_LINES: usize = 10;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum SampleTreeEntry {
+    Sample {
+        name: String,
+        expanded: bool,
+        depth: usize,
+        has_children: bool,
+    },
+    BlockGroup {
+        id: gen_core::HashId,
+        name: String,
+        depth: usize,
+    },
+}
+
+impl SampleTreeEntry {
+    pub fn depth(&self) -> usize {
+        match self {
+            SampleTreeEntry::Sample { depth, .. } => *depth,
+            SampleTreeEntry::BlockGroup { depth, .. } => *depth,
+        }
+    }
+}
+
+pub struct SampleTree<'a> {
+    data: &'a CollectionExplorerData,
+}
+
+impl<'a> SampleTree<'a> {
+    pub fn new(data: &'a CollectionExplorerData) -> Self {
+        Self { data }
+    }
+
+    pub fn build_entries(&self, state: &CollectionExplorerState) -> Vec<SampleTreeEntry> {
+        let mut entries = Vec::new();
+        let mut visited = HashSet::new();
+        let mut remaining = AUTO_UNFURL_LINES;
+
+        let mut roots = self.data.sample_roots.clone();
+        if roots.is_empty() {
+            roots = self.data.collection_samples.clone();
+        }
+
+        for root in roots {
+            self.push_sample(&root, 0, &mut visited, state, &mut entries, &mut remaining);
+            if remaining == 0 {
+                break;
+            }
+        }
+
+        for sample_name in &self.data.collection_samples {
+            if !visited.contains(sample_name) {
+                self.push_sample(
+                    sample_name,
+                    0,
+                    &mut visited,
+                    state,
+                    &mut entries,
+                    &mut remaining,
+                );
+                if remaining == 0 {
+                    break;
+                }
+            }
+        }
+
+        entries
+    }
+
+    pub fn selected_scroll(
+        &self,
+        state: &CollectionExplorerState,
+        entries: &[SampleTreeEntry],
+    ) -> u16 {
+        state
+            .list_state
+            .selected
+            .and_then(|idx| entries.get(idx))
+            .map(|entry| (entry.depth() as u16).saturating_mul(2))
+            .unwrap_or(0)
+    }
+
+    pub fn selected_sample_name(
+        &self,
+        state: &CollectionExplorerState,
+        entries: &[SampleTreeEntry],
+    ) -> Option<String> {
+        state
+            .list_state
+            .selected
+            .and_then(|idx| entries.get(idx))
+            .and_then(|entry| match entry {
+                SampleTreeEntry::Sample { name, .. } => Some(name.clone()),
+                _ => None,
+            })
+    }
+
+    fn push_sample(
+        &self,
+        sample_name: &str,
+        depth: usize,
+        visited: &mut HashSet<String>,
+        state: &CollectionExplorerState,
+        entries: &mut Vec<SampleTreeEntry>,
+        remaining: &mut usize,
+    ) {
+        if *remaining == 0 {
+            return;
+        }
+        if !visited.insert(sample_name.to_string()) {
+            return;
+        }
+
+        let children = self
+            .data
+            .sample_children
+            .get(sample_name)
+            .cloned()
+            .unwrap_or_default();
+        let block_groups = self
+            .data
+            .sample_block_groups
+            .get(sample_name)
+            .cloned()
+            .unwrap_or_default();
+        let expanded = state.is_sample_expanded(sample_name) || *remaining > 0;
+
+        entries.push(SampleTreeEntry::Sample {
+            name: sample_name.to_string(),
+            expanded,
+            depth,
+            has_children: !children.is_empty() || !block_groups.is_empty(),
+        });
+        *remaining = remaining.saturating_sub(1);
+
+        if !expanded || *remaining == 0 {
+            return;
+        }
+
+        for (id, name) in block_groups {
+            if *remaining == 0 {
+                return;
+            }
+            entries.push(SampleTreeEntry::BlockGroup {
+                id,
+                name,
+                depth: depth + 1,
+            });
+            *remaining = remaining.saturating_sub(1);
+        }
+
+        for child in children {
+            if *remaining == 0 {
+                return;
+            }
+            self.push_sample(&child, depth + 1, visited, state, entries, remaining);
+        }
+    }
+}


### PR DESCRIPTION
This is an add-on to #81 in response to the "we should use get_all_sequences" bit on a test. It adds a lineage to block groups so when a mating operation happens, there is a way to trace which block group came from which sample. I did it this way instead of the previous attempt to have a path lineage because of how w currently manage ploidyness w/ chromosome_index caused a lot of problems when we just mashed the block groups together. 

Some changes to note:
* When updating with a fasta/sequence/vcf/etc., we apply changes to all matching blockgroups. There's no disambiguation currently to just select the lineage of a blockgroup like parent:chr1 currently.
* get_or_create_sample_blockgroups returns a Vec of blockgroups instead of a single blockgroup since now we're in a multiple-bg realm
* Refactored the merge behavior again to duplicate parent -> child blockgroups/accessions/path instead of merge

In using it, a few other pieces were bolted on:

* Updated the view page to show sample hierarchy
* Added a sample level get_all_sequences for testing mostly
* Added default values for the sample name + parent names to keep the cli simpler in basic cases
