### PR TITLE
Fix diff operation on empty branch

### DIFF
--- a/gen-diff/src/operations.rs
+++ b/gen-diff/src/operations.rs
@@ -131,7 +131,8 @@ pub fn collect_operation_diff(
 
         (operations_in_order, added_ops, removed_ops)
     } else {
-        (vec![to_hash], vec![to_hash], vec![])
+        let upstream_operations = Operation::get_upstream(op_conn, &to_hash);
+        (upstream_operations.clone(), upstream_operations, vec![])
     };
 
     let added_graphs = build_block_group_diffs(workspace, op_conn, &added_ops, db_path)?;


### PR DESCRIPTION
If the from_hash is None, we should do all the upstream operations of to_hash, not just to_hash. When doing a diff against an empty branch, we currently just return the diff of the tip of the source branch instead of all operations.