### PR TITLE
Skip poll once plot loads

### DIFF
--- a/src/views/block_group.rs
+++ b/src/views/block_group.rs
@@ -1109,6 +1109,7 @@ pub fn view_block_group(
             }
 
             is_loading = false;
+            continue;
         }
 
         // If an animation is running, wake up after tick_rate to advance it.


### PR DESCRIPTION
1 line bugfix to the event loop of the fullscreen viewer.