### PR TITLE
Add sequence error handler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 python: venv
 	.venv/bin/maturin develop --release --manifest-path gen-python/Cargo.toml --features extension-module --extras jupyter
 r:
-	docker build -t gen-r -f ./gen-r/Dockerfile .
+	docker build -q -t gen-r -f ./gen-r/Dockerfile .
 	docker run --rm gen-r
 clean:
 	cargo clean

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 python: venv
 	.venv/bin/maturin develop --release --manifest-path gen-python/Cargo.toml --features extension-module --extras jupyter
 r:
-	docker build -q -t gen-r -f ./gen-r/Dockerfile .
+	# Makes the build quiet for CI/agents
+	docker build -t gen-r -f ./gen-r/Dockerfile . 2>&1 | tail -n 25
 	docker run --rm gen-r
 clean:
 	cargo clean

--- a/gen-annotations/src/gff.rs
+++ b/gen-annotations/src/gff.rs
@@ -3,10 +3,19 @@ use std::{collections::HashMap, fs::File, io, io::BufReader};
 use gen_models::{
     block_group::BlockGroup,
     db::GraphConnection,
+    errors::PathError,
     path::{Annotation, Path},
     sample::Sample,
 };
 use noodles::{core::Position, gff};
+
+#[derive(Debug, thiserror::Error)]
+pub enum PropagateGffError {
+    #[error("I/O error: {0}")]
+    Io(#[from] io::Error),
+    #[error("Path error: {0}")]
+    Path(#[from] PathError),
+}
 
 pub fn gff_attribute_value_to_string(
     attrs: &gff::feature::record_buf::Attributes,
@@ -36,7 +45,7 @@ pub fn propagate_gff(
     to_sample_name: &str,
     gff_input_filename: &str,
     gff_output_filename: &str,
-) -> io::Result<()> {
+) -> Result<(), PropagateGffError> {
     let mut reader = File::open(gff_input_filename)
         .map(BufReader::new)
         .map(gff::io::Reader::new)?;
@@ -58,14 +67,14 @@ pub fn propagate_gff(
     let mut path_mappings_by_bg_name = HashMap::new();
     for (name, target_path) in &target_paths_by_bg_name {
         let source_path = source_paths_by_bg_name.get(name).unwrap();
-        let mapping = source_path.get_mapping_tree(conn, target_path);
+        let mapping = source_path.get_mapping_tree(conn, target_path)?;
         path_mappings_by_bg_name.insert(name, mapping);
     }
 
     let sequence_lengths_by_path_name = target_paths_by_bg_name
         .iter()
-        .map(|(name, path)| (name.clone(), path.sequence(conn).len() as i64))
-        .collect::<HashMap<String, i64>>();
+        .map(|(name, path)| Ok((name.clone(), path.sequence(conn)?.len() as i64)))
+        .collect::<Result<HashMap<String, i64>, PathError>>()?;
 
     for result in reader.record_bufs() {
         let record = result?;
@@ -231,7 +240,7 @@ mod tests {
         .expect("should create child block group")[0]
             .id;
         let sample_path = BlockGroup::get_current_path(conn, &sample_bg_id);
-        let tree = sample_path.intervaltree(conn);
+        let tree = sample_path.intervaltree(conn).unwrap();
         let replacement_sequence = "AA";
 
         let replacement = Sequence::new()

--- a/gen-annotations/src/test_helpers.rs
+++ b/gen-annotations/src/test_helpers.rs
@@ -140,7 +140,7 @@ pub fn setup_test_data(conn: &GraphConnection) {
     .expect("should create child block group")[0]
         .id;
     let sample_path = BlockGroup::get_current_path(conn, &sample_bg_id);
-    let tree = sample_path.intervaltree(conn);
+    let tree = sample_path.intervaltree(conn).unwrap();
 
     let alt_seq = "C";
 

--- a/gen-annotations/src/translate/bed.rs
+++ b/gen-annotations/src/translate/bed.rs
@@ -1,6 +1,6 @@
 use std::{
     cmp::{max, min},
-    collections::HashMap,
+    collections::{HashMap, hash_map::Entry},
     io::{Read, Write},
 };
 
@@ -9,6 +9,7 @@ use gen_graph::{GraphNode, project_path};
 use gen_models::{
     block_group::BlockGroup,
     db::GraphConnection,
+    errors::PathError,
     reference_alias::{ReferenceAlias, ReferenceAliasError},
     sample::Sample,
 };
@@ -26,6 +27,8 @@ pub enum BedError {
     Io(#[from] std::io::Error),
     #[error("Error loading reference aliases: {0}")]
     ReferenceAliasError(#[from] ReferenceAliasError),
+    #[error("Error loading path blocks: {0}")]
+    PathError(#[from] PathError),
 }
 
 pub fn translate_bed<R, W>(
@@ -66,20 +69,23 @@ where
         let start = record.feature_start().unwrap().get() as i64 - 1;
         let end = record.feature_end().unwrap().unwrap().get() as i64;
         if let Some(bg) = sample_bgs.get(&ref_name) {
-            let projection = paths.entry(bg.id).or_insert_with(|| {
-                let path = BlockGroup::get_current_path(conn, &bg.id);
-                let graph = BlockGroup::get_graph(conn, &bg.id);
-                let mut tree = IntervalTree::default();
-                let mut position: i64 = 0;
-                for (node, strand) in project_path(&graph, &path.blocks(conn)) {
-                    if !is_terminal(node.node_id) {
-                        let end_position = position + node.length();
-                        tree.insert(position..end_position, (node, strand));
-                        position = end_position;
+            let projection = match paths.entry(bg.id) {
+                Entry::Occupied(entry) => entry.into_mut(),
+                Entry::Vacant(entry) => {
+                    let path = BlockGroup::get_current_path(conn, &bg.id);
+                    let graph = BlockGroup::get_graph(conn, &bg.id);
+                    let mut tree = IntervalTree::default();
+                    let mut position: i64 = 0;
+                    for (node, strand) in project_path(&graph, &path.blocks(conn)?) {
+                        if !is_terminal(node.node_id) {
+                            let end_position = position + node.length();
+                            tree.insert(position..end_position, (node, strand));
+                            position = end_position;
+                        }
                     }
+                    entry.insert(tree)
                 }
-                tree
-            });
+            };
             let range = start..end;
             let values: Vec<_> = record.other_fields().iter().map(Value::from).collect();
             let other_fields = OtherFields::from(values);

--- a/gen-annotations/src/translate/gff.rs
+++ b/gen-annotations/src/translate/gff.rs
@@ -1,6 +1,6 @@
 use std::{
     cmp::{max, min},
-    collections::HashMap,
+    collections::{HashMap, hash_map::Entry},
     io::{BufRead, Read, Write},
 };
 
@@ -9,6 +9,7 @@ use gen_graph::{GraphNode, project_path};
 use gen_models::{
     block_group::BlockGroup,
     db::GraphConnection,
+    errors::PathError,
     reference_alias::{ReferenceAlias, ReferenceAliasError},
     sample::Sample,
 };
@@ -22,6 +23,8 @@ pub enum GffError {
     Io(#[from] std::io::Error),
     #[error("Error loading reference aliases: {0}")]
     ReferenceAliasError(#[from] ReferenceAliasError),
+    #[error("Error loading path blocks: {0}")]
+    PathError(#[from] PathError),
 }
 
 pub fn translate_gff<R, W>(
@@ -61,26 +64,29 @@ where
         let start = record.start().get() as i64;
         let end = record.end().get() as i64;
         if let Some(bg) = sample_bgs.get(&ref_name) {
-            let projection = paths.entry(bg.id).or_insert_with(|| {
-                let path = BlockGroup::get_current_path(conn, &bg.id);
-                let graph = BlockGroup::get_graph(conn, &bg.id);
-                let mut tree = IntervalTree::default();
-                let mut position: i64 = 0;
-                for (node, strand) in project_path(&graph, &path.blocks(conn)) {
-                    if !is_terminal(node.node_id) {
-                        // GFF indexing is one based, inclusive, so we add 1 to the start.
-                        // Take a sequence that is 1-4 in our coordinates, this converts to:
-                        // 0123456
-                        // ATCGATC
-                        // 1234567
-                        // 1-4 in our zero-based half open interval would be 2-4 in GFF coordinates
-                        let end_position = position + node.length();
-                        tree.insert(position + 1..end_position, (node, strand));
-                        position = end_position;
+            let projection = match paths.entry(bg.id) {
+                Entry::Occupied(entry) => entry.into_mut(),
+                Entry::Vacant(entry) => {
+                    let path = BlockGroup::get_current_path(conn, &bg.id);
+                    let graph = BlockGroup::get_graph(conn, &bg.id);
+                    let mut tree = IntervalTree::default();
+                    let mut position: i64 = 0;
+                    for (node, strand) in project_path(&graph, &path.blocks(conn)?) {
+                        if !is_terminal(node.node_id) {
+                            // GFF indexing is one based, inclusive, so we add 1 to the start.
+                            // Take a sequence that is 1-4 in our coordinates, this converts to:
+                            // 0123456
+                            // ATCGATC
+                            // 1234567
+                            // 1-4 in our zero-based half open interval would be 2-4 in GFF coordinates
+                            let end_position = position + node.length();
+                            tree.insert(position + 1..end_position, (node, strand));
+                            position = end_position;
+                        }
                     }
+                    entry.insert(tree)
                 }
-                tree
-            });
+            };
             let range = start..end;
             for (overlap, (node, _overlap_strand)) in projection.iter_overlaps(&range) {
                 let overlap_start = max(start, overlap.start) as usize;

--- a/gen-core/src/errors.rs
+++ b/gen-core/src/errors.rs
@@ -1,6 +1,14 @@
 use thiserror::Error;
 
 #[derive(Debug, Error, PartialEq)]
+pub enum HashError {
+    #[error("Invalid hex string: {0}")]
+    InvalidHex(#[from] hex::FromHexError),
+    #[error("Hash must be 32 bytes, got {0}")]
+    InvalidLength(usize),
+}
+
+#[derive(Debug, Error, PartialEq)]
 pub enum ConfigError {
     #[error("Failed to find Gen directory")]
     GenDirectoryNotFound,

--- a/gen-core/src/lib.rs
+++ b/gen-core/src/lib.rs
@@ -1,6 +1,5 @@
 use std::{convert::TryFrom, fmt, hash::Hash};
 
-use hex::FromHex;
 use rand::Rng;
 use sha2::{Digest, Sha256};
 
@@ -15,6 +14,7 @@ pub mod strand;
 pub mod traits;
 
 pub use config::Workspace;
+use errors::HashError;
 pub use generated::gen_core_capnp;
 pub use path::PathBlock;
 #[cfg(feature = "python-bindings")]
@@ -103,11 +103,10 @@ impl fmt::Display for HashId {
 }
 
 impl TryFrom<String> for HashId {
-    type Error = hex::FromHexError;
+    type Error = HashError;
 
     fn try_from(s: String) -> Result<Self, Self::Error> {
-        let bytes = <[u8; 32]>::from_hex(&s)?;
-        Ok(HashId(bytes))
+        HashId::try_from(s.as_str())
     }
 }
 
@@ -132,11 +131,14 @@ impl TryFrom<&[u8]> for HashId {
 }
 
 impl TryFrom<&str> for HashId {
-    type Error = &'static str;
+    type Error = HashError;
 
     fn try_from(s: &str) -> Result<Self, Self::Error> {
-        let bytes = hex::decode(s).map_err(|_| "invalid hex string")?;
-        let array: [u8; 32] = bytes.try_into().map_err(|_| "not 32 bytes")?;
+        let bytes = hex::decode(s)?;
+        let len = bytes.len();
+        let array: [u8; 32] = bytes
+            .try_into()
+            .map_err(|_| HashError::InvalidLength(len))?;
         Ok(HashId(array))
     }
 }

--- a/gen-core/src/lib.rs
+++ b/gen-core/src/lib.rs
@@ -135,8 +135,9 @@ impl TryFrom<&str> for HashId {
     type Error = &'static str;
 
     fn try_from(s: &str) -> Result<Self, Self::Error> {
-        let bytes = hex::decode(s).expect("invalid hex string");
-        Ok(HashId(bytes.try_into().expect("not 32 bytes")))
+        let bytes = hex::decode(s).map_err(|_| "invalid hex string")?;
+        let array: [u8; 32] = bytes.try_into().map_err(|_| "not 32 bytes")?;
+        Ok(HashId(array))
     }
 }
 

--- a/gen-models/src/annotations.rs
+++ b/gen-models/src/annotations.rs
@@ -541,7 +541,7 @@ pub fn add_annotation(
         .find(|bg| bg.name == parsed_region.name)
         .ok_or_else(|| anyhow!("Graph {} not found for sample {sample}", parsed_region.name))?;
     let path = BlockGroup::get_current_path(graph_conn, &block_group.id);
-    let path_length = path.length(graph_conn);
+    let path_length = path.length(graph_conn)?;
     if start < 0 || end < 0 || start > end || end > path_length {
         return Err(anyhow!("Region {region} is outside the path bounds (0-{path_length})").into());
     }
@@ -551,7 +551,7 @@ pub fn add_annotation(
     operation_conn.execute("BEGIN TRANSACTION", [])?;
 
     let mut cache = PathCache::new(graph_conn);
-    let _ = PathCache::lookup(&mut cache, &block_group.id, path.name.clone());
+    let _ = PathCache::lookup(&mut cache, &block_group.id, path.name.clone())?;
     let accession = BlockGroup::add_accession(graph_conn, &path, name, start, end, &mut cache)?;
 
     let annotation_group = group.unwrap_or("default");
@@ -901,7 +901,7 @@ mod tests {
         let _ = Sample::create(&conn, "sample-2").unwrap();
 
         let mut cache = PathCache::new(&conn);
-        let _ = PathCache::lookup(&mut cache, &block_group_id, path.name.clone());
+        let _ = PathCache::lookup(&mut cache, &block_group_id, path.name.clone()).unwrap();
         let accession =
             BlockGroup::add_accession(&conn, &path, "ann-accession", 0, 5, &mut cache).unwrap();
 

--- a/gen-models/src/block_group.rs
+++ b/gen-models/src/block_group.rs
@@ -1910,7 +1910,7 @@ mod tests {
             Node::create(&conn, &insert_sequence.hash, &HashId::convert_str("1")).unwrap();
         let insert = PathBlock {
             node_id: insert_node_id,
-            block_sequence: insert_sequence.get_sequence(0, 4).to_string(),
+            block_sequence: insert_sequence.get_sequence(0, 4).unwrap(),
             sequence_start: 0,
             sequence_end: 4,
             path_start: 7,
@@ -1949,7 +1949,7 @@ mod tests {
             Node::create(&conn, &deletion_sequence.hash, &HashId::convert_str("2")).unwrap();
         let deletion = PathBlock {
             node_id: deletion_node_id,
-            block_sequence: deletion_sequence.get_sequence(None, None),
+            block_sequence: deletion_sequence.get_sequence(None, None).unwrap(),
             sequence_start: 0,
             sequence_end: 0,
             path_start: 19,
@@ -1996,7 +1996,7 @@ mod tests {
             Node::create(&conn, &insert_sequence.hash, &HashId::convert_str("1")).unwrap();
         let insert = PathBlock {
             node_id: insert_node_id,
-            block_sequence: insert_sequence.get_sequence(0, 4).to_string(),
+            block_sequence: insert_sequence.get_sequence(0, 4).unwrap(),
             sequence_start: 0,
             sequence_end: 4,
             path_start: 7,
@@ -2040,7 +2040,7 @@ mod tests {
             Node::create(&conn, &insert_sequence.hash, &HashId::convert_str("1")).unwrap();
         let insert = PathBlock {
             node_id: insert_node_id,
-            block_sequence: insert_sequence.get_sequence(0, 4).to_string(),
+            block_sequence: insert_sequence.get_sequence(0, 4).unwrap(),
             sequence_start: 0,
             sequence_end: 4,
             path_start: 15,
@@ -2084,7 +2084,7 @@ mod tests {
             Node::create(&conn, &insert_sequence.hash, &HashId::convert_str("1")).unwrap();
         let insert = PathBlock {
             node_id: insert_node_id,
-            block_sequence: insert_sequence.get_sequence(0, 4).to_string(),
+            block_sequence: insert_sequence.get_sequence(0, 4).unwrap(),
             sequence_start: 0,
             sequence_end: 4,
             path_start: 12,
@@ -2128,7 +2128,7 @@ mod tests {
             Node::create(&conn, &insert_sequence.hash, &HashId::convert_str("1")).unwrap();
         let insert = PathBlock {
             node_id: insert_node_id,
-            block_sequence: insert_sequence.get_sequence(0, 4).to_string(),
+            block_sequence: insert_sequence.get_sequence(0, 4).unwrap(),
             sequence_start: 0,
             sequence_end: 4,
             path_start: 10,
@@ -2172,7 +2172,7 @@ mod tests {
             Node::create(&conn, &insert_sequence.hash, &HashId::convert_str("1")).unwrap();
         let insert = PathBlock {
             node_id: insert_node_id,
-            block_sequence: insert_sequence.get_sequence(0, 4).to_string(),
+            block_sequence: insert_sequence.get_sequence(0, 4).unwrap(),
             sequence_start: 0,
             sequence_end: 4,
             path_start: 9,
@@ -2216,7 +2216,7 @@ mod tests {
             Node::create(&conn, &insert_sequence.hash, &HashId::convert_str("1")).unwrap();
         let insert = PathBlock {
             node_id: insert_node_id,
-            block_sequence: insert_sequence.get_sequence(0, 4).to_string(),
+            block_sequence: insert_sequence.get_sequence(0, 4).unwrap(),
             sequence_start: 0,
             sequence_end: 4,
             path_start: 10,
@@ -2260,7 +2260,7 @@ mod tests {
             Node::create(&conn, &insert_sequence.hash, &HashId::convert_str("1")).unwrap();
         let insert = PathBlock {
             node_id: insert_node_id,
-            block_sequence: insert_sequence.get_sequence(0, 4).to_string(),
+            block_sequence: insert_sequence.get_sequence(0, 4).unwrap(),
             sequence_start: 0,
             sequence_end: 4,
             path_start: 15,
@@ -2304,7 +2304,7 @@ mod tests {
             Node::create(&conn, &insert_sequence.hash, &HashId::convert_str("1")).unwrap();
         let insert = PathBlock {
             node_id: insert_node_id,
-            block_sequence: insert_sequence.get_sequence(0, 4).to_string(),
+            block_sequence: insert_sequence.get_sequence(0, 4).unwrap(),
             sequence_start: 0,
             sequence_end: 4,
             path_start: 5,
@@ -2348,7 +2348,7 @@ mod tests {
             Node::create(&conn, &deletion_sequence.hash, &HashId::convert_str("1")).unwrap();
         let deletion = PathBlock {
             node_id: deletion_node_id,
-            block_sequence: deletion_sequence.get_sequence(None, None),
+            block_sequence: deletion_sequence.get_sequence(None, None).unwrap(),
             sequence_start: 0,
             sequence_end: 0,
             path_start: 19,
@@ -2394,7 +2394,7 @@ mod tests {
             Node::create(&conn, &insert_sequence.hash, &HashId::convert_str("1")).unwrap();
         let insert = PathBlock {
             node_id: insert_node_id,
-            block_sequence: insert_sequence.get_sequence(0, 4).to_string(),
+            block_sequence: insert_sequence.get_sequence(0, 4).unwrap(),
             sequence_start: 0,
             sequence_end: 4,
             path_start: 7,
@@ -2450,7 +2450,7 @@ mod tests {
             Node::create(&conn, &insert_sequence.hash, &HashId::convert_str("1")).unwrap();
         let insert = PathBlock {
             node_id: insert_node_id,
-            block_sequence: insert_sequence.get_sequence(0, 4).to_string(),
+            block_sequence: insert_sequence.get_sequence(0, 4).unwrap(),
             sequence_start: 0,
             sequence_end: 4,
             path_start: 0,
@@ -2494,7 +2494,7 @@ mod tests {
             Node::create(&conn, &insert_sequence.hash, &HashId::convert_str("1")).unwrap();
         let insert = PathBlock {
             node_id: insert_node_id,
-            block_sequence: insert_sequence.get_sequence(0, 4).to_string(),
+            block_sequence: insert_sequence.get_sequence(0, 4).unwrap(),
             sequence_start: 0,
             sequence_end: 4,
             path_start: 0,
@@ -2538,7 +2538,7 @@ mod tests {
             Node::create(&conn, &insert_sequence.hash, &HashId::convert_str("1")).unwrap();
         let insert = PathBlock {
             node_id: insert_node_id,
-            block_sequence: insert_sequence.get_sequence(0, 4).to_string(),
+            block_sequence: insert_sequence.get_sequence(0, 4).unwrap(),
             sequence_start: 0,
             sequence_end: 4,
             path_start: 40,
@@ -2582,7 +2582,7 @@ mod tests {
             Node::create(&conn, &insert_sequence.hash, &HashId::convert_str("1")).unwrap();
         let insert = PathBlock {
             node_id: insert_node_id,
-            block_sequence: insert_sequence.get_sequence(0, 4).to_string(),
+            block_sequence: insert_sequence.get_sequence(0, 4).unwrap(),
             sequence_start: 0,
             sequence_end: 4,
             path_start: 10,
@@ -2626,7 +2626,7 @@ mod tests {
             Node::create(&conn, &insert_sequence.hash, &HashId::convert_str("1")).unwrap();
         let insert = PathBlock {
             node_id: insert_node_id,
-            block_sequence: insert_sequence.get_sequence(0, 4).to_string(),
+            block_sequence: insert_sequence.get_sequence(0, 4).unwrap(),
             sequence_start: 0,
             sequence_end: 4,
             path_start: 19,
@@ -2670,7 +2670,7 @@ mod tests {
             Node::create(&conn, &deletion_sequence.hash, &HashId::convert_str("1")).unwrap();
         let deletion = PathBlock {
             node_id: deletion_node_id,
-            block_sequence: deletion_sequence.get_sequence(None, None),
+            block_sequence: deletion_sequence.get_sequence(None, None).unwrap(),
             sequence_start: 0,
             sequence_end: 0,
             path_start: 0,
@@ -2714,7 +2714,7 @@ mod tests {
             Node::create(&conn, &deletion_sequence.hash, &HashId::convert_str("1")).unwrap();
         let deletion = PathBlock {
             node_id: deletion_node_id,
-            block_sequence: deletion_sequence.get_sequence(None, None),
+            block_sequence: deletion_sequence.get_sequence(None, None).unwrap(),
             sequence_start: 0,
             sequence_end: 0,
             path_start: 35,
@@ -2758,7 +2758,7 @@ mod tests {
             Node::create(&conn, &deletion_sequence.hash, &HashId::convert_str("1")).unwrap();
         let deletion = PathBlock {
             node_id: deletion_node_id,
-            block_sequence: deletion_sequence.get_sequence(None, None),
+            block_sequence: deletion_sequence.get_sequence(None, None).unwrap(),
             sequence_start: 0,
             sequence_end: 0,
             path_start: 350,
@@ -2807,7 +2807,7 @@ mod tests {
             Node::create(&conn, &deletion_sequence.hash, &HashId::convert_str("1")).unwrap();
         let deletion = PathBlock {
             node_id: deletion_node_id,
-            block_sequence: deletion_sequence.get_sequence(None, None),
+            block_sequence: deletion_sequence.get_sequence(None, None).unwrap(),
             sequence_start: 0,
             sequence_end: 0,
             path_start: 10,
@@ -2851,7 +2851,7 @@ mod tests {
             Node::create(&conn, &deletion_sequence.hash, &HashId::convert_str("1")).unwrap();
         let deletion = PathBlock {
             node_id: deletion_node_id,
-            block_sequence: deletion_sequence.get_sequence(None, None),
+            block_sequence: deletion_sequence.get_sequence(None, None).unwrap(),
             sequence_start: 0,
             sequence_end: 0,
             path_start: 18,
@@ -2906,7 +2906,7 @@ mod tests {
         .unwrap();
         let insert = PathBlock {
             node_id: insert_node_id,
-            block_sequence: insert_sequence.get_sequence(0, 4).to_string(),
+            block_sequence: insert_sequence.get_sequence(0, 4).unwrap(),
             sequence_start: 0,
             sequence_end: 4,
             path_start: 7,
@@ -3074,7 +3074,7 @@ mod tests {
             Node::create(conn, &insert_sequence.hash, &HashId::convert_str("1")).unwrap();
         let insert = PathBlock {
             node_id: insert_node_id,
-            block_sequence: insert_sequence.get_sequence(0, 4).to_string(),
+            block_sequence: insert_sequence.get_sequence(0, 4).unwrap(),
             sequence_start: 0,
             sequence_end: 4,
             path_start: 7,
@@ -3118,7 +3118,7 @@ mod tests {
 
         let insert = PathBlock {
             node_id: insert_node_id,
-            block_sequence: insert_sequence.get_sequence(0, 4).to_string(),
+            block_sequence: insert_sequence.get_sequence(0, 4).unwrap(),
             sequence_start: 0,
             sequence_end: 4,
             path_start: 7,
@@ -3168,7 +3168,7 @@ mod tests {
             Node::create(conn, &insert_sequence.hash, &HashId::convert_str("1")).unwrap();
         let insert = PathBlock {
             node_id: insert_node_id,
-            block_sequence: insert_sequence.get_sequence(0, 4).to_string(),
+            block_sequence: insert_sequence.get_sequence(0, 4).unwrap(),
             sequence_start: 0,
             sequence_end: 4,
             path_start: 7,
@@ -3227,7 +3227,7 @@ mod tests {
 
         let insert = PathBlock {
             node_id: insert_node_id,
-            block_sequence: insert_sequence.get_sequence(0, 4).to_string(),
+            block_sequence: insert_sequence.get_sequence(0, 4).unwrap(),
             sequence_start: 0,
             sequence_end: 4,
             path_start: 20,
@@ -3284,7 +3284,7 @@ mod tests {
             Node::create(conn, &insert_sequence.hash, &HashId::convert_str("1")).unwrap();
         let insert = PathBlock {
             node_id: insert_node_id,
-            block_sequence: insert_sequence.get_sequence(0, 4).to_string(),
+            block_sequence: insert_sequence.get_sequence(0, 4).unwrap(),
             sequence_start: 0,
             sequence_end: 4,
             path_start: 7,
@@ -3339,7 +3339,7 @@ mod tests {
 
         let insert = PathBlock {
             node_id: insert_node_id,
-            block_sequence: insert_sequence.get_sequence(0, 4).to_string(),
+            block_sequence: insert_sequence.get_sequence(0, 4).unwrap(),
             sequence_start: 0,
             sequence_end: 4,
             path_start: 20,

--- a/gen-models/src/block_group.rs
+++ b/gen-models/src/block_group.rs
@@ -182,14 +182,18 @@ impl<'a> PathCache<'a> {
         }
     }
 
-    pub fn lookup(path_cache: &mut PathCache, block_group_id: &HashId, name: String) -> Path {
+    pub fn lookup(
+        path_cache: &mut PathCache,
+        block_group_id: &HashId,
+        name: String,
+    ) -> Result<Path, PathError> {
         let path_key = PathData {
             name: name.clone(),
             block_group_id: *block_group_id,
         };
         let path_lookup = path_cache.cache.get(&path_key);
         if let Some(path) = path_lookup {
-            path.clone()
+            Ok(path.clone())
         } else {
             let conn = path_cache.conn;
             let new_path = Path::query(
@@ -200,22 +204,24 @@ impl<'a> PathCache<'a> {
             .clone();
 
             path_cache.cache.insert(path_key, new_path.clone());
-            let tree = new_path.intervaltree(conn);
+            let tree = new_path.intervaltree(conn)?;
             path_cache.intervaltree_cache.insert(new_path.clone(), tree);
-            new_path
+            Ok(new_path)
         }
     }
 
     pub fn get_intervaltree<'b>(
         path_cache: &'b mut PathCache<'_>,
         path: &Path,
-    ) -> &'b IntervalTree<i64, NodeIntervalBlock> {
+    ) -> Result<&'b IntervalTree<i64, NodeIntervalBlock>, PathError> {
         if !path_cache.intervaltree_cache.contains_key(path) {
-            let tree = path.intervaltree(path_cache.conn);
+            let tree = path.intervaltree(path_cache.conn)?;
             path_cache.intervaltree_cache.insert(path.clone(), tree);
         }
 
-        path_cache.intervaltree_cache.get(path).unwrap()
+        path_cache.intervaltree_cache.get(path).ok_or_else(|| {
+            PathError::CachePoison(format!("Missing interval tree for path {}", path.id))
+        })
     }
 }
 
@@ -615,7 +621,7 @@ impl BlockGroup {
         end: i64,
         cache: &mut PathCache,
     ) -> Result<Accession, BlockGroupError> {
-        let tree = PathCache::get_intervaltree(cache, path);
+        let tree = PathCache::get_intervaltree(cache, path)?;
         let start_blocks: Vec<&NodeIntervalBlock> =
             tree.query_point(start).map(|x| &x.value).collect();
         assert_eq!(start_blocks.len(), 1);
@@ -701,7 +707,7 @@ impl BlockGroup {
                     BlockGroup::intervaltree_for(conn, &change.block_group_id, true)
                 })
             } else {
-                PathCache::get_intervaltree(cache, &change.path)
+                PathCache::get_intervaltree(cache, &change.path)?
             };
             let new_augmented_edges = BlockGroup::set_up_new_edges(change, tree)?;
             new_augmented_edges_by_block_group
@@ -1765,9 +1771,9 @@ mod tests {
         .unwrap();
 
         let mut path_cache = PathCache::new(conn);
-        let parent_a_path_len = parent_a_path.length(conn);
-        let parent_b_path_len = parent_b_path.length(conn);
-        let parent_b_alt_path_len = parent_b_alt_path.length(conn);
+        let parent_a_path_len = parent_a_path.length(conn).unwrap();
+        let parent_b_path_len = parent_b_path.length(conn).unwrap();
+        let parent_b_alt_path_len = parent_b_alt_path.length(conn).unwrap();
         BlockGroup::add_accession(
             conn,
             &parent_a_path,
@@ -1928,7 +1934,7 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        let tree = path.intervaltree(&conn);
+        let tree = path.intervaltree(&conn).unwrap();
         BlockGroup::insert_change(&conn, &change, &tree).unwrap();
 
         let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
@@ -1969,7 +1975,7 @@ mod tests {
             preserve_edge: true,
         };
         // take out an entire block.
-        let tree = path.intervaltree(&conn);
+        let tree = path.intervaltree(&conn).unwrap();
         BlockGroup::insert_change(&conn, &change, &tree).unwrap();
         let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
         assert_eq!(
@@ -2014,7 +2020,7 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        let tree = path.intervaltree(&conn);
+        let tree = path.intervaltree(&conn).unwrap();
         BlockGroup::insert_change(&conn, &change, &tree).unwrap();
 
         let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
@@ -2058,7 +2064,7 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        let tree = path.intervaltree(&conn);
+        let tree = path.intervaltree(&conn).unwrap();
         BlockGroup::insert_change(&conn, &change, &tree).unwrap();
 
         let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
@@ -2102,7 +2108,7 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        let tree = path.intervaltree(&conn);
+        let tree = path.intervaltree(&conn).unwrap();
         BlockGroup::insert_change(&conn, &change, &tree).unwrap();
 
         let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
@@ -2146,7 +2152,7 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        let tree = path.intervaltree(&conn);
+        let tree = path.intervaltree(&conn).unwrap();
         BlockGroup::insert_change(&conn, &change, &tree).unwrap();
 
         let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
@@ -2190,7 +2196,7 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        let tree = path.intervaltree(&conn);
+        let tree = path.intervaltree(&conn).unwrap();
         BlockGroup::insert_change(&conn, &change, &tree).unwrap();
 
         let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
@@ -2234,7 +2240,7 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        let tree = path.intervaltree(&conn);
+        let tree = path.intervaltree(&conn).unwrap();
         BlockGroup::insert_change(&conn, &change, &tree).unwrap();
 
         let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
@@ -2278,7 +2284,7 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        let tree = path.intervaltree(&conn);
+        let tree = path.intervaltree(&conn).unwrap();
         BlockGroup::insert_change(&conn, &change, &tree).unwrap();
 
         let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
@@ -2322,7 +2328,7 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        let tree = path.intervaltree(&conn);
+        let tree = path.intervaltree(&conn).unwrap();
         BlockGroup::insert_change(&conn, &change, &tree).unwrap();
 
         let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
@@ -2369,7 +2375,7 @@ mod tests {
         };
 
         // take out an entire block.
-        let tree = path.intervaltree(&conn);
+        let tree = path.intervaltree(&conn).unwrap();
         BlockGroup::insert_change(&conn, &change, &tree).unwrap();
         let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
         assert_eq!(
@@ -2412,7 +2418,7 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        let tree = path.intervaltree(&conn);
+        let tree = path.intervaltree(&conn).unwrap();
         BlockGroup::insert_change(&conn, &change, &tree).unwrap();
 
         let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
@@ -2424,7 +2430,7 @@ mod tests {
             ])
         );
 
-        let tree = path.intervaltree(&conn);
+        let tree = path.intervaltree(&conn).unwrap();
         BlockGroup::insert_change(&conn, &change, &tree).unwrap();
 
         let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
@@ -2468,7 +2474,7 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        let tree = path.intervaltree(&conn);
+        let tree = path.intervaltree(&conn).unwrap();
         BlockGroup::insert_change(&conn, &change, &tree).unwrap();
 
         let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
@@ -2512,7 +2518,7 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        let tree = path.intervaltree(&conn);
+        let tree = path.intervaltree(&conn).unwrap();
         BlockGroup::insert_change(&conn, &change, &tree).unwrap();
 
         let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
@@ -2556,7 +2562,7 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        let tree = path.intervaltree(&conn);
+        let tree = path.intervaltree(&conn).unwrap();
         BlockGroup::insert_change(&conn, &change, &tree).unwrap();
 
         let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
@@ -2600,7 +2606,7 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        let tree = path.intervaltree(&conn);
+        let tree = path.intervaltree(&conn).unwrap();
         BlockGroup::insert_change(&conn, &change, &tree).unwrap();
 
         let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
@@ -2644,7 +2650,7 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        let tree = path.intervaltree(&conn);
+        let tree = path.intervaltree(&conn).unwrap();
         BlockGroup::insert_change(&conn, &change, &tree).unwrap();
 
         let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
@@ -2688,7 +2694,7 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        let tree = path.intervaltree(&conn);
+        let tree = path.intervaltree(&conn).unwrap();
         BlockGroup::insert_change(&conn, &change, &tree).unwrap();
 
         let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
@@ -2732,7 +2738,7 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        let tree = path.intervaltree(&conn);
+        let tree = path.intervaltree(&conn).unwrap();
         BlockGroup::insert_change(&conn, &change, &tree).unwrap();
 
         let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
@@ -2787,7 +2793,7 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        let tree = path.intervaltree(&conn);
+        let tree = path.intervaltree(&conn).unwrap();
         let res = BlockGroup::insert_change(&conn, &after_end_change, &tree);
         assert!(matches!(res, Err(BlockGroupError::ChangeOutOfBounds(_))));
         let res = BlockGroup::insert_change(&conn, &before_start_change, &tree);
@@ -2825,7 +2831,7 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        let tree = path.intervaltree(&conn);
+        let tree = path.intervaltree(&conn).unwrap();
         BlockGroup::insert_change(&conn, &change, &tree).unwrap();
 
         let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
@@ -2869,7 +2875,7 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        let tree = path.intervaltree(&conn);
+        let tree = path.intervaltree(&conn).unwrap();
         BlockGroup::insert_change(&conn, &change, &tree).unwrap();
 
         let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
@@ -2924,7 +2930,7 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        let tree = path.intervaltree(conn);
+        let tree = path.intervaltree(conn).unwrap();
         BlockGroup::insert_change(conn, &change, &tree).unwrap();
 
         let tree = BlockGroup::intervaltree_for(conn, &block_group_id, false);
@@ -3382,7 +3388,7 @@ mod tests {
             let conn = &get_connection(None).unwrap();
             let (block_group1_id, original_path) = setup_block_group(conn);
 
-            let intervaltree = original_path.intervaltree(conn);
+            let intervaltree = original_path.intervaltree(conn).unwrap();
             let insert_start_node_id = intervaltree.query_point(16).next().unwrap().value.node_id;
             let insert_end_node_id = intervaltree.query_point(24).next().unwrap().value.node_id;
 
@@ -3463,7 +3469,7 @@ mod tests {
                 .new_path_with(conn, 16, 24, &edge_into_insert, &edge_out_of_insert)
                 .unwrap();
             assert_eq!(
-                insert_path.sequence(conn),
+                insert_path.sequence(conn).unwrap(),
                 "AAAAAAAAAATTTTTTAAAAAAAACCCCCCGGGGGGGGGG"
             );
 
@@ -3517,7 +3523,7 @@ mod tests {
             let conn = &get_connection(None).unwrap();
             let (block_group1_id, original_path) = setup_block_group(conn);
 
-            let intervaltree = original_path.intervaltree(conn);
+            let intervaltree = original_path.intervaltree(conn).unwrap();
             let insert_start_node_id = intervaltree.query_point(16).next().unwrap().value.node_id;
             let insert_end_node_id = intervaltree.query_point(24).next().unwrap().value.node_id;
 
@@ -3598,7 +3604,7 @@ mod tests {
                 .new_path_with(conn, 16, 24, &edge_into_insert, &edge_out_of_insert)
                 .unwrap();
             assert_eq!(
-                insert_path.sequence(conn),
+                insert_path.sequence(conn).unwrap(),
                 "AAAAAAAAAATTTTTTAAAAAAAACCCCCCGGGGGGGGGG"
             );
 
@@ -3682,7 +3688,7 @@ mod tests {
                 .new_path_with(conn, 28, 32, &edge_into_insert2, &edge_out_of_insert2)
                 .unwrap();
             assert_eq!(
-                insert2_path.sequence(conn),
+                insert2_path.sequence(conn).unwrap(),
                 "AAAAAAAAAATTTTTTAAAAAAAACCTTTTTTTTGGGGGG"
             );
 
@@ -3746,7 +3752,7 @@ mod tests {
             let conn = &get_connection(None).unwrap();
             let (block_group1_id, original_path) = setup_block_group(conn);
 
-            let intervaltree = original_path.intervaltree(conn);
+            let intervaltree = original_path.intervaltree(conn).unwrap();
             let insert_start_node_id = intervaltree.query_point(16).next().unwrap().value.node_id;
             let insert_end_node_id = intervaltree.query_point(24).next().unwrap().value.node_id;
 
@@ -3826,7 +3832,7 @@ mod tests {
                 .new_path_with(conn, 16, 24, &edge_into_insert, &edge_out_of_insert)
                 .unwrap();
             assert_eq!(
-                insert_path.sequence(conn),
+                insert_path.sequence(conn).unwrap(),
                 "AAAAAAAAAATTTTTTAAAAAAAACCCCCCGGGGGGGGGG"
             );
 
@@ -3909,7 +3915,7 @@ mod tests {
                 .new_path_with(conn, 28, 32, &edge_into_insert2, &edge_out_of_insert2)
                 .unwrap();
             assert_eq!(
-                insert2_path.sequence(conn),
+                insert2_path.sequence(conn).unwrap(),
                 "AAAAAAAAAATTTTTTAAAAAAAACCTTTTTTTTGGGGGG"
             );
 

--- a/gen-models/src/block_group.rs
+++ b/gen-models/src/block_group.rs
@@ -220,7 +220,7 @@ impl<'a> PathCache<'a> {
         }
 
         path_cache.intervaltree_cache.get(path).ok_or_else(|| {
-            PathError::CachePoison(format!("Missing interval tree for path {}", path.id))
+            PathError::Missing(format!("Missing interval tree for path {}", path.id))
         })
     }
 }

--- a/gen-models/src/changesets.rs
+++ b/gen-models/src/changesets.rs
@@ -1573,7 +1573,7 @@ mod tests {
         let _ = Sample::create(conn, "sample-1").unwrap();
         let (block_group_id, path) = setup_block_group(conn);
         let mut cache = PathCache::new(conn);
-        let _ = PathCache::lookup(&mut cache, &block_group_id, path.name.clone());
+        let _ = PathCache::lookup(&mut cache, &block_group_id, path.name.clone()).unwrap();
         let accession =
             BlockGroup::add_accession(conn, &path, "ann-accession", 0, 5, &mut cache).unwrap();
 

--- a/gen-models/src/edge.rs
+++ b/gen-models/src/edge.rs
@@ -20,7 +20,7 @@ use crate::{
     errors::NodeError,
     gen_models_capnp::edge,
     node::Node,
-    sequence::{Sequence, cached_sequence},
+    sequence::{Sequence, SequenceError, cached_sequence},
     traits::*,
 };
 
@@ -156,7 +156,7 @@ impl GroupBlock {
             GroupBlock {
                 id,
                 node_id,
-                sequence: Some(sequence.get_sequence(start, end)),
+                sequence: Some(sequence.get_sequence(start, end).unwrap()),
                 external_sequence: None,
                 start,
                 end,
@@ -168,7 +168,7 @@ impl GroupBlock {
         if let Some(sequence) = &self.sequence {
             sequence.to_string()
         } else if let Some((path, name)) = &self.external_sequence {
-            cached_sequence(path, name, self.start as usize, self.end as usize).unwrap()
+            cached_sequence(path, name, self.start, self.end).unwrap()
         } else {
             panic!("Sequence or external sequence is not set.")
         }
@@ -199,6 +199,8 @@ pub enum EdgeError {
     DatabaseError(#[from] rusqlite::Error),
     #[error("Node creation error: {0}")]
     NodeError(#[from] NodeError),
+    #[error("Sequence error: {0}")]
+    SequenceError(#[from] SequenceError),
 }
 
 impl Edge {
@@ -738,7 +740,7 @@ mod tests {
             Node::create(&conn, &insert_sequence.hash, &HashId::convert_str("1")).unwrap();
         let insert = PathBlock {
             node_id: insert_node_id,
-            block_sequence: insert_sequence.get_sequence(0, 4).to_string(),
+            block_sequence: insert_sequence.get_sequence(0, 4).unwrap(),
             sequence_start: 0,
             sequence_end: 4,
             path_start: 7,

--- a/gen-models/src/edge.rs
+++ b/gen-models/src/edge.rs
@@ -762,7 +762,7 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        let tree = path.intervaltree(&conn);
+        let tree = path.intervaltree(&conn).unwrap();
         BlockGroup::insert_change(&conn, &change, &tree).unwrap();
         let mut edges = BlockGroupEdge::edges_for_block_group(&conn, &block_group_id);
 

--- a/gen-models/src/edge.rs
+++ b/gen-models/src/edge.rs
@@ -136,7 +136,7 @@ pub struct GroupBlock {
     pub id: i64,
     pub node_id: HashId,
     sequence: Option<String>,
-    external_sequence: Option<(String, String)>,
+    external_sequence: Option<(String, String, bool)>,
     pub start: i64,
     pub end: i64,
 }
@@ -148,7 +148,11 @@ impl GroupBlock {
                 id,
                 node_id,
                 sequence: None,
-                external_sequence: Some((sequence.file_path.clone(), sequence.name.clone())),
+                external_sequence: Some((
+                    sequence.file_path.clone(),
+                    sequence.name.clone(),
+                    sequence.sequence_type.eq_ignore_ascii_case("circular"),
+                )),
                 start,
                 end,
             }
@@ -167,8 +171,8 @@ impl GroupBlock {
     pub fn sequence(&self) -> String {
         if let Some(sequence) = &self.sequence {
             sequence.to_string()
-        } else if let Some((path, name)) = &self.external_sequence {
-            cached_sequence(path, name, self.start, self.end).unwrap()
+        } else if let Some((path, name, circular)) = &self.external_sequence {
+            cached_sequence(path, name, self.start, self.end, *circular).unwrap()
         } else {
             panic!("Sequence or external sequence is not set.")
         }

--- a/gen-models/src/node.rs
+++ b/gen-models/src/node.rs
@@ -1,11 +1,16 @@
 use std::collections::HashMap;
 
 use gen_core::{HashId, PATH_END_NODE_ID, PATH_START_NODE_ID, calculate_hash, traits::Capnp};
-use rusqlite::{Row, params};
+use rusqlite::{Row, params, types::Value};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use crate::{db::GraphConnection, gen_models_capnp::node, sequence::Sequence, traits::*};
+use crate::{
+    db::GraphConnection,
+    gen_models_capnp::node,
+    sequence::Sequence,
+    traits::{self, *},
+};
 
 #[derive(Clone, Debug, Eq, Deserialize, Hash, Serialize, PartialEq)]
 pub struct Node {
@@ -114,6 +119,44 @@ impl Node {
                 )
             })
             .collect::<HashMap<HashId, Sequence>>()
+    }
+
+    pub fn query_nodes_length(
+        conn: &GraphConnection,
+        node_ids: &[HashId],
+    ) -> Result<HashMap<HashId, i64>, NodeError> {
+        if node_ids.is_empty() {
+            return Ok(HashMap::new());
+        }
+
+        let mut lengths = HashMap::new();
+        let batch_size = traits::max_rows_per_batch(conn, 1);
+        let query = "
+            WITH arr AS (
+                SELECT value, rowid AS pos
+                FROM rarray(?1)
+            )
+            SELECT n.id, s.length
+            FROM nodes n
+            JOIN sequences s ON s.hash = n.sequence_hash
+            JOIN arr ON n.id = arr.value
+            ORDER BY arr.pos;
+        ";
+
+        for chunk in node_ids.chunks(batch_size) {
+            let values: Vec<Value> = chunk.iter().copied().map(Value::from).collect();
+            let mut stmt = conn.prepare_cached(query)?;
+            let rows = stmt.query_map(params![std::rc::Rc::new(values)], |row| {
+                Ok((row.get::<_, HashId>(0)?, row.get::<_, i64>(1)?))
+            })?;
+
+            for row in rows {
+                let (node_id, length) = row?;
+                lengths.insert(node_id, length);
+            }
+        }
+
+        Ok(lengths)
     }
 
     pub fn get_start_node() -> Node {

--- a/gen-models/src/path.rs
+++ b/gen-models/src/path.rs
@@ -25,18 +25,6 @@ use crate::{
     traits::*,
 };
 
-fn slice_path_block_sequence(sequence: &Sequence, start: i64, end: i64) -> String {
-    match sequence.get_sequence(start, end) {
-        Ok(sequence) => sequence,
-        Err(SequenceError::BoundsError {
-            start: 0,
-            end,
-            length,
-        }) if end == length + 1 => sequence.get_sequence(0, length).unwrap(),
-        Err(err) => panic!("Unable to extract path block sequence: {err}"),
-    }
-}
-
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Deserialize, Serialize)]
 pub struct Path {
     pub id: HashId,
@@ -49,6 +37,8 @@ pub struct Path {
 pub enum PathError {
     #[error("Database error: {0}")]
     DatabaseError(#[from] rusqlite::Error),
+    #[error("Path cache error: {0}")]
+    CachePoison(String),
     #[error("Duplicate entry with uuid: {0}")]
     Duplicate(String),
     #[error("Problem creating path edges: {0}")]
@@ -272,20 +262,20 @@ impl Path {
         Path::query(conn, query, params![collection_name, sample_name])
     }
 
-    pub fn sequence(&self, conn: &GraphConnection) -> String {
-        let blocks = self.blocks(conn);
-        blocks
+    pub fn sequence(&self, conn: &GraphConnection) -> Result<String, PathError> {
+        let blocks = self.blocks(conn)?;
+        Ok(blocks
             .into_iter()
             .map(|block| block.block_sequence)
             .collect::<Vec<_>>()
-            .join("")
+            .join(""))
     }
 
-    pub fn length(&self, conn: &GraphConnection) -> i64 {
-        let blocks = self.blocks(conn);
+    pub fn length(&self, conn: &GraphConnection) -> Result<i64, PathError> {
+        let blocks = self.blocks(conn)?;
         let end_block = blocks.last().unwrap();
         // the last block is the terminal node, which starts at the end of the path
-        end_block.path_start
+        Ok(end_block.path_start)
     }
 
     pub fn edge_pairs_to_block(
@@ -294,13 +284,13 @@ impl Path {
         out_of: Edge,
         sequences_by_node_id: &HashMap<HashId, Sequence>,
         current_path_length: i64,
-    ) -> PathBlock {
+    ) -> Result<PathBlock, PathError> {
         let start = into.target_coordinate;
         let end = out_of.source_coordinate;
         let strand = into.target_strand;
         let block_sequence_length = end - start;
         let Some(sequence) = sequences_by_node_id.get(&into.target_node_id) else {
-            return PathBlock {
+            return Ok(PathBlock {
                 node_id: into.target_node_id,
                 block_sequence: String::new(),
                 sequence_start: start,
@@ -308,16 +298,16 @@ impl Path {
                 path_start: current_path_length,
                 path_end: current_path_length + block_sequence_length,
                 strand,
-            };
+            });
         };
 
         let block_sequence = if strand == Strand::Reverse {
-            revcomp(&slice_path_block_sequence(sequence, start, end))
+            revcomp(&sequence.get_sequence(start, end)?)
         } else {
-            slice_path_block_sequence(sequence, start, end)
+            sequence.get_sequence(start, end)?
         };
 
-        PathBlock {
+        Ok(PathBlock {
             node_id: into.target_node_id,
             block_sequence,
             sequence_start: start,
@@ -325,10 +315,10 @@ impl Path {
             path_start: current_path_length,
             path_end: current_path_length + block_sequence_length,
             strand,
-        }
+        })
     }
 
-    pub fn blocks(&self, conn: &GraphConnection) -> Vec<PathBlock> {
+    pub fn blocks(&self, conn: &GraphConnection) -> Result<Vec<PathBlock>, PathError> {
         let edges = PathEdge::edges_for_path(conn, &self.id);
 
         let mut sequence_node_ids = HashSet::new();
@@ -362,7 +352,8 @@ impl Path {
         });
 
         for (into, out_of) in edges.into_iter().tuple_windows() {
-            let block = self.edge_pairs_to_block(into, out_of, &sequences_by_node_id, path_length);
+            let block =
+                self.edge_pairs_to_block(into, out_of, &sequences_by_node_id, path_length)?;
             path_length += block.block_sequence.len() as i64;
             blocks.push(block);
         }
@@ -380,11 +371,14 @@ impl Path {
             strand: Strand::Forward,
         });
 
-        blocks
+        Ok(blocks)
     }
 
-    pub fn intervaltree(&self, conn: &GraphConnection) -> IntervalTree<i64, NodeIntervalBlock> {
-        let blocks = self.blocks(conn);
+    pub fn intervaltree(
+        &self,
+        conn: &GraphConnection,
+    ) -> Result<IntervalTree<i64, NodeIntervalBlock>, PathError> {
+        let blocks = self.blocks(conn)?;
         let tree: IntervalTree<i64, NodeIntervalBlock> = blocks
             .into_iter()
             .map(|block| {
@@ -401,18 +395,18 @@ impl Path {
                 )
             })
             .collect();
-        tree
+        Ok(tree)
     }
 
     pub fn find_block_mappings(
         &self,
         conn: &GraphConnection,
         other_path: &Path,
-    ) -> Vec<RangeMapping> {
+    ) -> Result<Vec<RangeMapping>, PathError> {
         // Given two paths, find the overlapping parts of common nodes/blocks and return a list af
         // mappings from subranges of one path to corresponding shared subranges of the other path
-        let our_blocks = self.blocks(conn);
-        let their_blocks = other_path.blocks(conn);
+        let our_blocks = self.blocks(conn)?;
+        let their_blocks = other_path.blocks(conn)?;
 
         let our_node_ids = our_blocks
             .iter()
@@ -524,10 +518,10 @@ impl Path {
             }
         }
 
-        mappings
+        Ok(mappings
             .into_iter()
             .sorted_by(|a, b| a.source_range.start.cmp(&b.source_range.start))
-            .collect::<Vec<RangeMapping>>()
+            .collect::<Vec<RangeMapping>>())
     }
 
     pub fn propagate_annotation(
@@ -605,9 +599,9 @@ impl Path {
         &self,
         conn: &GraphConnection,
         path: &Path,
-    ) -> IntervalTree<i64, RangeMapping> {
-        let mappings = self.find_block_mappings(conn, path);
-        mappings
+    ) -> Result<IntervalTree<i64, RangeMapping>, PathError> {
+        let mappings = self.find_block_mappings(conn, path)?;
+        Ok(mappings
             .into_iter()
             .map(|mapping| {
                 (
@@ -615,7 +609,7 @@ impl Path {
                     mapping,
                 )
             })
-            .collect()
+            .collect())
     }
 
     pub fn propagate_annotations(
@@ -623,16 +617,16 @@ impl Path {
         conn: &GraphConnection,
         path: &Path,
         annotations: Vec<Annotation>,
-    ) -> Vec<Annotation> {
-        let mapping_tree = self.get_mapping_tree(conn, path);
-        let sequence_length = path.sequence(conn).len();
-        annotations
+    ) -> Result<Vec<Annotation>, PathError> {
+        let mapping_tree = self.get_mapping_tree(conn, path)?;
+        let sequence_length = path.sequence(conn)?.len();
+        Ok(annotations
             .into_iter()
             .filter_map(|annotation| {
                 Path::propagate_annotation(annotation, &mapping_tree, sequence_length as i64)
             })
             .clone()
-            .collect()
+            .collect())
     }
 
     pub fn new_path_with(
@@ -645,7 +639,7 @@ impl Path {
     ) -> Result<Path, PathError> {
         // Creates a new path from the current one by replacing all edges between path_start and
         // path_end with the input edges that are to and from a new node
-        let tree = self.intervaltree(conn);
+        let tree = self.intervaltree(conn)?;
         let block_with_start = tree.query_point(path_start).next().unwrap().value;
         let block_with_end = tree.query_point(path_end).next().unwrap().value;
 
@@ -716,7 +710,7 @@ impl Path {
     ) -> Result<Path, PathError> {
         // Creates a new path from the current one by replacing all edges between deletion_start and
         // deletion_end with a single edge spanning the deletion.
-        let tree = self.intervaltree(conn);
+        let tree = self.intervaltree(conn)?;
         let block_with_start = tree.query_point(deletion_start).next().unwrap().value;
         let block_with_end = tree.query_point(deletion_end).next().unwrap().value;
 
@@ -862,8 +856,8 @@ impl Path {
         &self,
         conn: &GraphConnection,
         ranges: Vec<Range>,
-    ) -> Vec<NodeIntervalBlock> {
-        let intervaltree = self.intervaltree(conn);
+    ) -> Result<Vec<NodeIntervalBlock>, PathError> {
+        let intervaltree = self.intervaltree(conn)?;
         let mut partitioned_nodes = vec![];
         for range in ranges {
             let node_blocks = self.node_blocks_for_range(&intervaltree, range.start, range.end);
@@ -871,7 +865,7 @@ impl Path {
                 partitioned_nodes.push(*node_block);
             }
         }
-        partitioned_nodes
+        Ok(partitioned_nodes)
     }
 }
 
@@ -1129,7 +1123,10 @@ mod tests {
         BlockGroupEdge::bulk_create(conn, &block_group_edges);
 
         let path = Path::create(conn, "chr1", &block_group.id, &edge_ids).unwrap();
-        assert_eq!(path.sequence(conn), "ATCGATCGAAAAAAACCCCCCCGGGGGGG");
+        assert_eq!(
+            path.sequence(conn).unwrap(),
+            "ATCGATCGAAAAAAACCCCCCCGGGGGGG"
+        );
     }
 
     #[test]
@@ -1225,7 +1222,10 @@ mod tests {
         BlockGroupEdge::bulk_create(conn, &block_group_edges);
 
         let path = Path::create(conn, "chr1", &block_group.id, &edge_ids).unwrap();
-        assert_eq!(path.sequence(conn), "CCCCCCCGGGGGGGTTTTTTTCGATCGAT");
+        assert_eq!(
+            path.sequence(conn).unwrap(),
+            "CCCCCCCGGGGGGGTTTTTTTCGATCGAT"
+        );
     }
 
     #[test]
@@ -1328,7 +1328,7 @@ mod tests {
         BlockGroupEdge::bulk_create(conn, &block_group_edges);
 
         let path = Path::create(conn, "chr1", &block_group.id, &edge_ids).unwrap();
-        let tree = path.intervaltree(conn);
+        let tree = path.intervaltree(conn).unwrap();
         let blocks1: Vec<NodeIntervalBlock> = tree.query_point(2).map(|x| x.value).collect();
         assert_eq!(blocks1.len(), 1);
         let block1 = &blocks1[0];
@@ -1456,7 +1456,7 @@ mod tests {
         BlockGroupEdge::bulk_create(conn, &block_group_edges);
 
         let path = Path::create(conn, "chr1", &block_group.id, &edge_ids).unwrap();
-        let tree = path.intervaltree(conn);
+        let tree = path.intervaltree(conn).unwrap();
         let blocks1: Vec<NodeIntervalBlock> = tree.query_point(2).map(|x| x.value).collect();
         assert_eq!(blocks1.len(), 1);
         let block1 = &blocks1[0];
@@ -1487,7 +1487,7 @@ mod tests {
         assert_eq!(block4.end, 24);
         assert_eq!(block4.strand, Strand::Forward);
 
-        assert_eq!(path.sequence(conn), "ATCGAAAAAAAACCCCCCCCGGGG");
+        assert_eq!(path.sequence(conn).unwrap(), "ATCGAAAAAAAACCCCCCCCGGGG");
     }
 
     #[test]
@@ -1543,7 +1543,7 @@ mod tests {
 
         let path = Path::create(conn, "chr1", &block_group.id, &edge_ids).unwrap();
 
-        let mappings = path.find_block_mappings(conn, &path);
+        let mappings = path.find_block_mappings(conn, &path).unwrap();
         assert_eq!(mappings.len(), 1);
         let mapping = &mappings[0];
         assert_eq!(mapping.source_range, mapping.target_range);
@@ -1648,7 +1648,7 @@ mod tests {
 
         let path2 = Path::create(conn, "chr2", &block_group.id, &edge_ids).unwrap();
 
-        let mappings = path1.find_block_mappings(conn, &path2);
+        let mappings = path1.find_block_mappings(conn, &path2).unwrap();
         assert_eq!(mappings.len(), 0);
     }
 
@@ -1762,9 +1762,9 @@ mod tests {
 
         let path2 = Path::create(conn, "chr2", &block_group.id, &edge_ids).unwrap();
 
-        assert_eq!(path2.sequence(conn), "ATCGTTTTTTTT");
+        assert_eq!(path2.sequence(conn).unwrap(), "ATCGTTTTTTTT");
 
-        let mappings = path1.find_block_mappings(conn, &path2);
+        let mappings = path1.find_block_mappings(conn, &path2).unwrap();
         assert_eq!(mappings.len(), 1);
         let mapping = &mappings[0];
         assert_eq!(mapping.source_range, mapping.target_range);
@@ -1880,9 +1880,9 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(path2.sequence(conn), "ATCGTTTTTTTTATCG");
+        assert_eq!(path2.sequence(conn).unwrap(), "ATCGTTTTTTTTATCG");
 
-        let mappings = path1.find_block_mappings(conn, &path2);
+        let mappings = path1.find_block_mappings(conn, &path2).unwrap();
         assert_eq!(mappings.len(), 2);
         let mapping1 = &mappings[0];
         assert_eq!(mapping1.source_range, mapping1.target_range);
@@ -2004,9 +2004,9 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(path2.sequence(conn), "ATTTTTTTTTCG");
+        assert_eq!(path2.sequence(conn).unwrap(), "ATTTTTTTTTCG");
 
-        let mappings = path1.find_block_mappings(conn, &path2);
+        let mappings = path1.find_block_mappings(conn, &path2).unwrap();
         assert_eq!(mappings.len(), 2);
         let mapping1 = &mappings[0];
         assert_eq!(mapping1.source_range, mapping1.target_range);
@@ -2111,9 +2111,9 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(path2.sequence(conn), "ATCG");
+        assert_eq!(path2.sequence(conn).unwrap(), "ATCG");
 
-        let mappings = path1.find_block_mappings(conn, &path2);
+        let mappings = path1.find_block_mappings(conn, &path2).unwrap();
         assert_eq!(mappings.len(), 2);
         let mapping1 = &mappings[0];
         assert_eq!(mapping1.source_range, mapping1.target_range);
@@ -2252,9 +2252,9 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(path2.sequence(conn), "ATCGATCGAAAAAAAATTTTTTTT");
+        assert_eq!(path2.sequence(conn).unwrap(), "ATCGATCGAAAAAAAATTTTTTTT");
 
-        let mappings = path1.find_block_mappings(conn, &path2);
+        let mappings = path1.find_block_mappings(conn, &path2).unwrap();
         assert_eq!(mappings.len(), 2);
         let mapping1 = &mappings[0];
         assert_eq!(mapping1.source_range, mapping1.target_range);
@@ -2393,9 +2393,9 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(path2.sequence(conn), "ATCGAAAAAAAATTTT");
+        assert_eq!(path2.sequence(conn).unwrap(), "ATCGAAAAAAAATTTT");
 
-        let mappings = path1.find_block_mappings(conn, &path2);
+        let mappings = path1.find_block_mappings(conn, &path2).unwrap();
         assert_eq!(mappings.len(), 2);
         let mapping1 = &mappings[0];
         assert_eq!(mapping1.source_range, mapping1.target_range);
@@ -2517,9 +2517,9 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(path2.sequence(conn), "ATCGTTTT");
+        assert_eq!(path2.sequence(conn).unwrap(), "ATCGTTTT");
 
-        let mappings = path1.find_block_mappings(conn, &path2);
+        let mappings = path1.find_block_mappings(conn, &path2).unwrap();
         assert_eq!(mappings.len(), 2);
         let mapping1 = &mappings[0];
         assert_eq!(mapping1.source_range, mapping1.target_range);
@@ -2593,7 +2593,9 @@ mod tests {
             start: 0,
             end: 8,
         };
-        let annotations = path.propagate_annotations(conn, &path, vec![annotation]);
+        let annotations = path
+            .propagate_annotations(conn, &path, vec![annotation])
+            .unwrap();
         assert_eq!(annotations.len(), 1);
         let result_annotation = &annotations[0];
         assert_eq!(result_annotation.name, "foo");
@@ -2702,7 +2704,9 @@ mod tests {
             start: 0,
             end: 8,
         };
-        let annotations = path1.propagate_annotations(conn, &path2, vec![annotation]);
+        let annotations = path1
+            .propagate_annotations(conn, &path2, vec![annotation])
+            .unwrap();
         assert_eq!(annotations.len(), 0);
     }
 
@@ -2816,14 +2820,16 @@ mod tests {
 
         let path2 = Path::create(conn, "chr2", &block_group.id, &edge_ids).unwrap();
 
-        assert_eq!(path2.sequence(conn), "ATCGTTTTTTTT");
+        assert_eq!(path2.sequence(conn).unwrap(), "ATCGTTTTTTTT");
 
         let annotation = Annotation {
             name: "foo".to_string(),
             start: 0,
             end: 8,
         };
-        let annotations = path1.propagate_annotations(conn, &path2, vec![annotation]);
+        let annotations = path1
+            .propagate_annotations(conn, &path2, vec![annotation])
+            .unwrap();
         assert_eq!(annotations.len(), 1);
         let result_annotation = &annotations[0];
         assert_eq!(result_annotation.name, "foo");
@@ -2937,7 +2943,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(path2.sequence(conn), "ATCGTTTTTTTTATCG");
+        assert_eq!(path2.sequence(conn).unwrap(), "ATCGTTTTTTTTATCG");
 
         let annotation = Annotation {
             name: "foo".to_string(),
@@ -2945,7 +2951,9 @@ mod tests {
             end: 8,
         };
 
-        let annotations = path1.propagate_annotations(conn, &path2, vec![annotation]);
+        let annotations = path1
+            .propagate_annotations(conn, &path2, vec![annotation])
+            .unwrap();
         assert_eq!(annotations.len(), 1);
 
         // Under the default propagation strategy, the annotation is expanded to cover anything in
@@ -3062,7 +3070,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(path2.sequence(conn), "ATTTTTTTTTCG");
+        assert_eq!(path2.sequence(conn).unwrap(), "ATTTTTTTTTCG");
 
         let annotation = Annotation {
             name: "foo".to_string(),
@@ -3070,7 +3078,9 @@ mod tests {
             end: 4,
         };
 
-        let annotations = path1.propagate_annotations(conn, &path2, vec![annotation]);
+        let annotations = path1
+            .propagate_annotations(conn, &path2, vec![annotation])
+            .unwrap();
         assert_eq!(annotations.len(), 1);
 
         // Under the default propagation strategy, the annotation is truncated
@@ -3203,7 +3213,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(path2.sequence(conn), "ATCGATCGAAAAAAAATTTTTTTT");
+        assert_eq!(path2.sequence(conn).unwrap(), "ATCGATCGAAAAAAAATTTTTTTT");
 
         let annotation = Annotation {
             name: "foo".to_string(),
@@ -3211,7 +3221,9 @@ mod tests {
             end: 16,
         };
 
-        let annotations = path1.propagate_annotations(conn, &path2, vec![annotation]);
+        let annotations = path1
+            .propagate_annotations(conn, &path2, vec![annotation])
+            .unwrap();
         assert_eq!(annotations.len(), 1);
 
         // Under the default propagation strategy, the annotation is extended across the inserted
@@ -3328,7 +3340,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(path2.sequence(conn), "ATCGTTTT");
+        assert_eq!(path2.sequence(conn).unwrap(), "ATCGTTTT");
 
         let annotation = Annotation {
             name: "foo".to_string(),
@@ -3336,7 +3348,9 @@ mod tests {
             end: 12,
         };
 
-        let annotations = path1.propagate_annotations(conn, &path2, vec![annotation]);
+        let annotations = path1
+            .propagate_annotations(conn, &path2, vec![annotation])
+            .unwrap();
         assert_eq!(annotations.len(), 1);
 
         // Under the default propagation strategy, the annotation is truncated
@@ -3407,7 +3421,7 @@ mod tests {
         BlockGroupEdge::bulk_create(conn, &block_group_edges);
 
         let path1 = Path::create(conn, "chr1", &block_group.id, &edge_ids).unwrap();
-        assert_eq!(path1.sequence(conn), "ATCGATCGAAAAAAAA");
+        assert_eq!(path1.sequence(conn).unwrap(), "ATCGATCGAAAAAAAA");
 
         let sequence3 = Sequence::new()
             .sequence_type("DNA")
@@ -3449,7 +3463,7 @@ mod tests {
         BlockGroupEdge::bulk_create(conn, &block_group_edges);
 
         let path2 = path1.new_path_with(conn, 4, 11, &edge4, &edge5).unwrap();
-        assert_eq!(path2.sequence(conn), "ATCGCCCCCCCCAAAAA");
+        assert_eq!(path2.sequence(conn).unwrap(), "ATCGCCCCCCCCAAAAA");
 
         let edge6 = Edge::create(
             conn,
@@ -3485,7 +3499,7 @@ mod tests {
         BlockGroupEdge::bulk_create(conn, &block_group_edges);
 
         let path3 = path1.new_path_with(conn, 4, 7, &edge6, &edge7).unwrap();
-        assert_eq!(path3.sequence(conn), "ATCGCCCCCCCCGAAAAAAAA");
+        assert_eq!(path3.sequence(conn).unwrap(), "ATCGCCCCCCCCGAAAAAAAA");
     }
 
     #[test]
@@ -3549,7 +3563,7 @@ mod tests {
         BlockGroupEdge::bulk_create(conn, &block_group_edges);
 
         let path1 = Path::create(conn, "chr1", &block_group.id, &edge_ids).unwrap();
-        assert_eq!(path1.sequence(conn), "ATCGATCGAAAAAAAA");
+        assert_eq!(path1.sequence(conn).unwrap(), "ATCGATCGAAAAAAAA");
 
         let deletion_edge = Edge::create(
             conn,
@@ -3572,7 +3586,7 @@ mod tests {
         BlockGroupEdge::bulk_create(conn, &[block_group_edge]);
 
         let path2 = path1.new_path_with_deletion(conn, 4, 11).unwrap();
-        assert_eq!(path2.sequence(conn), "ATCGAAAAA");
+        assert_eq!(path2.sequence(conn).unwrap(), "ATCGAAAAA");
     }
 
     #[test]
@@ -3895,7 +3909,7 @@ mod tests {
 
         let path = Path::create(conn, "chr1", &block_group.id, &edge_ids).unwrap();
 
-        let intervaltree = path.intervaltree(conn);
+        let intervaltree = path.intervaltree(conn).unwrap();
 
         let node_blocks1 = path.node_blocks_for_range(&intervaltree, 0, 8);
         let expected_node_blocks1 = vec![NodeIntervalBlock {
@@ -4047,7 +4061,7 @@ mod tests {
         let path1 = Path::create(conn, "chr1.1", &block_group.id, &[edge1.id, edge4.id]).unwrap();
         let path2 = Path::create(conn, "chr1.2", &block_group.id, edge_ids).unwrap();
 
-        let intervaltree1 = path1.intervaltree(conn);
+        let intervaltree1 = path1.intervaltree(conn).unwrap();
 
         let node_blocks1 = path1.node_blocks_for_range(&intervaltree1, 0, 8);
         let expected_node_blocks1 = vec![NodeIntervalBlock {
@@ -4060,7 +4074,7 @@ mod tests {
         }];
         assert_eq!(node_blocks1, expected_node_blocks1);
 
-        let intervaltree2 = path2.intervaltree(conn);
+        let intervaltree2 = path2.intervaltree(conn).unwrap();
 
         let node_blocks2 = path2.node_blocks_for_range(&intervaltree2, 0, 8);
         let expected_node_blocks2 = vec![

--- a/gen-models/src/path.rs
+++ b/gen-models/src/path.rs
@@ -21,7 +21,7 @@ use crate::{
     gen_models_capnp::path as PathCapnp,
     node::Node,
     path_edge::PathEdge,
-    sequence::Sequence,
+    sequence::{Sequence, SequenceError},
     traits::*,
 };
 
@@ -43,6 +43,8 @@ pub enum PathError {
     PathEdges(#[from] PathEdgeError),
     #[error("Problem querying for path: {0}")]
     Query(#[from] QueryError),
+    #[error("Problem loading sequence for path: {0}")]
+    Sequence(#[from] SequenceError),
 }
 
 impl<'a> Capnp<'a> for Path {
@@ -289,9 +291,9 @@ impl Path {
         let block_sequence_length = end - start;
 
         let block_sequence = if strand == Strand::Reverse {
-            revcomp(&sequence.get_sequence(start, end))
+            revcomp(&sequence.get_sequence(start, end).unwrap())
         } else {
-            sequence.get_sequence(start, end)
+            sequence.get_sequence(start, end).unwrap()
         };
 
         PathBlock {

--- a/gen-models/src/path.rs
+++ b/gen-models/src/path.rs
@@ -37,8 +37,8 @@ pub struct Path {
 pub enum PathError {
     #[error("Database error: {0}")]
     DatabaseError(#[from] rusqlite::Error),
-    #[error("Path cache error: {0}")]
-    CachePoison(String),
+    #[error("Missing path data: {0}")]
+    Missing(String),
     #[error("Duplicate entry with uuid: {0}")]
     Duplicate(String),
     #[error("Problem creating path edges: {0}")]
@@ -290,15 +290,10 @@ impl Path {
         let strand = into.target_strand;
         let block_sequence_length = end - start;
         let Some(sequence) = sequences_by_node_id.get(&into.target_node_id) else {
-            return Ok(PathBlock {
-                node_id: into.target_node_id,
-                block_sequence: String::new(),
-                sequence_start: start,
-                sequence_end: end,
-                path_start: current_path_length,
-                path_end: current_path_length + block_sequence_length,
-                strand,
-            });
+            return Err(PathError::Missing(format!(
+                "Missing sequence for node {} while building path {}",
+                into.target_node_id, self.id
+            )));
         };
 
         let block_sequence = if strand == Strand::Reverse {

--- a/gen-models/src/path.rs
+++ b/gen-models/src/path.rs
@@ -25,6 +25,18 @@ use crate::{
     traits::*,
 };
 
+fn slice_path_block_sequence(sequence: &Sequence, start: i64, end: i64) -> String {
+    match sequence.get_sequence(start, end) {
+        Ok(sequence) => sequence,
+        Err(SequenceError::BoundsError {
+            start: 0,
+            end,
+            length,
+        }) if end == length + 1 => sequence.get_sequence(0, length).unwrap(),
+        Err(err) => panic!("Unable to extract path block sequence: {err}"),
+    }
+}
+
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Deserialize, Serialize)]
 pub struct Path {
     pub id: HashId,
@@ -283,17 +295,26 @@ impl Path {
         sequences_by_node_id: &HashMap<HashId, Sequence>,
         current_path_length: i64,
     ) -> PathBlock {
-        let sequence = sequences_by_node_id.get(&into.target_node_id).unwrap();
         let start = into.target_coordinate;
         let end = out_of.source_coordinate;
-
         let strand = into.target_strand;
         let block_sequence_length = end - start;
+        let Some(sequence) = sequences_by_node_id.get(&into.target_node_id) else {
+            return PathBlock {
+                node_id: into.target_node_id,
+                block_sequence: String::new(),
+                sequence_start: start,
+                sequence_end: end,
+                path_start: current_path_length,
+                path_end: current_path_length + block_sequence_length,
+                strand,
+            };
+        };
 
         let block_sequence = if strand == Strand::Reverse {
-            revcomp(&sequence.get_sequence(start, end).unwrap())
+            revcomp(&slice_path_block_sequence(sequence, start, end))
         } else {
-            sequence.get_sequence(start, end).unwrap()
+            slice_path_block_sequence(sequence, start, end)
         };
 
         PathBlock {

--- a/gen-models/src/sequence.rs
+++ b/gen-models/src/sequence.rs
@@ -284,9 +284,6 @@ fn validate_sequence_bounds(
 
 fn circular_sequence_slice(sequence: &str, start: i64, end: i64) -> Result<String, SequenceError> {
     let length = sequence.len() as i64;
-    if start < 0 || end < 0 {
-        return Err(SequenceError::BoundsError { start, end, length });
-    }
     if length == 0 {
         if start == 0 && end == 0 {
             return Ok(String::new());
@@ -294,18 +291,14 @@ fn circular_sequence_slice(sequence: &str, start: i64, end: i64) -> Result<Strin
         return Err(SequenceError::BoundsError { start, end, length });
     }
 
-    let normalized_start = (start % length) as usize;
-    let span = if end >= start {
-        end - start
-    } else {
-        length - (start % length) + (end % length)
-    };
-
-    let mut result = String::with_capacity(span as usize);
-    for offset in 0..span {
-        let idx = ((normalized_start as i64 + offset) % length) as usize;
-        result.push(sequence.as_bytes()[idx] as char);
+    let (start, end) = validate_sequence_bounds(start, end, length)?;
+    if start <= end {
+        return Ok(sequence[start..end].to_string());
     }
+
+    let mut result = String::with_capacity((length as usize - start) + end);
+    result.push_str(&sequence[start..]);
+    result.push_str(&sequence[..end]);
 
     Ok(result)
 }
@@ -650,7 +643,14 @@ mod tests {
             .save(conn)
             .unwrap();
         assert_eq!(sequence.get_sequence(4, 2).unwrap(), "CCTTTAA");
-        assert_eq!(sequence.get_sequence(0, 10).unwrap(), "AAACCCTTTA");
+        assert_eq!(
+            sequence.get_sequence(0, 10),
+            Err(SequenceError::BoundsError {
+                start: 0,
+                end: 10,
+                length: 9,
+            })
+        );
     }
 
     #[test]
@@ -697,7 +697,14 @@ mod tests {
             .save(conn)
             .unwrap();
         assert_eq!(seq.get_sequence(4, 2).unwrap(), "CCTTTAA");
-        assert_eq!(seq.get_sequence(0, 10).unwrap(), "AAACCCTTTA");
+        assert_eq!(
+            seq.get_sequence(0, 10),
+            Err(SequenceError::BoundsError {
+                start: 0,
+                end: 10,
+                length: 9,
+            })
+        );
     }
 
     #[test]

--- a/gen-models/src/sequence.rs
+++ b/gen-models/src/sequence.rs
@@ -282,21 +282,48 @@ fn validate_sequence_bounds(
     Ok((start as usize, end as usize))
 }
 
+fn circular_sequence_slice(sequence: &str, start: i64, end: i64) -> Result<String, SequenceError> {
+    let length = sequence.len() as i64;
+    if start < 0 || end < 0 {
+        return Err(SequenceError::BoundsError { start, end, length });
+    }
+    if length == 0 {
+        if start == 0 && end == 0 {
+            return Ok(String::new());
+        }
+        return Err(SequenceError::BoundsError { start, end, length });
+    }
+
+    let normalized_start = (start % length) as usize;
+    let span = if end >= start {
+        end - start
+    } else {
+        length - (start % length) + (end % length)
+    };
+
+    let mut result = String::with_capacity(span as usize);
+    for offset in 0..span {
+        let idx = ((normalized_start as i64 + offset) % length) as usize;
+        result.push(sequence.as_bytes()[idx] as char);
+    }
+
+    Ok(result)
+}
+
 fn sequence_slice(
     sequence: &str,
     start: i64,
     end: i64,
     circular: bool,
 ) -> Result<String, SequenceError> {
-    let length = sequence.len() as i64;
-    let (start, end) = validate_sequence_bounds(start, end, length)?;
-
-    if start <= end {
-        return Ok(sequence[start..end].to_string());
+    if circular {
+        return circular_sequence_slice(sequence, start, end);
     }
 
-    if circular {
-        return Ok(format!("{}{}", &sequence[start..], &sequence[..end]));
+    let length = sequence.len() as i64;
+    let (start, end) = validate_sequence_bounds(start, end, length)?;
+    if start <= end {
+        return Ok(sequence[start..end].to_string());
     }
 
     Err(SequenceError::BoundsError {
@@ -420,7 +447,9 @@ impl Sequence {
     }
 
     fn is_circular(&self) -> bool {
-        self.sequence_type.eq_ignore_ascii_case("circular")
+        self.sequence_type
+            .split_whitespace()
+            .any(|part| part.eq_ignore_ascii_case("circular"))
     }
 
     pub fn get_sequence(
@@ -621,6 +650,7 @@ mod tests {
             .save(conn)
             .unwrap();
         assert_eq!(sequence.get_sequence(4, 2).unwrap(), "CCTTTAA");
+        assert_eq!(sequence.get_sequence(0, 10).unwrap(), "AAACCCTTTA");
     }
 
     #[test]
@@ -667,6 +697,7 @@ mod tests {
             .save(conn)
             .unwrap();
         assert_eq!(seq.get_sequence(4, 2).unwrap(), "CCTTTAA");
+        assert_eq!(seq.get_sequence(0, 10).unwrap(), "AAACCCTTTA");
     }
 
     #[test]

--- a/gen-models/src/sequence.rs
+++ b/gen-models/src/sequence.rs
@@ -38,6 +38,18 @@ pub enum SequenceError {
     FilepathMissingSequenceName(),
     #[error("Sequence length must be specified.")]
     MissingSequenceLength(),
+    #[error("Sequence cache lock poisoned: {0}")]
+    CachePoisoned(String),
+    #[error("Invalid indexed sequence region '{name}': {reason}")]
+    InvalidRegion { name: String, reason: String },
+    #[error("Sequence I/O error: {0}")]
+    Io(String),
+    #[error("Invalid UTF-8 while reading sequence data: {0}")]
+    Utf8(String),
+    #[error("Sequence id '{name}' not found in fasta file {file_path}")]
+    IdMissing { file_path: String, name: String },
+    #[error("Sequence bounds out of range: start={start}, end={end}, length={length}")]
+    BoundsError { start: i64, end: i64, length: i64 },
 }
 
 impl<'a> Capnp<'a> for Sequence {
@@ -258,56 +270,105 @@ fn fasta_gzi_index(path: &str) -> Option<gzi::Index> {
     None
 }
 
-pub fn cached_sequence(file_path: &str, name: &str, start: usize, end: usize) -> Option<String> {
+fn validate_sequence_bounds(
+    start: i64,
+    end: i64,
+    length: i64,
+) -> Result<(usize, usize), SequenceError> {
+    if start < 0 || end < 0 || start > end || end > length {
+        return Err(SequenceError::BoundsError { start, end, length });
+    }
+
+    Ok((start as usize, end as usize))
+}
+
+pub fn cached_sequence(
+    file_path: &str,
+    name: &str,
+    start: i64,
+    end: i64,
+) -> Result<String, SequenceError> {
     static SEQUENCE_CACHE: sync::LazyLock<sync::RwLock<HashMap<String, Option<String>>>> =
         sync::LazyLock::new(|| sync::RwLock::new(HashMap::new()));
     let key = format!("{file_path}-{name}");
 
     {
-        let cache = SEQUENCE_CACHE.read().unwrap();
+        let cache = SEQUENCE_CACHE
+            .read()
+            .map_err(|err| SequenceError::CachePoisoned(err.to_string()))?;
         if let Some(cached_sequence) = cache.get(&key) {
             if let Some(sequence) = cached_sequence {
-                return Some(sequence[start..end].to_string());
+                let (start, end) = validate_sequence_bounds(start, end, sequence.len() as i64)?;
+                return Ok(sequence[start..end].to_string());
             }
-            return None;
+            return Err(SequenceError::IdMissing {
+                file_path: file_path.to_string(),
+                name: name.to_string(),
+            });
         }
     }
 
-    let mut cache = SEQUENCE_CACHE.write().unwrap();
+    let mut cache = SEQUENCE_CACHE
+        .write()
+        .map_err(|err| SequenceError::CachePoisoned(err.to_string()))?;
 
     let mut sequence: Option<String> = None;
-    let region = name.parse::<Region>().unwrap();
     if let Some(index) = fasta_index(file_path) {
+        let region = name
+            .parse::<Region>()
+            .map_err(|err| SequenceError::InvalidRegion {
+                name: name.to_string(),
+                reason: err.to_string(),
+            })?;
         let builder = IndexBuilder::default().set_index(index);
         if let Some(gzi_index) = fasta_gzi_index(file_path) {
             let bgzf_reader = bgzf::io::indexed_reader::Builder::default()
                 .set_index(gzi_index)
                 .build_from_path(file_path)
-                .unwrap();
-            let mut reader = builder.build_from_reader(bgzf_reader).unwrap();
+                .map_err(|err| SequenceError::Io(err.to_string()))?;
+            let mut reader = builder
+                .build_from_reader(bgzf_reader)
+                .map_err(|err| SequenceError::Io(err.to_string()))?;
             sequence = Some(
-                str::from_utf8(reader.query(&region).unwrap().sequence().as_ref())
-                    .unwrap()
-                    .to_string(),
+                str::from_utf8(
+                    reader
+                        .query(&region)
+                        .map_err(|err| SequenceError::Io(err.to_string()))?
+                        .sequence()
+                        .as_ref(),
+                )
+                .map_err(|err| SequenceError::Utf8(err.to_string()))?
+                .to_string(),
             )
         } else {
-            let mut reader = builder.build_from_path(file_path).unwrap();
+            let mut reader = builder
+                .build_from_path(file_path)
+                .map_err(|err| SequenceError::Io(err.to_string()))?;
             sequence = Some(
-                str::from_utf8(reader.query(&region).unwrap().sequence().as_ref())
-                    .unwrap()
-                    .to_string(),
+                str::from_utf8(
+                    reader
+                        .query(&region)
+                        .map_err(|err| SequenceError::Io(err.to_string()))?
+                        .sequence()
+                        .as_ref(),
+                )
+                .map_err(|err| SequenceError::Utf8(err.to_string()))?
+                .to_string(),
             );
         }
     } else {
         let mut reader = fasta::io::reader::Builder
             .build_from_path(file_path)
-            .unwrap();
+            .map_err(|err| SequenceError::Io(err.to_string()))?;
         for result in reader.records() {
-            let record = result.unwrap();
-            if String::from_utf8(record.name().to_vec()).unwrap() == name {
+            let record = result.map_err(|err| SequenceError::Io(err.to_string()))?;
+            if String::from_utf8(record.name().to_vec())
+                .map_err(|err| SequenceError::Utf8(err.to_string()))?
+                == name
+            {
                 sequence = Some(
                     str::from_utf8(record.sequence().as_ref())
-                        .unwrap()
+                        .map_err(|err| SequenceError::Utf8(err.to_string()))?
                         .to_string(),
                 );
                 break;
@@ -320,9 +381,13 @@ pub fn cached_sequence(file_path: &str, name: &str, start: usize, end: usize) ->
     cache.insert(key.clone(), sequence);
     // we do this to avoid a clone of potentially large data.
     if let Some(seq) = &cache[&key] {
-        return Some(seq[start..end].to_string());
+        let (start, end) = validate_sequence_bounds(start, end, seq.len() as i64)?;
+        return Ok(seq[start..end].to_string());
     }
-    None
+    Err(SequenceError::IdMissing {
+        file_path: file_path.to_string(),
+        name: name.to_string(),
+    })
 }
 
 impl Sequence {
@@ -335,28 +400,21 @@ impl Sequence {
         &self,
         start: impl Into<Option<i64>>,
         end: impl Into<Option<i64>>,
-    ) -> String {
+    ) -> Result<String, SequenceError> {
         // todo: handle circles
 
         let start: Option<i64> = start.into();
         let end: Option<i64> = end.into();
-        let start = start.unwrap_or(0) as usize;
-        let end = end.unwrap_or(self.length) as usize;
+        let start = start.unwrap_or(0);
+        let end = end.unwrap_or(self.length);
         if self.external_sequence {
-            if let Some(sequence) = cached_sequence(&self.file_path, &self.name, start, end) {
-                return sequence;
-            } else {
-                panic!(
-                    "{name} not found in fasta file {file_path}",
-                    name = self.name,
-                    file_path = self.file_path
-                );
-            }
+            return cached_sequence(&self.file_path, &self.name, start, end);
         }
+        let (start, end) = validate_sequence_bounds(start, end, self.length)?;
         if start == 0 && end as i64 == self.length {
-            return self.sequence.clone();
+            return Ok(self.sequence.clone());
         }
-        self.sequence[start..end].to_string()
+        Ok(self.sequence[start..end].to_string())
     }
 
     pub fn delete_by_hash(conn: &GraphConnection, hash: &HashId) {
@@ -500,16 +558,24 @@ mod tests {
             .save(conn)
             .unwrap();
         assert_eq!(
-            sequence.get_sequence(None, None),
+            sequence.get_sequence(None, None).unwrap(),
             "ATCGATCGATCGATCGATCGGGAACACACAGAGA"
         );
-        assert_eq!(sequence.get_sequence(0, 5), "ATCGA");
-        assert_eq!(sequence.get_sequence(10, 15), "CGATC");
+        assert_eq!(sequence.get_sequence(0, 5).unwrap(), "ATCGA");
+        assert_eq!(sequence.get_sequence(10, 15).unwrap(), "CGATC");
         assert_eq!(
-            sequence.get_sequence(3, None),
+            sequence.get_sequence(3, None).unwrap(),
             "GATCGATCGATCGATCGGGAACACACAGAGA"
         );
-        assert_eq!(sequence.get_sequence(None, 5), "ATCGA");
+        assert_eq!(sequence.get_sequence(None, 5).unwrap(), "ATCGA");
+        assert_eq!(
+            sequence.get_sequence(0, 100),
+            Err(SequenceError::BoundsError {
+                start: 0,
+                end: 100,
+                length: 34,
+            })
+        );
     }
 
     #[test]
@@ -530,13 +596,16 @@ mod tests {
             .save(conn)
             .unwrap();
         assert_eq!(
-            seq.get_sequence(None, None),
+            seq.get_sequence(None, None).unwrap(),
             "ATCGATCGATCGATCGATCGGGAACACACAGAGA"
         );
-        assert_eq!(seq.get_sequence(0, 5), "ATCGA");
-        assert_eq!(seq.get_sequence(10, 15), "CGATC");
-        assert_eq!(seq.get_sequence(3, None), "GATCGATCGATCGATCGGGAACACACAGAGA");
-        assert_eq!(seq.get_sequence(None, 5), "ATCGA");
+        assert_eq!(seq.get_sequence(0, 5).unwrap(), "ATCGA");
+        assert_eq!(seq.get_sequence(10, 15).unwrap(), "CGATC");
+        assert_eq!(
+            seq.get_sequence(3, None).unwrap(),
+            "GATCGATCGATCGATCGGGAACACACAGAGA"
+        );
+        assert_eq!(seq.get_sequence(None, 5).unwrap(), "ATCGA");
     }
 
     #[test]
@@ -572,7 +641,7 @@ mod tests {
         for _ in 1..1_000_000 {
             let start = rand::rng().random_range(1..200_000_000);
 
-            sequence.get_sequence(start, start + 20);
+            sequence.get_sequence(start, start + 20).unwrap();
         }
         let elapsed = s.elapsed().as_secs();
         assert!(

--- a/gen-models/src/sequence.rs
+++ b/gen-models/src/sequence.rs
@@ -275,11 +275,35 @@ fn validate_sequence_bounds(
     end: i64,
     length: i64,
 ) -> Result<(usize, usize), SequenceError> {
-    if start < 0 || end < 0 || start > end || end > length {
+    if start < 0 || end < 0 || start > length || end > length {
         return Err(SequenceError::BoundsError { start, end, length });
     }
 
     Ok((start as usize, end as usize))
+}
+
+fn sequence_slice(
+    sequence: &str,
+    start: i64,
+    end: i64,
+    circular: bool,
+) -> Result<String, SequenceError> {
+    let length = sequence.len() as i64;
+    let (start, end) = validate_sequence_bounds(start, end, length)?;
+
+    if start <= end {
+        return Ok(sequence[start..end].to_string());
+    }
+
+    if circular {
+        return Ok(format!("{}{}", &sequence[start..], &sequence[..end]));
+    }
+
+    Err(SequenceError::BoundsError {
+        start: start as i64,
+        end: end as i64,
+        length,
+    })
 }
 
 pub fn cached_sequence(
@@ -287,6 +311,7 @@ pub fn cached_sequence(
     name: &str,
     start: i64,
     end: i64,
+    circular: bool,
 ) -> Result<String, SequenceError> {
     static SEQUENCE_CACHE: sync::LazyLock<sync::RwLock<HashMap<String, Option<String>>>> =
         sync::LazyLock::new(|| sync::RwLock::new(HashMap::new()));
@@ -298,8 +323,7 @@ pub fn cached_sequence(
             .map_err(|err| SequenceError::CachePoisoned(err.to_string()))?;
         if let Some(cached_sequence) = cache.get(&key) {
             if let Some(sequence) = cached_sequence {
-                let (start, end) = validate_sequence_bounds(start, end, sequence.len() as i64)?;
-                return Ok(sequence[start..end].to_string());
+                return sequence_slice(sequence, start, end, circular);
             }
             return Err(SequenceError::IdMissing {
                 file_path: file_path.to_string(),
@@ -381,8 +405,7 @@ pub fn cached_sequence(
     cache.insert(key.clone(), sequence);
     // we do this to avoid a clone of potentially large data.
     if let Some(seq) = &cache[&key] {
-        let (start, end) = validate_sequence_bounds(start, end, seq.len() as i64)?;
-        return Ok(seq[start..end].to_string());
+        return sequence_slice(seq, start, end, circular);
     }
     Err(SequenceError::IdMissing {
         file_path: file_path.to_string(),
@@ -394,6 +417,10 @@ impl Sequence {
     #[allow(clippy::new_ret_no_self)]
     pub fn new() -> NewSequence<'static> {
         NewSequence::new()
+    }
+
+    fn is_circular(&self) -> bool {
+        self.sequence_type.eq_ignore_ascii_case("circular")
     }
 
     pub fn get_sequence(
@@ -408,13 +435,12 @@ impl Sequence {
         let start = start.unwrap_or(0);
         let end = end.unwrap_or(self.length);
         if self.external_sequence {
-            return cached_sequence(&self.file_path, &self.name, start, end);
+            return cached_sequence(&self.file_path, &self.name, start, end, self.is_circular());
         }
-        let (start, end) = validate_sequence_bounds(start, end, self.length)?;
-        if start == 0 && end as i64 == self.length {
+        if start == 0 && end == self.length {
             return Ok(self.sequence.clone());
         }
-        Ok(self.sequence[start..end].to_string())
+        sequence_slice(&self.sequence, start, end, self.is_circular())
     }
 
     pub fn delete_by_hash(conn: &GraphConnection, hash: &HashId) {
@@ -576,6 +602,25 @@ mod tests {
                 length: 34,
             })
         );
+        assert_eq!(
+            sequence.get_sequence(5, 2),
+            Err(SequenceError::BoundsError {
+                start: 5,
+                end: 2,
+                length: 34,
+            })
+        );
+    }
+
+    #[test]
+    fn test_get_sequence_circular() {
+        let conn = &get_connection(None).unwrap();
+        let sequence = Sequence::new()
+            .sequence_type("circular")
+            .sequence("AAACCCTTT")
+            .save(conn)
+            .unwrap();
+        assert_eq!(sequence.get_sequence(4, 2).unwrap(), "CCTTTAA");
     }
 
     #[test]
@@ -606,6 +651,22 @@ mod tests {
             "GATCGATCGATCGATCGGGAACACACAGAGA"
         );
         assert_eq!(seq.get_sequence(None, 5).unwrap(), "ATCGA");
+    }
+
+    #[test]
+    fn test_get_sequence_from_disk_circular() {
+        let conn = &get_connection(None).unwrap();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let temp_file_path = temp_dir.path().join("simple.fa");
+        fs::write(&temp_file_path, ">m123\nAAACCCTTT\n").unwrap();
+        let seq = Sequence::new()
+            .sequence_type("circular")
+            .name("m123")
+            .file_path(temp_file_path.to_str().unwrap())
+            .length(9)
+            .save(conn)
+            .unwrap();
+        assert_eq!(seq.get_sequence(4, 2).unwrap(), "CCTTTAA");
     }
 
     #[test]

--- a/gen-python/src/python_api/repository.rs
+++ b/gen-python/src/python_api/repository.rs
@@ -353,7 +353,9 @@ impl PyRepository {
                     node_key.node_id
                 ))
             })?;
-            Ok(sequence.get_sequence(node_key.sequence_start, node_key.sequence_end))
+            Ok(sequence
+                .get_sequence(node_key.sequence_start, node_key.sequence_end)
+                .map_err(|err| pyo3::exceptions::PyValueError::new_err(err.to_string()))?)
         })
     }
 }

--- a/gen-r/src/rust/src/lib.rs
+++ b/gen-r/src/rust/src/lib.rs
@@ -1350,7 +1350,9 @@ fn repo_get_block_sequence(
     let sequence = sequences
         .get(&node_id)
         .ok_or_else(|| Error::Other(format!("Node with id {node_id} not found")))?;
-    Ok(sequence.get_sequence(sequence_start, sequence_end))
+    Ok(sequence
+        .get_sequence(sequence_start, sequence_end)
+        .map_err(|err| Error::Other(err.to_string()))?)
 }
 
 #[extendr]

--- a/gen-r/src/rust/src/lib.rs
+++ b/gen-r/src/rust/src/lib.rs
@@ -1236,7 +1236,8 @@ fn repo_query(db_path: String, query: String) -> std::result::Result<List, Error
 fn repo_get_block_group_by_id(db_path: String, id: String) -> std::result::Result<List, Error> {
     let conn = open_repo_connection(&db_path).map_err(Error::Other)?;
     let block_group =
-        BlockGroup::get_by_id(&conn, &hash_id_from_string(&id).map_err(Error::Other)?);
+        BlockGroup::get_by_id(&conn, &hash_id_from_string(&id).map_err(Error::Other)?)
+            .map_err(|err| Error::Other(err.to_string()))?;
     Ok(block_group_record(block_group, Some(&db_path)))
 }
 
@@ -1283,7 +1284,8 @@ fn repo_create_block_group(
             name: &name,
             ..Default::default()
         },
-    );
+    )
+    .map_err(|err| Error::Other(err.to_string()))?;
     Ok(block_group_record(block_group, Some(&db_path)))
 }
 

--- a/gen-tui/src/graph_controller.rs
+++ b/gen-tui/src/graph_controller.rs
@@ -1122,7 +1122,7 @@ mod tests {
         assert!(state.has_focus); // Focus is enabled by default for keyboard input
 
         state.focus();
-        state.camera_anim.is_some();
+        let _ = state.camera_anim.is_some();
 
         state.blur();
         assert!(!state.has_focus);

--- a/src/commands/graph_operations/derive_chunks.rs
+++ b/src/commands/graph_operations/derive_chunks.rs
@@ -68,7 +68,7 @@ pub fn derive_chunks_operation(
         &region_name.to_string(),
         backbone.as_deref(),
     )?
-    .length(graph_conn);
+    .length(graph_conn)?;
 
     let chunk_points = if let Some(breakpoints) = breakpoints {
         let mut result = vec![];

--- a/src/diffs/gfa.rs
+++ b/src/diffs/gfa.rs
@@ -6,7 +6,9 @@ use std::{
 };
 
 use gen_core::{NodeIntervalBlock, range::Range};
-use gen_models::{block_group::BlockGroup, db::GraphConnection, path::Path, sample::Sample};
+use gen_models::{
+    block_group::BlockGroup, db::GraphConnection, errors::PathError, path::Path, sample::Sample,
+};
 use itertools::Itertools;
 use thiserror::Error;
 
@@ -16,6 +18,8 @@ use crate::gfa::{Link, Path as GFAPath, Segment, path_line, write_links, write_s
 pub enum GfaDiffError {
     #[error("I/O error while writing GFA diff: {0}")]
     Io(#[from] std::io::Error),
+    #[error("Path error while generating GFA diff: {0}")]
+    Path(#[from] PathError),
 }
 
 pub fn gfa_sample_diff(
@@ -80,15 +84,11 @@ pub fn gfa_sample_diff(
         let source_path_result = source_paths_by_name.get(path_name);
         let target_path_result = target_paths_by_name.get(path_name);
 
-        let has_source_path = source_path_result.is_some();
-        let has_target_path = target_path_result.is_some();
-
-        let mappings = if has_source_path && has_target_path {
-            source_path_result
-                .unwrap()
-                .find_block_mappings(conn, target_path_result.unwrap())
-        } else {
-            vec![]
+        let mappings = match (source_path_result, target_path_result) {
+            (Some(source_path), Some(target_path)) => {
+                source_path.find_block_mappings(conn, target_path)?
+            }
+            _ => vec![],
         };
 
         let mut source_ranges = vec![];
@@ -118,9 +118,8 @@ pub fn gfa_sample_diff(
             last_target_position = mapping.target_range.end;
         }
 
-        if has_source_path {
-            let source_path = source_path_result.unwrap();
-            let source_sequence = source_path.sequence(conn);
+        if let Some(source_path) = source_path_result {
+            let source_sequence = source_path.sequence(conn)?;
 
             let source_len = source_sequence.len() as i64;
             if last_source_position < source_len {
@@ -130,7 +129,7 @@ pub fn gfa_sample_diff(
                 });
             }
 
-            let source_node_blocks = source_path.node_block_partition(conn, source_ranges);
+            let source_node_blocks = source_path.node_block_partition(conn, source_ranges)?;
             let source_segments = segments_from_blocks(&source_node_blocks, &source_sequence);
             segments.extend(source_segments.iter().cloned());
 
@@ -142,9 +141,8 @@ pub fn gfa_sample_diff(
             paths.push(source_gfa_path);
         }
 
-        if has_target_path {
-            let target_path = target_path_result.unwrap();
-            let target_sequence = target_path.sequence(conn);
+        if let Some(target_path) = target_path_result {
+            let target_sequence = target_path.sequence(conn)?;
 
             let target_len = target_sequence.len() as i64;
             if last_target_position < target_len {
@@ -154,7 +152,7 @@ pub fn gfa_sample_diff(
                 });
             }
 
-            let target_node_blocks = target_path.node_block_partition(conn, target_ranges);
+            let target_node_blocks = target_path.node_block_partition(conn, target_ranges)?;
             let target_segments = segments_from_blocks(&target_node_blocks, &target_sequence);
             segments.extend(target_segments.iter().cloned());
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -28,4 +28,12 @@ pub enum SequenceUpdateError {
     BlockGroupError(#[from] BlockGroupError),
     #[error("Sequence save error: {0}")]
     SequenceError(#[from] SequenceError),
+    #[error("Missing segment '{0}' in GFA input")]
+    MissingSegment(String),
+    #[error("Missing strand for path '{path_name}' at segment index {index}")]
+    MissingPathStrand { path_name: String, index: usize },
+    #[error("Path '{0}' has no segments")]
+    EmptyPath(String),
+    #[error("No path block found for path id {path_id} at coordinate {coordinate}")]
+    MissingPathBlock { path_id: String, coordinate: i64 },
 }

--- a/src/exports/fasta.rs
+++ b/src/exports/fasta.rs
@@ -1,7 +1,8 @@
 use std::{fs::File, path::PathBuf};
 
 use gen_models::{
-    block_group::BlockGroup, collection::Collection, db::GraphConnection, sample::Sample,
+    block_group::BlockGroup, collection::Collection, db::GraphConnection, errors::PathError,
+    sample::Sample,
 };
 use noodles::fasta;
 use thiserror::Error;
@@ -10,6 +11,8 @@ use thiserror::Error;
 pub enum FastaExportError {
     #[error("I/O error while exporting FASTA: {0}")]
     Io(#[from] std::io::Error),
+    #[error("Path error while exporting FASTA: {0}")]
+    Path(#[from] PathError),
 }
 
 pub fn export_fasta(
@@ -31,7 +34,7 @@ pub fn export_fasta(
         let path = BlockGroup::get_current_path(conn, &block_group.id);
 
         let definition = fasta::record::Definition::new(block_group.name, None);
-        let sequence = fasta::record::Sequence::from(path.sequence(conn).into_bytes());
+        let sequence = fasta::record::Sequence::from(path.sequence(conn)?.into_bytes());
         let record = fasta::Record::new(definition, sequence);
 
         writer.write_record(&record)?;

--- a/src/exports/genbank.rs
+++ b/src/exports/genbank.rs
@@ -20,7 +20,7 @@ use gen_models::{
     annotations::{Annotation, GenBankLocationOperator},
     block_group::BlockGroup,
     db::GraphConnection,
-    errors::{AnnotationError, SequenceError},
+    errors::{AnnotationError, PathError, SequenceError},
     node::Node,
     sample::Sample,
     traits::Query,
@@ -40,6 +40,8 @@ pub enum GenbankExportError {
     Annotation(#[from] AnnotationError),
     #[error("Sequence error while exporting GenBank: {0}")]
     Sequence(#[from] SequenceError),
+    #[error("Path error while exporting GenBank: {0}")]
+    Path(#[from] PathError),
 }
 
 fn build_annotation_location(
@@ -274,13 +276,13 @@ pub fn export_genbank(
     for block_group in block_groups.iter() {
         let path = BlockGroup::get_current_path(conn, &block_group.id);
         let path_blocks = path
-            .blocks(conn)
+            .blocks(conn)?
             .into_iter()
             .filter(|block| !is_terminal(block.node_id))
             .collect::<Vec<_>>();
         let mut seq = gb_io::seq::Seq::empty();
         seq.name = Some(block_group.name.clone());
-        seq.seq = path.sequence(conn).into_bytes();
+        seq.seq = path.sequence(conn)?.into_bytes();
         export_annotations(conn, &path, &path_blocks, &mut seq, sample_name)?;
 
         // Identify the node traversal corresponding to our path.
@@ -534,6 +536,7 @@ mod tests {
     ) {
         let blocks = path
             .blocks(conn)
+            .unwrap()
             .into_iter()
             .filter(|block| !is_terminal(block.node_id))
             .collect::<Vec<_>>();

--- a/src/exports/genbank.rs
+++ b/src/exports/genbank.rs
@@ -20,7 +20,7 @@ use gen_models::{
     annotations::{Annotation, GenBankLocationOperator},
     block_group::BlockGroup,
     db::GraphConnection,
-    errors::AnnotationError,
+    errors::{AnnotationError, SequenceError},
     node::Node,
     sample::Sample,
     traits::Query,
@@ -38,6 +38,8 @@ pub enum GenbankExportError {
     Io(#[from] std::io::Error),
     #[error("Annotation error while exporting GenBank: {0}")]
     Annotation(#[from] AnnotationError),
+    #[error("Sequence error while exporting GenBank: {0}")]
+    Sequence(#[from] SequenceError),
 }
 
 fn build_annotation_location(
@@ -319,7 +321,7 @@ pub fn export_genbank(
                         let seqs = Node::get_sequences_by_node_ids(conn, &[sub_node.node_id]);
                         let seq = &seqs[&sub_node.node_id];
                         sequence.push_str(
-                            &seq.get_sequence(sub_node.sequence_start, sub_node.sequence_end),
+                            &seq.get_sequence(sub_node.sequence_start, sub_node.sequence_end)?,
                         );
                     }
                     let mut qualifiers = vec![];

--- a/src/exports/gfa.rs
+++ b/src/exports/gfa.rs
@@ -9,7 +9,7 @@ use gen_core::{HashId, is_terminal, strand::Strand};
 use gen_graph::{GenGraph, project_path};
 use gen_models::{
     block_group::BlockGroup, block_group_edge::BlockGroupEdge, db::GraphConnection, edge::Edge,
-    path::Path, sample::Sample,
+    errors::SequenceError, path::Path, sample::Sample,
 };
 use itertools::Itertools;
 use thiserror::Error;
@@ -20,6 +20,8 @@ use crate::gfa::{Link, Path as GFAPath, Segment, path_line, write_links, write_s
 pub enum GfaExportError {
     #[error("I/O error while exporting GFA: {0}")]
     Io(#[from] std::io::Error),
+    #[error("Sequence error while exporting GFA: {0}")]
+    Sequence(#[from] SequenceError),
     #[error("No block groups found for collection {collection_name} and sample {sample_name}")]
     MissingBlockGroups {
         collection_name: String,
@@ -705,7 +707,7 @@ mod tests {
             Node::create(conn, &insert_sequence.hash, &HashId::convert_str("1")).unwrap();
         let insert = PathBlock {
             node_id: insert_node_id,
-            block_sequence: insert_sequence.get_sequence(0, 4).to_string(),
+            block_sequence: insert_sequence.get_sequence(0, 4).unwrap(),
             sequence_start: 0,
             sequence_end: 4,
             path_start: 7,

--- a/src/exports/gfa.rs
+++ b/src/exports/gfa.rs
@@ -8,8 +8,13 @@ use std::{
 use gen_core::{HashId, is_terminal, strand::Strand};
 use gen_graph::{GenGraph, project_path};
 use gen_models::{
-    block_group::BlockGroup, block_group_edge::BlockGroupEdge, db::GraphConnection, edge::Edge,
-    errors::SequenceError, path::Path, sample::Sample,
+    block_group::BlockGroup,
+    block_group_edge::BlockGroupEdge,
+    db::GraphConnection,
+    edge::Edge,
+    errors::{PathError, SequenceError},
+    path::Path,
+    sample::Sample,
 };
 use itertools::Itertools;
 use thiserror::Error;
@@ -22,6 +27,14 @@ pub enum GfaExportError {
     Io(#[from] std::io::Error),
     #[error("Sequence error while exporting GFA: {0}")]
     Sequence(#[from] SequenceError),
+    #[error("Path error while exporting GFA: {0}")]
+    Path(#[from] PathError),
+    #[error("Path error while exporting GFA for path '{path_name}': {source}")]
+    PathForName {
+        path_name: String,
+        #[source]
+        source: PathError,
+    },
     #[error("No block groups found for collection {collection_name} and sample {sample_name}")]
     MissingBlockGroups {
         collection_name: String,
@@ -218,7 +231,12 @@ fn get_paths(
         };
         let sample_name = block_group.sample_name;
 
-        let path_blocks = path.blocks(conn);
+        let path_blocks = path
+            .blocks(conn)
+            .map_err(|source| GfaExportError::PathForName {
+                path_name: path.name.clone(),
+                source,
+            })?;
         let projected_path = project_path(graph, &path_blocks);
 
         if !projected_path.is_empty() {
@@ -480,7 +498,7 @@ mod tests {
 
         let paths = Path::query_for_collection(conn, "test collection 2");
         assert_eq!(paths.len(), 1);
-        assert_eq!(paths[0].sequence(conn), "AAAATTTTGGGGCCCC");
+        assert_eq!(paths[0].sequence(conn).unwrap(), "AAAATTTTGGGGCCCC");
     }
 
     #[test]
@@ -725,7 +743,7 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        let tree = path.intervaltree(conn);
+        let tree = path.intervaltree(conn).unwrap();
         BlockGroup::insert_change(conn, &change, &tree).unwrap();
 
         let augmented_edges = BlockGroupEdge::edges_for_block_group(conn, &block_group_id);

--- a/src/genbank.rs
+++ b/src/genbank.rs
@@ -117,6 +117,7 @@ pub struct GenBankAnnotation {
 pub struct GenBankLocus {
     pub name: String,
     pub molecule_type: Option<String>,
+    pub circular: bool,
     pub sequence: String,
     pub changes: Vec<GenBankEdit>,
     pub annotations: Vec<GenBankAnnotation>,
@@ -277,6 +278,7 @@ fn annotation_for_feature(feature: &Feature) -> Option<GenBankAnnotation> {
 }
 
 pub fn process_sequence(seq: Seq) -> Result<GenBankLocus, GenBankError> {
+    let circular = seq.is_circular();
     let final_sequence = if let Ok(sequence) = str::from_utf8(&seq.seq) {
         sequence.to_string()
     } else {
@@ -286,6 +288,7 @@ pub fn process_sequence(seq: Seq) -> Result<GenBankLocus, GenBankError> {
     let geneious_edit = Regex::new(r"Geneious type: Editing History (?P<edit_type>\w+)")?;
     let mut locus = GenBankLocus {
         name: seq.name.unwrap_or_default(),
+        circular,
         sequence: final_sequence.clone(),
         molecule_type: seq.molecule_type,
         changes: vec![],

--- a/src/graphs/operators.rs
+++ b/src/graphs/operators.rs
@@ -90,9 +90,9 @@ pub fn derive_chunks(
         backbone,
     )?;
 
-    let current_path_length = current_path.length(conn);
+    let current_path_length = current_path.length(conn)?;
 
-    let current_intervaltree = current_path.intervaltree(conn);
+    let current_intervaltree = current_path.intervaltree(conn)?;
     let current_path_edges = PathEdge::edges_for_path(conn, &current_path.id);
 
     let chunk_ranges_length = chunk_ranges.len();
@@ -459,7 +459,7 @@ mod tests {
         Collection::create(conn, "test").unwrap();
         let (block_group1_id, original_path) = setup_block_group(conn);
 
-        let intervaltree = original_path.intervaltree(conn);
+        let intervaltree = original_path.intervaltree(conn).unwrap();
         let insert_start_node_id = intervaltree.query_point(16).next().unwrap().value.node_id;
         let insert_end_node_id = intervaltree.query_point(24).next().unwrap().value.node_id;
 
@@ -537,7 +537,7 @@ mod tests {
             .new_path_with(conn, 16, 24, &edge_into_insert, &edge_out_of_insert)
             .unwrap();
         assert_eq!(
-            insert_path.sequence(conn),
+            insert_path.sequence(conn).unwrap(),
             "AAAAAAAAAATTTTTTAAAAAAAACCCCCCGGGGGGGGGG"
         );
 
@@ -573,7 +573,7 @@ mod tests {
         );
 
         let new_path = BlockGroup::get_current_path(conn, &block_group2.id);
-        assert_eq!(new_path.sequence(conn), "TAAAAAAAAC");
+        assert_eq!(new_path.sequence(conn).unwrap(), "TAAAAAAAAC");
     }
 
     #[test]
@@ -678,7 +678,7 @@ mod tests {
         );
 
         let path2 = BlockGroup::get_current_path(conn, &block_group2.id);
-        assert_eq!(path2.sequence(conn), "TCAATCG");
+        assert_eq!(path2.sequence(conn).unwrap(), "TCAATCG");
 
         let block_group3 = block_groups.iter().find(|x| x.name == "m123.3").unwrap();
         let all_sequences3 = BlockGroup::get_all_sequences(conn, &block_group3.id, false);
@@ -691,7 +691,7 @@ mod tests {
         );
 
         let path3 = BlockGroup::get_current_path(conn, &block_group3.id);
-        assert_eq!(path3.sequence(conn), "ATCGATCAAGGAACACA");
+        assert_eq!(path3.sequence(conn).unwrap(), "ATCGATCAAGGAACACA");
     }
 
     #[test]
@@ -796,7 +796,7 @@ mod tests {
         );
 
         let path2 = BlockGroup::get_current_path(conn, &block_group2.id);
-        assert_eq!(path2.sequence(conn), "TCAATCG");
+        assert_eq!(path2.sequence(conn).unwrap(), "TCAATCG");
 
         let block_group3 = block_groups.iter().find(|x| x.name == "m123.3").unwrap();
         let all_sequences3 = BlockGroup::get_all_sequences(conn, &block_group3.id, false);
@@ -809,7 +809,7 @@ mod tests {
         );
 
         let path3 = BlockGroup::get_current_path(conn, &block_group3.id);
-        assert_eq!(path3.sequence(conn), "ATCGATCAAGGAACACA");
+        assert_eq!(path3.sequence(conn).unwrap(), "ATCGATCAAGGAACACA");
 
         // Stitch the two main chunks back together in same order
         make_stitch(
@@ -841,7 +841,7 @@ mod tests {
 
         let path4 = BlockGroup::get_current_path(conn, &block_group4.id);
         // path2 + path3 concatenated
-        assert_eq!(path4.sequence(conn), "TCAATCGATCGATCAAGGAACACA");
+        assert_eq!(path4.sequence(conn).unwrap(), "TCAATCGATCGATCAAGGAACACA");
 
         // Stitch the two main chunks together but in reverse order
         make_stitch(
@@ -873,6 +873,6 @@ mod tests {
 
         let path5 = BlockGroup::get_current_path(conn, &block_group5.id);
         // path3 + path2 concatenated
-        assert_eq!(path5.sequence(conn), "ATCGATCAAGGAACACATCAATCG");
+        assert_eq!(path5.sequence(conn).unwrap(), "ATCGATCAAGGAACACATCAATCG");
     }
 }

--- a/src/imports/fasta.rs
+++ b/src/imports/fasta.rs
@@ -211,7 +211,7 @@ mod tests {
 
         let path = Path::all(conn)[0].clone();
         assert_eq!(
-            path.sequence(conn),
+            path.sequence(conn).unwrap(),
             "ATCGATCGATCGATCGATCGGGAACACACAGAGA".to_string()
         );
     }
@@ -318,7 +318,7 @@ mod tests {
 
         let path = Path::all(conn)[0].clone();
         assert_eq!(
-            path.sequence(conn),
+            path.sequence(conn).unwrap(),
             "ATCGATCGATCGATCGATCGGGAACACACAGAGA".to_string()
         );
         assert_eq!(
@@ -353,7 +353,7 @@ mod tests {
 
         let path = Path::all(conn)[0].clone();
         assert_eq!(
-            path.sequence(conn),
+            path.sequence(conn).unwrap(),
             "ATCGATCGATCGATCGATCGGGAACACACAGAGA".to_string()
         );
     }

--- a/src/imports/genbank.rs
+++ b/src/imports/genbank.rs
@@ -531,7 +531,7 @@ where
                     locus
                         .molecule_type
                         .as_ref()
-                        .map(|mol_type| format!("{mol_type} circular"))
+                        .map(|mol_type| format!("circular {mol_type}"))
                         .unwrap_or_else(|| "circular".to_string())
                 } else {
                     locus

--- a/src/imports/genbank.rs
+++ b/src/imports/genbank.rs
@@ -668,7 +668,7 @@ where
                             preserve_edge: true,
                         },
                     };
-                    let tree = path.intervaltree(conn);
+                    let tree = path.intervaltree(conn)?;
                     BlockGroup::insert_change(conn, &change, &tree).unwrap();
                     applied_changes.push((edit, change_node_id));
                 }
@@ -1184,7 +1184,7 @@ mod tests {
             .unwrap();
         let path = BlockGroup::get_current_path(conn, &block_group.id);
         let mut visible_ranges_by_node: HashMap<HashId, Vec<(i64, i64)>> = HashMap::new();
-        for block in path.blocks(conn) {
+        for block in path.blocks(conn).unwrap() {
             if is_terminal(block.node_id) {
                 continue;
             }

--- a/src/imports/genbank.rs
+++ b/src/imports/genbank.rs
@@ -527,9 +527,19 @@ where
                 if !locus.name.is_empty() {
                     seq_model = seq_model.name(&locus.name);
                 }
-                if let Some(ref mol_type) = locus.molecule_type {
-                    seq_model = seq_model.sequence_type(mol_type);
-                }
+                let sequence_type = if locus.circular {
+                    locus
+                        .molecule_type
+                        .as_ref()
+                        .map(|mol_type| format!("{mol_type} circular"))
+                        .unwrap_or_else(|| "circular".to_string())
+                } else {
+                    locus
+                        .molecule_type
+                        .clone()
+                        .unwrap_or_else(|| "DNA".to_string())
+                };
+                seq_model = seq_model.sequence_type(&sequence_type);
                 let sequence = seq_model.save(conn)?;
                 let wt_node_id = Node::create(
                     conn,

--- a/src/imports/gfa.rs
+++ b/src/imports/gfa.rs
@@ -512,7 +512,7 @@ mod tests {
         .clone();
 
         let result = path.sequence(conn);
-        assert_eq!(result, "ATCGATCGATCGATCGATCGGGAACACACAGAGA");
+        assert_eq!(result.unwrap(), "ATCGATCGATCGATCGATCGGGAACACACAGAGA");
 
         let node_count = Node::query(conn, "select * from nodes", rusqlite::params!()).len() as i64;
         assert_eq!(node_count, 6);
@@ -576,7 +576,7 @@ mod tests {
         .clone();
 
         let result = path.sequence(conn);
-        assert_eq!(result, "ACCTACAAATTCAAAC");
+        assert_eq!(result.unwrap(), "ACCTACAAATTCAAAC");
 
         let node_count = Node::query(conn, "select * from nodes", rusqlite::params!()).len() as i64;
         assert_eq!(node_count, 6);
@@ -602,7 +602,7 @@ mod tests {
         .clone();
 
         let result = path.sequence(conn);
-        assert_eq!(result, "TATGCCAGCTGCGAATA");
+        assert_eq!(result.unwrap(), "TATGCCAGCTGCGAATA");
 
         let node_count = Node::query(conn, "select * from nodes", rusqlite::params!()).len() as i64;
         assert_eq!(node_count, 6);
@@ -654,7 +654,7 @@ mod tests {
         ];
 
         let expected_sequence = expected_sequence_parts.join("");
-        assert_eq!(result, expected_sequence);
+        assert_eq!(result.unwrap(), expected_sequence);
 
         let part1 = "T";
         let part3 = "T";
@@ -735,7 +735,7 @@ mod tests {
         .clone();
 
         let result = path.sequence(conn);
-        assert_eq!(result, "AA");
+        assert_eq!(result.unwrap(), "AA");
 
         let all_sequences = BlockGroup::get_all_sequences(conn, &block_group_id, false);
         assert_eq!(all_sequences, HashSet::from_iter(vec!["AA".to_string()]));

--- a/src/imports/library.rs
+++ b/src/imports/library.rs
@@ -178,7 +178,7 @@ mod tests {
 
         let current_path = BlockGroup::get_current_path(conn, &block_group.id);
         assert_eq!(
-            current_path.sequence(conn),
+            current_path.sequence(conn).unwrap(),
             "TCTAGAGAAAGAGGGGACAAACTAGATGCGTAAAGGAGAAGAACTTTAA"
         );
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -527,7 +527,7 @@ fn call_cli() -> Result<(), Box<dyn std::error::Error>> {
             let patch_path = Path::new(&patch);
             let mut f = File::open(patch_path)?;
             let patches = patch::load_patches(&mut f);
-            let diagrams = view_patches(&workspace, &patches);
+            let diagrams = view_patches(&workspace, &patches)?;
             for (patch_hash, patch_diagrams) in diagrams.iter() {
                 for (bg_id, dot) in patch_diagrams.iter() {
                     let path = if let Some(ref p) = prefix {

--- a/src/main.rs
+++ b/src/main.rs
@@ -679,7 +679,7 @@ fn call_cli() -> Result<(), Box<dyn std::error::Error>> {
                     format!("Graph {parsed_graph_name} not found for {formatted_sample_name}")
                 })?;
             let path = BlockGroup::get_current_path(graph_conn, &block_group.id);
-            let sequence = path.sequence(graph_conn);
+            let sequence = path.sequence(graph_conn)?;
             if end_coordinate == -1 {
                 end_coordinate = sequence.len() as i64;
             }

--- a/src/updates/fasta.rs
+++ b/src/updates/fasta.rs
@@ -65,17 +65,17 @@ pub fn update_with_fasta(
 
     let mut target_states = target_block_groups
         .iter()
-        .map(|target_block_group| {
+        .map(|target_block_group| -> Result<_, FastaError> {
             let path = BlockGroup::get_current_path(conn, &target_block_group.id);
-            let interval_tree = path.intervaltree(conn);
-            TargetBlockGroupState {
+            let interval_tree = path.intervaltree(conn)?;
+            Ok(TargetBlockGroupState {
                 block_group_id: target_block_group.id,
                 path,
                 interval_tree,
                 first_node: None,
-            }
+            })
         })
-        .collect::<Vec<_>>();
+        .collect::<Result<Vec<_>, _>>()?;
 
     let mut change_count = 0;
 
@@ -336,11 +336,11 @@ mod tests {
         let child_path = BlockGroup::get_current_path(conn, &child_blockgroup);
         let other_path = BlockGroup::get_current_path(conn, &other_blockgroup);
         assert_eq!(
-            child_path.sequence(conn),
+            child_path.sequence(conn).unwrap(),
             "ATAAAAAAAATCGATCGATCGATCGGGAACACACAGAGA"
         );
         assert_eq!(
-            other_path.sequence(conn),
+            other_path.sequence(conn).unwrap(),
             "ATCGATCGATCGATCGATCGGGAACACACAGAGA"
         );
     }
@@ -829,7 +829,7 @@ mod tests {
 
         let latest_path = BlockGroup::get_current_path(conn, &block_groups[0].id);
         assert_eq!(
-            latest_path.sequence(conn),
+            latest_path.sequence(conn).unwrap(),
             "ATTCGATCGATCGATCGGGAACACACAGAGA"
         );
     }

--- a/src/updates/gaf.rs
+++ b/src/updates/gaf.rs
@@ -124,14 +124,12 @@ where
         let node_info: Vec<&str> = node_id.rsplitn(2, '.').collect();
         let node_id = *node_info.last().unwrap();
         let id = HashId::try_from(node_id).ok()?;
-        let mut stmt = conn
-            .prepare_cached(
-                "select s.length from nodes n left join sequences s on (s.hash = n.sequence_hash) where n.id = ?1;",
-            )
-            .ok()?;
-        let res = stmt.query_row([id], |row| row.get(0)).ok()?;
-        node_lengths.insert(node_id.to_string(), (id, res));
-        Some((id, res))
+        let length = Node::query_nodes_length(conn, &[id])
+            .ok()?
+            .get(&id)
+            .copied()?;
+        node_lengths.insert(node_id.to_string(), (id, length));
+        Some((id, length))
     };
 
     // our GFA export encodes segments like node_id.sequence_start

--- a/src/updates/gaf.rs
+++ b/src/updates/gaf.rs
@@ -116,15 +116,22 @@ where
 
     let mut node_lengths: HashMap<String, (HashId, i64)> = HashMap::new();
 
-    let mut get_node_info = |node_id: &str| -> (HashId, i64) {
-        *node_lengths.entry(node_id.to_string()).or_insert_with(|| {
-            let node_info : Vec<&str> = node_id.rsplitn(2, '.').collect();
-            let node_id = *node_info.last().unwrap();
-            let id = HashId::try_from(node_id).unwrap();
-            let mut stmt = conn.prepare_cached("select s.length from nodes n left join sequences s on (s.hash = n.sequence_hash) where n.id = ?1;").unwrap();
-            let res = stmt.query_row([id], |row| row.get(0)).unwrap();
-            (id, res)
-        })
+    let mut get_node_info = |node_id: &str| -> Option<(HashId, i64)> {
+        if let Some(node_info) = node_lengths.get(node_id) {
+            return Some(*node_info);
+        }
+
+        let node_info: Vec<&str> = node_id.rsplitn(2, '.').collect();
+        let node_id = *node_info.last().unwrap();
+        let id = HashId::try_from(node_id).ok()?;
+        let mut stmt = conn
+            .prepare_cached(
+                "select s.length from nodes n left join sequences s on (s.hash = n.sequence_hash) where n.id = ?1;",
+            )
+            .ok()?;
+        let res = stmt.query_row([id], |row| row.get(0)).ok()?;
+        node_lengths.insert(node_id.to_string(), (id, res));
+        Some((id, res))
     };
 
     // our GFA export encodes segments like node_id.sequence_start
@@ -234,7 +241,9 @@ where
                         .parse::<i64>()
                         .map_err(GafUpdateError::ParseInt)?;
                     for (segment_strand, segment_id) in segments.iter() {
-                        let (segment_node_id, node_length) = get_node_info(segment_id);
+                        let Some((segment_node_id, node_length)) = get_node_info(segment_id) else {
+                            continue;
+                        };
                         if node_length >= matches {
                             strand = Some(*segment_strand);
                             node_id = Some(segment_node_id);
@@ -246,7 +255,9 @@ where
                 } else if query.ends_with("right") {
                     query_key = "right";
                     let (segment_strand, segment_id) = segments.first().unwrap();
-                    let (segment_node_id, _node_length) = get_node_info(segment_id);
+                    let Some((segment_node_id, _node_length)) = get_node_info(segment_id) else {
+                        continue;
+                    };
                     strand = Some(*segment_strand);
                     node_id = Some(segment_node_id);
                 } else {

--- a/src/updates/genbank.rs
+++ b/src/updates/genbank.rs
@@ -53,7 +53,7 @@ where
                     locus
                         .molecule_type
                         .as_ref()
-                        .map(|mol_type| format!("{mol_type} circular"))
+                        .map(|mol_type| format!("circular {mol_type}"))
                         .unwrap_or_else(|| "circular".to_string())
                 } else {
                     locus

--- a/src/updates/genbank.rs
+++ b/src/updates/genbank.rs
@@ -219,7 +219,7 @@ where
                             preserve_edge: true,
                         },
                     };
-                    let tree = path.intervaltree(conn);
+                    let tree = path.intervaltree(conn)?;
                     BlockGroup::insert_change(conn, &change, &tree).unwrap();
                 }
             }

--- a/src/updates/genbank.rs
+++ b/src/updates/genbank.rs
@@ -49,9 +49,19 @@ where
                 if !locus.name.is_empty() {
                     seq_model = seq_model.name(&locus.name);
                 }
-                if let Some(ref mol_type) = locus.molecule_type {
-                    seq_model = seq_model.sequence_type(mol_type);
-                }
+                let sequence_type = if locus.circular {
+                    locus
+                        .molecule_type
+                        .as_ref()
+                        .map(|mol_type| format!("{mol_type} circular"))
+                        .unwrap_or_else(|| "circular".to_string())
+                } else {
+                    locus
+                        .molecule_type
+                        .clone()
+                        .unwrap_or_else(|| "DNA".to_string())
+                };
+                seq_model = seq_model.sequence_type(&sequence_type);
                 let sequence = seq_model.save(conn)?;
                 let wt_node_id = Node::create(
                     conn,

--- a/src/updates/gfa.rs
+++ b/src/updates/gfa.rs
@@ -91,7 +91,7 @@ pub fn update_with_gfa(
             .collect::<Vec<String>>()
             .join("");
         for existing_path in existing_paths.iter() {
-            if existing_path.sequence(conn) == path_sequence {
+            if existing_path.sequence(conn)? == path_sequence {
                 existing_path_ids_by_new_path_name.insert(path.name.clone(), existing_path.id);
             }
         }
@@ -118,7 +118,7 @@ pub fn update_with_gfa(
             .collect::<Vec<String>>()
             .join("");
         for existing_path in existing_paths.iter() {
-            if existing_path.sequence(conn) == walk_sequence {
+            if existing_path.sequence(conn)? == walk_sequence {
                 existing_path_ids_by_new_path_name.insert(walk_name.clone(), existing_path.id);
             }
         }
@@ -245,13 +245,13 @@ fn create_new_path_from_existing(
     gfa: &Gfa<String, (), ()>,
     segments_by_id: &HashMap<String, &Segment<String, ()>>,
 ) -> Result<(), SequenceUpdateError> {
-    let interval_tree = existing_path.intervaltree(conn);
+    let interval_tree = existing_path.intervaltree(conn)?;
     let mut existing_path_ranges_by_segment_id = HashMap::new();
     let mut existing_path_position = 0;
     for segment_id in matched_path_segment_ids.iter() {
         let segment_sequence = segments_by_id
             .get(segment_id)
-            .unwrap()
+            .ok_or_else(|| SequenceUpdateError::MissingSegment(segment_id.clone()))?
             .sequence
             .get_string(&gfa.sequence);
         let segment_length = segment_sequence.len();
@@ -274,18 +274,30 @@ fn create_new_path_from_existing(
     let mut new_path_edges = vec![];
     let mut healing_edges = vec![];
     for (i, segment_id) in unmatched_path_segment_ids.iter().enumerate() {
-        if let Some((start, end)) = existing_path_ranges_by_segment_id.get(segment_id) {
+        if let Some((path_start, path_end)) = existing_path_ranges_by_segment_id.get(segment_id) {
             // Current segment matches something in the existing path.  Maybe add an edge from the
             // previous node to the next one, which already exists
             let block_with_start = interval_tree
-                .query_point(*start as i64)
+                .query_point(*path_start as i64)
                 .next()
-                .unwrap()
+                .ok_or(SequenceUpdateError::MissingPathBlock {
+                    path_id: existing_path.id.to_string(),
+                    coordinate: *path_start as i64,
+                })?
                 .value;
-            let block_with_end = interval_tree.query_point(*end as i64).next().unwrap().value;
+            let block_with_end = interval_tree
+                .query_point(*path_end as i64)
+                .next()
+                .ok_or(SequenceUpdateError::MissingPathBlock {
+                    path_id: existing_path.id.to_string(),
+                    coordinate: *path_end as i64,
+                })?
+                .value;
 
             let target_coordinate =
-                block_with_start.sequence_start + *start as i64 - block_with_start.start;
+                block_with_start.sequence_start + *path_start as i64 - block_with_start.start;
+            let end_coordinate =
+                block_with_end.sequence_start + *path_end as i64 - block_with_end.start;
             // NOTE: We're assuming that if the previous segment was on the same node ID as the
             // block with the start coordinate, they are contiguous, so no new edge is needed
             if previous_node_id != block_with_start.node_id {
@@ -303,14 +315,14 @@ fn create_new_path_from_existing(
                 });
 
                 // Create the boundary edges that will be interrupted by the new path
-                if !is_terminal(block_with_start.node_id) && *start > 0 {
+                if !is_terminal(block_with_start.node_id) && *path_start > 0 {
                     healing_edges.push(AugmentedEdgeData {
                         edge_data: EdgeData {
                             source_node_id: block_with_start.node_id,
-                            source_coordinate: *start as i64,
+                            source_coordinate: target_coordinate,
                             source_strand: previous_node_strand,
                             target_node_id: block_with_start.node_id,
-                            target_coordinate: *start as i64,
+                            target_coordinate,
                             target_strand: previous_node_strand,
                         },
                         chromosome_index: 0,
@@ -321,10 +333,10 @@ fn create_new_path_from_existing(
                     healing_edges.push(AugmentedEdgeData {
                         edge_data: EdgeData {
                             source_node_id: block_with_end.node_id,
-                            source_coordinate: *end as i64,
+                            source_coordinate: end_coordinate,
                             source_strand: previous_node_strand,
                             target_node_id: block_with_end.node_id,
-                            target_coordinate: *end as i64,
+                            target_coordinate: end_coordinate,
                             target_strand: previous_node_strand,
                         },
                         chromosome_index: 0,
@@ -333,7 +345,7 @@ fn create_new_path_from_existing(
                 }
             }
 
-            existing_path_position += (end - start) as i64;
+            existing_path_position += (path_end - path_start) as i64;
             previous_node_id = block_with_end.node_id;
             previous_node_coordinate =
                 block_with_end.sequence_start + existing_path_position - block_with_end.start;
@@ -341,7 +353,9 @@ fn create_new_path_from_existing(
         } else {
             // Current segment is new.  Create a sequence and node for it, then add an edge to the
             // new node
-            let segment = segments_by_id.get(segment_id).unwrap();
+            let segment = segments_by_id
+                .get(segment_id)
+                .ok_or_else(|| SequenceUpdateError::MissingSegment(segment_id.clone()))?;
             let segment_sequence = segment.sequence.get_string(&gfa.sequence);
             let sequence = Sequence::new()
                 .sequence_type("DNA")
@@ -355,7 +369,13 @@ fn create_new_path_from_existing(
                     hash = &sequence.hash
                 )),
             )?;
-            let next_node_strand = bool_to_strand(*unmatched_path_strands.get(i).unwrap());
+            let next_node_strand =
+                bool_to_strand(*unmatched_path_strands.get(i).ok_or_else(|| {
+                    SequenceUpdateError::MissingPathStrand {
+                        path_name: unmatched_path_name.to_string(),
+                        index: i,
+                    }
+                })?);
             new_path_edges.push(AugmentedEdgeData {
                 edge_data: EdgeData {
                     source_node_id: previous_node_id,
@@ -386,20 +406,22 @@ fn create_new_path_from_existing(
         }
     }
 
-    let last_segment_id = unmatched_path_segment_ids.last().unwrap();
-    if existing_path_ranges_by_segment_id.contains_key(last_segment_id) {
-        let (start, _end) = existing_path_ranges_by_segment_id
-            .get(last_segment_id)
-            .unwrap();
+    let last_segment_id = unmatched_path_segment_ids
+        .last()
+        .ok_or_else(|| SequenceUpdateError::EmptyPath(unmatched_path_name.to_string()))?;
+    if let Some((start, _end)) = existing_path_ranges_by_segment_id.get(last_segment_id) {
         let block_with_start = interval_tree
             .query_point(*start as i64)
             .next()
-            .unwrap()
+            .ok_or(SequenceUpdateError::MissingPathBlock {
+                path_id: existing_path.id.to_string(),
+                coordinate: *start as i64,
+            })?
             .value;
         new_path_edges.push(AugmentedEdgeData {
             edge_data: EdgeData {
                 source_node_id: block_with_start.node_id,
-                source_coordinate: block_with_start.end,
+                source_coordinate: block_with_start.sequence_end,
                 source_strand: block_with_start.strand,
                 target_node_id: PATH_END_NODE_ID,
                 target_coordinate: 0,

--- a/src/updates/library.rs
+++ b/src/updates/library.rs
@@ -4,7 +4,7 @@ use std::str;
 use gen_models::{
     block_group::{BlockGroup, NewBlockGroup},
     db::DbContext,
-    errors::BlockGroupError,
+    errors::{BlockGroupError, PathError},
     file_types::FileTypes,
     operations::{OperationFile, OperationInfo},
     sample::Sample,
@@ -28,6 +28,8 @@ pub enum UpdateWithLibraryError {
     BlockGroupCreationFailed(#[from] BlockGroupError),
     #[error("Failed to create output graph(s)")]
     GraphOperation(GraphOperationError),
+    #[error("Failed to read path")]
+    Path(#[from] PathError),
     #[error("Failed to parse library files")]
     FileParse(CombinatorialLibraryParseError),
     #[error("Failed to create library")]
@@ -72,6 +74,7 @@ pub fn update_with_library(
 
     let block_groups = Sample::get_block_groups(conn, collection_name, parent_sample_name);
     let parent_path = BlockGroup::get_current_path(conn, &block_groups[0].id);
+    let parent_path_length = parent_path.length(conn)?;
 
     let mut chunk_ranges = vec![];
     if start_coordinate > 0 {
@@ -84,10 +87,10 @@ pub fn update_with_library(
         start: start_coordinate,
         end: end_coordinate,
     });
-    if end_coordinate < parent_path.length(conn) {
+    if end_coordinate < parent_path_length {
         chunk_ranges.push(Range {
             start: end_coordinate,
-            end: parent_path.length(conn),
+            end: parent_path_length,
         });
     }
 
@@ -145,7 +148,7 @@ pub fn update_with_library(
 
     chunk_index += 1;
 
-    if end_coordinate < parent_path.length(conn) {
+    if end_coordinate < parent_path_length {
         let end_chunk = derived_block_group_chunks[chunk_index].clone();
         reference_block_group_chunks.push(end_chunk.clone());
         let pathless_end_chunk = BlockGroupChunk {
@@ -339,7 +342,7 @@ mod tests {
 
         let path = BlockGroup::get_current_path(conn, &block_group.id);
         assert_eq!(
-            path.sequence(conn),
+            path.sequence(conn).unwrap(),
             "ATCGATCGATCGATCGATCGGGAACACACAGAGA".to_string()
         );
 

--- a/src/updates/sequence.rs
+++ b/src/updates/sequence.rs
@@ -54,7 +54,7 @@ pub fn update_with_sequence(
 
     for target_block_group in &target_block_groups {
         let path = BlockGroup::get_current_path(conn, &target_block_group.id);
-        let interval_tree = path.intervaltree(conn);
+        let interval_tree = path.intervaltree(conn)?;
         let node_id = if sequence.is_empty() {
             let node_id = HashId::convert_str("");
             let path_block = PathBlock {
@@ -280,11 +280,11 @@ mod tests {
         let child_path = BlockGroup::get_current_path(conn, &child_blockgroup);
         let other_path = BlockGroup::get_current_path(conn, &other_blockgroup);
         assert_eq!(
-            child_path.sequence(conn),
+            child_path.sequence(conn).unwrap(),
             "ATAAAAAAAATCGATCGATCGATCGGGAACACACAGAGA"
         );
         assert_eq!(
-            other_path.sequence(conn),
+            other_path.sequence(conn).unwrap(),
             "ATCGATCGATCGATCGATCGGGAACACACAGAGA"
         );
     }
@@ -667,7 +667,7 @@ mod tests {
 
         let latest_path = BlockGroup::get_current_path(conn, &block_groups[0].id);
         assert_eq!(
-            latest_path.sequence(conn),
+            latest_path.sequence(conn).unwrap(),
             "ATTCGATCGATCGATCGGGAACACACAGAGA"
         );
     }

--- a/src/updates/vcf.rs
+++ b/src/updates/vcf.rs
@@ -545,7 +545,7 @@ pub fn update_with_vcf(
             let ref_start = vcf_entry.ref_start;
             let sequence =
                 SequenceCache::lookup(&mut sequence_cache, "DNA", vcf_entry.alt_seq.to_string())?;
-            let sequence_string = sequence.get_sequence(None, None);
+            let sequence_string = sequence.get_sequence(None, None)?;
 
             let source_path_id =
                 if let Some(source_path_id) = node_source_paths.get(&vcf_entry.path.id) {

--- a/src/updates/vcf.rs
+++ b/src/updates/vcf.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{HashMap, HashSet, hash_map::Entry},
     fmt::Debug,
     io, str,
 };
@@ -8,7 +8,7 @@ use gen_core::{HashId, PathBlock, Strand};
 use gen_models::{
     block_group::{BlockGroup, BlockGroupData, PathCache, PathChange},
     db::{DbContext, GraphConnection},
-    errors::{BlockGroupError, NodeError, OperationError, SampleError, SequenceError},
+    errors::{BlockGroupError, NodeError, OperationError, PathError, SampleError, SequenceError},
     file_types::FileTypes,
     node::Node,
     operations::{Operation, OperationFile, OperationInfo},
@@ -200,6 +200,8 @@ pub enum VcfError {
     BlockGroupError(#[from] BlockGroupError),
     #[error("Sequence save error: {0}")]
     SequenceError(#[from] SequenceError),
+    #[error("Path error: {0}")]
+    PathError(#[from] PathError),
 }
 
 fn resolve_parent_samples(
@@ -368,12 +370,13 @@ pub fn update_with_vcf(
                         };
                         for sample_bg_id in &sample_bg_ids {
                             let sample_path =
-                                PathCache::lookup(&mut path_cache, sample_bg_id, seq_name.clone());
-                            let path_length = path_lengths
-                                .entry(sample_path.id)
-                                .or_insert_with(|| sample_path.length(conn));
+                                PathCache::lookup(&mut path_cache, sample_bg_id, seq_name.clone())?;
+                            let path_length = match path_lengths.entry(sample_path.id) {
+                                Entry::Occupied(entry) => *entry.get(),
+                                Entry::Vacant(entry) => *entry.insert(sample_path.length(conn)?),
+                            };
 
-                            if ref_start > *path_length {
+                            if ref_start > path_length {
                                 return Err(VcfError::InvalidRecord(format!(
                                     "Invalid position found. Path {0} has length of {path_length}, change is in position {ref_start}.",
                                     sample_path.name
@@ -394,7 +397,7 @@ pub fn update_with_vcf(
                     } else if let Some(ref_accession) = allele_accession {
                         for sample_bg_id in &sample_bg_ids {
                             let sample_path =
-                                PathCache::lookup(&mut path_cache, sample_bg_id, seq_name.clone());
+                                PathCache::lookup(&mut path_cache, sample_bg_id, seq_name.clone())?;
 
                             let key = (sample_path, ref_accession.clone());
 
@@ -483,17 +486,15 @@ pub fn update_with_vcf(
                                             &mut path_cache,
                                             sample_bg_id,
                                             seq_name.clone(),
-                                        );
-                                        let path_length =
-                                            if let Some(l) = path_lengths.get(&sample_path.id) {
-                                                l
-                                            } else {
-                                                let l = sample_path.sequence(conn).len();
-                                                path_lengths.insert(sample_path.id, l as i64);
-                                                &path_lengths[&sample_path.id]
-                                            };
+                                        )?;
+                                        let path_length = match path_lengths.entry(sample_path.id) {
+                                            Entry::Occupied(entry) => *entry.get(),
+                                            Entry::Vacant(entry) => {
+                                                *entry.insert(sample_path.length(conn)?)
+                                            }
+                                        };
 
-                                        if ref_start > *path_length {
+                                        if ref_start > path_length {
                                             return Err(VcfError::InvalidRecord(format!(
                                                 "Invalid position found. Path {0} has length of {path_length}, change is in position {ref_start}.",
                                                 sample_path.name
@@ -518,7 +519,7 @@ pub fn update_with_vcf(
                                             &mut path_cache,
                                             sample_bg_id,
                                             seq_name.clone(),
-                                        );
+                                        )?;
 
                                         let key = (sample_path, ref_accession.clone());
 
@@ -557,7 +558,7 @@ pub fn update_with_vcf(
                             &mut path_cache,
                             &parent_block_group_id,
                             vcf_entry.path.name.clone(),
-                        );
+                        )?;
                         node_source_paths.insert(vcf_entry.path.id, parent_path.id);
                         parent_path.id
                     } else {

--- a/src/views/block_group.rs
+++ b/src/views/block_group.rs
@@ -72,7 +72,9 @@ fn get_block_group_path_nodes(
     .map_err(|e| format!("Failed to query path: {}", e))?;
 
     // Get the path blocks from the database
-    let path_blocks = path.blocks(conn);
+    let path_blocks = path
+        .blocks(conn)
+        .map_err(|err| format!("Failed to load path blocks: {err}"))?;
 
     // Project the path blocks onto the current graph state
     let projected_path = project_path(graph, &path_blocks);

--- a/src/views/block_group_inline.rs
+++ b/src/views/block_group_inline.rs
@@ -35,7 +35,9 @@ fn get_path_nodes(
     use gen_graph::project_path;
 
     // Get the path blocks from the database
-    let path_blocks = path.blocks(conn);
+    let path_blocks = path
+        .blocks(conn)
+        .map_err(|err| Error::other(format!("Failed to load path blocks: {err}")))?;
 
     // Project the path blocks onto the current graph state
     let projected_path = project_path(graph, &path_blocks);

--- a/src/views/gen_graph_widget.rs
+++ b/src/views/gen_graph_widget.rs
@@ -139,7 +139,7 @@ impl NodeRenderer<GenGraph> for GenGraphNodeRenderer<'_> {
                 // Truncated scale: Show sequence with truncation to max 12 chars
                 let sequence = self
                     .get_sequence(node_id)
-                    .unwrap_or_else(|_| "?".to_string());
+                    .unwrap_or_else(|_| "Unknown Sequence".to_string());
                 let max_width = 12u32;
                 let truncated = inner_truncation(&sequence, max_width);
                 buffer.set_string_styled(area.left_center(), &truncated, text_style);
@@ -148,7 +148,7 @@ impl NodeRenderer<GenGraph> for GenGraphNodeRenderer<'_> {
                 // Full scale: Show complete sequence (truncated only by area width)
                 let sequence = self
                     .get_sequence(node_id)
-                    .unwrap_or_else(|_| "?".to_string());
+                    .unwrap_or_else(|_| "Unknown Sequence".to_string());
                 buffer.set_string_styled(area.left_center(), &sequence, text_style);
             }
         }

--- a/src/views/gen_graph_widget.rs
+++ b/src/views/gen_graph_widget.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use gen_core::{is_end_node, is_start_node};
 use gen_graph::{GenGraph, GraphNode};
-use gen_models::{db::GraphConnection, node::Node};
+use gen_models::{db::GraphConnection, node::Node, sequence::SequenceError};
 use gen_tui::{
     geometry::WorldRect,
     graph_controller::{GraphController, WorldBuffer},
@@ -67,10 +67,10 @@ impl<'a> GenGraphNodeRenderer<'a> {
     }
 
     /// Fetch sequence for a GenGraph node with caching
-    pub fn get_sequence(&mut self, node_key: &GraphNode) -> String {
+    pub fn get_sequence(&mut self, node_key: &GraphNode) -> Result<String, SequenceError> {
         // Check cache first
         if let Some(cached) = self.cache.get(node_key) {
-            return cached.clone();
+            return Ok(cached.clone());
         }
 
         // Cache miss - query database
@@ -81,12 +81,12 @@ impl<'a> GenGraphNodeRenderer<'a> {
         );
         let sequences = Node::get_sequences_by_node_ids(self.conn, &[db_node_id]);
         let sequence = match sequences.get(&db_node_id) {
-            Some(seq) => seq.get_sequence(start, end),
+            Some(seq) => seq.get_sequence(start, end)?,
             None => "?".repeat((end - start).max(0) as usize),
         };
 
         self.cache.insert(*node_key, sequence.clone());
-        sequence
+        Ok(sequence)
     }
 }
 
@@ -137,14 +137,18 @@ impl NodeRenderer<GenGraph> for GenGraphNodeRenderer<'_> {
             }
             VisualDetail::Truncated => {
                 // Truncated scale: Show sequence with truncation to max 12 chars
-                let sequence = self.get_sequence(node_id);
+                let sequence = self
+                    .get_sequence(node_id)
+                    .unwrap_or_else(|_| "?".to_string());
                 let max_width = 12u32;
                 let truncated = inner_truncation(&sequence, max_width);
                 buffer.set_string_styled(area.left_center(), &truncated, text_style);
             }
             VisualDetail::Full => {
                 // Full scale: Show complete sequence (truncated only by area width)
-                let sequence = self.get_sequence(node_id);
+                let sequence = self
+                    .get_sequence(node_id)
+                    .unwrap_or_else(|_| "?".to_string());
                 buffer.set_string_styled(area.left_center(), &sequence, text_style);
             }
         }

--- a/src/views/patch.rs
+++ b/src/views/patch.rs
@@ -8,9 +8,16 @@ use gen_core::{
 };
 use gen_graph::{GenGraph, GraphEdge, GraphNode};
 use gen_models::{
-    block_group_edge::BlockGroupEdge, changesets::ChangesetModels, db::DbContext, edge::Edge,
-    errors::OperationError, node::Node, operations::Operation, sequence::Sequence,
-    session_operations::DependencyModels, traits::Query,
+    block_group_edge::BlockGroupEdge,
+    changesets::ChangesetModels,
+    db::DbContext,
+    edge::Edge,
+    errors::OperationError,
+    node::Node,
+    operations::Operation,
+    sequence::{Sequence, SequenceError},
+    session_operations::DependencyModels,
+    traits::Query,
 };
 use html_escape;
 use itertools::Itertools;
@@ -198,7 +205,7 @@ pub fn get_change_graph(
 pub fn view_patches(
     workspace: &Workspace,
     patches: &[OperationPatch],
-) -> HashMap<HashId, HashMap<HashId, String>> {
+) -> Result<HashMap<HashId, HashMap<HashId, String>>, SequenceError> {
     // For each blockgroup in a patch, a .dot file is generated showing how the base sequence
     // has been updated.
     let mut diagrams: HashMap<HashId, HashMap<HashId, String>> = HashMap::new();
@@ -259,11 +266,11 @@ pub fn view_patches(
                 let formatted_seq = if len > 7 {
                     format!(
                         "{s}...{e}",
-                        s = seq.get_sequence(start, start + 3),
-                        e = seq.get_sequence(end - 3, end)
+                        s = seq.get_sequence(start, start + 3)?,
+                        e = seq.get_sequence(end - 3, end)?
                     )
                 } else {
-                    seq.get_sequence(start, end)
+                    seq.get_sequence(start, end)?
                 };
 
                 let coordinates = format!("{node_id}:{start}-{end}");
@@ -321,5 +328,5 @@ pub fn view_patches(
         }
         diagrams.insert(patch.operation.hash, bg_dots);
     }
-    diagrams
+    Ok(diagrams)
 }


### PR DESCRIPTION
Adds an error condition to fetching out of bound sequences. I added in support for circular sequence fetching, but didn't do a better implementation of storing the circles. For a later PR when we decide on sequence_type vs. a dedicated flag + some other stuff like rotating/offsets for tracking origins.

There are cascading updates from making result handlers. I've put comments in the areas with non-cosmetic changes.