### PR TITLE
Update filepath for out-of-directory files and track filename

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -105,6 +116,15 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "async-compression"
@@ -291,11 +311,30 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bzip2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
+dependencies = [
+ "bzip2-sys",
+]
+
+[[package]]
+name = "bzip2"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
 dependencies = [
  "libbz2-rs-sys",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -515,6 +554,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
 name = "circular"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -661,6 +710,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
 name = "convert_case"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -711,6 +766,21 @@ checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crc32fast"
@@ -915,6 +985,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deflate64"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2"
+
+[[package]]
 name = "deltae"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -927,6 +1003,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -959,6 +1046,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1430,6 +1518,7 @@ dependencies = [
  "url",
  "url-parse",
  "webbrowser",
+ "zip",
 ]
 
 [[package]]
@@ -1726,6 +1815,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "home"
@@ -2039,6 +2137,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -2473,6 +2580,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "lzma-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e"
+dependencies = [
+ "byteorder",
+ "crc",
+]
+
+[[package]]
 name = "lzma-sys"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2732,7 +2849,7 @@ dependencies = [
  "async-compression",
  "bitflags 2.11.1",
  "bstr",
- "bzip2",
+ "bzip2 0.6.1",
  "flate2",
  "futures",
  "indexmap",
@@ -3017,6 +3134,16 @@ dependencies = [
  "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
 ]
 
 [[package]]
@@ -4058,6 +4185,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
 ]
 
 [[package]]
@@ -5591,6 +5729,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "zerotrie"
@@ -5626,6 +5778,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "aes",
+ "arbitrary",
+ "bzip2 0.5.2",
+ "constant_time_eq",
+ "crc32fast",
+ "crossbeam-utils",
+ "deflate64",
+ "displaydoc",
+ "flate2",
+ "getrandom 0.3.4",
+ "hmac",
+ "indexmap",
+ "lzma-rs",
+ "memchr",
+ "pbkdf2",
+ "sha1",
+ "thiserror 2.0.18",
+ "time",
+ "xz2",
+ "zeroize",
+ "zopfli",
+ "zstd",
+]
+
+[[package]]
 name = "zlib-rs"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5636,6 +5818,18 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,7 @@ capnp = "0.24"
 indexmap = "2.11.3"
 anyhow = { version = "1.0.100", features = ["backtrace"] }
 postcard = { version = "1.1.3", default-features = false, features = ["alloc"] }
+zip = "2.4.2"
 
 [dev-dependencies]
 cargo-llvm-cov = "0.8.5"

--- a/gen-capnp-schemas/gen-models.capnp
+++ b/gen-capnp-schemas/gen-models.capnp
@@ -147,6 +147,17 @@ struct FileAddition {
   checksum @3 :List(UInt8);
 }
 
+struct OperationFile {
+  filename @0 :Text;
+  filePath @1 :Text;
+  fileType @2 :FileType;
+}
+
+struct OperationInfo {
+  files @0 :List(OperationFile);
+  description @1 :Text;
+}
+
 struct OperationSummary {
   id @0 :Int64;
   operationHash @1 :List(UInt8);
@@ -206,13 +217,18 @@ struct DatabaseChangeset {
 
 struct ManifestOperation {
   operation @0 :Operation;
-  fileAdditions @1 :List(FileAddition);
+  fileAdditions @1 :List(ManifestOperationFileAddition);
   annotationFileAdditions @4 :List(FileAddition);
   annotationFileDetails @5 :List(ManifestAnnotationFileAddition);
   operationSummary :union {
     none @2 :Void;
     some @3 :OperationSummary;
   }
+}
+
+struct ManifestOperationFileAddition {
+  fileAddition @0 :FileAddition;
+  filename @1 :Text;
 }
 
 struct ManifestAnnotationFileAddition {

--- a/gen-capnp-schemas/gen-schema.capnp
+++ b/gen-capnp-schemas/gen-schema.capnp
@@ -8,7 +8,7 @@ using GenModels = import "gen-models.capnp";
 # Operation patch structure for serializing and deserializing patches
 struct PatchFile {
   file @0 :GenModels.FileAddition;
-  contents @1 :Data;
+  archivePath @1 :Text;
 }
 
 struct OperationPatch {

--- a/gen-capnp-schemas/gen-schema.capnp
+++ b/gen-capnp-schemas/gen-schema.capnp
@@ -6,9 +6,14 @@
 using GenModels = import "gen-models.capnp";
 
 # Operation patch structure for serializing and deserializing patches
+struct PatchFile {
+  file @0 :GenModels.FileAddition;
+  contents @1 :Data;
+}
+
 struct OperationPatch {
   operation @0 :GenModels.Operation;
-  files @1 :List(GenModels.FileAddition);
+  files @1 :List(PatchFile);
   summary @2 :GenModels.OperationSummary;
   dependencies @3 :GenModels.DependencyModels;  # Serialized DependencyModels as bytes
   changeset @4 :GenModels.DatabaseChangeset;

--- a/gen-core/src/config.rs
+++ b/gen-core/src/config.rs
@@ -6,6 +6,7 @@ use std::{
 use crate::{HashId, errors::ConfigError};
 
 pub const CHANGESET_DIR_NAME: &str = "changesets";
+pub const ASSETS_DIR_NAME: &str = "assets";
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Workspace {
@@ -32,6 +33,8 @@ impl Workspace {
         ensure_dir(&gen_path);
         let changesets = gen_path.join(CHANGESET_DIR_NAME);
         ensure_dir(&changesets);
+        let assets = gen_path.join(ASSETS_DIR_NAME);
+        ensure_dir(&assets);
         gen_path
     }
 
@@ -60,6 +63,13 @@ impl Workspace {
         self.find_gen_dir()
             .map(|dir| dir.join("gen.db"))
             .ok_or(ConfigError::GenDirectoryNotFound)
+    }
+
+    pub fn asset_dir(&self) -> Result<PathBuf, ConfigError> {
+        Ok(self
+            .find_gen_dir()
+            .ok_or(ConfigError::GenDirectoryNotFound)?
+            .join(ASSETS_DIR_NAME))
     }
 
     pub fn changeset_path(&self, hash: &HashId) -> PathBuf {
@@ -174,5 +184,18 @@ mod tests {
                 .join(format!("{hash}"))
         );
         assert!(path.is_dir());
+    }
+
+    #[test]
+    fn asset_dir_creates_assets_directory() {
+        let tmp_dir = tempdir().unwrap();
+        let tmp_dir_path = tmp_dir.path().to_path_buf();
+        let workspace = Workspace::new(&tmp_dir_path);
+        workspace.ensure_gen_dir();
+
+        let asset_dir = workspace.asset_dir().unwrap();
+
+        assert_eq!(asset_dir, tmp_dir_path.join(".gen").join(ASSETS_DIR_NAME));
+        assert!(asset_dir.is_dir());
     }
 }

--- a/gen-models/migrations/operations/03-operation-files-filename/down.sql
+++ b/gen-models/migrations/operations/03-operation-files-filename/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE operation_files
+DROP COLUMN filename;

--- a/gen-models/migrations/operations/03-operation-files-filename/up.sql
+++ b/gen-models/migrations/operations/03-operation-files-filename/up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE operation_files
+ADD COLUMN filename TEXT NOT NULL DEFAULT '';
+

--- a/gen-models/src/changesets.rs
+++ b/gen-models/src/changesets.rs
@@ -1859,7 +1859,9 @@ mod tests {
                 &context,
                 &mut session,
                 &OperationInfo {
-                    files: vec![OperationFile::new("test".to_string(), FileTypes::None)],
+                    files: vec![
+                        OperationFile::new("test".to_string()).set_file_type(FileTypes::None),
+                    ],
                     description: "test".to_string(),
                 },
                 "test",

--- a/gen-models/src/changesets.rs
+++ b/gen-models/src/changesets.rs
@@ -1859,10 +1859,7 @@ mod tests {
                 &context,
                 &mut session,
                 &OperationInfo {
-                    files: vec![OperationFile {
-                        file_path: "test".to_string(),
-                        file_type: FileTypes::None,
-                    }],
+                    files: vec![OperationFile::new("test".to_string(), FileTypes::None)],
                     description: "test".to_string(),
                 },
                 "test",

--- a/gen-models/src/errors.rs
+++ b/gen-models/src/errors.rs
@@ -142,6 +142,15 @@ pub enum FileAdditionError {
 
     #[error("HashId generation failed: {0}")]
     HashIdError(String),
+
+    #[error("Config Error: {0}")]
+    ConfigError(#[from] ConfigError),
+
+    #[error("Path '{path}' is not within repo root '{repo_root}'")]
+    PathOutsideRepo {
+        path: std::path::PathBuf,
+        repo_root: std::path::PathBuf,
+    },
 }
 
 #[derive(Debug, Error)]

--- a/gen-models/src/manifest.rs
+++ b/gen-models/src/manifest.rs
@@ -18,6 +18,12 @@ pub struct ManifestOperationFileAddition {
     pub filename: String,
 }
 
+#[derive(Debug, thiserror::Error)]
+pub enum ManifestOperationFileAdditionError {
+    #[error("Database error: {0}")]
+    DatabaseError(#[from] rusqlite::Error),
+}
+
 impl<'a> Capnp<'a> for ManifestOperationFileAddition {
     type Builder = manifest_operation_file_addition::Builder<'a>;
     type Reader = manifest_operation_file_addition::Reader<'a>;
@@ -40,18 +46,17 @@ impl ManifestOperationFileAddition {
     pub fn get_files_for_operation(
         conn: &OperationsConnection,
         operation_hash: &HashId,
-    ) -> Vec<Self> {
+    ) -> Result<Vec<Self>, ManifestOperationFileAdditionError> {
         let query = "select fa.*, of.filename from file_additions fa left join operation_files of on (fa.id = of.file_addition_id) where of.operation_hash = ?1";
-        let mut stmt = conn.prepare(query).unwrap();
+        let mut stmt = conn.prepare(query)?;
         stmt.query_map(rusqlite::params![operation_hash], |row| {
             Ok(Self {
                 file_addition: FileAddition::process_row(row),
                 filename: row.get(4)?,
             })
-        })
-        .unwrap()
-        .map(|row| row.unwrap())
-        .collect()
+        })?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(ManifestOperationFileAdditionError::from)
     }
 }
 
@@ -334,8 +339,9 @@ impl<'a> ManifestGenerator<'a> {
 
             for hash in hashes.iter() {
                 if let Some(op) = operations_map.get(hash) {
-                    let file_additions =
-                        ManifestOperationFileAddition::get_files_for_operation(self.conn, &op.hash);
+                    let file_additions = ManifestOperationFileAddition::get_files_for_operation(
+                        self.conn, &op.hash,
+                    )?;
                     let annotation_file_additions =
                         AnnotationFile::get_files_for_operation(self.conn, &op.hash)
                             .into_iter()
@@ -382,6 +388,8 @@ pub enum ManifestError {
     OperationNotFound(String),
     #[error("Branch not found")]
     BranchNotFound,
+    #[error("Manifest operation file addition error: {0}")]
+    ManifestOperationFileAdditionError(#[from] ManifestOperationFileAdditionError),
 }
 
 pub struct ManifestComparer;
@@ -400,6 +408,7 @@ impl ManifestComparer {
             .iter()
             .map(|op| &op.operation.hash)
             .collect();
+
         let ops2_hashes: std::collections::HashSet<_> = manifest2
             .operations
             .iter()

--- a/gen-models/src/manifest.rs
+++ b/gen-models/src/manifest.rs
@@ -36,6 +36,25 @@ impl<'a> Capnp<'a> for ManifestOperationFileAddition {
     }
 }
 
+impl ManifestOperationFileAddition {
+    pub fn get_files_for_operation(
+        conn: &OperationsConnection,
+        operation_hash: &HashId,
+    ) -> Vec<Self> {
+        let query = "select fa.*, of.filename from file_additions fa left join operation_files of on (fa.id = of.file_addition_id) where of.operation_hash = ?1";
+        let mut stmt = conn.prepare(query).unwrap();
+        stmt.query_map(rusqlite::params![operation_hash], |row| {
+            Ok(Self {
+                file_addition: FileAddition::process_row(row),
+                filename: row.get(4)?,
+            })
+        })
+        .unwrap()
+        .map(|row| row.unwrap())
+        .collect()
+    }
+}
+
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct ManifestAnnotationFileAddition {
     pub file_addition: FileAddition,
@@ -315,18 +334,8 @@ impl<'a> ManifestGenerator<'a> {
 
             for hash in hashes.iter() {
                 if let Some(op) = operations_map.get(hash) {
-                    let query = "select fa.*, of.filename from file_additions fa left join operation_files of on (fa.id = of.file_addition_id) where of.operation_hash = ?1";
-                    let mut stmt = self.conn.prepare(query).unwrap();
-                    let file_additions = stmt
-                        .query_map(rusqlite::params![op.hash], |row| {
-                            Ok(ManifestOperationFileAddition {
-                                file_addition: FileAddition::process_row(row),
-                                filename: row.get(4)?,
-                            })
-                        })
-                        .unwrap()
-                        .map(|row| row.unwrap())
-                        .collect::<Vec<_>>();
+                    let file_additions =
+                        ManifestOperationFileAddition::get_files_for_operation(self.conn, &op.hash);
                     let annotation_file_additions =
                         AnnotationFile::get_files_for_operation(self.conn, &op.hash)
                             .into_iter()

--- a/gen-models/src/manifest.rs
+++ b/gen-models/src/manifest.rs
@@ -6,10 +6,35 @@ use crate::{
     db::OperationsConnection,
     gen_models_capnp::{
         manifest, manifest_annotation_file_addition, manifest_diff, manifest_operation,
+        manifest_operation_file_addition,
     },
     operations::{FileAddition, Operation, OperationSummary},
     traits::Query,
 };
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ManifestOperationFileAddition {
+    pub file_addition: FileAddition,
+    pub filename: String,
+}
+
+impl<'a> Capnp<'a> for ManifestOperationFileAddition {
+    type Builder = manifest_operation_file_addition::Builder<'a>;
+    type Reader = manifest_operation_file_addition::Reader<'a>;
+
+    fn write_capnp(&self, builder: &mut Self::Builder) {
+        let mut file_addition_builder = builder.reborrow().init_file_addition();
+        self.file_addition.write_capnp(&mut file_addition_builder);
+        builder.set_filename(&self.filename);
+    }
+
+    fn read_capnp(reader: Self::Reader) -> Self {
+        Self {
+            file_addition: FileAddition::read_capnp(reader.get_file_addition().unwrap()),
+            filename: reader.get_filename().unwrap().to_string().unwrap(),
+        }
+    }
+}
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct ManifestAnnotationFileAddition {
@@ -64,7 +89,7 @@ impl<'a> Capnp<'a> for ManifestAnnotationFileAddition {
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct ManifestOperation {
     pub operation: Operation,
-    pub file_additions: Vec<FileAddition>,
+    pub file_additions: Vec<ManifestOperationFileAddition>,
     pub annotation_file_additions: Vec<ManifestAnnotationFileAddition>,
     pub operation_summary: Option<OperationSummary>,
 }
@@ -120,7 +145,9 @@ impl<'a> Capnp<'a> for ManifestOperation {
         let file_additions_reader = reader.get_file_additions().unwrap();
         let mut file_additions = Vec::new();
         for file_addition_reader in file_additions_reader.iter() {
-            file_additions.push(FileAddition::read_capnp(file_addition_reader));
+            file_additions.push(ManifestOperationFileAddition::read_capnp(
+                file_addition_reader,
+            ));
         }
 
         let annotation_file_additions = if reader.has_annotation_file_details() {
@@ -288,7 +315,18 @@ impl<'a> ManifestGenerator<'a> {
 
             for hash in hashes.iter() {
                 if let Some(op) = operations_map.get(hash) {
-                    let file_additions = FileAddition::get_files_for_operation(self.conn, &op.hash);
+                    let query = "select fa.*, of.filename from file_additions fa left join operation_files of on (fa.id = of.file_addition_id) where of.operation_hash = ?1";
+                    let mut stmt = self.conn.prepare(query).unwrap();
+                    let file_additions = stmt
+                        .query_map(rusqlite::params![op.hash], |row| {
+                            Ok(ManifestOperationFileAddition {
+                                file_addition: FileAddition::process_row(row),
+                                filename: row.get(4)?,
+                            })
+                        })
+                        .unwrap()
+                        .map(|row| row.unwrap())
+                        .collect::<Vec<_>>();
                     let annotation_file_additions =
                         AnnotationFile::get_files_for_operation(self.conn, &op.hash)
                             .into_iter()
@@ -424,11 +462,14 @@ mod tests {
 
         let manifest_operation = ManifestOperation {
             operation: operation.clone(),
-            file_additions: vec![FileAddition {
-                id: HashId([1u8; 32]),
-                file_path: "/path/to/file.fa".to_string(),
-                file_type: FileTypes::Fasta,
-                checksum: HashId([2u8; 32]),
+            file_additions: vec![ManifestOperationFileAddition {
+                file_addition: FileAddition {
+                    id: HashId([1u8; 32]),
+                    file_path: "/path/to/file.fa".to_string(),
+                    file_type: FileTypes::Fasta,
+                    checksum: HashId([2u8; 32]),
+                },
+                filename: "file.fa".to_string(),
             }],
             annotation_file_additions: vec![ManifestAnnotationFileAddition {
                 file_addition: FileAddition {

--- a/gen-models/src/operations.rs
+++ b/gen-models/src/operations.rs
@@ -523,21 +523,34 @@ impl FileAddition {
         HashId(calculate_hash(&combined))
     }
 
+    fn asset_filename(checksum: &HashId, file_type: FileTypes) -> String {
+        format!("{checksum}.{}", FileTypes::suffix(file_type))
+    }
+
+    fn asset_path(
+        workspace: &Workspace,
+        checksum: &HashId,
+        file_type: FileTypes,
+    ) -> Result<PathBuf, FileAdditionError> {
+        Ok(workspace
+            .asset_dir()?
+            .join(Self::asset_filename(checksum, file_type)))
+    }
+
     fn asset_relative_path(
         workspace: &Workspace,
         checksum: &HashId,
         file_type: FileTypes,
     ) -> Result<String, FileAdditionError> {
         let repo_root = workspace.repo_root()?;
-        let asset_dir = workspace.asset_dir()?;
+        let asset_path = Self::asset_path(workspace, checksum, file_type)?;
 
-        Ok(asset_dir
+        Ok(asset_path
             .strip_prefix(&repo_root)
             .map_err(|_| FileAdditionError::PathOutsideRepo {
-                path: asset_dir.clone(),
+                path: asset_path.clone(),
                 repo_root: repo_root.clone(),
             })?
-            .join(format!("{checksum}.{}", FileTypes::suffix(file_type)))
             .to_string_lossy()
             .to_string())
     }
@@ -625,9 +638,7 @@ impl FileAddition {
         checksum: &HashId,
         file_type: FileTypes,
     ) -> Result<(), FileAdditionError> {
-        let assets_dir = workspace.asset_dir()?;
-
-        let asset_path = assets_dir.join(format!("{checksum}.{}", FileTypes::suffix(file_type)));
+        let asset_path = Self::asset_path(workspace, checksum, file_type)?;
         if asset_path.exists() {
             return Ok(());
         }
@@ -746,9 +757,7 @@ impl FileAddition {
     }
 
     pub fn store_file(&self, workspace: &Workspace) -> Result<(), FileStoreError> {
-        let assets_dir = workspace.asset_dir()?;
-
-        let asset_path = assets_dir.join(self.clone().hashed_filename());
+        let asset_path = workspace.asset_dir()?.join(self.clone().hashed_filename());
         if asset_path.exists() {
             return Ok(());
         }
@@ -766,11 +775,7 @@ impl FileAddition {
     }
 
     pub fn hashed_filename(self) -> String {
-        format!(
-            "{}.{}",
-            self.checksum.clone(),
-            &FileTypes::suffix(self.file_type)
-        )
+        Self::asset_filename(&self.checksum, self.file_type)
     }
 }
 

--- a/gen-models/src/operations.rs
+++ b/gen-models/src/operations.rs
@@ -368,6 +368,7 @@ pub struct OperationFile {
     pub filename: String,
     pub file_path: String,
     pub file_type: FileTypes,
+    pub checksum_override: Option<HashId>,
 }
 
 impl OperationFile {
@@ -382,6 +383,7 @@ impl OperationFile {
             filename,
             file_path,
             file_type,
+            checksum_override: None,
         }
     }
 }
@@ -730,6 +732,9 @@ impl FileAddition {
         } else {
             workspace.repo_root()?.join(&self.file_path)
         };
+        if source_path == asset_path {
+            return Ok(());
+        }
         fs::copy(source_path, asset_path)?;
         Ok(())
     }

--- a/gen-models/src/operations.rs
+++ b/gen-models/src/operations.rs
@@ -372,8 +372,9 @@ pub struct OperationFile {
 }
 
 impl OperationFile {
-    pub fn new(file_path: impl Into<String>, file_type: FileTypes) -> Self {
+    pub fn new(file_path: impl Into<String>) -> Self {
         let file_path = file_path.into();
+        let file_type = FileTypes::infer_from_path(&file_path);
         let filename = Path::new(&file_path)
             .file_name()
             .and_then(|name| name.to_str())
@@ -385,6 +386,11 @@ impl OperationFile {
             file_type,
             checksum_override: None,
         }
+    }
+
+    pub fn set_file_type(mut self, file_type: FileTypes) -> Self {
+        self.file_type = file_type;
+        self
     }
 }
 
@@ -411,7 +417,7 @@ pub fn add_files_operation(
                 FileAddition::get_or_create(workspace, operation_conn, path, file_type, None)?;
             Ok::<(FileAddition, String), FileAdditionError>((
                 file_addition,
-                OperationFile::new(path.clone(), file_type).filename,
+                OperationFile::new(path.clone()).filename,
             ))
         })
         .collect::<Result<Vec<_>, _>>()?;
@@ -555,7 +561,7 @@ impl FileAddition {
             .to_string())
     }
 
-    /// Returns a usable path for system file access. It prefers an absolute path
+    /// Returns a usable path for system file access. It prefers returning an absolute path
     /// when one can be resolved, and otherwise falls back to the original input.
     fn source_file_path(
         workspace: &Workspace,
@@ -632,6 +638,8 @@ impl FileAddition {
         Ok(file_path.to_string())
     }
 
+    /// This exists along with store_file because one uses the model Self attributes to
+    /// identify where to store it, while this works without having an initialized model.
     fn ensure_asset_copy(
         workspace: &Workspace,
         source_path: &Path,
@@ -767,9 +775,6 @@ impl FileAddition {
         } else {
             workspace.repo_root()?.join(&self.file_path)
         };
-        if source_path == asset_path {
-            return Ok(());
-        }
         fs::copy(source_path, asset_path)?;
         Ok(())
     }
@@ -2741,6 +2746,16 @@ mod tests {
     }
 
     #[test]
+    fn test_operation_file_new_infers_file_type_from_path() {
+        let operation_file = OperationFile::new("fixtures/sample.gb");
+
+        assert_eq!(operation_file.filename, "sample.gb");
+        assert_eq!(operation_file.file_path, "fixtures/sample.gb");
+        assert_eq!(operation_file.file_type, FileTypes::GenBank);
+        assert_eq!(operation_file.checksum_override, None);
+    }
+
+    #[test]
     fn test_generate_file_addition_id_consistency() {
         let checksum = HashId([1u8; 32]);
         let file_path = "/path/to/file.txt";
@@ -2776,7 +2791,23 @@ mod tests {
     }
 
     #[test]
-    fn test_source_and_stored_file_paths_absolute_path_in_repo() {
+    fn test_source_file_path_returns_absolute_path_from_file_in_repo() {
+        let context = setup_gen();
+        let workspace = context.workspace();
+        let repo_root = workspace.base_dir();
+
+        let absolute_path = repo_root.join("inputs").join("absolute.txt");
+        fs::create_dir_all(absolute_path.parent().unwrap()).unwrap();
+        fs::write(&absolute_path, b"absolute").unwrap();
+        let absolute_string = absolute_path.to_string_lossy().to_string();
+
+        let absolute = FileAddition::source_file_path(workspace, absolute_string.as_str()).unwrap();
+
+        assert_eq!(absolute, absolute_string);
+    }
+
+    #[test]
+    fn test_stored_file_path_returns_relative_path_from_file_in_repo() {
         let context = setup_gen();
         let workspace = context.workspace();
         let repo_root = workspace.base_dir();
@@ -2791,7 +2822,6 @@ mod tests {
             .to_string_lossy()
             .to_string();
 
-        let absolute = FileAddition::source_file_path(workspace, absolute_string.as_str()).unwrap();
         let relative = FileAddition::stored_file_path(
             workspace,
             absolute_string.as_str(),
@@ -2800,12 +2830,11 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(absolute, absolute_string);
         assert_eq!(relative, relative_string);
     }
 
     #[test]
-    fn test_source_and_stored_file_paths_relative_path_in_repo() {
+    fn test_source_file_path_returns_absolute_path_from_relative_path_in_repo() {
         let context = setup_gen();
         let workspace = context.workspace();
         let repo_root = workspace.repo_root().unwrap();
@@ -2818,6 +2847,22 @@ mod tests {
         let absolute_string = absolute_path.to_string_lossy().to_string();
 
         let absolute = FileAddition::source_file_path(workspace, relative_string.as_str()).unwrap();
+
+        assert_eq!(absolute, absolute_string);
+    }
+
+    #[test]
+    fn test_stored_file_path_returns_relative_path_from_relative_path_in_repo() {
+        let context = setup_gen();
+        let workspace = context.workspace();
+        let repo_root = workspace.repo_root().unwrap();
+
+        let relative_path = PathBuf::from("relative/path/file.txt");
+        let absolute_path = repo_root.join(&relative_path);
+        fs::create_dir_all(absolute_path.parent().unwrap()).unwrap();
+        fs::write(&absolute_path, b"relative").unwrap();
+        let relative_string = relative_path.to_string_lossy().to_string();
+
         let relative = FileAddition::stored_file_path(
             workspace,
             relative_string.as_str(),
@@ -2826,12 +2871,26 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(absolute, absolute_string);
         assert_eq!(relative, relative_string);
     }
 
     #[test]
-    fn test_source_and_stored_file_paths_outside_repo_fallbacks() {
+    fn test_source_file_path_fallback_to_initial_path() {
+        let context = setup_gen();
+        let workspace = context.workspace();
+
+        let mut outside_file = tempfile::NamedTempFile::new().unwrap();
+        outside_file.write_all(b"outside repo").unwrap();
+        outside_file.flush().unwrap();
+        let outside_string = outside_file.path().to_string_lossy().to_string();
+
+        let absolute = FileAddition::source_file_path(workspace, outside_string.as_str()).unwrap();
+
+        assert_eq!(absolute, outside_string);
+    }
+
+    #[test]
+    fn test_stored_file_path_returns_asset_path_on_file_outside_repo() {
         let context = setup_gen();
         let workspace = context.workspace();
 
@@ -2841,7 +2900,6 @@ mod tests {
         let outside_string = outside_file.path().to_string_lossy().to_string();
         let checksum = calculate_file_checksum(outside_file.path()).unwrap();
 
-        let absolute = FileAddition::source_file_path(workspace, outside_string.as_str()).unwrap();
         let relative = FileAddition::stored_file_path(
             workspace,
             outside_string.as_str(),
@@ -2850,7 +2908,6 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(absolute, outside_string);
         assert_eq!(
             relative,
             format!(
@@ -2861,11 +2918,19 @@ mod tests {
     }
 
     #[test]
-    fn test_source_and_stored_file_paths_without_connection_path() {
+    fn test_source_file_path_gives_initial_path_if_no_resolution() {
         let context = setup_gen();
         let workspace = context.workspace();
 
         let absolute = FileAddition::source_file_path(workspace, "detached/file.txt").unwrap();
+        assert_eq!(absolute, "detached/file.txt");
+    }
+
+    #[test]
+    fn test_stored_file_path_gives_initial_path_if_no_resolution() {
+        let context = setup_gen();
+        let workspace = context.workspace();
+
         let relative = FileAddition::stored_file_path(
             workspace,
             "detached/file.txt",
@@ -2873,10 +2938,23 @@ mod tests {
             FileTypes::Fasta,
         )
         .unwrap();
-        assert_eq!(absolute, "detached/file.txt");
         assert_eq!(relative, "detached/file.txt");
+    }
+
+    #[test]
+    fn test_source_file_path_empty() {
+        let context = setup_gen();
+        let workspace = context.workspace();
 
         let absolute_empty = FileAddition::source_file_path(workspace, "").unwrap();
+        assert_eq!(absolute_empty, "");
+    }
+
+    #[test]
+    fn test_stored_file_path_empty() {
+        let context = setup_gen();
+        let workspace = context.workspace();
+
         let relative_empty = FileAddition::stored_file_path(
             workspace,
             "",
@@ -2884,7 +2962,6 @@ mod tests {
             FileTypes::Fasta,
         )
         .unwrap();
-        assert_eq!(absolute_empty, "");
         assert_eq!(relative_empty, "");
     }
 

--- a/gen-models/src/operations.rs
+++ b/gen-models/src/operations.rs
@@ -160,11 +160,11 @@ impl Operation {
         conn: &OperationsConnection,
         operation_hash: &HashId,
         file_addition_id: &HashId,
+        filename: &str,
     ) -> SQLResult<()> {
-        let query =
-            "INSERT INTO operation_files (operation_hash, file_addition_id) VALUES (?1, ?2)";
+        let query = "INSERT INTO operation_files (operation_hash, file_addition_id, filename) VALUES (?1, ?2, ?3)";
         let mut stmt = conn.prepare(query).unwrap();
-        stmt.execute(params![operation_hash, file_addition_id])?;
+        stmt.execute(params![operation_hash, file_addition_id, filename])?;
         Ok(())
     }
 
@@ -365,8 +365,25 @@ impl Query for Operation {
 }
 
 pub struct OperationFile {
+    pub filename: String,
     pub file_path: String,
     pub file_type: FileTypes,
+}
+
+impl OperationFile {
+    pub fn new(file_path: impl Into<String>, file_type: FileTypes) -> Self {
+        let file_path = file_path.into();
+        let filename = Path::new(&file_path)
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or(&file_path)
+            .to_string();
+        Self {
+            filename,
+            file_path,
+            file_type,
+        }
+    }
 }
 
 pub struct OperationInfo {
@@ -387,25 +404,25 @@ pub fn add_files_operation(
     let file_additions = files
         .iter()
         .map(|path| {
-            FileAddition::get_or_create(
-                workspace,
-                operation_conn,
-                path,
-                FileTypes::infer_from_path(path),
-                None,
-            )
+            let file_type = FileTypes::infer_from_path(path);
+            let file_addition =
+                FileAddition::get_or_create(workspace, operation_conn, path, file_type, None)?;
+            Ok::<(FileAddition, String), FileAdditionError>((
+                file_addition,
+                OperationFile::new(path.clone(), file_type).filename,
+            ))
         })
         .collect::<Result<Vec<_>, _>>()?;
 
     let unique_file_additions = file_additions
         .into_iter()
-        .unique_by(|file_addition| file_addition.id)
+        .unique_by(|(file_addition, filename)| (file_addition.id, filename.clone()))
         .collect::<Vec<_>>();
 
     let operation_hash = HashId(calculate_hash(
         &unique_file_additions
             .iter()
-            .map(|file_addition| file_addition.id.to_string())
+            .map(|(file_addition, filename)| format!("{}:{filename}", file_addition.id))
             .sorted()
             .join(":"),
     ));
@@ -422,8 +439,8 @@ pub fn add_files_operation(
         Err(err) => return Err(err.into()),
     };
 
-    for file_addition in &unique_file_additions {
-        Operation::add_file(operation_conn, &operation.hash, &file_addition.id)?;
+    for (file_addition, filename) in &unique_file_additions {
+        Operation::add_file(operation_conn, &operation.hash, &file_addition.id, filename)?;
     }
 
     Operation::add_database(operation_conn, &operation.hash, &db_uuid)?;
@@ -448,7 +465,11 @@ pub fn add_files_operation(
         &DependencyModels::default(),
     );
 
-    for file_addition in unique_file_additions {
+    for file_addition in unique_file_additions
+        .into_iter()
+        .map(|(file_addition, _filename)| file_addition)
+        .unique_by(|file_addition| file_addition.id)
+    {
         file_addition.store_file(workspace)?;
     }
 
@@ -500,7 +521,20 @@ impl FileAddition {
         HashId(calculate_hash(&combined))
     }
 
-    fn normalize_file_paths(workspace: &Workspace, file_path: &str) -> (String, String) {
+    fn asset_relative_path(checksum: &HashId, file_type: FileTypes) -> String {
+        Path::new(".gen")
+            .join("assets")
+            .join(format!("{checksum}.{}", FileTypes::suffix(file_type)))
+            .to_string_lossy()
+            .to_string()
+    }
+
+    fn normalize_file_paths(
+        workspace: &Workspace,
+        file_path: &str,
+        checksum: Option<&HashId>,
+        file_type: FileTypes,
+    ) -> (String, String) {
         if file_path.is_empty() {
             return (String::new(), String::new());
         }
@@ -530,8 +564,39 @@ impl FileAddition {
             }
         };
 
+        if provided_path.is_absolute()
+            && let Some(checksum) = checksum
+        {
+            return (
+                file_path.to_string(),
+                Self::asset_relative_path(checksum, file_type),
+            );
+        }
+
         let fallback = file_path.to_string();
         (fallback.clone(), fallback)
+    }
+
+    fn ensure_asset_copy(
+        workspace: &Workspace,
+        source_path: &Path,
+        checksum: &HashId,
+        file_type: FileTypes,
+    ) -> Result<(), FileAdditionError> {
+        let gen_dir = workspace
+            .find_gen_dir()
+            .ok_or(ConfigError::GenDirectoryNotFound)
+            .map_err(|err| FileAdditionError::FileReadError(io::Error::other(err.to_string())))?;
+        let assets_dir = gen_dir.join("assets");
+        fs::create_dir_all(&assets_dir)?;
+
+        let asset_path = assets_dir.join(format!("{checksum}.{}", FileTypes::suffix(file_type)));
+        if asset_path.exists() {
+            return Ok(());
+        }
+
+        fs::copy(source_path, asset_path)?;
+        Ok(())
     }
 
     pub fn get_or_create(
@@ -541,18 +606,18 @@ impl FileAddition {
         file_type: FileTypes,
         checksum_override: Option<HashId>,
     ) -> Result<FileAddition, FileAdditionError> {
-        let (absolute_file_path, relative_file_path) =
-            FileAddition::normalize_file_paths(workspace, file_path);
+        let (source_file_path, preliminary_relative_path) =
+            FileAddition::normalize_file_paths(workspace, file_path, None, file_type);
 
         // TODO: Verify checksum_override actually matches the file's checksum?
         let checksum = if let Some(checksum_override) = checksum_override {
             checksum_override
         } else {
-            let absolute_path = Path::new(&absolute_file_path);
+            let absolute_path = Path::new(&source_file_path);
             let checksum_path = if absolute_path.is_file() {
-                absolute_file_path.as_str()
+                source_file_path.as_str()
             } else {
-                relative_file_path.as_str()
+                preliminary_relative_path.as_str()
             };
             match calculate_file_checksum(checksum_path) {
                 Ok(checksum) => checksum,
@@ -569,6 +634,18 @@ impl FileAddition {
                 },
             }
         };
+
+        let (absolute_file_path, relative_file_path) =
+            FileAddition::normalize_file_paths(workspace, file_path, Some(&checksum), file_type);
+
+        if Path::new(file_path).is_absolute() && relative_file_path != absolute_file_path {
+            FileAddition::ensure_asset_copy(
+                workspace,
+                Path::new(&absolute_file_path),
+                &checksum,
+                file_type,
+            )?;
+        }
 
         let id = FileAddition::generate_file_addition_id(&checksum, &relative_file_path);
 
@@ -2678,8 +2755,12 @@ mod tests {
             .to_string_lossy()
             .to_string();
 
-        let (absolute, relative) =
-            FileAddition::normalize_file_paths(workspace, absolute_string.as_str());
+        let (absolute, relative) = FileAddition::normalize_file_paths(
+            workspace,
+            absolute_string.as_str(),
+            None,
+            FileTypes::Fasta,
+        );
 
         assert_eq!(absolute, absolute_string);
         assert_eq!(relative, relative_string);
@@ -2698,8 +2779,12 @@ mod tests {
         let relative_string = relative_path.to_string_lossy().to_string();
         let absolute_string = absolute_path.to_string_lossy().to_string();
 
-        let (absolute, relative) =
-            FileAddition::normalize_file_paths(workspace, relative_string.as_str());
+        let (absolute, relative) = FileAddition::normalize_file_paths(
+            workspace,
+            relative_string.as_str(),
+            None,
+            FileTypes::Fasta,
+        );
 
         assert_eq!(absolute, absolute_string);
         assert_eq!(relative, relative_string);
@@ -2710,14 +2795,27 @@ mod tests {
         let context = setup_gen();
         let workspace = context.workspace();
 
-        let outside_path = tempfile::NamedTempFile::new().unwrap().into_temp_path();
-        let outside_string = outside_path.to_string_lossy().to_string();
+        let mut outside_file = tempfile::NamedTempFile::new().unwrap();
+        outside_file.write_all(b"outside repo").unwrap();
+        outside_file.flush().unwrap();
+        let outside_string = outside_file.path().to_string_lossy().to_string();
+        let checksum = calculate_file_checksum(outside_file.path()).unwrap();
 
-        let (absolute, relative) =
-            FileAddition::normalize_file_paths(workspace, outside_string.as_str());
+        let (absolute, relative) = FileAddition::normalize_file_paths(
+            workspace,
+            outside_string.as_str(),
+            Some(&checksum),
+            FileTypes::Fasta,
+        );
 
         assert_eq!(absolute, outside_string);
-        assert_eq!(relative, outside_string);
+        assert_eq!(
+            relative,
+            format!(
+                ".gen/assets/{checksum}.{}",
+                FileTypes::suffix(FileTypes::Fasta)
+            )
+        );
     }
 
     #[test]
@@ -2725,12 +2823,17 @@ mod tests {
         let context = setup_gen();
         let workspace = context.workspace();
 
-        let (absolute, relative) =
-            FileAddition::normalize_file_paths(workspace, "detached/file.txt");
+        let (absolute, relative) = FileAddition::normalize_file_paths(
+            workspace,
+            "detached/file.txt",
+            None,
+            FileTypes::Fasta,
+        );
         assert_eq!(absolute, "detached/file.txt");
         assert_eq!(relative, "detached/file.txt");
 
-        let (absolute_empty, relative_empty) = FileAddition::normalize_file_paths(workspace, "");
+        let (absolute_empty, relative_empty) =
+            FileAddition::normalize_file_paths(workspace, "", None, FileTypes::Fasta);
         assert_eq!(absolute_empty, "");
         assert_eq!(relative_empty, "");
     }
@@ -2805,6 +2908,36 @@ mod tests {
         .expect("Failed to create FileAddition");
 
         assert_ne!(fa1.id, fa1_new.id);
+
+        let mut outside_file = tempfile::NamedTempFile::new().unwrap();
+        outside_file.write_all(b"Outside repo file").unwrap();
+        outside_file.flush().unwrap();
+        let outside_path = outside_file.path().to_string_lossy().to_string();
+        let outside_checksum = calculate_file_checksum(outside_file.path()).unwrap();
+        let outside_asset_path = format!(
+            ".gen/assets/{outside_checksum}.{}",
+            FileTypes::suffix(FileTypes::Fasta)
+        );
+
+        let outside = FileAddition::get_or_create(
+            context.workspace(),
+            op_conn,
+            &outside_path,
+            FileTypes::Fasta,
+            None,
+        )
+        .expect("Failed to create external FileAddition");
+
+        assert_eq!(outside.file_path, outside_asset_path);
+        assert!(
+            context
+                .workspace()
+                .find_gen_dir()
+                .unwrap()
+                .join("assets")
+                .join(outside.clone().hashed_filename())
+                .exists()
+        );
     }
 
     #[test]
@@ -2865,6 +2998,50 @@ mod tests {
                     .clone()
                     .hashed_filename()
             )
+        );
+    }
+
+    #[test]
+    fn test_add_files_operation_tracks_distinct_filenames_for_same_asset() {
+        let context = setup_gen();
+        let graph_conn = context.graph().conn();
+        let operation_conn = context.operations().conn();
+
+        let db_uuid = metadata::get_db_uuid(graph_conn);
+        GenDatabase::create(operation_conn, &db_uuid, "default", "default.db").unwrap();
+        Branch::get_or_create(operation_conn, "main").unwrap();
+        OperationState::set_branch(operation_conn, "main");
+
+        let outside_dir = tempfile::tempdir().unwrap();
+        let alpha_path = outside_dir.path().join("alpha.fa");
+        let beta_path = outside_dir.path().join("beta.fa");
+        fs::write(&alpha_path, "shared contents").unwrap();
+        fs::write(&beta_path, "shared contents").unwrap();
+
+        let operation = add_files_operation(
+            &context,
+            &[
+                alpha_path.to_string_lossy().to_string(),
+                beta_path.to_string_lossy().to_string(),
+            ],
+            Some("same asset, different filenames"),
+        )
+        .unwrap();
+
+        let mut stmt = operation_conn
+            .prepare(
+                "select filename from operation_files where operation_hash = ?1 order by filename",
+            )
+            .unwrap();
+        let filenames = stmt
+            .query_map([operation.hash], |row| row.get::<_, String>(0))
+            .unwrap()
+            .map(|row| row.unwrap())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            filenames,
+            vec!["alpha.fa".to_string(), "beta.fa".to_string()]
         );
     }
 }

--- a/gen-models/src/operations.rs
+++ b/gen-models/src/operations.rs
@@ -8,7 +8,7 @@ use std::{
     string::ToString,
 };
 
-use gen_core::{HashId, Workspace, calculate_hash, errors::ConfigError, traits::Capnp};
+use gen_core::{HashId, Workspace, calculate_hash, traits::Capnp};
 use gen_graph::{OperationGraph, all_simple_paths};
 use itertools::Itertools;
 use petgraph::{Direction, graphmap::UnGraphMap};
@@ -523,22 +523,27 @@ impl FileAddition {
         HashId(calculate_hash(&combined))
     }
 
-    fn asset_relative_path(checksum: &HashId, file_type: FileTypes) -> String {
-        Path::new(".gen")
-            .join("assets")
+    fn asset_relative_path(
+        workspace: &Workspace,
+        checksum: &HashId,
+        file_type: FileTypes,
+    ) -> String {
+        let repo_root = workspace.repo_root().unwrap();
+        workspace
+            .asset_dir()
+            .unwrap()
+            .strip_prefix(&repo_root)
+            .unwrap()
             .join(format!("{checksum}.{}", FileTypes::suffix(file_type)))
             .to_string_lossy()
             .to_string()
     }
 
-    fn normalize_file_paths(
-        workspace: &Workspace,
-        file_path: &str,
-        checksum: Option<&HashId>,
-        file_type: FileTypes,
-    ) -> (String, String) {
+    /// Returns a usable path for system file access. It prefers an absolute path
+    /// when one can be resolved, and otherwise falls back to the original input.
+    fn source_file_path(workspace: &Workspace, file_path: &str) -> String {
         if file_path.is_empty() {
-            return (String::new(), String::new());
+            return String::new();
         }
         let repo_root = workspace.repo_root().unwrap();
 
@@ -546,37 +551,60 @@ impl FileAddition {
 
         if provided_path.is_absolute() {
             if provided_path.starts_with(&repo_root) {
-                let absolute = provided_path.to_string_lossy().to_string();
-                let relative = provided_path
-                    .strip_prefix(&repo_root)
-                    .unwrap()
-                    .to_string_lossy()
-                    .to_string();
-                return (absolute, relative);
+                return provided_path.to_string_lossy().to_string();
             }
         } else {
             let absolute = repo_root.join(provided_path);
             if absolute.exists() {
-                let relative = absolute
+                return absolute.to_string_lossy().to_string();
+            }
+        }
+
+        file_path.to_string()
+    }
+
+    /// Returns the file path as it should be stored relative to the gen
+    /// directory. If a file is within the gen directory, it returns a path
+    /// relative to the `.gen` folder. Otherwise, if the path is absolute, it
+    /// returns a path relative to the `.gen/assets` directory. If it is not
+    /// absolute and not within the gen directory, it is returned as-is.
+    fn stored_file_path(
+        workspace: &Workspace,
+        file_path: &str,
+        checksum: &HashId,
+        file_type: FileTypes,
+    ) -> String {
+        if file_path.is_empty() {
+            return String::new();
+        }
+        let repo_root = workspace.repo_root().unwrap();
+
+        let provided_path = Path::new(file_path);
+
+        if provided_path.is_absolute() {
+            if provided_path.starts_with(&repo_root) {
+                return provided_path
                     .strip_prefix(&repo_root)
                     .unwrap()
                     .to_string_lossy()
                     .to_string();
-                return (absolute.to_string_lossy().to_string(), relative);
             }
-        };
-
-        if provided_path.is_absolute()
-            && let Some(checksum) = checksum
-        {
-            return (
-                file_path.to_string(),
-                Self::asset_relative_path(checksum, file_type),
-            );
+        } else {
+            let absolute = repo_root.join(provided_path);
+            if absolute.exists() {
+                return absolute
+                    .strip_prefix(&repo_root)
+                    .unwrap()
+                    .to_string_lossy()
+                    .to_string();
+            }
         }
 
-        let fallback = file_path.to_string();
-        (fallback.clone(), fallback)
+        if provided_path.is_absolute() {
+            return Self::asset_relative_path(workspace, checksum, file_type);
+        }
+
+        file_path.to_string()
     }
 
     fn ensure_asset_copy(
@@ -585,12 +613,9 @@ impl FileAddition {
         checksum: &HashId,
         file_type: FileTypes,
     ) -> Result<(), FileAdditionError> {
-        let gen_dir = workspace
-            .find_gen_dir()
-            .ok_or(ConfigError::GenDirectoryNotFound)
+        let assets_dir = workspace
+            .asset_dir()
             .map_err(|err| FileAdditionError::FileReadError(io::Error::other(err.to_string())))?;
-        let assets_dir = gen_dir.join("assets");
-        fs::create_dir_all(&assets_dir)?;
 
         let asset_path = assets_dir.join(format!("{checksum}.{}", FileTypes::suffix(file_type)));
         if asset_path.exists() {
@@ -608,18 +633,14 @@ impl FileAddition {
         file_type: FileTypes,
         checksum_override: Option<HashId>,
     ) -> Result<FileAddition, FileAdditionError> {
-        let (source_file_path, preliminary_relative_path) =
-            FileAddition::normalize_file_paths(workspace, file_path, None, file_type);
-
-        // TODO: Verify checksum_override actually matches the file's checksum?
+        let source_file_path = FileAddition::source_file_path(workspace, file_path);
         let checksum = if let Some(checksum_override) = checksum_override {
             checksum_override
         } else {
-            let absolute_path = Path::new(&source_file_path);
-            let checksum_path = if absolute_path.is_file() {
+            let checksum_path = if Path::new(&source_file_path).is_file() {
                 source_file_path.as_str()
             } else {
-                preliminary_relative_path.as_str()
+                file_path
             };
             match calculate_file_checksum(checksum_path) {
                 Ok(checksum) => checksum,
@@ -636,14 +657,13 @@ impl FileAddition {
                 },
             }
         };
+        let relative_file_path =
+            FileAddition::stored_file_path(workspace, file_path, &checksum, file_type);
 
-        let (absolute_file_path, relative_file_path) =
-            FileAddition::normalize_file_paths(workspace, file_path, Some(&checksum), file_type);
-
-        if Path::new(file_path).is_absolute() && relative_file_path != absolute_file_path {
+        if Path::new(&source_file_path).is_file() {
             FileAddition::ensure_asset_copy(
                 workspace,
-                Path::new(&absolute_file_path),
+                Path::new(&source_file_path),
                 &checksum,
                 file_type,
             )?;
@@ -716,11 +736,7 @@ impl FileAddition {
     }
 
     pub fn store_file(&self, workspace: &Workspace) -> Result<(), FileStoreError> {
-        let gen_dir = workspace
-            .find_gen_dir()
-            .ok_or(ConfigError::GenDirectoryNotFound)?;
-        let assets_dir = gen_dir.join("assets");
-        fs::create_dir_all(&assets_dir)?;
+        let assets_dir = workspace.asset_dir()?;
 
         let asset_path = assets_dir.join(self.clone().hashed_filename());
         if asset_path.exists() {
@@ -2745,7 +2761,7 @@ mod tests {
     }
 
     #[test]
-    fn test_normalize_file_paths_absolute_path_in_repo() {
+    fn test_source_and_stored_file_paths_absolute_path_in_repo() {
         let context = setup_gen();
         let workspace = context.workspace();
         let repo_root = workspace.base_dir();
@@ -2760,10 +2776,11 @@ mod tests {
             .to_string_lossy()
             .to_string();
 
-        let (absolute, relative) = FileAddition::normalize_file_paths(
+        let absolute = FileAddition::source_file_path(workspace, absolute_string.as_str());
+        let relative = FileAddition::stored_file_path(
             workspace,
             absolute_string.as_str(),
-            None,
+            &calculate_file_checksum(&absolute_path).unwrap(),
             FileTypes::Fasta,
         );
 
@@ -2772,7 +2789,7 @@ mod tests {
     }
 
     #[test]
-    fn test_normalize_file_paths_relative_path_in_repo() {
+    fn test_source_and_stored_file_paths_relative_path_in_repo() {
         let context = setup_gen();
         let workspace = context.workspace();
         let repo_root = workspace.repo_root().unwrap();
@@ -2784,10 +2801,11 @@ mod tests {
         let relative_string = relative_path.to_string_lossy().to_string();
         let absolute_string = absolute_path.to_string_lossy().to_string();
 
-        let (absolute, relative) = FileAddition::normalize_file_paths(
+        let absolute = FileAddition::source_file_path(workspace, relative_string.as_str());
+        let relative = FileAddition::stored_file_path(
             workspace,
             relative_string.as_str(),
-            None,
+            &calculate_file_checksum(&absolute_path).unwrap(),
             FileTypes::Fasta,
         );
 
@@ -2796,7 +2814,7 @@ mod tests {
     }
 
     #[test]
-    fn test_normalize_file_paths_outside_repo_fallbacks() {
+    fn test_source_and_stored_file_paths_outside_repo_fallbacks() {
         let context = setup_gen();
         let workspace = context.workspace();
 
@@ -2806,10 +2824,11 @@ mod tests {
         let outside_string = outside_file.path().to_string_lossy().to_string();
         let checksum = calculate_file_checksum(outside_file.path()).unwrap();
 
-        let (absolute, relative) = FileAddition::normalize_file_paths(
+        let absolute = FileAddition::source_file_path(workspace, outside_string.as_str());
+        let relative = FileAddition::stored_file_path(
             workspace,
             outside_string.as_str(),
-            Some(&checksum),
+            &checksum,
             FileTypes::Fasta,
         );
 
@@ -2824,21 +2843,27 @@ mod tests {
     }
 
     #[test]
-    fn test_normalize_file_paths_without_connection_path() {
+    fn test_source_and_stored_file_paths_without_connection_path() {
         let context = setup_gen();
         let workspace = context.workspace();
 
-        let (absolute, relative) = FileAddition::normalize_file_paths(
+        let absolute = FileAddition::source_file_path(workspace, "detached/file.txt");
+        let relative = FileAddition::stored_file_path(
             workspace,
             "detached/file.txt",
-            None,
+            &HashId::convert_str("detached"),
             FileTypes::Fasta,
         );
         assert_eq!(absolute, "detached/file.txt");
         assert_eq!(relative, "detached/file.txt");
 
-        let (absolute_empty, relative_empty) =
-            FileAddition::normalize_file_paths(workspace, "", None, FileTypes::Fasta);
+        let absolute_empty = FileAddition::source_file_path(workspace, "");
+        let relative_empty = FileAddition::stored_file_path(
+            workspace,
+            "",
+            &HashId::convert_str("empty"),
+            FileTypes::Fasta,
+        );
         assert_eq!(absolute_empty, "");
         assert_eq!(relative_empty, "");
     }
@@ -2873,6 +2898,14 @@ mod tests {
         let relative1_id = FileAddition::generate_file_addition_id(&checksum, &relative1);
 
         assert_eq!(fa1.id, relative1_id);
+        assert!(
+            context
+                .workspace()
+                .asset_dir()
+                .unwrap()
+                .join(fa1.clone().hashed_filename())
+                .exists()
+        );
 
         // Second call with same file should return the same FileAddition
         let fa2 = FileAddition::get_or_create(
@@ -2937,9 +2970,8 @@ mod tests {
         assert!(
             context
                 .workspace()
-                .find_gen_dir()
+                .asset_dir()
                 .unwrap()
-                .join("assets")
                 .join(outside.clone().hashed_filename())
                 .exists()
         );
@@ -2986,7 +3018,7 @@ mod tests {
 
         assert_eq!(shared_file_1.id, shared_file_2.id);
 
-        let assets_dir = workspace.find_gen_dir().unwrap().join("assets");
+        let assets_dir = workspace.asset_dir().unwrap();
         let asset_names = fs::read_dir(&assets_dir)
             .unwrap()
             .map(|entry| entry.unwrap().file_name().into_string().unwrap())

--- a/gen-models/src/operations.rs
+++ b/gen-models/src/operations.rs
@@ -527,40 +527,46 @@ impl FileAddition {
         workspace: &Workspace,
         checksum: &HashId,
         file_type: FileTypes,
-    ) -> String {
-        let repo_root = workspace.repo_root().unwrap();
-        workspace
-            .asset_dir()
-            .unwrap()
+    ) -> Result<String, FileAdditionError> {
+        let repo_root = workspace.repo_root()?;
+        let asset_dir = workspace.asset_dir()?;
+
+        Ok(asset_dir
             .strip_prefix(&repo_root)
-            .unwrap()
+            .map_err(|_| FileAdditionError::PathOutsideRepo {
+                path: asset_dir.clone(),
+                repo_root: repo_root.clone(),
+            })?
             .join(format!("{checksum}.{}", FileTypes::suffix(file_type)))
             .to_string_lossy()
-            .to_string()
+            .to_string())
     }
 
     /// Returns a usable path for system file access. It prefers an absolute path
     /// when one can be resolved, and otherwise falls back to the original input.
-    fn source_file_path(workspace: &Workspace, file_path: &str) -> String {
+    fn source_file_path(
+        workspace: &Workspace,
+        file_path: &str,
+    ) -> Result<String, FileAdditionError> {
         if file_path.is_empty() {
-            return String::new();
+            return Ok(String::new());
         }
-        let repo_root = workspace.repo_root().unwrap();
+        let repo_root = workspace.repo_root()?;
 
         let provided_path = Path::new(file_path);
 
         if provided_path.is_absolute() {
             if provided_path.starts_with(&repo_root) {
-                return provided_path.to_string_lossy().to_string();
+                return Ok(provided_path.to_string_lossy().to_string());
             }
         } else {
             let absolute = repo_root.join(provided_path);
             if absolute.exists() {
-                return absolute.to_string_lossy().to_string();
+                return Ok(absolute.to_string_lossy().to_string());
             }
         }
 
-        file_path.to_string()
+        Ok(file_path.to_string())
     }
 
     /// Returns the file path as it should be stored relative to the gen
@@ -573,30 +579,36 @@ impl FileAddition {
         file_path: &str,
         checksum: &HashId,
         file_type: FileTypes,
-    ) -> String {
+    ) -> Result<String, FileAdditionError> {
         if file_path.is_empty() {
-            return String::new();
+            return Ok(String::new());
         }
-        let repo_root = workspace.repo_root().unwrap();
+        let repo_root = workspace.repo_root()?;
 
         let provided_path = Path::new(file_path);
 
         if provided_path.is_absolute() {
             if provided_path.starts_with(&repo_root) {
-                return provided_path
+                return Ok(provided_path
                     .strip_prefix(&repo_root)
-                    .unwrap()
+                    .map_err(|_| FileAdditionError::PathOutsideRepo {
+                        path: provided_path.to_path_buf(),
+                        repo_root: repo_root.clone(),
+                    })?
                     .to_string_lossy()
-                    .to_string();
+                    .to_string());
             }
         } else {
             let absolute = repo_root.join(provided_path);
             if absolute.exists() {
-                return absolute
+                return Ok(absolute
                     .strip_prefix(&repo_root)
-                    .unwrap()
+                    .map_err(|_| FileAdditionError::PathOutsideRepo {
+                        path: absolute.clone(),
+                        repo_root: repo_root.clone(),
+                    })?
                     .to_string_lossy()
-                    .to_string();
+                    .to_string());
             }
         }
 
@@ -604,7 +616,7 @@ impl FileAddition {
             return Self::asset_relative_path(workspace, checksum, file_type);
         }
 
-        file_path.to_string()
+        Ok(file_path.to_string())
     }
 
     fn ensure_asset_copy(
@@ -613,9 +625,7 @@ impl FileAddition {
         checksum: &HashId,
         file_type: FileTypes,
     ) -> Result<(), FileAdditionError> {
-        let assets_dir = workspace
-            .asset_dir()
-            .map_err(|err| FileAdditionError::FileReadError(io::Error::other(err.to_string())))?;
+        let assets_dir = workspace.asset_dir()?;
 
         let asset_path = assets_dir.join(format!("{checksum}.{}", FileTypes::suffix(file_type)));
         if asset_path.exists() {
@@ -633,7 +643,7 @@ impl FileAddition {
         file_type: FileTypes,
         checksum_override: Option<HashId>,
     ) -> Result<FileAddition, FileAdditionError> {
-        let source_file_path = FileAddition::source_file_path(workspace, file_path);
+        let source_file_path = FileAddition::source_file_path(workspace, file_path)?;
         let checksum = if let Some(checksum_override) = checksum_override {
             checksum_override
         } else {
@@ -658,7 +668,7 @@ impl FileAddition {
             }
         };
         let relative_file_path =
-            FileAddition::stored_file_path(workspace, file_path, &checksum, file_type);
+            FileAddition::stored_file_path(workspace, file_path, &checksum, file_type)?;
 
         if Path::new(&source_file_path).is_file() {
             FileAddition::ensure_asset_copy(
@@ -2776,13 +2786,14 @@ mod tests {
             .to_string_lossy()
             .to_string();
 
-        let absolute = FileAddition::source_file_path(workspace, absolute_string.as_str());
+        let absolute = FileAddition::source_file_path(workspace, absolute_string.as_str()).unwrap();
         let relative = FileAddition::stored_file_path(
             workspace,
             absolute_string.as_str(),
             &calculate_file_checksum(&absolute_path).unwrap(),
             FileTypes::Fasta,
-        );
+        )
+        .unwrap();
 
         assert_eq!(absolute, absolute_string);
         assert_eq!(relative, relative_string);
@@ -2801,13 +2812,14 @@ mod tests {
         let relative_string = relative_path.to_string_lossy().to_string();
         let absolute_string = absolute_path.to_string_lossy().to_string();
 
-        let absolute = FileAddition::source_file_path(workspace, relative_string.as_str());
+        let absolute = FileAddition::source_file_path(workspace, relative_string.as_str()).unwrap();
         let relative = FileAddition::stored_file_path(
             workspace,
             relative_string.as_str(),
             &calculate_file_checksum(&absolute_path).unwrap(),
             FileTypes::Fasta,
-        );
+        )
+        .unwrap();
 
         assert_eq!(absolute, absolute_string);
         assert_eq!(relative, relative_string);
@@ -2824,13 +2836,14 @@ mod tests {
         let outside_string = outside_file.path().to_string_lossy().to_string();
         let checksum = calculate_file_checksum(outside_file.path()).unwrap();
 
-        let absolute = FileAddition::source_file_path(workspace, outside_string.as_str());
+        let absolute = FileAddition::source_file_path(workspace, outside_string.as_str()).unwrap();
         let relative = FileAddition::stored_file_path(
             workspace,
             outside_string.as_str(),
             &checksum,
             FileTypes::Fasta,
-        );
+        )
+        .unwrap();
 
         assert_eq!(absolute, outside_string);
         assert_eq!(
@@ -2847,23 +2860,25 @@ mod tests {
         let context = setup_gen();
         let workspace = context.workspace();
 
-        let absolute = FileAddition::source_file_path(workspace, "detached/file.txt");
+        let absolute = FileAddition::source_file_path(workspace, "detached/file.txt").unwrap();
         let relative = FileAddition::stored_file_path(
             workspace,
             "detached/file.txt",
             &HashId::convert_str("detached"),
             FileTypes::Fasta,
-        );
+        )
+        .unwrap();
         assert_eq!(absolute, "detached/file.txt");
         assert_eq!(relative, "detached/file.txt");
 
-        let absolute_empty = FileAddition::source_file_path(workspace, "");
+        let absolute_empty = FileAddition::source_file_path(workspace, "").unwrap();
         let relative_empty = FileAddition::stored_file_path(
             workspace,
             "",
             &HashId::convert_str("empty"),
             FileTypes::Fasta,
-        );
+        )
+        .unwrap();
         assert_eq!(absolute_empty, "");
         assert_eq!(relative_empty, "");
     }

--- a/gen-models/src/session_operations.rs
+++ b/gen-models/src/session_operations.rs
@@ -71,7 +71,7 @@ pub fn end_operation(
                     operation_conn,
                     &op_file.file_path,
                     op_file.file_type,
-                    None,
+                    op_file.checksum_override,
                 ) {
                     Ok(fa) => fa,
                     Err(err) => return Err(OperationError::SQLError(format!("{err}"))),

--- a/gen-models/src/session_operations.rs
+++ b/gen-models/src/session_operations.rs
@@ -76,7 +76,7 @@ pub fn end_operation(
                     Ok(fa) => fa,
                     Err(err) => return Err(OperationError::SQLError(format!("{err}"))),
                 };
-                Operation::add_file(operation_conn, &operation.hash, &fa.id)
+                Operation::add_file(operation_conn, &operation.hash, &fa.id, &op_file.filename)
                     .map_err(|err| OperationError::SQLError(format!("{err}")))?;
                 if fa.file_type != FileTypes::Changeset && fa.file_type != FileTypes::None {
                     match fa.store_file(context.workspace()) {

--- a/gen-models/src/test_helpers.rs
+++ b/gen-models/src/test_helpers.rs
@@ -252,7 +252,7 @@ pub fn create_operation(
         context,
         &mut session,
         &OperationInfo {
-            files: vec![OperationFile::new(file_path.to_string(), file_type)],
+            files: vec![OperationFile::new(file_path.to_string()).set_file_type(file_type)],
             description: description.to_string(),
         },
         "test operation",

--- a/gen-models/src/test_helpers.rs
+++ b/gen-models/src/test_helpers.rs
@@ -252,10 +252,7 @@ pub fn create_operation(
         context,
         &mut session,
         &OperationInfo {
-            files: vec![OperationFile {
-                file_path: file_path.to_string(),
-                file_type,
-            }],
+            files: vec![OperationFile::new(file_path.to_string(), file_type)],
             description: description.to_string(),
         },
         "test operation",

--- a/gen-python/Cargo.lock
+++ b/gen-python/Cargo.lock
@@ -9,6 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -105,6 +116,15 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "async-compression"
@@ -268,11 +288,30 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bzip2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
+dependencies = [
+ "bzip2-sys",
+]
+
+[[package]]
+name = "bzip2"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
 dependencies = [
  "libbz2-rs-sys",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -314,7 +353,7 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fe67a3f89b693d2163cf3d94129125463ac5913e1c4322f2db905aa631d3c67"
 dependencies = [
- "embedded-io",
+ "embedded-io 0.7.1",
 ]
 
 [[package]]
@@ -342,6 +381,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -387,9 +428,18 @@ dependencies = [
  "js-sys",
  "num-traits",
  "pure-rust-locales",
- "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -448,6 +498,15 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "colorchoice"
@@ -509,6 +568,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
 name = "convert_case"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -559,6 +624,21 @@ checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crc32fast"
@@ -722,6 +802,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deflate64"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2"
+
+[[package]]
 name = "deltae"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -734,7 +820,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
- "serde_core",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -767,6 +863,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -821,6 +918,18 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "embedded-io"
@@ -909,19 +1018,6 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
-
-[[package]]
-name = "figment"
-version = "0.10.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cb01cd46b0cf372153850f4c6c272d9cbea2da513e07538405148f95bd789f3"
-dependencies = [
- "atomic",
- "serde",
- "serde_yaml",
- "uncased",
- "version_check",
-]
 
 [[package]]
 name = "filedescriptor"
@@ -1119,7 +1215,6 @@ dependencies = [
  "directories",
  "env_logger",
  "fallible-streaming-iterator",
- "figment",
  "flate2",
  "gb-io",
  "gen-annotations",
@@ -1133,7 +1228,7 @@ dependencies = [
  "html-escape",
  "httparse",
  "include_dir",
- "indexmap 2.14.0",
+ "indexmap",
  "indicatif",
  "interavl",
  "intervaltree",
@@ -1142,6 +1237,7 @@ dependencies = [
  "noodles",
  "once_cell",
  "petgraph",
+ "postcard",
  "rand 0.10.1",
  "rat-cursor",
  "rat-text",
@@ -1152,7 +1248,6 @@ dependencies = [
  "rusqlite_migration",
  "serde",
  "serde_json",
- "serde_with",
  "sha2",
  "tempfile",
  "thiserror 2.0.18",
@@ -1160,6 +1255,7 @@ dependencies = [
  "url",
  "url-parse",
  "webbrowser",
+ "zip",
 ]
 
 [[package]]
@@ -1240,7 +1336,7 @@ dependencies = [
  "gen-core",
  "gen-graph",
  "include_dir",
- "indexmap 2.14.0",
+ "indexmap",
  "intervaltree",
  "itertools 0.14.0",
  "noodles",
@@ -1368,12 +1464,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
@@ -1438,6 +1528,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "html-escape"
@@ -1706,17 +1805,6 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
- "serde",
-]
-
-[[package]]
-name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
@@ -1747,6 +1835,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -1900,6 +1997,16 @@ checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
 ]
 
 [[package]]
@@ -2113,6 +2220,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "lzma-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e"
+dependencies = [
+ "byteorder",
+ "crc",
+]
+
+[[package]]
 name = "lzma-sys"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2282,7 +2399,7 @@ checksum = "7480c171f2d2e108f64e504b073dceccd886bf4a5af06d18e65497a4a48e6dd2"
 dependencies = [
  "bstr",
  "futures",
- "indexmap 2.14.0",
+ "indexmap",
  "memchr",
  "noodles-bgzf",
  "noodles-core",
@@ -2299,7 +2416,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "167e7421ebf8c6dfc9e55982f0ee9708f5b6c04ed1489e7ea86b407c087b9a30"
 dependencies = [
  "futures",
- "indexmap 2.14.0",
+ "indexmap",
  "memchr",
  "noodles-bgzf",
  "noodles-core",
@@ -2357,10 +2474,10 @@ dependencies = [
  "async-compression",
  "bitflags 2.11.1",
  "bstr",
- "bzip2",
+ "bzip2 0.6.1",
  "flate2",
  "futures",
- "indexmap 2.14.0",
+ "indexmap",
  "md-5",
  "noodles-bam",
  "noodles-core",
@@ -2379,7 +2496,7 @@ checksum = "03338575b1537f6fa1006bb6138fafea98b73dd3dd687b96727076531de924cc"
 dependencies = [
  "bit-vec 0.8.0",
  "bstr",
- "indexmap 2.14.0",
+ "indexmap",
  "noodles-bgzf",
  "noodles-core",
  "tokio",
@@ -2419,7 +2536,7 @@ checksum = "44e0132682fb8a247443e7c14b391da1f638aa002b313e6287d6aa93bae6ffcc"
 dependencies = [
  "bstr",
  "futures",
- "indexmap 2.14.0",
+ "indexmap",
  "lexical-core",
  "noodles-bgzf",
  "noodles-core",
@@ -2435,7 +2552,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2000e62c15c3f4e53a5f8331d012530e6193075d534e1c54a378cba1b3ca3b71"
 dependencies = [
  "bstr",
- "indexmap 2.14.0",
+ "indexmap",
  "lexical-core",
  "noodles-bgzf",
  "noodles-core",
@@ -2452,7 +2569,7 @@ dependencies = [
  "bitflags 2.11.1",
  "bstr",
  "futures",
- "indexmap 2.14.0",
+ "indexmap",
  "lexical-core",
  "memchr",
  "noodles-bgzf",
@@ -2469,7 +2586,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caff826ea6e432861b726ae3be1100e72d07a238c7615c12ddc257ff3c23f555"
 dependencies = [
  "bstr",
- "indexmap 2.14.0",
+ "indexmap",
  "noodles-bgzf",
  "noodles-core",
  "noodles-csi",
@@ -2483,7 +2600,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c3edc79cf9c235cc803137a108fa20e6f9c4a3b6fa39e879c78504cc7d19d7"
 dependencies = [
  "futures",
- "indexmap 2.14.0",
+ "indexmap",
  "memchr",
  "noodles-bgzf",
  "noodles-core",
@@ -2606,6 +2723,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2661,7 +2788,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.14.0",
+ "indexmap",
  "serde",
  "serde_derive",
 ]
@@ -2743,6 +2870,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "serde",
 ]
 
 [[package]]
@@ -3188,26 +3327,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ref-cast"
-version = "1.0.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
-dependencies = [
- "ref-cast-impl",
-]
-
-[[package]]
-name = "ref-cast-impl"
-version = "1.0.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3444,30 +3563,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "schemars"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
-dependencies = [
- "dyn-clone",
- "ref-cast",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "schemars"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
-dependencies = [
- "dyn-clone",
- "ref-cast",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3535,47 +3630,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_with"
-version = "3.18.0"
+name = "sha1"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
- "base64",
- "chrono",
- "hex",
- "indexmap 1.9.3",
- "indexmap 2.14.0",
- "schemars 0.9.0",
- "schemars 1.2.1",
- "serde_core",
- "serde_json",
- "serde_with_macros",
- "time",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "3.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
-dependencies = [
- "darling 0.23.0",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap 2.14.0",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
 ]
 
 [[package]]
@@ -3913,14 +3975,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
- "itoa",
  "libc",
  "num-conv",
  "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",
- "time-macros",
 ]
 
 [[package]]
@@ -3928,16 +3988,6 @@ name = "time-core"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
-
-[[package]]
-name = "time-macros"
-version = "0.2.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
-dependencies = [
- "num-conv",
- "time-core",
-]
 
 [[package]]
 name = "tinystr"
@@ -4094,15 +4144,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
-name = "uncased"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
-dependencies = [
- "version_check",
-]
-
-[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4163,12 +4204,6 @@ name = "unit-prefix"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
@@ -4363,7 +4398,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.14.0",
+ "indexmap",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -4389,7 +4424,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.11.1",
  "hashbrown 0.15.5",
- "indexmap 2.14.0",
+ "indexmap",
  "semver",
 ]
 
@@ -4784,7 +4819,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.14.0",
+ "indexmap",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -4815,7 +4850,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.11.1",
- "indexmap 2.14.0",
+ "indexmap",
  "log",
  "serde",
  "serde_derive",
@@ -4834,7 +4869,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.14.0",
+ "indexmap",
  "log",
  "semver",
  "serde",
@@ -4928,6 +4963,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "zerotrie"
@@ -4963,6 +5012,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "aes",
+ "arbitrary",
+ "bzip2 0.5.2",
+ "constant_time_eq",
+ "crc32fast",
+ "crossbeam-utils",
+ "deflate64",
+ "displaydoc",
+ "flate2",
+ "getrandom 0.3.4",
+ "hmac",
+ "indexmap",
+ "lzma-rs",
+ "memchr",
+ "pbkdf2",
+ "sha1",
+ "thiserror 2.0.18",
+ "time",
+ "xz2",
+ "zeroize",
+ "zopfli",
+ "zstd",
+]
+
+[[package]]
 name = "zlib-rs"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4973,3 +5052,43 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/gen-python/src/imports.rs
+++ b/gen-python/src/imports.rs
@@ -136,10 +136,7 @@ pub fn import_genbank(
         name.as_ref(),
         &sample,
         OperationInfo {
-            files: vec![OperationFile {
-                file_path: filename.clone(),
-                file_type: FileTypes::GenBank,
-            }],
+            files: vec![OperationFile::new(filename.clone()).set_file_type(FileTypes::GenBank)],
             description: "GenBank Import".to_string(),
         },
         r#gen::imports::genbank::GenBankImportOptions::default()

--- a/gen-python/src/updates.rs
+++ b/gen-python/src/updates.rs
@@ -237,10 +237,10 @@ pub fn update_with_genbank(
         &sample,
         create_missing,
         &gen_models::operations::OperationInfo {
-            files: vec![gen_models::operations::OperationFile {
-                file_path: filename.clone(),
-                file_type: gen_models::file_types::FileTypes::GenBank,
-            }],
+            files: vec![
+                gen_models::operations::OperationFile::new(filename.clone())
+                    .set_file_type(gen_models::file_types::FileTypes::GenBank),
+            ],
             description: "Update from GenBank".to_string(),
         },
     ) {

--- a/gen-r/src/rust/src/lib.rs
+++ b/gen-r/src/rust/src/lib.rs
@@ -531,10 +531,10 @@ fn import_genbank(
         collection_name_opt.as_deref(),
         &sample,
         OperationInfo {
-            files: vec![OperationFile::new(
-                filename.clone(),
-                gen_models::file_types::FileTypes::GenBank,
-            )],
+            files: vec![
+                OperationFile::new(filename.clone())
+                    .set_file_type(gen_models::file_types::FileTypes::GenBank),
+            ],
             description: "GenBank Import".to_string(),
         },
         r#gen::imports::genbank::GenBankImportOptions::default()
@@ -845,10 +845,10 @@ fn update_with_genbank(
         &sample,
         create_missing,
         &OperationInfo {
-            files: vec![OperationFile::new(
-                filename.clone(),
-                gen_models::file_types::FileTypes::GenBank,
-            )],
+            files: vec![
+                OperationFile::new(filename.clone())
+                    .set_file_type(gen_models::file_types::FileTypes::GenBank),
+            ],
             description: "Update from GenBank".to_string(),
         },
     ) {

--- a/gen-r/src/rust/src/lib.rs
+++ b/gen-r/src/rust/src/lib.rs
@@ -531,10 +531,10 @@ fn import_genbank(
         collection_name_opt.as_deref(),
         &sample,
         OperationInfo {
-            files: vec![OperationFile {
-                file_path: filename.clone(),
-                file_type: gen_models::file_types::FileTypes::GenBank,
-            }],
+            files: vec![OperationFile::new(
+                filename.clone(),
+                gen_models::file_types::FileTypes::GenBank,
+            )],
             description: "GenBank Import".to_string(),
         },
         r#gen::imports::genbank::GenBankImportOptions::default()
@@ -845,10 +845,10 @@ fn update_with_genbank(
         &sample,
         create_missing,
         &OperationInfo {
-            files: vec![OperationFile {
-                file_path: filename.clone(),
-                file_type: gen_models::file_types::FileTypes::GenBank,
-            }],
+            files: vec![OperationFile::new(
+                filename.clone(),
+                gen_models::file_types::FileTypes::GenBank,
+            )],
             description: "Update from GenBank".to_string(),
         },
     ) {

--- a/src/commands/import/genbank.rs
+++ b/src/commands/import/genbank.rs
@@ -62,7 +62,7 @@ pub fn execute(cli_context: &CliContext, cmd: Command) -> Result<()> {
         name.as_ref(),
         cmd.sample.as_str(),
         OperationInfo {
-            files: vec![OperationFile::new(cmd.path.clone(), FileTypes::GenBank)],
+            files: vec![OperationFile::new(cmd.path.clone()).set_file_type(FileTypes::GenBank)],
             description: "GenBank Import".to_string(),
         },
         options,

--- a/src/commands/import/genbank.rs
+++ b/src/commands/import/genbank.rs
@@ -62,10 +62,7 @@ pub fn execute(cli_context: &CliContext, cmd: Command) -> Result<()> {
         name.as_ref(),
         cmd.sample.as_str(),
         OperationInfo {
-            files: vec![OperationFile {
-                file_path: cmd.path.clone(),
-                file_type: FileTypes::GenBank,
-            }],
+            files: vec![OperationFile::new(cmd.path.clone(), FileTypes::GenBank)],
             description: "GenBank Import".to_string(),
         },
         options,

--- a/src/commands/update/genbank.rs
+++ b/src/commands/update/genbank.rs
@@ -53,10 +53,7 @@ pub fn execute(cli_context: &CliContext, cmd: Command) -> Result<()> {
         &cmd.sample,
         cmd.create_missing,
         &OperationInfo {
-            files: vec![OperationFile {
-                file_path: cmd.path.clone(),
-                file_type: FileTypes::GenBank,
-            }],
+            files: vec![OperationFile::new(cmd.path.clone(), FileTypes::GenBank)],
             description: "Update from GenBank".to_string(),
         },
     ) {

--- a/src/commands/update/genbank.rs
+++ b/src/commands/update/genbank.rs
@@ -53,7 +53,7 @@ pub fn execute(cli_context: &CliContext, cmd: Command) -> Result<()> {
         &cmd.sample,
         cmd.create_missing,
         &OperationInfo {
-            files: vec![OperationFile::new(cmd.path.clone(), FileTypes::GenBank)],
+            files: vec![OperationFile::new(cmd.path.clone()).set_file_type(FileTypes::GenBank)],
             description: "Update from GenBank".to_string(),
         },
     ) {

--- a/src/exports/genbank.rs
+++ b/src/exports/genbank.rs
@@ -619,10 +619,10 @@ mod tests {
             None,
             Sample::DEFAULT_NAME,
             OperationInfo {
-                files: vec![OperationFile {
-                    file_path: path.to_str().unwrap().to_string(),
-                    file_type: FileTypes::GenBank,
-                }],
+                files: vec![OperationFile::new(
+                    path.to_str().unwrap().to_string(),
+                    FileTypes::GenBank,
+                )],
                 description: "test".to_string(),
             },
             GenBankImportOptions::default().annotation_name_from_path(&path),
@@ -650,10 +650,10 @@ mod tests {
             None,
             Sample::DEFAULT_NAME,
             OperationInfo {
-                files: vec![OperationFile {
-                    file_path: path.to_str().unwrap().to_string(),
-                    file_type: FileTypes::GenBank,
-                }],
+                files: vec![OperationFile::new(
+                    path.to_str().unwrap().to_string(),
+                    FileTypes::GenBank,
+                )],
                 description: "test".to_string(),
             },
             GenBankImportOptions::default().annotation_name_from_path(&path),
@@ -681,10 +681,10 @@ mod tests {
             None,
             Sample::DEFAULT_NAME,
             OperationInfo {
-                files: vec![OperationFile {
-                    file_path: path.to_str().unwrap().to_string(),
-                    file_type: FileTypes::GenBank,
-                }],
+                files: vec![OperationFile::new(
+                    path.to_str().unwrap().to_string(),
+                    FileTypes::GenBank,
+                )],
                 description: "test".to_string(),
             },
             GenBankImportOptions::default().annotation_name_from_path(&path),
@@ -711,10 +711,10 @@ mod tests {
             Some("fixtures"),
             "puc19-export",
             OperationInfo {
-                files: vec![OperationFile {
-                    file_path: path.to_str().unwrap().to_string(),
-                    file_type: FileTypes::GenBank,
-                }],
+                files: vec![OperationFile::new(
+                    path.to_str().unwrap().to_string(),
+                    FileTypes::GenBank,
+                )],
                 description: "test".to_string(),
             },
             GenBankImportOptions::default().annotation_name_from_path(&path),

--- a/src/exports/genbank.rs
+++ b/src/exports/genbank.rs
@@ -619,10 +619,10 @@ mod tests {
             None,
             Sample::DEFAULT_NAME,
             OperationInfo {
-                files: vec![OperationFile::new(
-                    path.to_str().unwrap().to_string(),
-                    FileTypes::GenBank,
-                )],
+                files: vec![
+                    OperationFile::new(path.to_str().unwrap().to_string())
+                        .set_file_type(FileTypes::GenBank),
+                ],
                 description: "test".to_string(),
             },
             GenBankImportOptions::default().annotation_name_from_path(&path),
@@ -650,10 +650,10 @@ mod tests {
             None,
             Sample::DEFAULT_NAME,
             OperationInfo {
-                files: vec![OperationFile::new(
-                    path.to_str().unwrap().to_string(),
-                    FileTypes::GenBank,
-                )],
+                files: vec![
+                    OperationFile::new(path.to_str().unwrap().to_string())
+                        .set_file_type(FileTypes::GenBank),
+                ],
                 description: "test".to_string(),
             },
             GenBankImportOptions::default().annotation_name_from_path(&path),
@@ -681,10 +681,10 @@ mod tests {
             None,
             Sample::DEFAULT_NAME,
             OperationInfo {
-                files: vec![OperationFile::new(
-                    path.to_str().unwrap().to_string(),
-                    FileTypes::GenBank,
-                )],
+                files: vec![
+                    OperationFile::new(path.to_str().unwrap().to_string())
+                        .set_file_type(FileTypes::GenBank),
+                ],
                 description: "test".to_string(),
             },
             GenBankImportOptions::default().annotation_name_from_path(&path),
@@ -711,10 +711,10 @@ mod tests {
             Some("fixtures"),
             "puc19-export",
             OperationInfo {
-                files: vec![OperationFile::new(
-                    path.to_str().unwrap().to_string(),
-                    FileTypes::GenBank,
-                )],
+                files: vec![
+                    OperationFile::new(path.to_str().unwrap().to_string())
+                        .set_file_type(FileTypes::GenBank),
+                ],
                 description: "test".to_string(),
             },
             GenBankImportOptions::default().annotation_name_from_path(&path),

--- a/src/imports/fasta.rs
+++ b/src/imports/fasta.rs
@@ -161,7 +161,7 @@ pub fn import_fasta(
         context,
         &mut session,
         &OperationInfo {
-            files: vec![OperationFile::new(fasta.to_string(), FileTypes::Fasta)],
+            files: vec![OperationFile::new(fasta.to_string()).set_file_type(FileTypes::Fasta)],
             description: "fasta_addition".to_string(),
         },
         &summary_str,

--- a/src/imports/fasta.rs
+++ b/src/imports/fasta.rs
@@ -161,10 +161,7 @@ pub fn import_fasta(
         context,
         &mut session,
         &OperationInfo {
-            files: vec![OperationFile {
-                file_path: fasta.to_string(),
-                file_type: FileTypes::Fasta,
-            }],
+            files: vec![OperationFile::new(fasta.to_string(), FileTypes::Fasta)],
             description: "fasta_addition".to_string(),
         },
         &summary_str,

--- a/src/imports/genbank.rs
+++ b/src/imports/genbank.rs
@@ -764,10 +764,10 @@ mod tests {
             Some("fixtures"),
             sample_name,
             OperationInfo {
-                files: vec![OperationFile::new(
-                    path.to_str().unwrap().to_string(),
-                    FileTypes::GenBank,
-                )],
+                files: vec![
+                    OperationFile::new(path.to_str().unwrap().to_string())
+                        .set_file_type(FileTypes::GenBank),
+                ],
                 description: "test".to_string(),
             },
             options.annotation_name_from_path(&path),
@@ -1039,7 +1039,9 @@ mod tests {
                 None,
                 Sample::DEFAULT_NAME,
                 OperationInfo {
-                    files: vec![OperationFile::new("".to_string(), FileTypes::GenBank)],
+                    files: vec![
+                        OperationFile::new("".to_string()).set_file_type(FileTypes::GenBank),
+                    ],
                     description: "test".to_string(),
                 },
                 GenBankImportOptions::default(),
@@ -1068,10 +1070,10 @@ mod tests {
             None,
             Sample::DEFAULT_NAME,
             OperationInfo {
-                files: vec![OperationFile::new(
-                    path.to_str().unwrap().to_string(),
-                    FileTypes::GenBank,
-                )],
+                files: vec![
+                    OperationFile::new(path.to_str().unwrap().to_string())
+                        .set_file_type(FileTypes::GenBank),
+                ],
                 description: "test".to_string(),
             },
             GenBankImportOptions::default(),
@@ -1100,7 +1102,7 @@ mod tests {
             None,
             "new-sample",
             OperationInfo {
-                files: vec![OperationFile::new("".to_string(), FileTypes::GenBank)],
+                files: vec![OperationFile::new("".to_string()).set_file_type(FileTypes::GenBank)],
                 description: "test".to_string(),
             },
             GenBankImportOptions::default(),
@@ -1261,7 +1263,9 @@ mod tests {
                 None,
                 Sample::DEFAULT_NAME,
                 OperationInfo {
-                    files: vec![OperationFile::new("".to_string(), FileTypes::GenBank)],
+                    files: vec![
+                        OperationFile::new("".to_string()).set_file_type(FileTypes::GenBank),
+                    ],
                     description: "test".to_string(),
                 },
                 GenBankImportOptions::default(),
@@ -1297,7 +1301,9 @@ mod tests {
                 None,
                 Sample::DEFAULT_NAME,
                 OperationInfo {
-                    files: vec![OperationFile::new("".to_string(), FileTypes::GenBank)],
+                    files: vec![
+                        OperationFile::new("".to_string()).set_file_type(FileTypes::GenBank),
+                    ],
                     description: "test".to_string(),
                 },
                 GenBankImportOptions::default(),
@@ -1350,7 +1356,9 @@ mod tests {
                 None,
                 Sample::DEFAULT_NAME,
                 OperationInfo {
-                    files: vec![OperationFile::new("".to_string(), FileTypes::GenBank)],
+                    files: vec![
+                        OperationFile::new("".to_string()).set_file_type(FileTypes::GenBank),
+                    ],
                     description: "test".to_string(),
                 },
                 GenBankImportOptions::default(),
@@ -1409,7 +1417,9 @@ mod tests {
                 None,
                 Sample::DEFAULT_NAME,
                 OperationInfo {
-                    files: vec![OperationFile::new("".to_string(), FileTypes::GenBank)],
+                    files: vec![
+                        OperationFile::new("".to_string()).set_file_type(FileTypes::GenBank),
+                    ],
                     description: "test".to_string(),
                 },
                 GenBankImportOptions::default(),
@@ -1466,7 +1476,9 @@ mod tests {
                 None,
                 Sample::DEFAULT_NAME,
                 OperationInfo {
-                    files: vec![OperationFile::new("".to_string(), FileTypes::GenBank)],
+                    files: vec![
+                        OperationFile::new("".to_string()).set_file_type(FileTypes::GenBank),
+                    ],
                     description: "test".to_string(),
                 },
                 GenBankImportOptions::default(),

--- a/src/imports/genbank.rs
+++ b/src/imports/genbank.rs
@@ -764,10 +764,10 @@ mod tests {
             Some("fixtures"),
             sample_name,
             OperationInfo {
-                files: vec![OperationFile {
-                    file_path: path.to_str().unwrap().to_string(),
-                    file_type: FileTypes::GenBank,
-                }],
+                files: vec![OperationFile::new(
+                    path.to_str().unwrap().to_string(),
+                    FileTypes::GenBank,
+                )],
                 description: "test".to_string(),
             },
             options.annotation_name_from_path(&path),
@@ -1039,10 +1039,7 @@ mod tests {
                 None,
                 Sample::DEFAULT_NAME,
                 OperationInfo {
-                    files: vec![OperationFile {
-                        file_path: "".to_string(),
-                        file_type: FileTypes::GenBank,
-                    }],
+                    files: vec![OperationFile::new("".to_string(), FileTypes::GenBank)],
                     description: "test".to_string(),
                 },
                 GenBankImportOptions::default(),
@@ -1071,10 +1068,10 @@ mod tests {
             None,
             Sample::DEFAULT_NAME,
             OperationInfo {
-                files: vec![OperationFile {
-                    file_path: path.to_str().unwrap().to_string(),
-                    file_type: FileTypes::GenBank,
-                }],
+                files: vec![OperationFile::new(
+                    path.to_str().unwrap().to_string(),
+                    FileTypes::GenBank,
+                )],
                 description: "test".to_string(),
             },
             GenBankImportOptions::default(),
@@ -1103,10 +1100,7 @@ mod tests {
             None,
             "new-sample",
             OperationInfo {
-                files: vec![OperationFile {
-                    file_path: "".to_string(),
-                    file_type: FileTypes::GenBank,
-                }],
+                files: vec![OperationFile::new("".to_string(), FileTypes::GenBank)],
                 description: "test".to_string(),
             },
             GenBankImportOptions::default(),
@@ -1267,10 +1261,7 @@ mod tests {
                 None,
                 Sample::DEFAULT_NAME,
                 OperationInfo {
-                    files: vec![OperationFile {
-                        file_path: "".to_string(),
-                        file_type: FileTypes::GenBank,
-                    }],
+                    files: vec![OperationFile::new("".to_string(), FileTypes::GenBank)],
                     description: "test".to_string(),
                 },
                 GenBankImportOptions::default(),
@@ -1306,10 +1297,7 @@ mod tests {
                 None,
                 Sample::DEFAULT_NAME,
                 OperationInfo {
-                    files: vec![OperationFile {
-                        file_path: "".to_string(),
-                        file_type: FileTypes::GenBank,
-                    }],
+                    files: vec![OperationFile::new("".to_string(), FileTypes::GenBank)],
                     description: "test".to_string(),
                 },
                 GenBankImportOptions::default(),
@@ -1362,10 +1350,7 @@ mod tests {
                 None,
                 Sample::DEFAULT_NAME,
                 OperationInfo {
-                    files: vec![OperationFile {
-                        file_path: "".to_string(),
-                        file_type: FileTypes::GenBank,
-                    }],
+                    files: vec![OperationFile::new("".to_string(), FileTypes::GenBank)],
                     description: "test".to_string(),
                 },
                 GenBankImportOptions::default(),
@@ -1424,10 +1409,7 @@ mod tests {
                 None,
                 Sample::DEFAULT_NAME,
                 OperationInfo {
-                    files: vec![OperationFile {
-                        file_path: "".to_string(),
-                        file_type: FileTypes::GenBank,
-                    }],
+                    files: vec![OperationFile::new("".to_string(), FileTypes::GenBank)],
                     description: "test".to_string(),
                 },
                 GenBankImportOptions::default(),
@@ -1484,10 +1466,7 @@ mod tests {
                 None,
                 Sample::DEFAULT_NAME,
                 OperationInfo {
-                    files: vec![OperationFile {
-                        file_path: "".to_string(),
-                        file_type: FileTypes::GenBank,
-                    }],
+                    files: vec![OperationFile::new("".to_string(), FileTypes::GenBank)],
                     description: "test".to_string(),
                 },
                 GenBankImportOptions::default(),

--- a/src/imports/gfa.rs
+++ b/src/imports/gfa.rs
@@ -451,10 +451,10 @@ pub fn import_gfa(
         context,
         &mut session,
         &OperationInfo {
-            files: vec![OperationFile::new(
-                gfa_path.to_str().unwrap().to_string(),
-                FileTypes::GFA,
-            )],
+            files: vec![
+                OperationFile::new(gfa_path.to_str().unwrap().to_string())
+                    .set_file_type(FileTypes::GFA),
+            ],
             description: "gfa_import".to_string(),
         },
         &format!("Imported GFA {path}", path = gfa_path.to_str().unwrap()),

--- a/src/imports/gfa.rs
+++ b/src/imports/gfa.rs
@@ -451,10 +451,10 @@ pub fn import_gfa(
         context,
         &mut session,
         &OperationInfo {
-            files: vec![OperationFile {
-                file_path: gfa_path.to_str().unwrap().to_string(),
-                file_type: FileTypes::GFA,
-            }],
+            files: vec![OperationFile::new(
+                gfa_path.to_str().unwrap().to_string(),
+                FileTypes::GFA,
+            )],
             description: "gfa_import".to_string(),
         },
         &format!("Imported GFA {path}", path = gfa_path.to_str().unwrap()),

--- a/src/imports/library.rs
+++ b/src/imports/library.rs
@@ -89,16 +89,10 @@ pub fn import_library(
 
     let mut files = vec![];
     if let Some(library_file_path) = library_file_path {
-        files.push(OperationFile::new(
-            library_file_path.to_string(),
-            FileTypes::CSV,
-        ));
+        files.push(OperationFile::new(library_file_path.to_string()).set_file_type(FileTypes::CSV));
     }
     if let Some(parts_file_path) = parts_file_path {
-        files.push(OperationFile::new(
-            parts_file_path.to_string(),
-            FileTypes::Fasta,
-        ));
+        files.push(OperationFile::new(parts_file_path.to_string()).set_file_type(FileTypes::Fasta));
     }
 
     let summary_str = format!("{library_name} created.\n");

--- a/src/imports/library.rs
+++ b/src/imports/library.rs
@@ -89,16 +89,16 @@ pub fn import_library(
 
     let mut files = vec![];
     if let Some(library_file_path) = library_file_path {
-        files.push(OperationFile {
-            file_path: library_file_path.to_string(),
-            file_type: FileTypes::CSV,
-        });
+        files.push(OperationFile::new(
+            library_file_path.to_string(),
+            FileTypes::CSV,
+        ));
     }
     if let Some(parts_file_path) = parts_file_path {
-        files.push(OperationFile {
-            file_path: parts_file_path.to_string(),
-            file_type: FileTypes::Fasta,
-        });
+        files.push(OperationFile::new(
+            parts_file_path.to_string(),
+            FileTypes::Fasta,
+        ));
     }
 
     let summary_str = format!("{library_name} created.\n");

--- a/src/main.rs
+++ b/src/main.rs
@@ -518,8 +518,7 @@ fn call_cli() -> Result<(), Box<dyn std::error::Error>> {
         }
         Some(Commands::PatchApply { patch }) => {
             let mut f = File::open(patch)?;
-            let patches = patch::load_patches(&mut f);
-            match patch::apply_patches(&db_context, &patches) {
+            match patch::apply_patch_archive(&db_context, &mut f) {
                 Ok(_) => {
                     println!("Patch applied");
                     Ok(())

--- a/src/operation_management.rs
+++ b/src/operation_management.rs
@@ -238,10 +238,10 @@ pub fn apply(
         &change_context,
         &mut session,
         &OperationInfo {
-            files: vec![OperationFile {
-                file_path: format!("{full_op_hash}/changeset"),
-                file_type: FileTypes::Changeset,
-            }],
+            files: vec![OperationFile::new(
+                format!("{full_op_hash}/changeset"),
+                FileTypes::Changeset,
+            )],
             description: "changeset_application".to_string(),
         },
         &format!("Applied changeset {full_op_hash}."),
@@ -545,8 +545,8 @@ fn apply_operations_to_remote(
         })?;
 
         for file_addition in &manifest_op.file_additions {
-            let src_path = local_base.join(&file_addition.file_path);
-            let dst_path = remote_base.join(&file_addition.file_path);
+            let src_path = local_base.join(&file_addition.file_addition.file_path);
+            let dst_path = remote_base.join(&file_addition.file_addition.file_path);
             // we do a conditional transfer because users may be making tmp files to just add nodes/etc. and don't actually
             // care about keeping those files around
             if src_path.exists() {
@@ -557,7 +557,7 @@ fn apply_operations_to_remote(
 
                 fs::copy(&src_path, &dst_path).map_err(|_| {
                     RemoteOperationError::FileTransferError(
-                        file_addition.file_path.clone(),
+                        file_addition.file_addition.file_path.clone(),
                         src_path.to_string_lossy().to_string(),
                         dst_path.to_string_lossy().to_string(),
                     )
@@ -636,11 +636,16 @@ fn apply_operations_to_remote(
                     let remote_file_addition = FileAddition::get_or_create(
                         remote_workspace,
                         remote_op_conn,
-                        &file_addition.file_path,
-                        file_addition.file_type,
+                        &file_addition.file_addition.file_path,
+                        file_addition.file_addition.file_type,
                         None,
                     )?;
-                    Operation::add_file(remote_op_conn, &operation.hash, &remote_file_addition.id)?;
+                    Operation::add_file(
+                        remote_op_conn,
+                        &operation.hash,
+                        &remote_file_addition.id,
+                        &file_addition.filename,
+                    )?;
                 }
                 for annotation_file in &manifest_op.annotation_file_additions {
                     let remote_file_addition = FileAddition::get_or_create(
@@ -1091,11 +1096,16 @@ fn ingest_manifest_operation(
                 let local_file_addition = FileAddition::get_or_create(
                     workspace,
                     operation_conn,
-                    &file_addition.file_path,
-                    file_addition.file_type,
+                    &file_addition.file_addition.file_path,
+                    file_addition.file_addition.file_type,
                     None,
                 )?;
-                Operation::add_file(operation_conn, &operation.hash, &local_file_addition.id)?;
+                Operation::add_file(
+                    operation_conn,
+                    &operation.hash,
+                    &local_file_addition.id,
+                    &file_addition.filename,
+                )?;
             }
             for annotation_file in &manifest_operation.annotation_file_additions {
                 let local_file_addition = FileAddition::get_or_create(
@@ -1196,15 +1206,15 @@ fn copy_operation_from_remote_fs(
     let remote_path = remote_workspace.repo_root()?;
     let repo_root = local_workspace.repo_root()?;
     for file_addition in &manifest_operation.file_additions {
-        let src_path = remote_path.join(&file_addition.file_path);
-        let dst_path = repo_root.join(&file_addition.file_path);
+        let src_path = remote_path.join(&file_addition.file_addition.file_path);
+        let dst_path = repo_root.join(&file_addition.file_addition.file_path);
         if src_path.exists() {
             if let Some(parent) = dst_path.parent() {
                 fs::create_dir_all(parent)?;
             }
             fs::copy(&src_path, &dst_path).map_err(|_| {
                 RemoteOperationError::FileTransferError(
-                    file_addition.file_path.clone(),
+                    file_addition.file_addition.file_path.clone(),
                     src_path.to_string_lossy().to_string(),
                     dst_path.to_string_lossy().to_string(),
                 )
@@ -2349,10 +2359,7 @@ mod tests {
 
                 let file_path = format!("test_file_{i}.fa");
                 let op_info = OperationInfo {
-                    files: vec![OperationFile {
-                        file_path: file_path.clone(),
-                        file_type: FileTypes::Fasta,
-                    }],
+                    files: vec![OperationFile::new(file_path.clone(), FileTypes::Fasta)],
                     description: format!("Test operation {i}"),
                 };
 

--- a/src/operation_management.rs
+++ b/src/operation_management.rs
@@ -853,8 +853,7 @@ pub fn push(context: &DbContext, remote: Option<&str>) -> Result<(), RemoteOpera
                             form = form
                                 .file(
                                     "assets",
-                                    FilePath::new(".gen")
-                                        .join("assets")
+                                    FilePath::new(&workspace.asset_dir()?)
                                         .join(op_file.hashed_filename()),
                                 )
                                 .unwrap();
@@ -865,8 +864,7 @@ pub fn push(context: &DbContext, remote: Option<&str>) -> Result<(), RemoteOpera
                             form = form
                                 .file(
                                     "assets",
-                                    FilePath::new(".gen")
-                                        .join("assets")
+                                    FilePath::new(&workspace.asset_dir()?)
                                         .join(annotation_file.file_addition.hashed_filename()),
                                 )
                                 .unwrap();
@@ -876,8 +874,7 @@ pub fn push(context: &DbContext, remote: Option<&str>) -> Result<(), RemoteOpera
                                 form = form
                                     .file(
                                         "assets",
-                                        FilePath::new(".gen")
-                                            .join("assets")
+                                        FilePath::new(&workspace.asset_dir()?)
                                             .join(index_file_addition.clone().hashed_filename()),
                                     )
                                     .unwrap();
@@ -1312,12 +1309,10 @@ fn download_remote_operation_assets(
         "dependencies",
     )?;
 
-    let gen_dir = workspace
-        .find_gen_dir()
-        .ok_or(ConfigError::GenDirectoryNotFound)?;
-    let gen_path = FilePath::new(&gen_dir);
+    let asset_dir = workspace.asset_dir()?;
+    let gen_path = FilePath::new(&asset_dir);
     for file in asset_response.files {
-        let destination = gen_path.join("assets").join(&file.asset_path);
+        let destination = gen_path.join(&file.asset_path);
         let user_destination = repo_root.join(&file.file_path);
         if !destination.exists() {
             download_binary(

--- a/src/operation_management.rs
+++ b/src/operation_management.rs
@@ -238,10 +238,10 @@ pub fn apply(
         &change_context,
         &mut session,
         &OperationInfo {
-            files: vec![OperationFile::new(
-                format!("{full_op_hash}/changeset"),
-                FileTypes::Changeset,
-            )],
+            files: vec![
+                OperationFile::new(format!("{full_op_hash}/changeset"))
+                    .set_file_type(FileTypes::Changeset),
+            ],
             description: "changeset_application".to_string(),
         },
         &format!("Applied changeset {full_op_hash}."),
@@ -2354,7 +2354,9 @@ mod tests {
 
                 let file_path = format!("test_file_{i}.fa");
                 let op_info = OperationInfo {
-                    files: vec![OperationFile::new(file_path.clone(), FileTypes::Fasta)],
+                    files: vec![
+                        OperationFile::new(file_path.clone()).set_file_type(FileTypes::Fasta),
+                    ],
                     description: format!("Test operation {i}"),
                 };
 

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -1,7 +1,14 @@
-use std::io::{Read, Write};
+use std::{
+    fs,
+    io::{Read, Write},
+};
 
 use flate2::{Compression, read::GzDecoder, write::GzEncoder};
-use gen_core::{HashId, errors::ConnectionError, traits::Capnp};
+use gen_core::{
+    HashId,
+    errors::{ConfigError, ConnectionError},
+    traits::Capnp,
+};
 use gen_models::{
     changesets::{DatabaseChangeset, apply_changeset},
     db::DbContext,
@@ -15,14 +22,81 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::{
-    gen_schema_capnp::{operation_patch, operation_patches},
+    gen_schema_capnp::{operation_patch, operation_patches, patch_file},
     get_connection,
 };
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
+struct PatchFile {
+    file: FileAddition,
+    contents: Vec<u8>,
+}
+
+impl PatchFile {
+    fn from_file_addition(
+        context: &DbContext,
+        file: FileAddition,
+    ) -> Result<Self, CreatePatchError> {
+        if file.file_path.is_empty() {
+            return Ok(Self {
+                file,
+                contents: Vec::new(),
+            });
+        }
+
+        let asset_path = context
+            .workspace()
+            .asset_dir()?
+            .join(file.clone().hashed_filename());
+        let contents = fs::read(asset_path)?;
+
+        Ok(Self { file, contents })
+    }
+
+    fn restore_into_asset_dir(&self, context: &DbContext) -> Result<(), PatchError> {
+        if self.file.file_path.is_empty() || self.contents.is_empty() {
+            return Ok(());
+        }
+
+        let asset_dir = context
+            .workspace()
+            .asset_dir()
+            .map_err(ConnectionError::from)?;
+        fs::create_dir_all(&asset_dir).map_err(|err| PatchError::Io(err.to_string()))?;
+
+        let asset_path = asset_dir.join(self.file.clone().hashed_filename());
+        if !asset_path.exists() {
+            fs::write(asset_path, &self.contents).map_err(|err| PatchError::Io(err.to_string()))?;
+        }
+
+        Ok(())
+    }
+}
+
+impl<'a> Capnp<'a> for PatchFile {
+    type Builder = patch_file::Builder<'a>;
+    type Reader = patch_file::Reader<'a>;
+
+    fn write_capnp(&self, builder: &mut Self::Builder) {
+        self.file.write_capnp(&mut builder.reborrow().init_file());
+        builder.set_contents(&self.contents);
+    }
+
+    fn read_capnp(reader: Self::Reader) -> Self {
+        Self {
+            file: FileAddition::read_capnp(reader.get_file().expect("should have file")),
+            contents: reader
+                .get_contents()
+                .expect("should have contents")
+                .to_vec(),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct OperationPatch {
     pub operation: Operation,
-    files: Vec<FileAddition>,
+    files: Vec<PatchFile>,
     summary: OperationSummary,
     dependencies: DependencyModels,
     changeset: DatabaseChangeset,
@@ -58,7 +132,7 @@ impl<'a> Capnp<'a> for OperationPatch {
         let files_reader = reader.get_files().expect("should have files");
         let mut files = Vec::with_capacity(files_reader.len() as usize);
         for file_reader in files_reader.iter() {
-            files.push(FileAddition::read_capnp(file_reader));
+            files.push(PatchFile::read_capnp(file_reader));
         }
 
         let summary =
@@ -114,6 +188,8 @@ pub enum PatchError {
     ChangesetError(#[from] ChangesetError),
     #[error("Connection Error: {0}")]
     ConnectionError(#[from] ConnectionError),
+    #[error("I/O error: {0}")]
+    Io(String),
     #[error("SQL Error: {0}")]
     SQLError(String),
     #[error("SQLite Error: {0}")]
@@ -132,6 +208,8 @@ pub enum CreatePatchError {
     SqliteError(#[from] SQLError),
     #[error("I/O Error: {0}")]
     Io(#[from] std::io::Error),
+    #[error("Config error: {0}")]
+    Config(#[from] ConfigError),
     #[error("Cap'n Proto error: {0}")]
     Capnp(#[from] capnp::Error),
 }
@@ -151,9 +229,13 @@ where
         let operation = Operation::get_by_id(op_conn, hash)
             .ok_or_else(|| CreatePatchError::OperationNotFound(*hash))?;
         println!("Creating patch for Operation {id}", id = operation.hash);
+        let files = FileAddition::get_files_for_operation(op_conn, &operation.hash)
+            .into_iter()
+            .map(|file| PatchFile::from_file_addition(context, file))
+            .collect::<Result<Vec<_>, _>>()?;
         patches.push(OperationPatch {
             operation: operation.clone(),
-            files: FileAddition::get_files_for_operation(op_conn, &operation.hash),
+            files,
             summary: OperationSummary::get(
                 op_conn,
                 "select * from operation_summaries where operation_hash = ?1",
@@ -208,6 +290,10 @@ where
 pub fn apply_patches(context: &DbContext, patches: &[OperationPatch]) -> Result<(), PatchError> {
     let workspace = context.workspace();
     for patch in patches.iter() {
+        for file in &patch.files {
+            file.restore_into_asset_dir(context)?;
+        }
+
         let changeset = &patch.changeset;
         let dependencies = &patch.dependencies;
         let mut change_context = context.clone();
@@ -237,11 +323,11 @@ pub fn apply_patches(context: &DbContext, patches: &[OperationPatch]) -> Result<
                 files: patch
                     .files
                     .iter()
-                    .map(|fa| OperationFile {
-                        filename: OperationFile::new(fa.file_path.clone()).filename,
-                        file_path: fa.file_path.clone(),
-                        file_type: fa.file_type,
-                        checksum_override: Some(fa.checksum),
+                    .map(|patch_file| OperationFile {
+                        filename: OperationFile::new(patch_file.file.file_path.clone()).filename,
+                        file_path: patch_file.file.file_path.clone(),
+                        file_type: patch_file.file.file_type,
+                        checksum_override: Some(patch_file.file.checksum),
                     })
                     .collect::<Vec<_>>(),
                 description: "unknown".to_string(),
@@ -255,13 +341,14 @@ pub fn apply_patches(context: &DbContext, patches: &[OperationPatch]) -> Result<
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
+    use std::{fs, path::PathBuf};
 
     use gen_models::{
         block_group::BlockGroup,
         operations::{Branch, OperationState},
         sample::Sample,
     };
+    use tempfile::Builder;
 
     use super::*;
     use crate::{
@@ -442,6 +529,8 @@ mod tests {
         // Verify we got the same patches back
         assert_eq!(loaded_patches[0].operation, op_1);
         assert_eq!(loaded_patches[1].operation, op_2);
+        assert!(!loaded_patches[0].files.is_empty());
+        assert!(!loaded_patches[1].files.is_empty());
     }
 
     #[test]
@@ -484,5 +573,67 @@ mod tests {
         )
         .unwrap();
         apply_patches(&fresh_context, &patches).unwrap();
+    }
+
+    #[test]
+    fn test_patch_restores_external_assets_into_target_workspace() {
+        let source_context = setup_gen_on_disk();
+        track_database(
+            source_context.graph().conn(),
+            source_context.operations().conn(),
+        )
+        .unwrap();
+
+        let fasta_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("fixtures/simple.fa");
+        let fixture_vcf_path =
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("fixtures/simple.vcf");
+        let collection = "test".to_string();
+        import_fasta(
+            &source_context,
+            &fasta_path.to_str().unwrap().to_string(),
+            &collection,
+            Sample::DEFAULT_NAME,
+            false,
+        )
+        .unwrap();
+
+        let external_file = Builder::new().suffix(".vcf").tempfile().unwrap();
+        fs::copy(&fixture_vcf_path, external_file.path()).unwrap();
+
+        let operation = update_with_vcf(
+            &source_context,
+            &external_file.path().to_string_lossy().to_string(),
+            &collection,
+            "".to_string(),
+            None,
+            vec![Sample::DEFAULT_NAME.to_string()],
+            false,
+        )
+        .unwrap();
+
+        let mut write_stream: Vec<u8> = Vec::new();
+        create_patch(&source_context, &[operation.hash], &mut write_stream).unwrap();
+        let patches = load_patches(&write_stream[..]);
+
+        let target_context = setup_gen_on_disk();
+        track_database(
+            target_context.graph().conn(),
+            target_context.operations().conn(),
+        )
+        .unwrap();
+
+        apply_patches(&target_context, &patches).unwrap();
+
+        let restored_file = &patches[0].files[0].file;
+        let restored_asset_path = target_context
+            .workspace()
+            .asset_dir()
+            .unwrap()
+            .join(restored_file.clone().hashed_filename());
+        assert!(restored_asset_path.exists());
+        assert_eq!(
+            fs::read(restored_asset_path).unwrap(),
+            fs::read(external_file.path()).unwrap()
+        );
     }
 }

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -237,7 +237,12 @@ pub fn apply_patches(context: &DbContext, patches: &[OperationPatch]) -> Result<
                 files: patch
                     .files
                     .iter()
-                    .map(|fa| OperationFile::new(fa.file_path.clone(), fa.file_type))
+                    .map(|fa| OperationFile {
+                        filename: OperationFile::new(fa.file_path.clone(), fa.file_type).filename,
+                        file_path: fa.file_path.clone(),
+                        file_type: fa.file_type,
+                        checksum_override: Some(fa.checksum),
+                    })
                     .collect::<Vec<_>>(),
                 description: "unknown".to_string(),
             },

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -237,10 +237,7 @@ pub fn apply_patches(context: &DbContext, patches: &[OperationPatch]) -> Result<
                 files: patch
                     .files
                     .iter()
-                    .map(|fa| OperationFile {
-                        file_path: fa.file_path.clone(),
-                        file_type: fa.file_type,
-                    })
+                    .map(|fa| OperationFile::new(fa.file_path.clone(), fa.file_type))
                     .collect::<Vec<_>>(),
                 description: "unknown".to_string(),
             },

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -1,9 +1,8 @@
 use std::{
-    fs,
-    io::{Read, Write},
+    fs::{self, File},
+    io::{Read, Seek, Write},
 };
 
-use flate2::{Compression, read::GzDecoder, write::GzEncoder};
 use gen_core::{
     HashId,
     errors::{ConfigError, ConnectionError},
@@ -13,6 +12,7 @@ use gen_models::{
     changesets::{DatabaseChangeset, apply_changeset},
     db::DbContext,
     errors::{ChangesetError, OperationError},
+    file_types::FileTypes,
     operations::{FileAddition, Operation, OperationFile, OperationInfo, OperationSummary},
     session_operations::{DependencyModels, end_operation, start_operation},
     traits::Query,
@@ -20,41 +20,58 @@ use gen_models::{
 use rusqlite::{Error as SQLError, params, types::Value};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+use zip::{CompressionMethod, ZipArchive, ZipWriter, result::ZipError, write::SimpleFileOptions};
 
 use crate::{
     gen_schema_capnp::{operation_patch, operation_patches, patch_file},
     get_connection,
 };
 
+const MANIFEST_ENTRY: &str = "manifest.capnp";
+
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 struct PatchFile {
     file: FileAddition,
-    contents: Vec<u8>,
+    archive_path: String,
 }
 
 impl PatchFile {
-    fn from_file_addition(
-        context: &DbContext,
-        file: FileAddition,
-    ) -> Result<Self, CreatePatchError> {
+    fn asset_entry_name(checksum: HashId, file_type: FileTypes) -> String {
+        format!("assets/{checksum}.{}", FileTypes::suffix(file_type))
+    }
+
+    fn from_file_addition(file: FileAddition) -> Result<Self, CreatePatchError> {
         if file.file_path.is_empty() {
             return Ok(Self {
+                archive_path: String::new(),
                 file,
-                contents: Vec::new(),
             });
         }
 
-        let asset_path = context
-            .workspace()
-            .asset_dir()?
-            .join(file.clone().hashed_filename());
-        let contents = fs::read(asset_path)?;
+        let archive_path = Self::asset_entry_name(file.checksum, file.file_type);
 
-        Ok(Self { file, contents })
+        Ok(Self { file, archive_path })
     }
 
-    fn restore_into_asset_dir(&self, context: &DbContext) -> Result<(), PatchError> {
-        if self.file.file_path.is_empty() || self.contents.is_empty() {
+    fn source_asset_path(
+        &self,
+        context: &DbContext,
+    ) -> Result<std::path::PathBuf, ConnectionError> {
+        Ok(context
+            .workspace()
+            .asset_dir()?
+            .join(self.file.clone().hashed_filename()))
+    }
+
+    fn restore_from_archive<R>(
+        &self,
+        context: &DbContext,
+        archive: &mut ZipArchive<R>,
+    ) -> Result<(), PatchError>
+    where
+        R: Read + Seek,
+    {
+        if self.file.file_path.is_empty() || self.archive_path.is_empty() {
             return Ok(());
         }
 
@@ -65,10 +82,15 @@ impl PatchFile {
         fs::create_dir_all(&asset_dir).map_err(|err| PatchError::Io(err.to_string()))?;
 
         let asset_path = asset_dir.join(self.file.clone().hashed_filename());
-        if !asset_path.exists() {
-            fs::write(asset_path, &self.contents).map_err(|err| PatchError::Io(err.to_string()))?;
+        if asset_path.exists() {
+            return Ok(());
         }
 
+        let mut zip_file = archive.by_name(&self.archive_path)?;
+        let mut asset_file =
+            File::create(asset_path).map_err(|err| PatchError::Io(err.to_string()))?;
+        std::io::copy(&mut zip_file, &mut asset_file)
+            .map_err(|err| PatchError::Io(err.to_string()))?;
         Ok(())
     }
 }
@@ -79,16 +101,17 @@ impl<'a> Capnp<'a> for PatchFile {
 
     fn write_capnp(&self, builder: &mut Self::Builder) {
         self.file.write_capnp(&mut builder.reborrow().init_file());
-        builder.set_contents(&self.contents);
+        builder.set_archive_path(&self.archive_path);
     }
 
     fn read_capnp(reader: Self::Reader) -> Self {
         Self {
             file: FileAddition::read_capnp(reader.get_file().expect("should have file")),
-            contents: reader
-                .get_contents()
-                .expect("should have contents")
-                .to_vec(),
+            archive_path: reader
+                .get_archive_path()
+                .expect("should have archive path")
+                .to_string()
+                .unwrap(),
         }
     }
 }
@@ -198,6 +221,14 @@ pub enum PatchError {
     DeserializationError(String),
     #[error("Operation Error: {0}")]
     OperationError(#[from] OperationError),
+    #[error("Zip Error: {0}")]
+    Zip(String),
+}
+
+impl From<ZipError> for PatchError {
+    fn from(value: ZipError) -> Self {
+        PatchError::Zip(value.to_string())
+    }
 }
 
 #[derive(Debug, Error)]
@@ -210,8 +241,95 @@ pub enum CreatePatchError {
     Io(#[from] std::io::Error),
     #[error("Config error: {0}")]
     Config(#[from] ConfigError),
+    #[error("Connection error: {0}")]
+    Connection(#[from] ConnectionError),
     #[error("Cap'n Proto error: {0}")]
     Capnp(#[from] capnp::Error),
+    #[error("Zip error: {0}")]
+    Zip(#[from] ZipError),
+}
+
+fn serialize_operation_patches(
+    operation_patches: &OperationPatches,
+) -> Result<Vec<u8>, CreatePatchError> {
+    let mut message = ::capnp::message::Builder::new_default();
+    let mut root = message.init_root::<operation_patches::Builder>();
+    operation_patches.write_capnp(&mut root);
+
+    let mut buffer = Vec::new();
+    ::capnp::serialize_packed::write_message(&mut buffer, &message)?;
+    Ok(buffer)
+}
+
+fn read_operation_patches<R>(archive: &mut ZipArchive<R>) -> Result<OperationPatches, PatchError>
+where
+    R: Read + Seek,
+{
+    let mut operation_patches_file = archive.by_name(MANIFEST_ENTRY)?;
+    let mut buffer = Vec::new();
+    operation_patches_file
+        .read_to_end(&mut buffer)
+        .map_err(|err| PatchError::Io(err.to_string()))?;
+    drop(operation_patches_file);
+
+    let message = ::capnp::serialize_packed::read_message(
+        &mut buffer.as_slice(),
+        ::capnp::message::ReaderOptions::new(),
+    )
+    .map_err(|err| PatchError::DeserializationError(err.to_string()))?;
+
+    let root = message
+        .get_root::<operation_patches::Reader>()
+        .map_err(|err| PatchError::DeserializationError(err.to_string()))?;
+
+    Ok(OperationPatches::read_capnp(root))
+}
+
+fn apply_patch(context: &DbContext, patch: &OperationPatch) -> Result<(), PatchError> {
+    let workspace = context.workspace();
+    let changeset = &patch.changeset;
+    let dependencies = &patch.dependencies;
+    let mut change_context = context.clone();
+    let repo_root = workspace.repo_root().map_err(ConnectionError::from)?;
+    let data_db_path = repo_root.join(&changeset.db_path);
+    let graph_conn = get_connection(&data_db_path)?;
+    change_context.set_graph(graph_conn);
+
+    let conn = change_context.graph().conn();
+    let mut session = start_operation(conn);
+
+    conn.execute("BEGIN TRANSACTION", [])?;
+    match apply_changeset(conn, &changeset.changes, dependencies) {
+        Ok(_) => {
+            conn.execute("END TRANSACTION", [])?;
+        }
+        Err(e) => {
+            conn.execute("ROLLBACK TRANSACTION;", [])?;
+            return Err(PatchError::ChangesetError(e));
+        }
+    }
+
+    end_operation(
+        &change_context,
+        &mut session,
+        &OperationInfo {
+            files: patch
+                .files
+                .iter()
+                .map(|patch_file| OperationFile {
+                    filename: OperationFile::new(patch_file.file.file_path.clone()).filename,
+                    file_path: patch_file.file.file_path.clone(),
+                    file_type: patch_file.file.file_type,
+                    checksum_override: Some(patch_file.file.checksum),
+                })
+                .collect::<Vec<_>>(),
+            description: "unknown".to_string(),
+        },
+        &patch.summary.summary,
+        None,
+    )?;
+
+    Ok(())
 }
 
 pub fn create_patch<W>(
@@ -220,19 +338,21 @@ pub fn create_patch<W>(
     write_stream: &mut W,
 ) -> Result<(), CreatePatchError>
 where
-    W: Write,
+    W: Write + Seek,
 {
     let op_conn = context.operations().conn();
     let workspace = context.workspace();
     let mut patches = vec![];
-    for hash in operations.iter() {
+    for hash in operations {
         let operation = Operation::get_by_id(op_conn, hash)
             .ok_or_else(|| CreatePatchError::OperationNotFound(*hash))?;
         println!("Creating patch for Operation {id}", id = operation.hash);
+
         let files = FileAddition::get_files_for_operation(op_conn, &operation.hash)
             .into_iter()
-            .map(|file| PatchFile::from_file_addition(context, file))
+            .map(PatchFile::from_file_addition)
             .collect::<Result<Vec<_>, _>>()?;
+
         patches.push(OperationPatch {
             operation: operation.clone(),
             files,
@@ -243,109 +363,76 @@ where
             )?,
             dependencies: operation.get_changeset_dependencies(workspace),
             changeset: operation.get_changeset(workspace),
-        })
+        });
     }
 
     let operation_patches = OperationPatches { patches };
+    let manifest_bytes = serialize_operation_patches(&operation_patches)?;
 
-    // Serialize using Cap'n Proto
-    let mut message = ::capnp::message::Builder::new_default();
-    let mut root = message.init_root::<operation_patches::Builder>();
-    operation_patches.write_capnp(&mut root);
+    let manifest_options =
+        SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
+    let asset_options = SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
 
-    // Write the packed message to a buffer
-    let mut capnp_buffer = Vec::new();
-    ::capnp::serialize_packed::write_message(&mut capnp_buffer, &message)?;
+    let mut archive = ZipWriter::new(write_stream);
+    archive.start_file(MANIFEST_ENTRY, manifest_options)?;
+    archive.write_all(&manifest_bytes)?;
 
-    // Compress the Cap'n Proto data
-    let mut e = GzEncoder::new(Vec::new(), Compression::default());
-    e.write_all(&capnp_buffer)?;
-    let compressed = e.finish()?;
-    write_stream.write_all(&compressed)?;
+    for patch in &operation_patches.patches {
+        for file in &patch.files {
+            if file.archive_path.is_empty() {
+                continue;
+            }
 
+            archive.start_file(&file.archive_path, asset_options)?;
+            let source_path = file.source_asset_path(context)?;
+            let mut source_file = File::open(source_path)?;
+            std::io::copy(&mut source_file, &mut archive)?;
+        }
+    }
+
+    archive.finish()?;
     Ok(())
 }
 
 pub fn load_patches<R>(reader: R) -> Vec<OperationPatch>
 where
-    R: Read,
+    R: Read + Seek,
 {
-    let mut d = GzDecoder::new(reader);
-    let mut capnp_buffer = Vec::new();
-    d.read_to_end(&mut capnp_buffer).unwrap();
+    let mut archive = ZipArchive::new(reader).unwrap();
+    read_operation_patches(&mut archive).unwrap().patches
+}
 
-    // Deserialize from Cap'n Proto
-    let message = ::capnp::serialize_packed::read_message(
-        &mut capnp_buffer.as_slice(),
-        ::capnp::message::ReaderOptions::new(),
-    )
-    .unwrap();
+pub fn apply_patch_archive<R>(context: &DbContext, reader: R) -> Result<(), PatchError>
+where
+    R: Read + Seek,
+{
+    let mut archive = ZipArchive::new(reader)?;
+    let operation_patches = read_operation_patches(&mut archive)?;
 
-    let root = message.get_root::<operation_patches::Reader>().unwrap();
-    let operation_patches = OperationPatches::read_capnp(root);
+    for patch in &operation_patches.patches {
+        for file in &patch.files {
+            file.restore_from_archive(context, &mut archive)?;
+        }
+        apply_patch(context, patch)?;
+    }
 
-    operation_patches.patches
+    Ok(())
 }
 
 pub fn apply_patches(context: &DbContext, patches: &[OperationPatch]) -> Result<(), PatchError> {
-    let workspace = context.workspace();
-    for patch in patches.iter() {
-        for file in &patch.files {
-            file.restore_into_asset_dir(context)?;
-        }
-
-        let changeset = &patch.changeset;
-        let dependencies = &patch.dependencies;
-        let mut change_context = context.clone();
-        let repo_root = workspace.repo_root().map_err(ConnectionError::from)?;
-        let data_db_path = repo_root.join(&changeset.db_path);
-        let graph_conn = get_connection(&data_db_path)?;
-        change_context.set_graph(graph_conn);
-
-        let conn = change_context.graph().conn();
-        let mut session = start_operation(conn);
-
-        conn.execute("BEGIN TRANSACTION", [])?;
-        match apply_changeset(conn, &changeset.changes, dependencies) {
-            Ok(_) => {
-                conn.execute("END TRANSACTION", [])?;
-            }
-            Err(e) => {
-                conn.execute("ROLLBACK TRANSACTION;", [])?;
-                return Err(PatchError::ChangesetError(e));
-            }
-        }
-
-        end_operation(
-            &change_context,
-            &mut session,
-            &OperationInfo {
-                files: patch
-                    .files
-                    .iter()
-                    .map(|patch_file| OperationFile {
-                        filename: OperationFile::new(patch_file.file.file_path.clone()).filename,
-                        file_path: patch_file.file.file_path.clone(),
-                        file_type: patch_file.file.file_type,
-                        checksum_override: Some(patch_file.file.checksum),
-                    })
-                    .collect::<Vec<_>>(),
-                description: "unknown".to_string(),
-            },
-            &patch.summary.summary,
-            None,
-        )?;
+    for patch in patches {
+        apply_patch(context, patch)?;
     }
     Ok(())
 }
 
 #[cfg(test)]
 mod tests {
-    use std::{fs, path::PathBuf};
+    use std::{fs, io::Cursor, path::PathBuf};
 
     use gen_models::{
         block_group::BlockGroup,
-        operations::{Branch, OperationState},
+        operations::{Branch, FileAddition, OperationState},
         sample::Sample,
     };
     use tempfile::Builder;
@@ -387,9 +474,10 @@ mod tests {
             false,
         )
         .unwrap();
-        let mut write_stream: Vec<u8> = Vec::new();
+        let mut write_stream = Cursor::new(Vec::new());
         create_patch(&context, &[op_1.hash, op_2.hash], &mut write_stream).unwrap();
-        load_patches(&write_stream[..]);
+        write_stream.set_position(0);
+        load_patches(&mut write_stream);
     }
 
     #[test]
@@ -420,16 +508,16 @@ mod tests {
             false,
         )
         .unwrap();
-        let mut write_stream: Vec<u8> = Vec::new();
+        let mut write_stream = Cursor::new(Vec::new());
         create_patch(&source_context, &[op_1.hash, op_2.hash], &mut write_stream).unwrap();
-        let patches = load_patches(&write_stream[..]);
+        write_stream.set_position(0);
 
         let target_context = setup_gen_on_disk();
         let target_conn = target_context.graph().conn();
         let target_operation_conn = target_context.operations().conn();
         track_database(target_conn, target_operation_conn).unwrap();
 
-        apply_patches(&target_context, &patches).unwrap();
+        apply_patch_archive(&target_context, &mut write_stream).unwrap();
         for bg in BlockGroup::query(conn, "select * from block_groups;", params![]).iter() {
             let seqs = BlockGroup::get_all_sequences(conn, &bg.id, false);
             assert!(!seqs.is_empty());
@@ -472,18 +560,18 @@ mod tests {
             false,
         )
         .unwrap();
-        let mut write_stream: Vec<u8> = Vec::new();
+        let mut write_stream = Cursor::new(Vec::new());
         create_patch(&context, &[op_2.hash], &mut write_stream).unwrap();
 
         operation_management::checkout(&context, &Some("main".to_string()), None).unwrap();
-        let patches = load_patches(&write_stream[..]);
+        write_stream.set_position(0);
 
-        apply_patches(&context, &patches).unwrap();
+        apply_patch_archive(&context, &mut write_stream).unwrap();
         let branch_ops = Branch::get_operations(operation_conn, main_branch.id);
         assert_eq!(branch_ops.len(), 2);
 
-        // ensure if we apply the operation again it'll be a no-op
-        let res = apply_patches(&context, &patches);
+        write_stream.set_position(0);
+        let res = apply_patch_archive(&context, &mut write_stream);
         assert_eq!(
             res,
             Err(PatchError::OperationError(OperationError::NoChanges))
@@ -521,12 +609,11 @@ mod tests {
         )
         .unwrap();
 
-        // Test Cap'n Proto serialization/deserialization
-        let mut write_stream: Vec<u8> = Vec::new();
+        let mut write_stream = Cursor::new(Vec::new());
         create_patch(&context, &[op_1.hash, op_2.hash], &mut write_stream).unwrap();
-        let loaded_patches = load_patches(&write_stream[..]);
+        write_stream.set_position(0);
+        let loaded_patches = load_patches(&mut write_stream);
 
-        // Verify we got the same patches back
         assert_eq!(loaded_patches[0].operation, op_1);
         assert_eq!(loaded_patches[1].operation, op_2);
         assert!(!loaded_patches[0].files.is_empty());
@@ -562,17 +649,17 @@ mod tests {
             false,
         )
         .unwrap();
-        let mut write_stream: Vec<u8> = Vec::new();
+        let mut write_stream = Cursor::new(Vec::new());
         create_patch(&context, &[op_2.hash], &mut write_stream).unwrap();
 
-        let patches = load_patches(&write_stream[..]);
         let fresh_context = setup_gen_on_disk();
         track_database(
             fresh_context.graph().conn(),
             fresh_context.operations().conn(),
         )
         .unwrap();
-        apply_patches(&fresh_context, &patches).unwrap();
+        write_stream.set_position(0);
+        apply_patch_archive(&fresh_context, &mut write_stream).unwrap();
     }
 
     #[test]
@@ -611,9 +698,18 @@ mod tests {
         )
         .unwrap();
 
-        let mut write_stream: Vec<u8> = Vec::new();
+        let expected_file = FileAddition::get_files_for_operation(
+            source_context.operations().conn(),
+            &operation.hash,
+        )
+        .into_iter()
+        .find(|file| file.file_type == FileTypes::VCF)
+        .unwrap();
+
+        let mut write_stream = Cursor::new(Vec::new());
         create_patch(&source_context, &[operation.hash], &mut write_stream).unwrap();
-        let patches = load_patches(&write_stream[..]);
+        write_stream.set_position(0);
+        let patches = load_patches(&mut write_stream);
 
         let target_context = setup_gen_on_disk();
         track_database(
@@ -622,9 +718,17 @@ mod tests {
         )
         .unwrap();
 
-        apply_patches(&target_context, &patches).unwrap();
+        write_stream.set_position(0);
+        apply_patch_archive(&target_context, &mut write_stream).unwrap();
 
-        let restored_file = &patches[0].files[0].file;
+        let restored_file = &patches[0]
+            .files
+            .iter()
+            .find(|patch_file| patch_file.file.file_type == FileTypes::VCF)
+            .unwrap()
+            .file;
+        assert_eq!(restored_file.checksum, expected_file.checksum);
+
         let restored_asset_path = target_context
             .workspace()
             .asset_dir()

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -238,7 +238,7 @@ pub fn apply_patches(context: &DbContext, patches: &[OperationPatch]) -> Result<
                     .files
                     .iter()
                     .map(|fa| OperationFile {
-                        filename: OperationFile::new(fa.file_path.clone(), fa.file_type).filename,
+                        filename: OperationFile::new(fa.file_path.clone()).filename,
                         file_path: fa.file_path.clone(),
                         file_type: fa.file_type,
                         checksum_override: Some(fa.checksum),

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -328,10 +328,7 @@ pub fn create_operation(
         context,
         &mut session,
         &OperationInfo {
-            files: vec![OperationFile {
-                file_path: file_path.to_string(),
-                file_type,
-            }],
+            files: vec![OperationFile::new(file_path.to_string(), file_type)],
             description: description.to_string(),
         },
         "test operation",

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -328,7 +328,7 @@ pub fn create_operation(
         context,
         &mut session,
         &OperationInfo {
-            files: vec![OperationFile::new(file_path.to_string(), file_type)],
+            files: vec![OperationFile::new(file_path.to_string()).set_file_type(file_type)],
             description: description.to_string(),
         },
         "test operation",

--- a/src/updates/fasta.rs
+++ b/src/updates/fasta.rs
@@ -199,10 +199,10 @@ pub fn update_with_fasta(
         context,
         &mut session,
         &OperationInfo {
-            files: vec![OperationFile {
-                file_path: fasta_file_path.to_string(),
-                file_type: FileTypes::Fasta,
-            }],
+            files: vec![OperationFile::new(
+                fasta_file_path.to_string(),
+                FileTypes::Fasta,
+            )],
             description: "fasta_update".to_string(),
         },
         &summary_str,

--- a/src/updates/fasta.rs
+++ b/src/updates/fasta.rs
@@ -199,10 +199,9 @@ pub fn update_with_fasta(
         context,
         &mut session,
         &OperationInfo {
-            files: vec![OperationFile::new(
-                fasta_file_path.to_string(),
-                FileTypes::Fasta,
-            )],
+            files: vec![
+                OperationFile::new(fasta_file_path.to_string()).set_file_type(FileTypes::Fasta),
+            ],
             description: "fasta_update".to_string(),
         },
         &summary_str,

--- a/src/updates/gaf.rs
+++ b/src/updates/gaf.rs
@@ -405,10 +405,10 @@ where
         context,
         &mut session,
         &OperationInfo {
-            files: vec![OperationFile::new(
-                gaf_path.as_ref().to_str().unwrap().to_string(),
-                FileTypes::GAF,
-            )],
+            files: vec![
+                OperationFile::new(gaf_path.as_ref().to_str().unwrap().to_string())
+                    .set_file_type(FileTypes::GAF),
+            ],
             description: "insert_via_gaf".to_string(),
         },
         &format!("{change_count} updates."),

--- a/src/updates/gaf.rs
+++ b/src/updates/gaf.rs
@@ -405,10 +405,10 @@ where
         context,
         &mut session,
         &OperationInfo {
-            files: vec![OperationFile {
-                file_path: gaf_path.as_ref().to_str().unwrap().to_string(),
-                file_type: FileTypes::GAF,
-            }],
+            files: vec![OperationFile::new(
+                gaf_path.as_ref().to_str().unwrap().to_string(),
+                FileTypes::GAF,
+            )],
             description: "insert_via_gaf".to_string(),
         },
         &format!("{change_count} updates."),

--- a/src/updates/genbank.rs
+++ b/src/updates/genbank.rs
@@ -278,10 +278,7 @@ mod tests {
                 Sample::DEFAULT_NAME,
                 false,
                 &OperationInfo {
-                    files: vec![OperationFile {
-                        file_path: "".to_string(),
-                        file_type: FileTypes::GenBank,
-                    }],
+                    files: vec![OperationFile::new("".to_string(), FileTypes::GenBank)],
                     description: "test".to_string(),
                 }
             ),
@@ -310,10 +307,10 @@ mod tests {
             Sample::DEFAULT_NAME,
             true,
             &OperationInfo {
-                files: vec![OperationFile {
-                    file_path: path.to_str().unwrap().to_string(),
-                    file_type: FileTypes::GenBank,
-                }],
+                files: vec![OperationFile::new(
+                    path.to_str().unwrap().to_string(),
+                    FileTypes::GenBank,
+                )],
                 description: "test".to_string(),
             },
         )
@@ -353,10 +350,7 @@ mod tests {
                 None,
                 Sample::DEFAULT_NAME,
                 OperationInfo {
-                    files: vec![OperationFile {
-                        file_path: "".to_string(),
-                        file_type: FileTypes::GenBank,
-                    }],
+                    files: vec![OperationFile::new("".to_string(), FileTypes::GenBank)],
                     description: "test".to_string(),
                 },
                 GenBankImportOptions::default().annotation_name_from_path(&path),
@@ -372,10 +366,7 @@ mod tests {
                 Sample::DEFAULT_NAME,
                 true,
                 &OperationInfo {
-                    files: vec![OperationFile {
-                        file_path: "".to_string(),
-                        file_type: FileTypes::GenBank,
-                    }],
+                    files: vec![OperationFile::new("".to_string(), FileTypes::GenBank)],
                     description: "test".to_string(),
                 },
             );
@@ -411,10 +402,7 @@ mod tests {
                 None,
                 Sample::DEFAULT_NAME,
                 OperationInfo {
-                    files: vec![OperationFile {
-                        file_path: "".to_string(),
-                        file_type: FileTypes::GenBank,
-                    }],
+                    files: vec![OperationFile::new("".to_string(), FileTypes::GenBank)],
                     description: "test".to_string(),
                 },
                 GenBankImportOptions::default().annotation_name_from_path(&path),
@@ -430,10 +418,7 @@ mod tests {
                 Sample::DEFAULT_NAME,
                 true,
                 &OperationInfo {
-                    files: vec![OperationFile {
-                        file_path: "".to_string(),
-                        file_type: FileTypes::GenBank,
-                    }],
+                    files: vec![OperationFile::new("".to_string(), FileTypes::GenBank)],
                     description: "test".to_string(),
                 },
             );
@@ -481,10 +466,7 @@ mod tests {
                 None,
                 Sample::DEFAULT_NAME,
                 OperationInfo {
-                    files: vec![OperationFile {
-                        file_path: "".to_string(),
-                        file_type: FileTypes::GenBank,
-                    }],
+                    files: vec![OperationFile::new("".to_string(), FileTypes::GenBank)],
                     description: "test".to_string(),
                 },
                 GenBankImportOptions::default().annotation_name_from_path(&path),
@@ -500,10 +482,7 @@ mod tests {
                 Sample::DEFAULT_NAME,
                 false,
                 &OperationInfo {
-                    files: vec![OperationFile {
-                        file_path: "".to_string(),
-                        file_type: FileTypes::GenBank,
-                    }],
+                    files: vec![OperationFile::new("".to_string(), FileTypes::GenBank)],
                     description: "test".to_string(),
                 },
             );

--- a/src/updates/genbank.rs
+++ b/src/updates/genbank.rs
@@ -278,7 +278,9 @@ mod tests {
                 Sample::DEFAULT_NAME,
                 false,
                 &OperationInfo {
-                    files: vec![OperationFile::new("".to_string(), FileTypes::GenBank)],
+                    files: vec![
+                        OperationFile::new("".to_string()).set_file_type(FileTypes::GenBank),
+                    ],
                     description: "test".to_string(),
                 }
             ),
@@ -307,10 +309,10 @@ mod tests {
             Sample::DEFAULT_NAME,
             true,
             &OperationInfo {
-                files: vec![OperationFile::new(
-                    path.to_str().unwrap().to_string(),
-                    FileTypes::GenBank,
-                )],
+                files: vec![
+                    OperationFile::new(path.to_str().unwrap().to_string())
+                        .set_file_type(FileTypes::GenBank),
+                ],
                 description: "test".to_string(),
             },
         )
@@ -350,7 +352,9 @@ mod tests {
                 None,
                 Sample::DEFAULT_NAME,
                 OperationInfo {
-                    files: vec![OperationFile::new("".to_string(), FileTypes::GenBank)],
+                    files: vec![
+                        OperationFile::new("".to_string()).set_file_type(FileTypes::GenBank),
+                    ],
                     description: "test".to_string(),
                 },
                 GenBankImportOptions::default().annotation_name_from_path(&path),
@@ -366,7 +370,9 @@ mod tests {
                 Sample::DEFAULT_NAME,
                 true,
                 &OperationInfo {
-                    files: vec![OperationFile::new("".to_string(), FileTypes::GenBank)],
+                    files: vec![
+                        OperationFile::new("".to_string()).set_file_type(FileTypes::GenBank),
+                    ],
                     description: "test".to_string(),
                 },
             );
@@ -402,7 +408,9 @@ mod tests {
                 None,
                 Sample::DEFAULT_NAME,
                 OperationInfo {
-                    files: vec![OperationFile::new("".to_string(), FileTypes::GenBank)],
+                    files: vec![
+                        OperationFile::new("".to_string()).set_file_type(FileTypes::GenBank),
+                    ],
                     description: "test".to_string(),
                 },
                 GenBankImportOptions::default().annotation_name_from_path(&path),
@@ -418,7 +426,9 @@ mod tests {
                 Sample::DEFAULT_NAME,
                 true,
                 &OperationInfo {
-                    files: vec![OperationFile::new("".to_string(), FileTypes::GenBank)],
+                    files: vec![
+                        OperationFile::new("".to_string()).set_file_type(FileTypes::GenBank),
+                    ],
                     description: "test".to_string(),
                 },
             );
@@ -466,7 +476,9 @@ mod tests {
                 None,
                 Sample::DEFAULT_NAME,
                 OperationInfo {
-                    files: vec![OperationFile::new("".to_string(), FileTypes::GenBank)],
+                    files: vec![
+                        OperationFile::new("".to_string()).set_file_type(FileTypes::GenBank),
+                    ],
                     description: "test".to_string(),
                 },
                 GenBankImportOptions::default().annotation_name_from_path(&path),
@@ -482,7 +494,9 @@ mod tests {
                 Sample::DEFAULT_NAME,
                 false,
                 &OperationInfo {
-                    files: vec![OperationFile::new("".to_string(), FileTypes::GenBank)],
+                    files: vec![
+                        OperationFile::new("".to_string()).set_file_type(FileTypes::GenBank),
+                    ],
                     description: "test".to_string(),
                 },
             );

--- a/src/updates/gfa.rs
+++ b/src/updates/gfa.rs
@@ -218,7 +218,7 @@ pub fn update_with_gfa(
         context,
         &mut session,
         &OperationInfo {
-            files: vec![OperationFile::new(gfa_path.to_string(), FileTypes::GFA)],
+            files: vec![OperationFile::new(gfa_path.to_string()).set_file_type(FileTypes::GFA)],
             description: "gfa_update".to_string(),
         },
         &summary_str,

--- a/src/updates/gfa.rs
+++ b/src/updates/gfa.rs
@@ -218,10 +218,7 @@ pub fn update_with_gfa(
         context,
         &mut session,
         &OperationInfo {
-            files: vec![OperationFile {
-                file_path: gfa_path.to_string(),
-                file_type: FileTypes::GFA,
-            }],
+            files: vec![OperationFile::new(gfa_path.to_string(), FileTypes::GFA)],
             description: "gfa_update".to_string(),
         },
         &summary_str,

--- a/src/updates/library.rs
+++ b/src/updates/library.rs
@@ -182,16 +182,10 @@ pub fn update_with_library(
 
     let mut files = vec![];
     if let Some(library_file_path) = library_file_path {
-        files.push(OperationFile::new(
-            library_file_path.to_string(),
-            FileTypes::CSV,
-        ));
+        files.push(OperationFile::new(library_file_path.to_string()).set_file_type(FileTypes::CSV));
     }
     if let Some(parts_file_path) = parts_file_path {
-        files.push(OperationFile::new(
-            parts_file_path.to_string(),
-            FileTypes::Fasta,
-        ));
+        files.push(OperationFile::new(parts_file_path.to_string()).set_file_type(FileTypes::Fasta));
     }
 
     let summary_str = format!("{region_name} created.\n");

--- a/src/updates/library.rs
+++ b/src/updates/library.rs
@@ -182,16 +182,16 @@ pub fn update_with_library(
 
     let mut files = vec![];
     if let Some(library_file_path) = library_file_path {
-        files.push(OperationFile {
-            file_path: library_file_path.to_string(),
-            file_type: FileTypes::CSV,
-        });
+        files.push(OperationFile::new(
+            library_file_path.to_string(),
+            FileTypes::CSV,
+        ));
     }
     if let Some(parts_file_path) = parts_file_path {
-        files.push(OperationFile {
-            file_path: parts_file_path.to_string(),
-            file_type: FileTypes::Fasta,
-        });
+        files.push(OperationFile::new(
+            parts_file_path.to_string(),
+            FileTypes::Fasta,
+        ));
     }
 
     let summary_str = format!("{region_name} created.\n");

--- a/src/updates/vcf.rs
+++ b/src/updates/vcf.rs
@@ -639,10 +639,7 @@ pub fn update_with_vcf(
         context,
         &mut session,
         &OperationInfo {
-            files: vec![OperationFile {
-                file_path: vcf_path.to_string(),
-                file_type: FileTypes::VCF,
-            }],
+            files: vec![OperationFile::new(vcf_path.to_string(), FileTypes::VCF)],
             description: "vcf_addition".to_string(),
         },
         &summary_str,

--- a/src/updates/vcf.rs
+++ b/src/updates/vcf.rs
@@ -639,7 +639,7 @@ pub fn update_with_vcf(
         context,
         &mut session,
         &OperationInfo {
-            files: vec![OperationFile::new(vcf_path.to_string(), FileTypes::VCF)],
+            files: vec![OperationFile::new(vcf_path.to_string()).set_file_type(FileTypes::VCF)],
             description: "vcf_addition".to_string(),
         },
         &summary_str,

--- a/src/views/annotations.rs
+++ b/src/views/annotations.rs
@@ -282,9 +282,9 @@ fn resolve_annotation_file_path(
             return Some(repo_path);
         }
     }
-    let gen_dir = workspace.find_gen_dir()?;
-    let asset_path = gen_dir
-        .join("assets")
+    let asset_path = workspace
+        .asset_dir()
+        .ok()?
         .join(file_addition.clone().hashed_filename());
     if asset_path.exists() {
         return Some(asset_path);


### PR DESCRIPTION
If a file outside of the gen directory is added, we store the absolute path to it. Given the asset store changes, we can instead refer to the copy of the file in assets. Given these assets have checksums as names, I added a new column to OperationFiles to track the filename.