### PR TITLE
fix(gen-python): replace db_path with DbContext

### DIFF
--- a/gen-python/Cargo.lock
+++ b/gen-python/Cargo.lock
@@ -314,7 +314,7 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fe67a3f89b693d2163cf3d94129125463ac5913e1c4322f2db905aa631d3c67"
 dependencies = [
- "embedded-io",
+ "embedded-io 0.7.1",
 ]
 
 [[package]]
@@ -387,7 +387,6 @@ dependencies = [
  "js-sys",
  "num-traits",
  "pure-rust-locales",
- "serde",
  "wasm-bindgen",
  "windows-link",
 ]
@@ -448,6 +447,15 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "colorchoice"
@@ -734,7 +742,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
- "serde_core",
 ]
 
 [[package]]
@@ -824,6 +831,18 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
+name = "embedded-io"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9eb1aa714776b75c7e67e1da744b81a129b3ff919c8712b5e1b32252c1f07cc7"
@@ -909,19 +928,6 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
-
-[[package]]
-name = "figment"
-version = "0.10.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cb01cd46b0cf372153850f4c6c272d9cbea2da513e07538405148f95bd789f3"
-dependencies = [
- "atomic",
- "serde",
- "serde_yaml",
- "uncased",
- "version_check",
-]
 
 [[package]]
 name = "filedescriptor"
@@ -1119,7 +1125,6 @@ dependencies = [
  "directories",
  "env_logger",
  "fallible-streaming-iterator",
- "figment",
  "flate2",
  "gb-io",
  "gen-annotations",
@@ -1133,7 +1138,7 @@ dependencies = [
  "html-escape",
  "httparse",
  "include_dir",
- "indexmap 2.14.0",
+ "indexmap",
  "indicatif",
  "interavl",
  "intervaltree",
@@ -1142,6 +1147,7 @@ dependencies = [
  "noodles",
  "once_cell",
  "petgraph",
+ "postcard",
  "rand 0.10.1",
  "rat-cursor",
  "rat-text",
@@ -1152,7 +1158,6 @@ dependencies = [
  "rusqlite_migration",
  "serde",
  "serde_json",
- "serde_with",
  "sha2",
  "tempfile",
  "thiserror 2.0.18",
@@ -1240,7 +1245,7 @@ dependencies = [
  "gen-core",
  "gen-graph",
  "include_dir",
- "indexmap 2.14.0",
+ "indexmap",
  "intervaltree",
  "itertools 0.14.0",
  "noodles",
@@ -1365,12 +1370,6 @@ checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
 dependencies = [
  "byteorder",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -1702,17 +1701,6 @@ checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
 dependencies = [
  "proc-macro2",
  "quote",
-]
-
-[[package]]
-name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
- "serde",
 ]
 
 [[package]]
@@ -2282,7 +2270,7 @@ checksum = "7480c171f2d2e108f64e504b073dceccd886bf4a5af06d18e65497a4a48e6dd2"
 dependencies = [
  "bstr",
  "futures",
- "indexmap 2.14.0",
+ "indexmap",
  "memchr",
  "noodles-bgzf",
  "noodles-core",
@@ -2299,7 +2287,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "167e7421ebf8c6dfc9e55982f0ee9708f5b6c04ed1489e7ea86b407c087b9a30"
 dependencies = [
  "futures",
- "indexmap 2.14.0",
+ "indexmap",
  "memchr",
  "noodles-bgzf",
  "noodles-core",
@@ -2360,7 +2348,7 @@ dependencies = [
  "bzip2",
  "flate2",
  "futures",
- "indexmap 2.14.0",
+ "indexmap",
  "md-5",
  "noodles-bam",
  "noodles-core",
@@ -2379,7 +2367,7 @@ checksum = "03338575b1537f6fa1006bb6138fafea98b73dd3dd687b96727076531de924cc"
 dependencies = [
  "bit-vec 0.8.0",
  "bstr",
- "indexmap 2.14.0",
+ "indexmap",
  "noodles-bgzf",
  "noodles-core",
  "tokio",
@@ -2419,7 +2407,7 @@ checksum = "44e0132682fb8a247443e7c14b391da1f638aa002b313e6287d6aa93bae6ffcc"
 dependencies = [
  "bstr",
  "futures",
- "indexmap 2.14.0",
+ "indexmap",
  "lexical-core",
  "noodles-bgzf",
  "noodles-core",
@@ -2435,7 +2423,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2000e62c15c3f4e53a5f8331d012530e6193075d534e1c54a378cba1b3ca3b71"
 dependencies = [
  "bstr",
- "indexmap 2.14.0",
+ "indexmap",
  "lexical-core",
  "noodles-bgzf",
  "noodles-core",
@@ -2452,7 +2440,7 @@ dependencies = [
  "bitflags 2.11.1",
  "bstr",
  "futures",
- "indexmap 2.14.0",
+ "indexmap",
  "lexical-core",
  "memchr",
  "noodles-bgzf",
@@ -2469,7 +2457,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caff826ea6e432861b726ae3be1100e72d07a238c7615c12ddc257ff3c23f555"
 dependencies = [
  "bstr",
- "indexmap 2.14.0",
+ "indexmap",
  "noodles-bgzf",
  "noodles-core",
  "noodles-csi",
@@ -2483,7 +2471,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c3edc79cf9c235cc803137a108fa20e6f9c4a3b6fa39e879c78504cc7d19d7"
 dependencies = [
  "futures",
- "indexmap 2.14.0",
+ "indexmap",
  "memchr",
  "noodles-bgzf",
  "noodles-core",
@@ -2661,7 +2649,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.14.0",
+ "indexmap",
  "serde",
  "serde_derive",
 ]
@@ -2743,6 +2731,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "serde",
 ]
 
 [[package]]
@@ -3188,26 +3188,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ref-cast"
-version = "1.0.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
-dependencies = [
- "ref-cast-impl",
-]
-
-[[package]]
-name = "ref-cast-impl"
-version = "1.0.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3444,30 +3424,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "schemars"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
-dependencies = [
- "dyn-clone",
- "ref-cast",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "schemars"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
-dependencies = [
- "dyn-clone",
- "ref-cast",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3532,50 +3488,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serde_with"
-version = "3.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
-dependencies = [
- "base64",
- "chrono",
- "hex",
- "indexmap 1.9.3",
- "indexmap 2.14.0",
- "schemars 0.9.0",
- "schemars 1.2.1",
- "serde_core",
- "serde_json",
- "serde_with_macros",
- "time",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "3.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
-dependencies = [
- "darling 0.23.0",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap 2.14.0",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
 ]
 
 [[package]]
@@ -3913,14 +3825,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
- "itoa",
  "libc",
  "num-conv",
  "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",
- "time-macros",
 ]
 
 [[package]]
@@ -3928,16 +3838,6 @@ name = "time-core"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
-
-[[package]]
-name = "time-macros"
-version = "0.2.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
-dependencies = [
- "num-conv",
- "time-core",
-]
 
 [[package]]
 name = "tinystr"
@@ -4094,15 +3994,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
-name = "uncased"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
-dependencies = [
- "version_check",
-]
-
-[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4163,12 +4054,6 @@ name = "unit-prefix"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
@@ -4363,7 +4248,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.14.0",
+ "indexmap",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -4389,7 +4274,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.11.1",
  "hashbrown 0.15.5",
- "indexmap 2.14.0",
+ "indexmap",
  "semver",
 ]
 
@@ -4784,7 +4669,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.14.0",
+ "indexmap",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -4815,7 +4700,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.11.1",
- "indexmap 2.14.0",
+ "indexmap",
  "log",
  "serde",
  "serde_derive",
@@ -4834,7 +4719,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.14.0",
+ "indexmap",
  "log",
  "semver",
  "serde",

--- a/gen-python/src/python_api/block_group.rs
+++ b/gen-python/src/python_api/block_group.rs
@@ -1,7 +1,5 @@
-use std::path::PathBuf;
-
-use r#gen::{core::HashId, get_connection};
-use gen_models::block_group::BlockGroup;
+use r#gen::core::HashId;
+use gen_models::{block_group::BlockGroup, db::DbContext};
 use pyo3::{exceptions::PyRuntimeError, prelude::*};
 
 use super::{
@@ -9,8 +7,23 @@ use super::{
     jupyter_widget::{PyGraphController, build_and_display_widget},
 };
 
-/// Exposes a BlockGroup to Python.
-#[pyclass]
+/// A block group returned by a ``Repository``.
+///
+/// ``BlockGroup`` objects cannot be shared across threads because they hold a
+/// reference to the database connection of the ``Repository`` that created them.
+///
+/// To use a block group's identity in another thread, capture its ``id``,
+/// open a fresh ``Repository`` in that thread, and look it up by id::
+///
+///     bg_id = bg.id
+///     path  = str(repo.db_path)
+///
+///     def worker():
+///         r = gen.Repository(path)
+///         bg = r.get_block_group_by_id(bg_id)
+///         ...
+// unsendable because DbContext contains Rc (rusqlite::Connection is !Sync)
+#[pyclass(unsendable)]
 #[derive(Clone)]
 pub struct PyBlockGroup {
     pub id: HashId,
@@ -20,8 +33,7 @@ pub struct PyBlockGroup {
     pub sample_name: String,
     #[pyo3(get)]
     pub name: String,
-    /// Path to the SQLite database for the Repository that created this block group.
-    pub db_path: Option<PathBuf>,
+    pub context: Option<DbContext>,
 }
 
 #[pymethods]
@@ -33,7 +45,7 @@ impl PyBlockGroup {
             collection_name,
             sample_name,
             name,
-            db_path: None,
+            context: None,
         }
     }
 
@@ -79,7 +91,7 @@ impl PyBlockGroup {
     /// skipped and only the widget is returned.
     ///
     /// Raises ``RuntimeError`` if this block group was not created via a
-    /// ``Repository`` (i.e. ``db_path`` is unset).
+    /// ``Repository``.
     ///
     /// Parameters
     /// ----------
@@ -100,20 +112,24 @@ impl PyBlockGroup {
     ) -> PyResult<PyObject> {
         let py = slf.py();
 
-        let (db_path, bg_id) = {
+        let (context, bg_id) = {
             let bg = slf.borrow();
-            match bg.db_path.clone() {
-                Some(p) => (p, bg.id),
+            match bg.context.clone() {
+                Some(ctx) => (ctx, bg.id),
                 None => {
                     return Err(PyRuntimeError::new_err(
-                        "plot() requires a db_path; obtain BlockGroup via Repository",
+                        "plot() requires a Repository context; obtain BlockGroups via Repository by query or id.",
                     ));
                 }
             }
         };
 
-        let conn = get_connection(&db_path).map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
-        let graph = BlockGroup::get_graph(&conn, &bg_id);
+        let conn = context.graph().conn();
+        let graph = BlockGroup::get_graph(conn, &bg_id);
+        let db_path = context
+            .gen_db_path()
+            .map(|p| p.with_file_name("default.db"))
+            .unwrap_or_default();
         let mut ctrl = PyGraphController::new(db_path, graph);
         if let Some(node_detail) = detail {
             ctrl.set_detail(node_detail)?;

--- a/gen-python/src/python_api/jupyter_widget.rs
+++ b/gen-python/src/python_api/jupyter_widget.rs
@@ -150,8 +150,9 @@ impl PyGraphController {
         block_group: &PyBlockGroup,
     ) -> PyResult<Self> {
         let bg_id = block_group.id;
-        let graph = repo.with_connection(|conn| BlockGroup::get_graph(conn, &bg_id));
-        Ok(Self::new(repo.db_path.clone(), graph))
+        let graph = BlockGroup::get_graph(repo.context.graph().conn(), &bg_id);
+        let db_path = repo.context.workspace().ensure_gen_dir().join("default.db");
+        Ok(Self::new(db_path, graph))
     }
 
     /// Set the level of node detail.

--- a/gen-python/src/python_api/repository.rs
+++ b/gen-python/src/python_api/repository.rs
@@ -1,10 +1,8 @@
-use std::{path::PathBuf, sync::Mutex};
-
-use r#gen::{core::HashId, get_connection};
+use r#gen::{get_connection, get_operation_connection};
 use gen_core::config::Workspace;
 use gen_models::{
     block_group::{BlockGroup, NewBlockGroup},
-    db::GraphConnection,
+    db::DbContext,
     node::Node,
     traits::Query,
 };
@@ -13,6 +11,7 @@ use pyo3::{prelude::*, types::PyModule};
 use super::{
     block_group::PyBlockGroup,
     factory::Factory,
+    hash_id::PyHashId,
     jupyter_widget::{PyGraphController, build_and_display_widget},
     node_key::PyNodeKey,
     utils::{block_group_err_to_pyerr, path_to_py_path, py_query, sqlite_err_to_pyerr},
@@ -22,30 +21,25 @@ use super::{
 ///
 /// This class manages the database connection and provides methods for
 /// querying and manipulating the database.
-#[pyclass(name = "Repository")]
+// unsendable because DbContext contains Rc (rusqlite::Connection is !Sync)
+#[pyclass(name = "Repository", unsendable)]
 pub struct PyRepository {
-    // We use custom getters, hence no #[pyo3(get)]
-    pub gen_dir: PathBuf,
-    pub db_path: PathBuf,
-    pub conn: Mutex<Option<GraphConnection>>, // Private to Rust, not exposed to Python
-    pub factory: Factory,                     // Embedded factory for BlockGroup transformations
+    pub context: DbContext,
+    pub factory: Factory,
 }
 
-// Regular Rust implementation outside of PyO3 exposure
 impl PyRepository {
-    // Private helper method that provides a connection to a closure
-    // This pattern avoids exposing Rust-specific types like MutexGuard to Python
-    // while still ensuring proper connection management
-    pub fn with_connection<F, T>(&self, op: F) -> T
-    where
-        F: FnOnce(&GraphConnection) -> T,
-    {
-        let mut conn_guard = self.conn.lock().unwrap();
-        if conn_guard.is_none() {
-            *conn_guard = Some(get_connection(self.db_path.to_str().unwrap()).unwrap());
+    /// Converts a model [`BlockGroup`] into a [`PyBlockGroup`], cloning the
+    /// repository's [`DbContext`] into it so the block group can issue its own
+    /// queries without holding a reference back to the repository.
+    fn into_py_block_group(&self, bg: BlockGroup) -> PyBlockGroup {
+        PyBlockGroup {
+            id: bg.id,
+            collection_name: bg.collection_name,
+            sample_name: bg.sample_name,
+            name: bg.name,
+            context: Some(self.context.clone()),
         }
-
-        op(conn_guard.as_ref().unwrap())
     }
 }
 
@@ -54,44 +48,49 @@ impl PyRepository {
     #[new]
     #[pyo3(signature = (path = Option::<String>::None))]
     fn new(path: Option<String>) -> PyResult<Self> {
-        // PathBuf instead of Path to avoid borrowing issues
-        let gen_dir: PathBuf = match path {
-            Some(path_str) => PathBuf::from(path_str),
-            None => Workspace::from_current_dir().ensure_gen_dir(),
+        let workspace = match path {
+            Some(p) => Workspace::new(p),
+            None => Workspace::from_current_dir(),
         };
-
+        let gen_dir = workspace.ensure_gen_dir();
         let db_path = gen_dir.join("default.db");
+        let ops_path = gen_dir.join("gen.db");
 
-        // Initialize with no connection - it will be created lazily
-        // We do need to use a Mutex for memory safety
+        let graph_conn = get_connection(db_path)
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+        let ops_conn = get_operation_connection(Some(ops_path))
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+
         Ok(PyRepository {
-            gen_dir,
-            db_path,
-            conn: Mutex::new(None),
-            factory: Factory::new(), // Initialize the factory
+            context: DbContext::new(workspace, graph_conn, ops_conn),
+            factory: Factory::new(),
         })
     }
 
     #[getter]
     fn get_gen_dir(&self, py: Python) -> PyResult<PyObject> {
-        path_to_py_path(py, &self.gen_dir)
+        path_to_py_path(py, &self.context.workspace().ensure_gen_dir())
     }
 
     #[getter]
     fn get_db_path(&self, py: Python) -> PyResult<PyObject> {
-        path_to_py_path(py, &self.db_path)
+        path_to_py_path(
+            py,
+            &self.context.workspace().ensure_gen_dir().join("default.db"),
+        )
     }
 
-    // Database operations directly on PyRepository
     fn execute(&self, query: &str) -> PyResult<()> {
-        self.with_connection(|conn| {
-            conn.execute(query, []).map_err(sqlite_err_to_pyerr)?;
-            Ok(())
-        })
+        self.context
+            .graph()
+            .conn()
+            .execute(query, [])
+            .map_err(sqlite_err_to_pyerr)?;
+        Ok(())
     }
 
     fn query(&self, query: &str) -> PyResult<Vec<Vec<PyObject>>> {
-        self.with_connection(|conn| py_query(conn, query))
+        py_query(self.context.graph().conn(), query)
     }
 
     /// Retrieves a BlockGroup by its ID.
@@ -101,27 +100,31 @@ impl PyRepository {
     ///
     /// Returns:
     ///     A PyBlockGroup instance representing the requested BlockGroup
-    fn get_block_group_by_id(&self, id: &HashId) -> PyResult<PyBlockGroup> {
-        self.with_connection(|conn| {
-            let block_group = match BlockGroup::get_by_id(conn, id) {
-                Ok(bg) => bg,
-                Err(r#gen::models::block_group::BlockGroupError::QueryError(_)) => {
-                    return Err(pyo3::exceptions::PyValueError::new_err(format!(
-                        "BlockGroup with id {:?} not found",
-                        id
-                    )));
-                }
-                Err(e) => return Err(block_group_err_to_pyerr(e)),
-            };
+    fn get_block_group(
+        &self,
+        name: &str,
+        sample_name: &str,
+        collection_name: &str,
+    ) -> PyResult<PyBlockGroup> {
+        let id = BlockGroup::get_id(collection_name, sample_name, name, None);
+        let conn = self.context.graph().conn();
+        let block_group = BlockGroup::get_by_id(conn, &id).map_err(block_group_err_to_pyerr)?;
+        Ok(self.into_py_block_group(block_group))
+    }
 
-            Ok(PyBlockGroup {
-                id: block_group.id,
-                collection_name: block_group.collection_name,
-                sample_name: block_group.sample_name,
-                name: block_group.name,
-                db_path: Some(self.db_path.clone()),
-            })
-        })
+    fn get_block_group_by_id(&self, id: &PyHashId) -> PyResult<PyBlockGroup> {
+        let conn = self.context.graph().conn();
+        let block_group = match BlockGroup::get_by_id(conn, &id.hash_id) {
+            Ok(bg) => bg,
+            Err(r#gen::models::block_group::BlockGroupError::QueryError(_)) => {
+                return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                    "BlockGroup with id {} not found",
+                    id.hash_id
+                )));
+            }
+            Err(e) => return Err(block_group_err_to_pyerr(e)),
+        };
+        Ok(self.into_py_block_group(block_group))
     }
 
     /// Retrieves all BlockGroups.
@@ -129,23 +132,11 @@ impl PyRepository {
     /// Returns:
     ///     A vector of PyBlockGroup instances
     fn get_block_groups(&self) -> PyResult<Vec<PyBlockGroup>> {
-        self.with_connection(|conn| {
-            let block_groups = BlockGroup::all(conn);
-
-            let db_path = self.db_path.clone();
-            let result = block_groups
-                .into_iter()
-                .map(|bg| PyBlockGroup {
-                    id: bg.id,
-                    collection_name: bg.collection_name,
-                    sample_name: bg.sample_name,
-                    name: bg.name,
-                    db_path: Some(db_path.clone()),
-                })
-                .collect();
-
-            Ok(result)
-        })
+        let conn = self.context.graph().conn();
+        Ok(BlockGroup::all(conn)
+            .into_iter()
+            .map(|bg| self.into_py_block_group(bg))
+            .collect())
     }
 
     /// Retrieves all BlockGroups belonging to a specific collection.
@@ -156,27 +147,15 @@ impl PyRepository {
     /// Returns:
     ///     A vector of PyBlockGroup instances
     fn get_block_groups_by_collection(&self, collection_name: &str) -> PyResult<Vec<PyBlockGroup>> {
-        self.with_connection(|conn| {
-            let block_groups = BlockGroup::query(
-                conn,
-                "SELECT * FROM block_groups WHERE collection_name = ?1",
-                rusqlite::params![collection_name],
-            );
-
-            let db_path = self.db_path.clone();
-            let result = block_groups
-                .into_iter()
-                .map(|bg| PyBlockGroup {
-                    id: bg.id,
-                    collection_name: bg.collection_name,
-                    sample_name: bg.sample_name,
-                    name: bg.name,
-                    db_path: Some(db_path.clone()),
-                })
-                .collect();
-
-            Ok(result)
-        })
+        let conn = self.context.graph().conn();
+        Ok(BlockGroup::query(
+            conn,
+            "SELECT * FROM block_groups WHERE collection_name = ?1",
+            rusqlite::params![collection_name],
+        )
+        .into_iter()
+        .map(|bg| self.into_py_block_group(bg))
+        .collect())
     }
 
     // Factory methods:
@@ -196,20 +175,13 @@ impl PyRepository {
     /// Raises:
     ///     PyModuleNotFoundError: If rustworkx is not installed
     fn block_group_to_rustworkx(&self, block_group: &PyBlockGroup) -> PyResult<PyObject> {
-        Python::with_gil(|py| {
-            // Check if rustworkx is installed
-            match PyModule::import(py, "rustworkx") {
-                Ok(_) => {
-                    // rustworkx is available, proceed with the conversion
-                    self.with_connection(|conn| self.factory.to_rustworkx(conn, &block_group.id))
-                }
-                Err(_) => {
-                    // rustworkx is not available, return a helpful error message
-                    Err(pyo3::exceptions::PyModuleNotFoundError::new_err(
-                        "The 'rustworkx' module is not installed. Please install it using 'pip install rustworkx' to use this functionality.",
-                    ))
-                }
-            }
+        Python::with_gil(|py| match PyModule::import(py, "rustworkx") {
+            Ok(_) => self
+                .factory
+                .to_rustworkx(self.context.graph().conn(), &block_group.id),
+            Err(_) => Err(pyo3::exceptions::PyModuleNotFoundError::new_err(
+                "The 'rustworkx' module is not installed. Please install it using 'pip install rustworkx' to use this functionality.",
+            )),
         })
     }
 
@@ -221,7 +193,8 @@ impl PyRepository {
     /// Returns:
     ///     A Python dictionary containing the graph representation
     fn block_group_to_dict(&self, block_group: &PyBlockGroup) -> PyResult<PyObject> {
-        self.with_connection(|conn| self.factory.to_dict(conn, &block_group.id))
+        self.factory
+            .to_dict(self.context.graph().conn(), &block_group.id)
     }
 
     /// Converts a BlockGroup to a NetworkX graph representation
@@ -235,20 +208,13 @@ impl PyRepository {
     /// Raises:
     ///     PyModuleNotFoundError: If networkx is not installed
     fn block_group_to_networkx(&self, block_group: &PyBlockGroup) -> PyResult<PyObject> {
-        Python::with_gil(|py| {
-            // Check if networkx is installed
-            match PyModule::import(py, "networkx") {
-                Ok(_) => {
-                    // networkx is available, proceed with the conversion
-                    self.with_connection(|conn| self.factory.to_networkx(conn, &block_group.id))
-                }
-                Err(_) => {
-                    // networkx is not available, return a helpful error message
-                    Err(pyo3::exceptions::PyModuleNotFoundError::new_err(
-                        "The 'networkx' module is not installed. Please install it using 'pip install networkx' to use this functionality.",
-                    ))
-                }
-            }
+        Python::with_gil(|py| match PyModule::import(py, "networkx") {
+            Ok(_) => self
+                .factory
+                .to_networkx(self.context.graph().conn(), &block_group.id),
+            Err(_) => Err(pyo3::exceptions::PyModuleNotFoundError::new_err(
+                "The 'networkx' module is not installed. Please install it using 'pip install networkx' to use this functionality.",
+            )),
         })
     }
 
@@ -268,28 +234,18 @@ impl PyRepository {
         collection_name: String,
         sample_name: String,
     ) -> PyResult<PyBlockGroup> {
-        self.with_connection(|conn| {
-            let block_group = match BlockGroup::create(
-                conn,
-                NewBlockGroup {
-                    collection_name: &collection_name,
-                    sample_name: &sample_name,
-                    name: &name,
-                    ..Default::default()
-                },
-            ) {
-                Ok(bg) => bg,
-                Err(e) => return Err(block_group_err_to_pyerr(e)),
-            };
-
-            Ok(PyBlockGroup {
-                id: block_group.id,
-                collection_name: block_group.collection_name,
-                sample_name: block_group.sample_name,
-                name: block_group.name,
-                db_path: Some(self.db_path.clone()),
-            })
-        })
+        let conn = self.context.graph().conn();
+        let block_group = BlockGroup::create(
+            conn,
+            NewBlockGroup {
+                collection_name: &collection_name,
+                sample_name: &sample_name,
+                name: &name,
+                ..Default::default()
+            },
+        )
+        .map_err(block_group_err_to_pyerr)?;
+        Ok(self.into_py_block_group(block_group))
     }
 
     /// Plot a BlockGroup's graph as an interactive Jupyter widget.
@@ -327,9 +283,10 @@ impl PyRepository {
         cols: Option<u32>,
         detail: Option<&str>,
     ) -> PyResult<PyObject> {
-        let bg_id = block_group.id;
-        let graph = self.with_connection(|conn| BlockGroup::get_graph(conn, &bg_id));
-        let mut ctrl = PyGraphController::new(self.db_path.clone(), graph);
+        let conn = self.context.graph().conn();
+        let graph = BlockGroup::get_graph(conn, &block_group.id);
+        let db_path = self.context.workspace().ensure_gen_dir().join("default.db");
+        let mut ctrl = PyGraphController::new(db_path, graph);
         if let Some(node_detail) = detail {
             ctrl.set_detail(node_detail)?;
         }
@@ -345,32 +302,51 @@ impl PyRepository {
     /// Returns:
     ///     A string containing the sequence for the specified block
     fn get_block_sequence(&self, node_key: &PyNodeKey) -> PyResult<String> {
-        self.with_connection(|conn| {
-            let sequences_by_node_id = Node::get_sequences_by_node_ids(conn, &[node_key.node_id]);
-            let sequence = sequences_by_node_id.get(&node_key.node_id).ok_or_else(|| {
-                pyo3::exceptions::PyValueError::new_err(format!(
-                    "Node with id {:?} not found",
-                    node_key.node_id
-                ))
-            })?;
-            Ok(sequence
-                .get_sequence(node_key.sequence_start, node_key.sequence_end)
-                .map_err(|err| pyo3::exceptions::PyValueError::new_err(err.to_string()))?)
-        })
+        let conn = self.context.graph().conn();
+        let sequences_by_node_id = Node::get_sequences_by_node_ids(conn, &[node_key.node_id]);
+        let sequence = sequences_by_node_id.get(&node_key.node_id).ok_or_else(|| {
+            pyo3::exceptions::PyValueError::new_err(format!(
+                "Node with id {:?} not found",
+                node_key.node_id
+            ))
+        })?;
+        Ok(sequence
+            .get_sequence(node_key.sequence_start, node_key.sequence_end)
+            .map_err(|err| pyo3::exceptions::PyValueError::new_err(err.to_string()))?)
     }
 }
 
 #[cfg(test)]
 mod python_tests {
-    use r#gen::test_helpers::setup_gen;
+    use r#gen::{
+        core::HashId,
+        test_helpers::{create_bg, setup_gen, setup_gen_on_disk},
+    };
     use pyo3::{prelude::*, py_run};
 
-    use crate::python_api::repository::PyRepository;
+    use crate::python_api::{factory::Factory, hash_id::PyHashId, repository::PyRepository};
+
+    fn make_repo_with_data(py: Python) -> Py<PyRepository> {
+        use gen_models::collection::Collection;
+        let context = setup_gen_on_disk();
+        let conn = context.graph().conn();
+        Collection::create(conn, "col-a").unwrap();
+        Collection::create(conn, "col-b").unwrap();
+        create_bg(conn, "col-a", "s1", "bg1");
+        create_bg(conn, "col-b", "s1", "bg2");
+        Py::new(
+            py,
+            PyRepository {
+                context,
+                factory: Factory::new(),
+            },
+        )
+        .unwrap()
+    }
 
     #[test]
     fn test_repository_creation() {
         setup_gen();
-        // Run python code to confirm that the repository class is available, with the repository class passed in from Rust
         pyo3::prepare_freethreaded_python();
         Python::with_gil(|py| {
             let repository = py.get_type::<PyRepository>();
@@ -378,12 +354,47 @@ mod python_tests {
                 py,
                 repository,
                 r#"
-                # Create a repository in the present working directory
                 repo = repository()
-
-                # Test that the repository was created successfully
                 assert hasattr(repo, "gen_dir")
                 assert hasattr(repo, "db_path")
+            "#
+            );
+        });
+    }
+
+    #[test]
+    fn test_get_block_groups() {
+        pyo3::prepare_freethreaded_python();
+        Python::with_gil(|py| {
+            let repo = make_repo_with_data(py);
+            py_run!(
+                py,
+                repo,
+                r#"
+                bgs = repo.get_block_groups()
+                assert len(bgs) == 2
+                names = {bg.name for bg in bgs}
+                assert names == {"bg1", "bg2"}
+            "#
+            );
+        });
+    }
+
+    #[test]
+    fn test_get_block_group_by_id_not_found() {
+        pyo3::prepare_freethreaded_python();
+        Python::with_gil(|py| {
+            let repo = make_repo_with_data(py);
+            let bad_id = Py::new(py, PyHashId::new(HashId([0u8; 32]))).unwrap();
+            py_run!(
+                py,
+                repo bad_id,
+                r#"
+                try:
+                    repo.get_block_group_by_id(bad_id)
+                    assert False, "expected ValueError"
+                except ValueError:
+                    pass
             "#
             );
         });

--- a/src/graphs/graph_search.rs
+++ b/src/graphs/graph_search.rs
@@ -774,7 +774,7 @@ mod tests {
     fn test_matcher() -> GenGraphMatcher {
         let ctx = setup_gen();
         let conn = ctx.graph().conn();
-        Collection::create(conn, "test");
+        let _ = Collection::create(conn, "test");
         let (block_group_id, _path) = setup_block_group(conn);
         let graph = BlockGroup::get_graph(conn, &block_group_id);
         GenGraphMatcher::new(conn, graph)
@@ -783,7 +783,7 @@ mod tests {
     fn test_protein_matcher() -> GenGraphMatcher {
         let ctx = setup_gen();
         let conn = ctx.graph().conn();
-        Collection::create(conn, "test");
+        let _ = Collection::create(conn, "test");
         let (block_group_id, _path) = setup_block_group(conn);
         let graph = BlockGroup::get_graph(conn, &block_group_id);
         GenGraphMatcher::new_protein(conn, graph)
@@ -792,7 +792,7 @@ mod tests {
     fn test_exact_matcher() -> GenGraphMatcher {
         let ctx = setup_gen();
         let conn = ctx.graph().conn();
-        Collection::create(conn, "test");
+        let _ = Collection::create(conn, "test");
         let (block_group_id, _path) = setup_block_group(conn);
         let graph = BlockGroup::get_graph(conn, &block_group_id);
         GenGraphMatcher::new_with_sequence_kind(conn, graph, SequenceKind::Exact)


### PR DESCRIPTION
DbHandle::path() was removed upstream, breaking PyRepository which stored a PathBuf to re-open connections and stamped that path onto every PyBlockGroup so they could open their own connections for plot().

  Replace both with DbContext:
  - PyRepository stores DbContext directly (eager open, no lazy Mutex init)
  - PyBlockGroup carries `Option<DbContext>` instead of `Option<PathBuf>`
  - Remove with_connection() closure pattern, now dead
  - Rename bg() -> into_py_block_group() to clarify intent
  - Drop stale DbHandle::path() tests; add Python-facing read method tests

(+ fix upstream clippy warning)