### PR TITLE
feat(gen-tui): cell-level highlight support

### DIFF
--- a/gen-tui/src/graph_controller.rs
+++ b/gen-tui/src/graph_controller.rs
@@ -337,8 +337,9 @@ where
         color
     }
 
-    /// Internal helper to apply a node rect highlight to the viewport graph.
-    /// Stores the domain NodeIndex directly — no world-coordinate conversion needed.
+    /// Render-only primitive shared by `set_cell_highlight` (initial paint) and the
+    /// highlight replay loop (re-paint after viewport rebuild). Kept separate so replay
+    /// can call it without pushing duplicate entries into `self.highlights`.
     fn apply_cell_highlight(
         viewport_graph: &mut CroppedGraph,
         graph: &G,
@@ -392,9 +393,12 @@ where
         self.set_path_highlight(PathStyle::new(color), path_nodes);
     }
 
-    /// Highlight the rectangle from `tl` to `br` (node-local col/row offsets,
-    /// exclusive end) for a single node.
+    /// Record and paint a cell-rect highlight with an explicit style. Persists the
+    /// highlight into `self.highlights` so it survives viewport rebuilds; delegates
+    /// the actual paint to `apply_cell_highlight`. Prefer `add_cell_highlight` when
+    /// you don't need to choose the color.
     ///
+    /// `tl`/`br` are node-local (col, row) offsets, exclusive end.
     /// Example — columns 5..12 on the top row:
     ///   set_cell_highlight(node_id, (5, 0), (12, 0), style)
     pub fn set_cell_highlight(
@@ -414,8 +418,9 @@ where
         self.highlights.push((kind, style));
     }
 
-    /// Highlight a cell rect using the next available theme accent color.
-    /// Returns the color that was chosen.
+    /// Convenience wrapper around `set_cell_highlight` that picks the next theme
+    /// accent color automatically. Returns the chosen color. Use this when you
+    /// don't need to control the style; use `set_cell_highlight` when you do.
     pub fn add_cell_highlight(
         &mut self,
         node_id: G::NodeId,
@@ -1231,6 +1236,9 @@ mod tests {
         assert!(state.has_focus); // Focus is enabled by default for keyboard input
 
         state.focus();
+        assert!(state.has_focus);
+
+        state.handle_mouse_scroll(5, 5, Duration::from_millis(100));
         assert!(state.camera_anim.is_some());
 
         state.blur();

--- a/gen-tui/src/graph_controller.rs
+++ b/gen-tui/src/graph_controller.rs
@@ -79,8 +79,9 @@ pub enum HighlightKind<N> {
     Edge(N, N),
     /// A path consisting of a sequence of nodes
     Path(Vec<N>),
-    /// Tint a sub-rectangle of a single node.
-    /// tl/br are (col, row) offsets from the node's top-left corner; br is exclusive.
+    /// Tint a rectangular region of a single node. The rectangle is defined by the
+    /// (col, row) position of its top-left corner (`tl`) and bottom-right corner (`br`).
+    /// The top-left of the node area is (0, 0). Both corners are inclusive.
     Cells {
         node: N,
         tl: (i64, i64),
@@ -398,8 +399,10 @@ where
     /// the actual paint to `apply_cell_highlight`. Prefer `add_cell_highlight` when
     /// you don't need to choose the color.
     ///
-    /// `tl`/`br` are node-local (col, row) offsets, exclusive end.
-    /// Example — columns 5..12 on the top row:
+    /// `tl`/`br` are the (col, row) positions of the top-left and bottom-right corners
+    /// of the rectangle to highlight. Both corners are inclusive. The top-left of the
+    /// node area is (0, 0).
+    /// Example — columns 5..=12 on the top row:
     ///   set_cell_highlight(node_id, (5, 0), (12, 0), style)
     pub fn set_cell_highlight(
         &mut self,

--- a/gen-tui/src/graph_controller.rs
+++ b/gen-tui/src/graph_controller.rs
@@ -79,6 +79,13 @@ pub enum HighlightKind<N> {
     Edge(N, N),
     /// A path consisting of a sequence of nodes
     Path(Vec<N>),
+    /// Tint a sub-rectangle of a single node.
+    /// tl/br are (col, row) offsets from the node's top-left corner; br is exclusive.
+    Cells {
+        node: N,
+        tl: (i64, i64),
+        br: (i64, i64),
+    },
 }
 
 impl<G, S> GraphController<G, S>
@@ -330,6 +337,24 @@ where
         color
     }
 
+    /// Internal helper to apply a node rect highlight to the viewport graph.
+    /// Stores the domain NodeIndex directly — no world-coordinate conversion needed.
+    fn apply_cell_highlight(
+        viewport_graph: &mut CroppedGraph,
+        graph: &G,
+        node_id: G::NodeId,
+        tl: (i64, i64),
+        br: (i64, i64),
+        style: PathStyle,
+    ) {
+        let node_idx = NodeIndex::new(<G as NodeIndexable>::to_index(graph, node_id));
+        if viewport_graph.node_positions.contains_key(&node_idx) {
+            viewport_graph
+                .cell_highlights
+                .push((node_idx, tl, br, style));
+        }
+    }
+
     /// Set a node highlight
     pub fn set_node_highlight(&mut self, node_id: G::NodeId, style: PathStyle) {
         let graph = &self.partition_controller.graph;
@@ -367,6 +392,47 @@ where
         self.set_path_highlight(PathStyle::new(color), path_nodes);
     }
 
+    /// Highlight the rectangle from `tl` to `br` (node-local col/row offsets,
+    /// exclusive end) for a single node.
+    ///
+    /// Example — columns 5..12 on the top row:
+    ///   set_cell_highlight(node_id, (5, 0), (12, 0), style)
+    pub fn set_cell_highlight(
+        &mut self,
+        node_id: G::NodeId,
+        tl: (i64, i64),
+        br: (i64, i64),
+        style: PathStyle,
+    ) {
+        let graph = &self.partition_controller.graph;
+        Self::apply_cell_highlight(&mut self.viewport_graph, graph, node_id, tl, br, style);
+        let kind = HighlightKind::Cells {
+            node: node_id,
+            tl,
+            br,
+        };
+        self.highlights.push((kind, style));
+    }
+
+    /// Highlight a cell rect using the next available theme accent color.
+    /// Returns the color that was chosen.
+    pub fn add_cell_highlight(
+        &mut self,
+        node_id: G::NodeId,
+        tl: (i64, i64),
+        br: (i64, i64),
+    ) -> Color {
+        let color = self.next_accent_color();
+        self.set_cell_highlight(node_id, tl, br, PathStyle::new(color));
+        color
+    }
+
+    /// Get a reference to the node rect highlights in the current viewport
+    #[allow(clippy::type_complexity)]
+    pub fn get_cell_highlights(&self) -> &[(NodeIndex, (i64, i64), (i64, i64), PathStyle)] {
+        &self.viewport_graph.cell_highlights
+    }
+
     /// Check if a specific style has any highlighting
     pub fn has_highlight(&self, style: &PathStyle) -> bool {
         self.highlights.iter().any(|(_, s)| s == style)
@@ -382,6 +448,9 @@ where
         self.viewport_graph
             .edge_highlights
             .retain(|(_, s)| s != style);
+        self.viewport_graph
+            .cell_highlights
+            .retain(|(_, _, _, s)| s != style);
         self.trigger_rebuild();
     }
 
@@ -390,6 +459,7 @@ where
         self.highlights.clear();
         self.viewport_graph.node_highlights.clear();
         self.viewport_graph.edge_highlights.clear();
+        self.viewport_graph.cell_highlights.clear();
         self.trigger_rebuild();
     }
 
@@ -906,6 +976,16 @@ where
                         *style,
                     );
                 }
+                HighlightKind::Cells { node, tl, br } => {
+                    Self::apply_cell_highlight(
+                        &mut self.viewport_graph,
+                        &self.partition_controller.graph,
+                        *node,
+                        *tl,
+                        *br,
+                        *style,
+                    );
+                }
             }
         }
 
@@ -1151,7 +1231,7 @@ mod tests {
         assert!(state.has_focus); // Focus is enabled by default for keyboard input
 
         state.focus();
-        let _ = state.camera_anim.is_some();
+        assert!(state.camera_anim.is_some());
 
         state.blur();
         assert!(!state.has_focus);

--- a/gen-tui/src/graph_widget.rs
+++ b/gen-tui/src/graph_widget.rs
@@ -253,6 +253,7 @@ where
         let detail_level = controller.get_detail_level();
         let node_highlights = controller.get_node_highlights();
         let edge_highlights = controller.get_edge_highlights();
+        let cell_highlights = controller.get_cell_highlights();
         plot_viewport_graph_with_highlights(
             viewport_graph,
             &mut world_buffer,
@@ -261,6 +262,7 @@ where
             detail_level,
             node_highlights,
             edge_highlights,
+            cell_highlights,
             &theme,
         );
 

--- a/gen-tui/src/plotter.rs
+++ b/gen-tui/src/plotter.rs
@@ -359,7 +359,9 @@ pub fn plot_viewport_graph_with_highlights<R, G>(
                 }
 
                 // Sub-rect highlight pass: tint only the matched column/row range.
-                // tl/br are node-local (col, row) offsets from world_rect.min, both inclusive.
+                // tl/br define the top-left and bottom-right corners of the rectangle to
+                // highlight; both are node-local (col, row) positions where (0,0) is the
+                // node's top-left. Both corners are inclusive.
                 if let Some((_, tl, br, path_style)) = cell_highlights
                     .iter()
                     .filter(|(idx, ..)| idx == domain_idx)

--- a/gen-tui/src/plotter.rs
+++ b/gen-tui/src/plotter.rs
@@ -255,6 +255,7 @@ pub fn plot_viewport_graph<R, G>(
         detail_level,
         &[],
         &[],
+        &[],
         theme,
     )
 }
@@ -275,7 +276,7 @@ pub fn plot_viewport_graph<R, G>(
 /// - `node_highlights`: List of node positions to highlight with their styles
 /// - `edge_highlights`: List of edge segments to highlight with their styles
 /// - `theme`: Theme colors for rendering
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::type_complexity)]
 pub fn plot_viewport_graph_with_highlights<R, G>(
     viewport_graph: &CroppedGraph,
     buffer: &mut WorldBuffer<'_>,
@@ -284,6 +285,12 @@ pub fn plot_viewport_graph_with_highlights<R, G>(
     detail_level: VisualDetail,
     node_highlights: &[(WorldPos, PathStyle)],
     edge_highlights: &[((WorldPos, WorldPos), PathStyle)],
+    cell_highlights: &[(
+        petgraph::prelude::NodeIndex,
+        (i64, i64),
+        (i64, i64),
+        PathStyle,
+    )],
     theme: &Theme,
 ) where
     R: NodeRenderer<G>,
@@ -345,6 +352,33 @@ pub fn plot_viewport_graph_with_highlights<R, G>(
                                 } else {
                                     style.bg(hl)
                                 };
+                                buffer.set_char_styled(pos, ch, new_style);
+                            }
+                        }
+                    }
+                }
+
+                // Sub-rect highlight pass: tint only the matched column/row range.
+                // tl/br are node-local (col, row) offsets from world_rect.min, both inclusive.
+                if let Some((_, tl, br, path_style)) = cell_highlights
+                    .iter()
+                    .filter(|(idx, ..)| idx == domain_idx)
+                    .next_back()
+                {
+                    let x0 = (world_rect.min.x + tl.0).max(world_rect.min.x);
+                    let x1 = (world_rect.min.x + br.0).min(world_rect.max.x);
+                    let y0 = (world_rect.min.y + tl.1).max(world_rect.min.y);
+                    let y1 = (world_rect.min.y + br.1).min(world_rect.max.y);
+                    for y in y0..=y1 {
+                        for x in x0..=x1 {
+                            let pos = WorldPos::new(x, y);
+                            if let Some((ch, style)) = buffer.get_char_styled(pos) {
+                                let fg = style.fg.unwrap_or(Color::Reset);
+                                let highlight_color = match path_style.color {
+                                    Color::Reset => theme[0x07],
+                                    color => color,
+                                };
+                                let new_style = style.fg(fg).bg(highlight_color);
                                 buffer.set_char_styled(pos, ch, new_style);
                             }
                         }

--- a/gen-tui/src/viewport_graph.rs
+++ b/gen-tui/src/viewport_graph.rs
@@ -34,8 +34,8 @@ pub struct CroppedGraph {
     /// Edge highlights: list of world position pairs with their associated styles
     pub edge_highlights: Vec<((WorldPos, WorldPos), crate::plotter::PathStyle)>,
     /// Sub-rect highlights keyed by domain NodeIndex.
-    /// tl/br are node-local (col, row) offsets from the node's top-left corner,
-    /// both inclusive.
+    /// tl/br define the top-left and bottom-right corners of the rectangle to highlight.
+    /// Both are (col, row) positions where (0, 0) is the node's top-left. Both inclusive.
     #[allow(clippy::type_complexity)]
     pub cell_highlights: Vec<(NodeIndex, (i64, i64), (i64, i64), crate::plotter::PathStyle)>,
 }

--- a/gen-tui/src/viewport_graph.rs
+++ b/gen-tui/src/viewport_graph.rs
@@ -33,6 +33,11 @@ pub struct CroppedGraph {
     pub node_highlights: Vec<(WorldPos, crate::plotter::PathStyle)>,
     /// Edge highlights: list of world position pairs with their associated styles
     pub edge_highlights: Vec<((WorldPos, WorldPos), crate::plotter::PathStyle)>,
+    /// Sub-rect highlights keyed by domain NodeIndex.
+    /// tl/br are node-local (col, row) offsets from the node's top-left corner,
+    /// both inclusive.
+    #[allow(clippy::type_complexity)]
+    pub cell_highlights: Vec<(NodeIndex, (i64, i64), (i64, i64), crate::plotter::PathStyle)>,
 }
 
 impl CroppedGraph {
@@ -48,6 +53,7 @@ impl CroppedGraph {
             included_nodes: HashSet::new(),
             node_highlights: Vec::new(),
             edge_highlights: Vec::new(),
+            cell_highlights: Vec::new(),
         }
     }
 

--- a/src/graphs/graph_search.rs
+++ b/src/graphs/graph_search.rs
@@ -774,7 +774,7 @@ mod tests {
     fn test_matcher() -> GenGraphMatcher {
         let ctx = setup_gen();
         let conn = ctx.graph().conn();
-        Collection::create(conn, "test");
+        let _ = Collection::create(conn, "test");
         let (block_group_id, _path) = setup_block_group(conn);
         let graph = BlockGroup::get_graph(conn, &block_group_id);
         GenGraphMatcher::new(conn, graph)
@@ -783,7 +783,7 @@ mod tests {
     fn test_protein_matcher() -> GenGraphMatcher {
         let ctx = setup_gen();
         let conn = ctx.graph().conn();
-        Collection::create(conn, "test");
+        let _ = Collection::create(conn, "test");
         let (block_group_id, _path) = setup_block_group(conn);
         let graph = BlockGroup::get_graph(conn, &block_group_id);
         GenGraphMatcher::new_protein(conn, graph)
@@ -792,7 +792,7 @@ mod tests {
     fn test_exact_matcher() -> GenGraphMatcher {
         let ctx = setup_gen();
         let conn = ctx.graph().conn();
-        Collection::create(conn, "test");
+        let _ = Collection::create(conn, "test");
         let (block_group_id, _path) = setup_block_group(conn);
         let graph = BlockGroup::get_graph(conn, &block_group_id);
         GenGraphMatcher::new_with_sequence_kind(conn, graph, SequenceKind::Exact)

--- a/src/views/gen_graph_widget.rs
+++ b/src/views/gen_graph_widget.rs
@@ -8,10 +8,13 @@ use gen_tui::{
     graph_controller::{GraphController, WorldBuffer},
     graph_widget::{GraphWidget, NODE_GLYPH},
     layout::VisualDetail,
-    plotter::{NodeRenderer, NodeSizer},
+    plotter::{NodeRenderer, NodeSizer, PathStyle},
     theme::current_theme,
 };
+use petgraph::{graph::NodeIndex, visit::NodeIndexable};
 use ratatui::style::Style;
+
+use crate::graphs::graph_search::GraphLocus;
 
 /// Labels for special start/end nodes
 pub mod label {
@@ -204,6 +207,82 @@ pub fn create_gen_graph_controller(
     controller.set_detail_level(VisualDetail::Truncated);
     controller.hide_cursor();
     controller
+}
+
+/// Center the graph controller on a specific graph node at a given fractional offset.
+///
+/// The caller must supply the full `GraphNode` key (node_id + sequence_start +
+/// sequence_end), because multiple graph nodes can share the same underlying
+/// `node_id` when they represent different sub-ranges of the same sequence.
+/// The offset `(0.5, 0.5)` centers on the middle of the node.
+///
+/// # Arguments
+/// * `controller` — the graph controller to position
+/// * `node`       — the exact `GraphNode` key to center on
+/// * `offset`     — fractional `(x, y)` position within the node (0.0–1.0)
+pub fn center_on_node_offset(
+    controller: &mut GraphController<GenGraph, GenGraphNodeSizer>,
+    node: GraphNode,
+    offset: (f64, f64),
+) {
+    // Find which partition owns this node.
+    let (partition_idx, _) = match controller
+        .partition_controller
+        .partition_table
+        .find_node(&node)
+    {
+        Ok(p) => p,
+        Err(_) => return,
+    };
+
+    // Ensure the partition is loaded and set it as the anchor.
+    let _ = controller.ensure_partition_loaded(partition_idx);
+    let _ = controller.set_anchor_partition(partition_idx);
+
+    // Resolve the domain NodeIndex from the node key.
+    let domain_idx = NodeIndex::new(NodeIndexable::to_index(controller.graph(), node));
+
+    // Look up the node's world position (available once the partition is loaded).
+    let world_pos = match controller.find_domain_node_world_position(domain_idx) {
+        Some(w) => w,
+        None => return,
+    };
+
+    // Snap the camera directly to the node's world position.
+    controller.viewport_state.camera_current = world_pos;
+    controller.viewport_state.camera_target = world_pos;
+    controller.viewport_state.camera_anim = None;
+
+    // Place the cursor on the node at the requested fractional offset.
+    controller.cursor.set_node(domain_idx, offset);
+
+    controller.trigger_rebuild();
+}
+
+/// Highlight only the matched bytes of a `GraphLocus`, using sub-rect tinting.
+///
+/// - Start node: tinted from `start_offset` to its right edge.
+/// - Middle nodes: fully tinted.
+/// - End node: tinted from its left edge to `end_offset` (exclusive).
+pub fn highlight_match_range(
+    controller: &mut GraphController<GenGraph, GenGraphNodeSizer>,
+    m: &GraphLocus,
+    style: PathStyle,
+) {
+    let path_len = m.blocks.len();
+    for (i, &node) in m.blocks.iter().enumerate() {
+        let col_start = if i == 0 { m.start_offset as i64 } else { 0 };
+        // br is inclusive, so end_offset (exclusive) - 1; saturate to avoid underflow on empty match
+        let col_end = if i == path_len - 1 {
+            m.end_offset.saturating_sub(1) as i64
+        } else {
+            node.length() - 1
+        };
+        controller.set_cell_highlight(node, (col_start, 0), (col_end, 0), style);
+    }
+    for (&src, &dst) in m.blocks.iter().zip(m.blocks.iter().skip(1)) {
+        controller.set_edge_highlight((src, dst), style);
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Human tl;dr
We already had 3 ways to highlight specific subsets of a graph: by node, by edge and by path
This PR adds "by cells" within a node (so by character) and adds a function to move the camera to exactly that spot.

## Claude
Adds a Cells variant to HighlightKind and a cell_highlights Vec to CroppedGraph, enabling sub-rectangle tinting of individual graph nodes. The tint pass runs after normal node rendering and blends onto whatever characters are already in the WorldBuffer.

Adds two public helpers to gen_graph_widget:
>   center_on_node_offset — loads the owning partition, sets it as anchor,
>   resolves the domain NodeIndex, and snaps the camera directly to the
>   node's world position at a fractional (x, y) offset.

>   highlight_match_range — iterates a GraphLocus, calls set_cell_highlight
>   on the start/end nodes with the correct column slice, fully tints middle
>   nodes, and adds edge highlights between consecutive locus blocks.

Together these let a caller navigate to a sequence search hit and paint exactly the matched columns — start offset on the first node, full width on interior nodes, end offset on the last — in a single call.