### PR TITLE
feat(gen-tui): annotation overlay and track rendering

### DIFF
--- a/gen-tui/src/graph_controller.rs
+++ b/gen-tui/src/graph_controller.rs
@@ -294,6 +294,25 @@ where
         }
     }
 
+    /// Internal helper to apply a node rect highlight to the viewport graph.
+    /// Resolves the node to its world position and stores that for consistency
+    /// with node_highlights and edge_highlights.
+    fn apply_cell_highlight(
+        viewport_graph: &mut CroppedGraph,
+        graph: &G,
+        node_id: G::NodeId,
+        tl: (i64, i64),
+        br: (i64, i64),
+        style: PathStyle,
+    ) {
+        let node_idx = NodeIndex::new(<G as NodeIndexable>::to_index(graph, node_id));
+        if let Some(&world_pos) = viewport_graph.node_positions.get(&node_idx) {
+            viewport_graph
+                .cell_highlights
+                .push((world_pos, tl, br, style));
+        }
+    }
+
     /// Pick the next unused accent color from the theme (slots 0x08–0x0F).
     ///
     /// Scans `self.highlights` for colors already in use and returns the first
@@ -336,25 +355,6 @@ where
         let color = self.next_accent_color();
         self.set_path_highlight(PathStyle::new(color), path_nodes);
         color
-    }
-
-    /// Render-only primitive shared by `set_cell_highlight` (initial paint) and the
-    /// highlight replay loop (re-paint after viewport rebuild). Kept separate so replay
-    /// can call it without pushing duplicate entries into `self.highlights`.
-    fn apply_cell_highlight(
-        viewport_graph: &mut CroppedGraph,
-        graph: &G,
-        node_id: G::NodeId,
-        tl: (i64, i64),
-        br: (i64, i64),
-        style: PathStyle,
-    ) {
-        let node_idx = NodeIndex::new(<G as NodeIndexable>::to_index(graph, node_id));
-        if viewport_graph.node_positions.contains_key(&node_idx) {
-            viewport_graph
-                .cell_highlights
-                .push((node_idx, tl, br, style));
-        }
     }
 
     /// Set a node highlight
@@ -437,7 +437,7 @@ where
 
     /// Get a reference to the node rect highlights in the current viewport
     #[allow(clippy::type_complexity)]
-    pub fn get_cell_highlights(&self) -> &[(NodeIndex, (i64, i64), (i64, i64), PathStyle)] {
+    pub fn get_cell_highlights(&self) -> &[(WorldPos, (i64, i64), (i64, i64), PathStyle)] {
         &self.viewport_graph.cell_highlights
     }
 

--- a/gen-tui/src/graph_widget.rs
+++ b/gen-tui/src/graph_widget.rs
@@ -7,7 +7,7 @@ use petgraph::visit::{
 use ratatui::{
     buffer::Buffer,
     layout::Rect,
-    style::Style,
+    style::{Modifier, Style},
     widgets::{Block, StatefulWidget, Widget},
 };
 
@@ -274,7 +274,23 @@ where
 
         if controller.cursor.is_visible() {
             let viewport_graph = controller.get_viewport_graph();
-            let cursor_bg = theme[0x07];
+            // Apply color, formatting and/or glyph swap
+            let apply_cursor_style = |ch: char, style: Style| -> (char, Style) {
+                if ch == NODE_GLYPH {
+                    let new_style = style
+                        .fg(theme[0x06])
+                        .bg(theme[0x00])
+                        .remove_modifier(Modifier::all());
+                    ('█', new_style) // alternative: ○
+                } else {
+                    let new_style = style
+                        .fg(theme[0x00])
+                        .bg(theme[0x06])
+                        .remove_modifier(Modifier::all())
+                        .add_modifier(Modifier::BOLD);
+                    (ch, new_style)
+                }
+            };
 
             if controller.cursor.is_coarse_mode() {
                 // Highlight the whole node in coarse mode
@@ -291,12 +307,13 @@ where
                             if let Some((current_char, current_style)) =
                                 cursor_buffer.get_char_styled(pos)
                             {
-                                let (char_to_render, new_style) = if current_char == NODE_GLYPH {
-                                    ('■', current_style.fg(cursor_bg).bg(theme[0x00]))
-                                } else {
-                                    (current_char, current_style.bg(cursor_bg))
-                                };
-                                cursor_buffer.set_char_styled(pos, char_to_render, new_style);
+                                let (char_to_render, new_style) =
+                                    apply_cursor_style(current_char, current_style);
+                                cursor_buffer.set_char_styled(
+                                    pos,
+                                    char_to_render,
+                                    new_style.add_modifier(Modifier::UNDERLINED),
+                                );
                             }
                         }
                     }
@@ -309,13 +326,13 @@ where
                     if let Some((current_char, current_style)) =
                         cursor_buffer.get_char_styled(cursor_world_pos)
                     {
-                        let (char_to_render, new_style) = if current_char == NODE_GLYPH {
-                            ('■', current_style.fg(cursor_bg))
-                        } else {
-                            (current_char, current_style.bg(cursor_bg))
-                        };
+                        let (char_to_render, new_style) =
+                            apply_cursor_style(current_char, current_style);
                         cursor_buffer.set_char_styled(cursor_world_pos, char_to_render, new_style);
                     }
+
+                    let below_pos = WorldPos::new(cursor_world_pos.x, cursor_world_pos.y - 1);
+                    cursor_buffer.set_char(below_pos, '^');
                 }
             }
         }

--- a/gen-tui/src/plotter.rs
+++ b/gen-tui/src/plotter.rs
@@ -285,12 +285,7 @@ pub fn plot_viewport_graph_with_highlights<R, G>(
     detail_level: VisualDetail,
     node_highlights: &[(WorldPos, PathStyle)],
     edge_highlights: &[((WorldPos, WorldPos), PathStyle)],
-    cell_highlights: &[(
-        petgraph::prelude::NodeIndex,
-        (i64, i64),
-        (i64, i64),
-        PathStyle,
-    )],
+    cell_highlights: &[(WorldPos, (i64, i64), (i64, i64), PathStyle)],
     theme: &Theme,
 ) where
     R: NodeRenderer<G>,
@@ -348,7 +343,7 @@ pub fn plot_viewport_graph_with_highlights<R, G>(
                             let pos = WorldPos::new(x, y);
                             if let Some((ch, style)) = buffer.get_char_styled(pos) {
                                 let new_style = if ch == NODE_GLYPH {
-                                    style.fg(hl).bg(theme[0x00])
+                                    style.fg(hl)
                                 } else {
                                     style.bg(hl)
                                 };
@@ -362,11 +357,13 @@ pub fn plot_viewport_graph_with_highlights<R, G>(
                 // tl/br define the top-left and bottom-right corners of the rectangle to
                 // highlight; both are node-local (col, row) positions where (0,0) is the
                 // node's top-left. Both corners are inclusive.
-                if let Some((_, tl, br, path_style)) = cell_highlights
-                    .iter()
-                    .filter(|(idx, ..)| idx == domain_idx)
-                    .next_back()
+                for (_, tl, br, path_style) in
+                    cell_highlights.iter().filter(|(nwp, ..)| nwp == world_pos)
                 {
+                    let hl = match path_style.color {
+                        Color::Reset => theme[0x07],
+                        color => color,
+                    };
                     let x0 = (world_rect.min.x + tl.0).max(world_rect.min.x);
                     let x1 = (world_rect.min.x + br.0).min(world_rect.max.x);
                     let y0 = (world_rect.min.y + tl.1).max(world_rect.min.y);
@@ -375,12 +372,11 @@ pub fn plot_viewport_graph_with_highlights<R, G>(
                         for x in x0..=x1 {
                             let pos = WorldPos::new(x, y);
                             if let Some((ch, style)) = buffer.get_char_styled(pos) {
-                                let fg = style.fg.unwrap_or(Color::Reset);
-                                let highlight_color = match path_style.color {
-                                    Color::Reset => theme[0x07],
-                                    color => color,
+                                let new_style = if ch == NODE_GLYPH {
+                                    style.fg(hl)
+                                } else {
+                                    style.bg(hl)
                                 };
-                                let new_style = style.fg(fg).bg(highlight_color);
                                 buffer.set_char_styled(pos, ch, new_style);
                             }
                         }

--- a/gen-tui/src/viewport_graph.rs
+++ b/gen-tui/src/viewport_graph.rs
@@ -33,11 +33,11 @@ pub struct CroppedGraph {
     pub node_highlights: Vec<(WorldPos, crate::plotter::PathStyle)>,
     /// Edge highlights: list of world position pairs with their associated styles
     pub edge_highlights: Vec<((WorldPos, WorldPos), crate::plotter::PathStyle)>,
-    /// Sub-rect highlights keyed by domain NodeIndex.
+    /// Sub-rect highlights keyed by world position (node centre).
     /// tl/br define the top-left and bottom-right corners of the rectangle to highlight.
     /// Both are (col, row) positions where (0, 0) is the node's top-left. Both inclusive.
     #[allow(clippy::type_complexity)]
-    pub cell_highlights: Vec<(NodeIndex, (i64, i64), (i64, i64), crate::plotter::PathStyle)>,
+    pub cell_highlights: Vec<(WorldPos, (i64, i64), (i64, i64), crate::plotter::PathStyle)>,
 }
 
 impl CroppedGraph {

--- a/src/graphs/graph_search.rs
+++ b/src/graphs/graph_search.rs
@@ -3,7 +3,7 @@ use std::{
     path::Path,
 };
 
-use gen_core::{HashId, PATH_END_NODE_ID, PATH_START_NODE_ID};
+use gen_core::{HashId, PATH_END_NODE_ID, PATH_START_NODE_ID, Strand};
 use gen_graph::{GenGraph, GraphNode};
 use gen_models::{db::GraphConnection, node::Node};
 use petgraph::Direction;
@@ -34,6 +34,43 @@ pub struct GraphLocus {
     pub end_offset: usize,
     /// Ordered sequence of nodes that spell the match. Length is at least 1.
     pub blocks: Vec<GraphNode>,
+    /// Strand of the matched sequence.
+    pub strand: Strand,
+}
+
+/// Return the sequence bytes spanned by `locus`.
+///
+/// Fetches node sequences from the database, concatenates the relevant slices
+/// across all blocks, and reverse-complements the result for `Strand::Reverse`
+/// loci.
+pub fn locus_sequence(conn: &GraphConnection, locus: &GraphLocus) -> Vec<u8> {
+    let node_ids: Vec<HashId> = locus.blocks.iter().map(|n| n.node_id).collect();
+    let sequences = Node::get_sequences_by_node_ids(conn, &node_ids);
+
+    let n = locus.blocks.len();
+    let mut out = Vec::new();
+    for (i, block) in locus.blocks.iter().enumerate() {
+        let full = sequences[&block.node_id]
+            .get_sequence(None, None)
+            .expect("sequence data corrupt")
+            .into_bytes();
+        let block_start = usize::try_from(block.sequence_start).expect("negative sequence_start");
+        let block_end = usize::try_from(block.sequence_end).expect("negative sequence_end");
+        let text = &full[block_start..block_end];
+        let start = if i == 0 { locus.start_offset } else { 0 };
+        let end = if i == n - 1 {
+            locus.end_offset
+        } else {
+            text.len()
+        };
+        out.extend_from_slice(&text[start..end]);
+    }
+
+    if locus.strand == Strand::Reverse {
+        reverse_complement(&out)
+    } else {
+        out
+    }
 }
 
 /// Biological interpretation of the sequences being searched.
@@ -282,8 +319,9 @@ impl GenGraphMatcher {
     /// configured sequence kind.
     ///
     /// For `SequenceKind::Dna`, reverse-complement matches are returned in graph
-    /// coordinates exactly like forward matches. The returned `GraphLocus`
-    /// currently does not record which query orientation matched.
+    /// coordinates exactly like forward matches. The returned strand field
+    /// records which orientation matched - `Forward` for the query as-provided,
+    /// `Reverse` for the reverse-complement.
     pub fn find_all(&self, query: &[u8]) -> Vec<GraphLocus> {
         if query.is_empty() {
             return Vec::new();
@@ -293,9 +331,16 @@ impl GenGraphMatcher {
         let mut out = self.find_all_query_orientation(query, matcher);
 
         if self.sequence_kind == SequenceKind::Dna {
+            for m in out.iter_mut() {
+                m.strand = Strand::Forward;
+            }
             let rc = reverse_complement(query);
             let rc_matcher = self.sequence_kind.matcher_for_query(&rc);
-            out.extend(self.find_all_query_orientation(&rc, rc_matcher));
+            let rc_matches = self.find_all_query_orientation(&rc, rc_matcher);
+            for mut m in rc_matches {
+                m.strand = Strand::Reverse;
+                out.push(m);
+            }
         }
 
         out
@@ -443,6 +488,7 @@ impl GenGraphMatcher {
                     start_offset: ts.start_offset,
                     end_offset: ts.state.offset,
                     blocks: ts.path,
+                    strand: Strand::Unknown,
                 });
                 continue;
             }

--- a/src/theme/base16.rs
+++ b/src/theme/base16.rs
@@ -5,6 +5,7 @@ use ratatui::style::Color;
 use serde::Deserialize;
 
 #[derive(Deserialize)]
+#[serde(rename_all = "lowercase")]
 struct RawPalette {
     base00: String,
     base01: String,
@@ -16,11 +17,17 @@ struct RawPalette {
     base07: String,
     base08: String,
     base09: String,
+    #[serde(alias = "base0A")]
     base0a: String,
+    #[serde(alias = "base0B")]
     base0b: String,
+    #[serde(alias = "base0C")]
     base0c: String,
+    #[serde(alias = "base0D")]
     base0d: String,
+    #[serde(alias = "base0E")]
     base0e: String,
+    #[serde(alias = "base0F")]
     base0f: String,
 }
 

--- a/src/views.rs
+++ b/src/views.rs
@@ -10,6 +10,7 @@ pub mod diff_graph;
 pub mod dot_export;
 pub mod gen_graph_widget;
 pub mod helpers;
+pub mod inline_label_placement;
 pub mod messages;
 pub mod operations;
 pub mod panels;

--- a/src/views/annotation_track.rs
+++ b/src/views/annotation_track.rs
@@ -1,18 +1,21 @@
 use std::{
     cmp::{max, min},
-    collections::HashMap,
+    collections::{HashMap, HashSet},
 };
 
 use gen_core::{HashId, Strand, is_end_node, is_start_node};
 use gen_graph::GenGraph;
 use gen_tui::{
-    CroppedGraph, GraphController, ViewportState, VisualDetail, WorldPos, WorldRect,
-    theme::current_theme,
+    GraphController, ViewportState, WorldRect, plotter::NodeSizer, theme::current_theme,
 };
 use petgraph::visit::NodeIndexable;
-use ratatui::{layout::Rect, style::Style};
+use ratatui::{
+    buffer::Buffer,
+    layout::Rect,
+    style::{Color, Style},
+};
 
-use crate::views::gen_graph_widget::GenGraphNodeSizer;
+use crate::graphs::graph_search::GraphLocus;
 
 #[derive(Clone, Debug)]
 pub struct AnnotationSegment {
@@ -34,6 +37,40 @@ pub struct AnnotationTrack {
     pub name: String,
     pub annotations: Vec<AnnotationSpan>,
     pub annotation_segments_by_node: HashMap<HashId, Vec<(usize, AnnotationSegment)>>,
+    pub min_rows: usize,
+    pub max_rows: usize,
+}
+
+pub fn graphlocus_to_annotation_span(locus: &GraphLocus, name: &str) -> AnnotationSpan {
+    let n = locus.blocks.len();
+    let segments = locus
+        .blocks
+        .iter()
+        .enumerate()
+        .map(|(i, node)| {
+            let start = if i == 0 {
+                node.sequence_start + locus.start_offset as i64
+            } else {
+                node.sequence_start
+            };
+            let end = if i == n - 1 {
+                node.sequence_start + locus.end_offset as i64
+            } else {
+                node.sequence_end
+            };
+            AnnotationSegment {
+                node_id: node.node_id,
+                start,
+                end,
+                strand: locus.strand,
+            }
+        })
+        .collect();
+    AnnotationSpan {
+        id: HashId::convert_str(name),
+        name: name.to_string(),
+        segments,
+    }
 }
 
 impl AnnotationTrack {
@@ -52,54 +89,329 @@ impl AnnotationTrack {
             name,
             annotations,
             annotation_segments_by_node: segments_by_node,
+            min_rows: 0,
+            max_rows: 9,
         }
+    }
+
+    /// Draw annotation track at the bottom of `area`. Returns height used, or 0 if nothing visible.
+    pub fn draw<S: NodeSizer<GenGraph>>(
+        &self,
+        buf: &mut Buffer,
+        area: Rect,
+        controller: &GraphController<GenGraph, S>,
+    ) -> u16 {
+        let (_, segments_by_annotation, truncated_count) =
+            collect_visual_segments(self, controller);
+        let visible_ranges: AnnotationVisibleRanges = segments_by_annotation
+            .iter()
+            .map(|(idx, segs)| {
+                let x1 = segs.iter().map(VisualSegment::start_x).min().unwrap_or(0);
+                let x2 = segs.iter().map(VisualSegment::end_x).max().unwrap_or(0);
+                (*idx, (x1, x2))
+            })
+            .collect();
+        let packed_rows = pack_visible_annotation_rows(&visible_ranges, self, self.max_rows);
+
+        let n = packed_rows.len().max(self.min_rows);
+        let height = (n as u16 + 1).max(1);
+        if area.height < height {
+            return 0;
+        }
+
+        let area = Rect {
+            x: area.x,
+            y: area.y + area.height - height,
+            width: area.width,
+            height,
+        };
+
+        let viewport_state = &controller.viewport_state;
+
+        let theme = current_theme();
+
+        let divider_style = Style::default().fg(theme[0x02]);
+        buf.set_string(
+            area.x,
+            area.y,
+            "─".repeat(area.width as usize),
+            divider_style,
+        );
+
+        if !self.name.is_empty() {
+            let header = if truncated_count > 0 {
+                format!("{} (+{truncated_count} in truncated regions)", self.name)
+            } else {
+                self.name.clone()
+            };
+            buf.set_string(area.x + 1, area.y, header, Style::default().fg(theme[0x04]));
+        }
+
+        let inner = Rect {
+            x: area.x,
+            y: area.y + 1,
+            width: area.width,
+            height: area.height - 1,
+        };
+
+        if inner.width == 0 {
+            return height;
+        }
+
+        let bg_color = theme[0x00];
+        for row in inner.y..inner.y + inner.height {
+            buf.set_string(
+                inner.x,
+                row,
+                " ".repeat(inner.width as usize),
+                Style::default().bg(bg_color),
+            );
+        }
+
+        let label_fg_over_bar = bg_color;
+
+        for (row_idx, row_annotations) in packed_rows.iter().take(inner.height as usize).enumerate()
+        {
+            let annotation_color = if row_idx % 2 == 0 {
+                theme[0x0B]
+            } else {
+                theme[0x0C]
+            };
+            let annotation_style = Style::default().fg(annotation_color).bg(bg_color);
+            let terminal_y = inner.y + row_idx as u16;
+
+            for idx in row_annotations {
+                let Some(mut segments) = segments_by_annotation.get(idx).cloned() else {
+                    continue;
+                };
+                segments.sort_by_key(|s| s.start_x());
+                let mut prev_end: Option<i64> = None;
+                for seg in &segments {
+                    let x1 = seg.start_x();
+                    let x2 = seg.end_x();
+                    place_bar(
+                        buf,
+                        inner,
+                        viewport_state,
+                        x1,
+                        x2,
+                        terminal_y,
+                        annotation_style,
+                    );
+                    if seg.start.1.is_none() {
+                        draw_truncation_marker(
+                            buf,
+                            inner,
+                            viewport_state,
+                            seg.start.0,
+                            terminal_y,
+                            annotation_style,
+                        );
+                    }
+                    if seg.end.1.is_none() {
+                        draw_truncation_marker(
+                            buf,
+                            inner,
+                            viewport_state,
+                            seg.end.0,
+                            terminal_y,
+                            annotation_style,
+                        );
+                    }
+                    if let Some(prev) = prev_end
+                        && x1 - prev > 1
+                    {
+                        draw_dashed_connector(
+                            buf,
+                            inner,
+                            viewport_state,
+                            prev + 1,
+                            x1 - 1,
+                            terminal_y,
+                            annotation_style,
+                        );
+                    }
+                    prev_end = Some(x2);
+                }
+            }
+
+            for idx in row_annotations {
+                let annotation_name = &self.annotations[*idx].name;
+                if annotation_name.is_empty() {
+                    continue;
+                }
+                let Some(visual_segs) = segments_by_annotation.get(idx) else {
+                    continue;
+                };
+                let x1 = visual_segs
+                    .iter()
+                    .map(VisualSegment::start_x)
+                    .min()
+                    .unwrap_or_default();
+                let x2 = visual_segs
+                    .iter()
+                    .map(VisualSegment::end_x)
+                    .max()
+                    .unwrap_or_default();
+
+                let span_strand = span_strand(&self.annotations[*idx]);
+                place_sticky_label(
+                    buf,
+                    inner,
+                    viewport_state,
+                    x1,
+                    x2,
+                    terminal_y,
+                    annotation_name,
+                    span_strand,
+                    annotation_style,
+                    label_fg_over_bar,
+                );
+            }
+        }
+
+        height
     }
 }
 
-type AnnotationSegmentsByIndex = HashMap<usize, Vec<(i64, i64)>>;
 type AnnotationVisibleRanges = HashMap<usize, (i64, i64)>;
-type AnnotationSegmentsResult = (AnnotationVisibleRanges, AnnotationSegmentsByIndex);
 
-/// Collect visible annotation segments by mapping sequence coordinates to world X coordinates.
+/// Bases from either node boundary that map to precise cells (0-indexed, inclusive).
+/// For example, if we truncate 123456789 to 12...89  this number would be 2
+const BORDER_BP: i64 = 5;
+
+/// Extra collection margin for labels that can remain visible outside the bar.
+const MIN_LABEL_LOOKAHEAD: i64 = 8;
+
+/// Fixed gap between annotation bar and label when label is external.
+const LABEL_SIDE_GUTTER: i64 = 1;
+
+/// Fixed gap reserved to the right of each annotation bar when packing rows
+const RIGHT_BAR_MARGIN: i64 = 4;
+
+/// How an annotation endpoint maps to the current visual representation.
 ///
-/// This is the gen-tui equivalent of the old `Viewer::collect_annotation_segments`. Instead of
-/// reading from `scaled_layout.labels`, it iterates over visible Data nodes in the CroppedGraph
-/// and uses `WorldPos` + `LayoutNode.size` to determine each node's X span in world coordinates.
-fn collect_annotation_segments(
-    track: &AnnotationTrack,
-    viewport_graph: &CroppedGraph,
-    viewport_state: &ViewportState,
-    graph: &GenGraph,
-) -> AnnotationSegmentsResult {
-    if track.annotations.is_empty() {
-        return (HashMap::new(), HashMap::new());
+/// `(base_x, Some(offset))` — exact cell at world position `base_x + offset`.
+/// `(node_mid_x, None)`     — falls in the truncated interior; draw `░` at `node_mid_x`.
+pub type EndpointX = (i64, Option<i64>);
+
+/// One resolved segment of an annotation, covering part of a single graph node.
+#[derive(Clone, Debug)]
+pub struct VisualSegment {
+    /// World X of node left edge.
+    pub node_x1: i64,
+    /// World X of node right edge.
+    pub node_x2: i64,
+    /// Resolved start endpoint.
+    pub start: EndpointX,
+    /// Resolved end endpoint.
+    pub end: EndpointX,
+}
+
+impl VisualSegment {
+    pub fn start_x(&self) -> i64 {
+        self.start.0 + self.start.1.unwrap_or(0)
     }
 
-    const HORIZONTAL_LOOKAHEAD: i64 = 8;
-    let mut visible_ranges: AnnotationVisibleRanges = HashMap::new();
-    let mut segments_by_annotation: AnnotationSegmentsByIndex = HashMap::new();
+    pub fn end_x(&self) -> i64 {
+        self.end.0 + self.end.1.unwrap_or(0)
+    }
+}
+
+/// Resolve one annotation sequence position to a visual endpoint.
+///
+/// * `dist_from_start` – bases from the node's first base (≥ 0).
+/// * `dist_from_end`   – bases from the node's last base, inclusive (≥ 0; 0 = last base).
+///
+/// For truncated nodes (`node_len > node_width`, `node_width ≥ 3`):
+/// - Positions within `BORDER_BP` bases of either boundary map to a precise border cell.
+/// - All other positions map to the node's middle cell with `offset = None`.
+///
+/// The middle cell (`node_width / 2`) is kept free of border mappings, ensuring
+/// `░` indicators only appear for genuinely ambiguous interior positions.
+fn resolve_endpoint(
+    dist_from_start: i64,
+    dist_from_end: i64,
+    node_x1: i64,
+    node_width: i64,
+    node_len: i64,
+) -> EndpointX {
+    if node_len <= node_width || node_width < 3 {
+        let offset = if node_len <= 0 {
+            0
+        } else {
+            (dist_from_start * node_width / node_len).clamp(0, node_width - 1)
+        };
+        return (node_x1, Some(offset));
+    }
+
+    // Truncated node. `half` is the mid-cell index (= 6 for width 13).
+    // Left border uses cells 0 .. half-1; right border uses cells half+1 .. end.
+    let half = node_width / 2;
+
+    if dist_from_start <= BORDER_BP {
+        return (node_x1, Some(dist_from_start.min(half - 1)));
+    }
+
+    if dist_from_end <= BORDER_BP {
+        return (node_x1, Some(node_width - 1 - dist_from_end.min(half - 1)));
+    }
+
+    (node_x1 + half, None)
+}
+
+/// Collect visible annotation segments, resolving endpoint positions against
+/// the current layout and detail level.
+///
+/// Returns `(visible_indices_sorted, segments_by_annotation, entirely_truncated_count)`.
+/// `entirely_truncated_count` is the number of visible annotations whose every segment
+/// falls entirely within a truncated node interior and is therefore visually omitted.
+pub fn collect_visual_segments<S: NodeSizer<GenGraph>>(
+    track: &AnnotationTrack,
+    controller: &GraphController<GenGraph, S>,
+) -> (Vec<usize>, HashMap<usize, Vec<VisualSegment>>, usize) {
+    if track.annotations.is_empty() {
+        return (Vec::new(), HashMap::new(), 0);
+    }
+
+    let viewport_state = &controller.viewport_state;
+    let viewport_graph = controller.get_viewport_graph();
+    let graph = controller.graph();
 
     let camera_rect = viewport_state.camera_rect();
-    let window_start = camera_rect.min.x;
-    let window_end = camera_rect.max.x;
-    let left_bound = window_start - HORIZONTAL_LOOKAHEAD;
-    let right_bound = window_end + HORIZONTAL_LOOKAHEAD;
+    let win_start = camera_rect.min.x;
+    let win_end = camera_rect.max.x;
+
+    let max_label_len = track
+        .annotations
+        .iter()
+        .map(|annotation| annotation.name.chars().count() as i64)
+        .max()
+        .unwrap_or(0);
+
+    // Labels can remain visible outside the bar by roughly their own width plus
+    // gutter. If collection only looks at the bar, a label can vanish before it
+    // has finished sliding out of the viewport.
+    let lookahead = MIN_LABEL_LOOKAHEAD.max(max_label_len + LABEL_SIDE_GUTTER * 2 + 1);
+    let left_bound = win_start - lookahead;
+    let right_bound = win_end + lookahead;
+
+    let mut segments_by_annotation: HashMap<usize, Vec<VisualSegment>> = HashMap::new();
+    let mut visible_indices: Vec<usize> = Vec::new();
+    let mut visible_set: HashSet<usize> = HashSet::new();
 
     for (world_pos, domain_idx, layout_node) in viewport_graph.data_nodes() {
-        // Resolve the domain GraphNode from the index
         let block = <&GenGraph as NodeIndexable>::from_index(&graph, domain_idx.index());
 
         if is_start_node(block.node_id) || is_end_node(block.node_id) {
             continue;
         }
 
-        // Compute the node's world-space X range from its center position and size
         let node_rect = WorldRect::from_center_and_size(world_pos, layout_node.size);
         let x1 = node_rect.min.x;
         let x2 = node_rect.max.x;
 
-        let near_horizontally = x2 >= left_bound && x1 <= right_bound;
-        if !near_horizontally {
+        if x2 < left_bound || x1 > right_bound {
             continue;
         }
 
@@ -112,48 +424,77 @@ fn collect_annotation_segments(
             continue;
         }
 
-        // label_len is the inclusive width of the node in world cells
-        let label_len = x2 - x1;
-        if label_len <= 0 {
-            continue;
-        }
+        let node_width = layout_node.size.0 as i64;
 
         for (idx, segment) in segments {
             let overlap_start = max(segment.start, block.sequence_start);
             let overlap_end = min(segment.end, block.sequence_end);
+
             if overlap_end <= overlap_start {
                 continue;
             }
 
-            // Map sequence coordinates to world X coordinates using relative positioning
-            // (same algorithm as the annotations branch, but with integer world coordinates)
-            let seg_x1 = x1 + (overlap_start - block.sequence_start) * label_len / node_len;
-            let seg_x2 = x1 + (overlap_end - block.sequence_start) * label_len / node_len;
-            let (seg_x1, seg_x2) = if seg_x2 < seg_x1 {
-                (seg_x2, seg_x1)
-            } else {
-                (seg_x1, seg_x2)
-            };
+            let seg_start = resolve_endpoint(
+                overlap_start - block.sequence_start,
+                block.sequence_end - 1 - overlap_start,
+                x1,
+                node_width,
+                node_len,
+            );
 
-            let is_on_screen = seg_x2 >= window_start && seg_x1 <= window_end;
-            if is_on_screen {
-                visible_ranges
-                    .entry(*idx)
-                    .and_modify(|range| {
-                        range.0 = range.0.min(seg_x1);
-                        range.1 = range.1.max(seg_x2);
-                    })
-                    .or_insert((seg_x1, seg_x2));
+            let seg_end = resolve_endpoint(
+                overlap_end - 1 - block.sequence_start,
+                block.sequence_end - overlap_end,
+                x1,
+                node_width,
+                node_len,
+            );
+
+            if visible_set.insert(*idx) {
+                visible_indices.push(*idx);
             }
 
             segments_by_annotation
                 .entry(*idx)
                 .or_default()
-                .push((seg_x1, seg_x2));
+                .push(VisualSegment {
+                    node_x1: x1,
+                    node_x2: x2,
+                    start: seg_start,
+                    end: seg_end,
+                });
         }
     }
 
-    (visible_ranges, segments_by_annotation)
+    // Filter out entirely truncated annotations (start and end on same node, both in truncated interior).
+    let mut entirely_truncated_count = 0;
+
+    visible_indices.retain(|idx| {
+        let Some(segs) = segments_by_annotation.get(idx) else {
+            return false;
+        };
+
+        let (Some(first), Some(last)) = (segs.first(), segs.last()) else {
+            return true;
+        };
+
+        let is_truncated =
+            first.node_x1 == last.node_x1 && first.start.1.is_none() && last.end.1.is_none();
+
+        if is_truncated {
+            entirely_truncated_count += 1;
+            segments_by_annotation.remove(idx);
+            false
+        } else {
+            true
+        }
+    });
+
+    (
+        visible_indices,
+        segments_by_annotation,
+        entirely_truncated_count,
+    )
 }
 
 fn pack_visible_annotation_rows(
@@ -179,7 +520,7 @@ fn pack_visible_annotation_rows(
     for (idx, (start, end)) in annotations {
         let label_len = track.annotations[*idx].name.chars().count() as i64;
         let occupied_start = *start - label_len - 1;
-        let occupied_end = *end;
+        let occupied_end = *end + RIGHT_BAR_MARGIN;
 
         let best_row = row_ends
             .iter()
@@ -203,183 +544,44 @@ fn pack_visible_annotation_rows(
     rows
 }
 
-/// Calculate the desired height for an annotation track panel.
-pub fn annotation_panel_height(track: &AnnotationTrack, max_height: u16) -> u16 {
-    if max_height < 2 {
-        return 0;
+fn span_strand(span: &AnnotationSpan) -> Option<Strand> {
+    let first = span.segments.first()?.strand;
+    if Strand::is_ambiguous(first) {
+        return None;
     }
-    if track.annotations.is_empty() {
-        return if track.name.is_empty() {
-            0
-        } else {
-            2.min(max_height)
-        };
+    if span.segments.iter().all(|s| s.strand == first) {
+        Some(first)
+    } else {
+        None
     }
-    let desired = track.annotations.len().saturating_add(1) as u16;
-    let cap = max_height.saturating_div(3).max(3);
-    desired.min(cap).min(max_height)
 }
 
-/// Draw the annotation track panel below the graph canvas.
-///
-/// This is the gen-tui equivalent of the old `Viewer::draw_annotations_panel`. Instead of
-/// rendering through ratatui's `Canvas` widget with braille coordinates, it writes directly
-/// to the terminal buffer. The X axis is synchronized with the graph's viewport by converting
-/// world X coordinates to terminal X via `ViewportState::world_to_terminal`.
-pub fn draw_annotations_panel(
-    frame: &mut ratatui::Frame,
-    area: Rect,
-    track: &AnnotationTrack,
-    controller: &GraphController<GenGraph, GenGraphNodeSizer>,
+/// Convert a world X coordinate to a terminal X coordinate.
+#[inline]
+pub(crate) fn world_x_to_term_x(viewport_state: &ViewportState, world_x: i64) -> i64 {
+    let cam_min_x = viewport_state.camera_rect().min.x;
+    viewport_state.viewport_bounds.x as i64 + (world_x - cam_min_x)
+}
+
+fn draw_truncation_marker(
+    buf: &mut Buffer,
+    inner: Rect,
+    viewport_state: &ViewportState,
+    world_x: i64,
+    terminal_y: u16,
+    style: Style,
 ) {
-    if area.height < 2 {
-        return;
-    }
+    let raw_x = world_x_to_term_x(viewport_state, world_x);
+    let area_left = inner.x as i64;
+    let area_right = (inner.x + inner.width - 1) as i64;
 
-    let theme = current_theme();
-
-    // Draw the divider line with track name
-    let divider_style = Style::default().fg(theme[0x02]);
-    let divider_y = area.y;
-    let divider = "─".repeat(area.width as usize);
-    frame
-        .buffer_mut()
-        .set_string(area.x, divider_y, divider, divider_style);
-
-    if !track.name.is_empty() {
-        frame.buffer_mut().set_string(
-            area.x + 1,
-            divider_y,
-            &track.name,
-            Style::default().fg(theme[0x04]),
-        );
-    }
-
-    let inner = Rect {
-        x: area.x,
-        y: area.y + 1,
-        width: area.width,
-        height: area.height - 1,
-    };
-
-    if inner.height == 0 || inner.width == 0 {
-        return;
-    }
-
-    // Fill background
-    let bg_color = theme[0x00];
-    let bg_style = Style::default().bg(bg_color);
-    for row in inner.y..inner.y + inner.height {
-        let blank = " ".repeat(inner.width as usize);
-        frame.buffer_mut().set_string(inner.x, row, blank, bg_style);
-    }
-
-    let zoomed_out = controller.get_detail_level() == VisualDetail::Minimal;
-    let annotation_color = theme[0x0B];
-    let annotation_label_style = Style::default().fg(annotation_color).bg(bg_color);
-    let annotation_bar_style = Style::default().bg(annotation_color);
-    let annotation_dot_style = Style::default().fg(annotation_color).bg(bg_color);
-
-    let (visible_ranges, segments_by_annotation) = collect_annotation_segments(
-        track,
-        controller.get_viewport_graph(),
-        &controller.viewport_state,
-        controller.graph(),
-    );
-    let packed_rows = pack_visible_annotation_rows(&visible_ranges, track, inner.height as usize);
-    if packed_rows.is_empty() {
-        return;
-    }
-
-    let viewport_state = &controller.viewport_state;
-
-    for (row, row_annotations) in packed_rows.iter().enumerate() {
-        // Each annotation row is drawn at a fixed terminal Y within the inner rect
-        let terminal_y = inner.y + row as u16;
-
-        for idx in row_annotations {
-            let Some(mut segments) = segments_by_annotation.get(idx).cloned() else {
-                continue;
-            };
-            segments.sort_by(|a, b| a.0.cmp(&b.0));
-
-            let annotation_name = &track.annotations[*idx].name;
-
-            // Draw the label to the left of the first segment
-            if let Some((first_x1, _)) = segments.first() {
-                let label_len = annotation_name.chars().count() as i64;
-                let label_world_x = first_x1 - label_len - 1;
-                if let Some((term_x, _)) =
-                    viewport_state.world_to_terminal(WorldPos::new(label_world_x, 0))
-                {
-                    // Clamp label to the panel area
-                    let label_start = term_x.max(inner.x);
-                    if label_start < inner.x + inner.width {
-                        frame.buffer_mut().set_string(
-                            label_start,
-                            terminal_y,
-                            annotation_name,
-                            annotation_label_style,
-                        );
-                    }
-                }
-            }
-
-            let mut prev_end: Option<i64> = None;
-            for (x1, x2) in &segments {
-                if zoomed_out {
-                    // Draw a single dot at the center
-                    let center = (x1 + x2) / 2;
-                    if let Some((term_x, _)) =
-                        viewport_state.world_to_terminal(WorldPos::new(center, 0))
-                        && term_x >= inner.x
-                        && term_x < inner.x + inner.width
-                    {
-                        frame.buffer_mut().set_string(
-                            term_x,
-                            terminal_y,
-                            "●",
-                            annotation_dot_style,
-                        );
-                    }
-                } else {
-                    // Draw a solid bar for the segment
-                    place_bar(
-                        frame,
-                        inner,
-                        viewport_state,
-                        *x1,
-                        *x2,
-                        terminal_y,
-                        annotation_bar_style,
-                    );
-                }
-
-                // Draw dashed connectors between disconnected segments of the same annotation
-                if !zoomed_out
-                    && let Some(prev) = prev_end
-                    && x1 - prev > 1
-                {
-                    draw_dashed_connector(
-                        frame,
-                        inner,
-                        viewport_state,
-                        prev + 1,
-                        x1 - 1,
-                        terminal_y,
-                        annotation_label_style,
-                    );
-                }
-
-                prev_end = Some(*x2);
-            }
-        }
+    if raw_x >= area_left && raw_x <= area_right {
+        buf.set_string(raw_x as u16, terminal_y, "░", style);
     }
 }
 
-/// Draw a solid bar from world x1 to world x2 at the given terminal y, clipped to the inner rect.
 fn place_bar(
-    frame: &mut ratatui::Frame,
+    buf: &mut Buffer,
     inner: Rect,
     viewport_state: &ViewportState,
     world_x1: i64,
@@ -387,34 +589,24 @@ fn place_bar(
     terminal_y: u16,
     style: Style,
 ) {
-    // Convert world X endpoints to terminal X
-    let term_x1 = viewport_state
-        .world_to_terminal(WorldPos::new(world_x1, 0))
-        .map(|(x, _)| x);
-    let term_x2 = viewport_state
-        .world_to_terminal(WorldPos::new(world_x2, 0))
-        .map(|(x, _)| x);
+    let area_left = inner.x as i64;
+    let area_right = (inner.x + inner.width - 1) as i64;
+    let raw_x1 = world_x_to_term_x(viewport_state, world_x1);
+    let raw_x2 = world_x_to_term_x(viewport_state, world_x2);
 
-    // Fall back to inner rect edges if off-screen
-    let start_x = term_x1.unwrap_or(inner.x).max(inner.x);
-    let end_x = term_x2
-        .unwrap_or(inner.x + inner.width - 1)
-        .min(inner.x + inner.width - 1);
-
-    if start_x > end_x {
+    if raw_x2 < area_left || raw_x1 > area_right {
         return;
     }
 
+    let start_x = raw_x1.max(area_left) as u16;
+    let end_x = raw_x2.min(area_right) as u16;
     let width = (end_x - start_x + 1) as usize;
-    let bar = " ".repeat(width);
-    frame
-        .buffer_mut()
-        .set_string(start_x, terminal_y, bar, style);
+
+    buf.set_string(start_x, terminal_y, "█".repeat(width), style);
 }
 
-/// Draw a dashed connector from world x_start to world x_end at the given terminal y.
 fn draw_dashed_connector(
-    frame: &mut ratatui::Frame,
+    buf: &mut Buffer,
     inner: Rect,
     viewport_state: &ViewportState,
     world_x_start: i64,
@@ -426,39 +618,137 @@ fn draw_dashed_connector(
         return;
     }
 
-    let term_x1 = viewport_state
-        .world_to_terminal(WorldPos::new(world_x_start, 0))
-        .map(|(x, _)| x);
-    let term_x2 = viewport_state
-        .world_to_terminal(WorldPos::new(world_x_end, 0))
-        .map(|(x, _)| x);
+    let area_left = inner.x as i64;
+    let area_right = (inner.x + inner.width - 1) as i64;
+    let raw_x1 = world_x_to_term_x(viewport_state, world_x_start);
+    let raw_x2 = world_x_to_term_x(viewport_state, world_x_end);
 
-    let start_x = term_x1.unwrap_or(inner.x).max(inner.x);
-    let end_x = term_x2
-        .unwrap_or(inner.x + inner.width - 1)
-        .min(inner.x + inner.width - 1);
-
-    if start_x > end_x {
+    if raw_x2 < area_left || raw_x1 > area_right {
         return;
     }
 
+    let start_x = raw_x1.max(area_left) as u16;
+    let end_x = raw_x2.min(area_right) as u16;
     let visible_width = (end_x - start_x + 1) as usize;
-    // Compute the offset into the dash pattern based on how far we are from the start
-    let pattern_offset =
-        (start_x as i64 - term_x1.unwrap_or(start_x) as i64).unsigned_abs() as usize;
 
-    let mut label = String::with_capacity(visible_width);
-    for i in 0..visible_width {
-        if (pattern_offset + i).is_multiple_of(2) {
-            label.push('-');
-        } else {
-            label.push(' ');
-        }
+    buf.set_string(start_x, terminal_y, "-".repeat(visible_width), style);
+}
+
+#[allow(clippy::too_many_arguments)]
+fn place_sticky_label(
+    buf: &mut Buffer,
+    inner: Rect,
+    viewport_state: &ViewportState,
+    annotation_world_x1: i64,
+    annotation_world_x2: i64,
+    terminal_y: u16,
+    label: &str,
+    strand: Option<Strand>,
+    normal_style: Style,
+    label_fg_over_bar: Color,
+) {
+    // TODO: this assumes one terminal cell per char. If annotation names can
+    // contain wide Unicode or combining marks, switch to unicode-width and
+    // grapheme-aware clipping/writing.
+    let label_len = label.chars().count() as i64;
+
+    if label_len == 0 || inner.width == 0 {
+        return;
     }
 
-    frame
-        .buffer_mut()
-        .set_string(start_x, terminal_y, label, style);
+    let area_left = inner.x as i64;
+    let area_right = (inner.x + inner.width - 1) as i64;
+
+    if area_right < area_left {
+        return;
+    }
+
+    let annotation_start = annotation_world_x1.min(annotation_world_x2);
+    let annotation_end = annotation_world_x1.max(annotation_world_x2);
+
+    let annotation_start_term = world_x_to_term_x(viewport_state, annotation_start);
+    let annotation_end_term = world_x_to_term_x(viewport_state, annotation_end);
+
+    let final_start = match strand {
+        Some(Strand::Forward) => (annotation_start_term - LABEL_SIDE_GUTTER - label_len)
+            .max(area_left + LABEL_SIDE_GUTTER)
+            .min(annotation_end_term - label_len),
+        Some(Strand::Reverse) => (annotation_end_term + LABEL_SIDE_GUTTER)
+            .min(area_right - label_len - LABEL_SIDE_GUTTER)
+            .max(annotation_start_term + LABEL_SIDE_GUTTER),
+        _ => (annotation_start_term - LABEL_SIDE_GUTTER - label_len)
+            .max(area_left + LABEL_SIDE_GUTTER)
+            .min(annotation_end_term - label_len),
+    };
+
+    let label_with_marker = match strand {
+        Some(Strand::Forward) => format!("{label}›"),
+        Some(Strand::Reverse) => format!("‹{label}"),
+        _ => label.to_string(),
+    };
+
+    draw_label_clipped_over_existing(
+        buf,
+        inner,
+        final_start,
+        terminal_y,
+        &label_with_marker,
+        normal_style,
+        label_fg_over_bar,
+    );
+}
+
+fn draw_label_clipped_over_existing(
+    buf: &mut Buffer,
+    inner: Rect,
+    start_x: i64,
+    terminal_y: u16,
+    label: &str,
+    normal_style: Style,
+    label_fg_over_bar: Color,
+) {
+    let area_left = inner.x as i64;
+    let area_right = (inner.x + inner.width - 1) as i64;
+
+    if area_right < area_left {
+        return;
+    }
+
+    let normal_fg = normal_style.fg.unwrap_or(Color::Reset);
+
+    for (i, ch) in label.chars().enumerate() {
+        let x = start_x + i as i64;
+
+        if x < area_left || x > area_right {
+            continue;
+        }
+
+        if ch == ' ' {
+            // Preserve the existing cell entirely for spaces in the label, so
+            // bars/connectors/backgrounds shine through instead of getting a
+            // visible label-colored gap.
+            continue;
+        }
+
+        let x = x as u16;
+
+        let Some(old_cell) = buf.cell((x, terminal_y)) else {
+            continue;
+        };
+
+        let old_symbol = old_cell.symbol();
+
+        let style = if old_symbol == "█" || old_symbol == "░" {
+            // The annotation bar is drawn as a full block glyph. Its visible
+            // color is the cell foreground, so reuse that fg as the label bg.
+            Style::default().fg(label_fg_over_bar).bg(old_cell.fg)
+        } else {
+            // Not over a bar: preserve whatever background is already there.
+            Style::default().fg(normal_fg).bg(old_cell.bg)
+        };
+
+        buf.set_string(x, terminal_y, ch.to_string(), style);
+    }
 }
 
 #[cfg(test)]

--- a/src/views/annotations.rs
+++ b/src/views/annotations.rs
@@ -151,7 +151,37 @@ fn build_annotation_spans(
         .collect()
 }
 
-fn parse_translated_gff<R: BufRead>(
+/// Parse a translated GFF3 file from a filesystem path.
+pub fn parse_translated_gff_file(
+    path: &std::path::Path,
+    node_filter: &HashSet<HashId>,
+    track_label: &str,
+) -> Result<Vec<AnnotationSpan>, Box<dyn std::error::Error>> {
+    let reader = BufReader::new(File::open(path)?);
+    Ok(parse_translated_gff(
+        reader,
+        node_filter,
+        track_label,
+        HashMap::new(),
+    ))
+}
+
+/// Parse a translated BED file from a filesystem path.
+pub fn parse_translated_bed_file(
+    path: &std::path::Path,
+    node_filter: &HashSet<HashId>,
+    track_label: &str,
+) -> Result<Vec<AnnotationSpan>, Box<dyn std::error::Error>> {
+    let reader = BufReader::new(File::open(path)?);
+    Ok(parse_translated_bed(
+        reader,
+        node_filter,
+        track_label,
+        HashMap::new(),
+    ))
+}
+
+pub fn parse_translated_gff<R: BufRead>(
     reader: R,
     node_filter: &HashSet<HashId>,
     track_label: &str,
@@ -206,7 +236,7 @@ fn parse_translated_gff<R: BufRead>(
     build_annotation_spans(track_label, segments_by_name)
 }
 
-fn parse_translated_bed<R: BufRead>(
+pub fn parse_translated_bed<R: BufRead>(
     reader: R,
     node_filter: &HashSet<HashId>,
     track_label: &str,

--- a/src/views/block_group.rs
+++ b/src/views/block_group.rs
@@ -681,23 +681,6 @@ pub fn view_block_group(
         terminal.draw(|frame| {
             let status_bar_height: u16 = 1;
 
-            // Collect annotation tracks to display
-            let mut track_panels: Vec<(&AnnotationTrack, u16)> = Vec::new();
-            for track in annotation_file_tracks.values() {
-                let height = crate::views::annotation_track::annotation_panel_height(track, 10);
-                if height > 0 {
-                    track_panels.push((track, height));
-                }
-            }
-            for track in annotation_group_tracks.values() {
-                let height = crate::views::annotation_track::annotation_panel_height(track, 10);
-                if height > 0 {
-                    track_panels.push((track, height));
-                }
-            }
-
-            let total_annotation_height: u16 = track_panels.iter().map(|(_, h)| *h).sum();
-
             // The outer layout is a vertical split between the main area, optional message bar, and status bar
             let show_message_bar = !messages.is_empty();
 
@@ -728,39 +711,17 @@ pub fn view_block_group(
             last_sidebar_area = sidebar_area;
             let viewer_root_area = sidebar_layout[1];
 
-            // Split viewer area between graph and annotation panels
-            let viewer_constraints = if total_annotation_height > 0 {
-                vec![
-                    Constraint::Min(10),                         // Graph area (minimum 10 lines)
-                    Constraint::Length(total_annotation_height), // Annotation panels
-                ]
-            } else {
-                vec![Constraint::Percentage(100)] // Just the graph
-            };
-
-            let viewer_layout = Layout::default()
-                .direction(Direction::Vertical)
-                .constraints(viewer_constraints)
-                .split(viewer_root_area);
-
-            let graph_root_area = viewer_layout[0];
-            let annotation_area = if viewer_layout.len() > 1 {
-                Some(viewer_layout[1])
-            } else {
-                None
-            };
-
-            // The panel pops up in the graph area, it does not overlap with the sidebar or annotations
+            // The panel pops up in the graph area, it does not overlap with the sidebar
             let panel_layout = Layout::default()
                 .direction(Direction::Vertical)
                 .constraints(vec![Constraint::Percentage(80), Constraint::Percentage(20)])
-                .split(graph_root_area);
+                .split(viewer_root_area);
             let panel_area = panel_layout[1];
 
             let canvas_area = if show_panel {
                 panel_layout[0]
             } else {
-                graph_root_area
+                viewer_root_area
             };
 
             // Set viewport bounds to the actual canvas area before updating animations
@@ -891,27 +852,17 @@ pub fn view_block_group(
                     .cursor();
                 frame.render_stateful_widget(widget, canvas_area, &mut graph_controller);
 
-                // Render annotation track panels below the graph
-                if let Some(annotation_area) = annotation_area {
-                    let mut current_y = annotation_area.y;
-                    for (track, height) in track_panels.iter() {
-                        if current_y + height > annotation_area.y + annotation_area.height {
-                            break; // No more room
-                        }
-                        let track_area = Rect {
-                            x: annotation_area.x,
-                            y: current_y,
-                            width: annotation_area.width,
-                            height: *height,
-                        };
-                        crate::views::annotation_track::draw_annotations_panel(
-                            frame,
-                            track_area,
-                            track,
-                            &graph_controller,
-                        );
-                        current_y = current_y.saturating_add(*height);
-                    }
+                // Overlay annotation tracks at the bottom of the canvas.
+                // Prepare after graph render so viewport state is accurate.
+                let mut remaining = canvas_area;
+                let tracks: Vec<&mut AnnotationTrack> = annotation_file_tracks
+                    .values_mut()
+                    .chain(annotation_group_tracks.values_mut())
+                    .collect();
+                for track in tracks.into_iter().rev() {
+                    let height = track.draw(frame.buffer_mut(), remaining, &graph_controller);
+                    if height == 0 { break; }
+                    remaining.height = remaining.height.saturating_sub(height);
                 }
             }
 

--- a/src/views/gen_graph_widget.rs
+++ b/src/views/gen_graph_widget.rs
@@ -4,7 +4,7 @@ use gen_core::{is_end_node, is_start_node};
 use gen_graph::{GenGraph, GraphNode};
 use gen_models::{db::GraphConnection, node::Node, sequence::SequenceError};
 use gen_tui::{
-    geometry::WorldRect,
+    geometry::{WorldPos, WorldRect},
     graph_controller::{GraphController, WorldBuffer},
     graph_widget::{GraphWidget, NODE_GLYPH},
     layout::VisualDetail,
@@ -40,8 +40,8 @@ impl NodeSizer<GenGraph> for GenGraphNodeSizer {
         let sequence_length = (node.sequence_end - node.sequence_start) as u64;
         match detail_level {
             VisualDetail::Minimal => (1u64, 1u64), // Just a glyph
-            VisualDetail::Truncated => (sequence_length.min(12), 1u64), // Truncated to max 12 chars
-            VisualDetail::Full => (sequence_length, 1u64), // Full sequence length
+            VisualDetail::Truncated => (sequence_length.min(13), 1u64), // 13 = 5 border + 1 mid + 5 border + 2
+            VisualDetail::Full => (sequence_length, 1u64),              // Full sequence length
         }
     }
 }
@@ -126,15 +126,15 @@ impl NodeRenderer<GenGraph> for GenGraphNodeRenderer<'_> {
         match detail_level {
             VisualDetail::Minimal => {
                 // Base scale: Just show a simple glyph
-                let text_style = Style::default().fg(theme[0x00]).bg(theme[0x05]);
+                let text_style = Style::default().fg(theme[0x05]).bg(theme[0x00]);
                 buffer.set_string_styled(area.left_center(), &NODE_GLYPH.to_string(), text_style);
             }
             VisualDetail::Truncated => {
-                // Truncated scale: Show sequence with truncation to max 12 chars
+                // 13 cells: 5 left bases + "..." + 5 right bases.
                 let sequence = self
                     .get_sequence(node_id)
                     .unwrap_or_else(|_| "Unknown Sequence".to_string());
-                let max_width = 12u32;
+                let max_width = 13u32;
                 let truncated = inner_truncation(&sequence, max_width);
                 buffer.set_string_styled(area.left_center(), &truncated, text_style);
             }
@@ -220,8 +220,8 @@ pub fn create_gen_graph_controller(
 /// * `controller` — the graph controller to position
 /// * `node`       — the exact `GraphNode` key to center on
 /// * `offset`     — fractional `(x, y)` position within the node (0.0–1.0)
-pub fn center_on_node_offset(
-    controller: &mut GraphController<GenGraph, GenGraphNodeSizer>,
+pub fn center_on_node_offset<S: NodeSizer<GenGraph>>(
+    controller: &mut GraphController<GenGraph, S>,
     node: GraphNode,
     offset: (f64, f64),
 ) {
@@ -259,27 +259,143 @@ pub fn center_on_node_offset(
     controller.trigger_rebuild();
 }
 
+/// Build a GraphNode → (WorldPos, node_size) lookup from the current viewport graph.
+pub fn viewport_pos_map<S: NodeSizer<GenGraph>>(
+    controller: &GraphController<GenGraph, S>,
+) -> HashMap<GraphNode, (WorldPos, (u64, u64))> {
+    let graph = controller.graph();
+    controller
+        .get_viewport_graph()
+        .data_nodes()
+        .map(|(world_pos, domain_idx, layout_node)| {
+            let node = <&GenGraph as NodeIndexable>::from_index(&graph, domain_idx.index());
+            (node, (world_pos, layout_node.size))
+        })
+        .collect()
+}
+
+/// Compute the world-space bounding corners of the matched region in a `GraphLocus`.
+///
+/// Returns `(left_pos, right_pos)` where:
+/// - `left_pos` is the world position of the first matched column in `blocks[0]`,
+///   with the minimum y across all blocks
+/// - `right_pos` is the world position of the last matched column in `blocks[last]`,
+///   with the maximum y across all blocks
+///
+/// Column offsets are clamped with `clamp_col` so they map correctly in every
+/// detail level (e.g. truncated nodes collapse interior columns to the `...` cell).
+///
+/// Returns `None` if no block in the locus is present in `pos_map` (all off-screen).
+pub fn locus_label_bounds(
+    locus: &GraphLocus,
+    pos_map: &HashMap<GraphNode, (WorldPos, (u64, u64))>,
+    detail_level: VisualDetail,
+) -> Option<(WorldPos, WorldPos)> {
+    let block_world_pos = |block: GraphNode, col_raw: i64| -> Option<WorldPos> {
+        let &(center, size) = pos_map.get(&block)?;
+        let rect = WorldRect::from_center_and_size(center, size);
+        let col = clamp_col(col_raw, block.length(), detail_level);
+        Some(WorldPos::new(rect.min.x + col, center.y))
+    };
+
+    let last = locus.blocks.len() - 1;
+
+    let left_pos = locus.blocks.iter().enumerate().find_map(|(i, &block)| {
+        let col_raw = if i == 0 { locus.start_offset as i64 } else { 0 };
+        block_world_pos(block, col_raw)
+    })?;
+
+    let right_pos = locus
+        .blocks
+        .iter()
+        .enumerate()
+        .rev()
+        .find_map(|(i, &block)| {
+            let col_raw = if i == last {
+                locus.end_offset.saturating_sub(1) as i64
+            } else {
+                block.length() - 1
+            };
+            block_world_pos(block, col_raw)
+        })?;
+
+    let mut y_min = i64::MAX;
+    let mut y_max = i64::MIN;
+    for &block in &locus.blocks {
+        let Some(&(center, _)) = pos_map.get(&block) else {
+            continue;
+        };
+        y_min = y_min.min(center.y);
+        y_max = y_max.max(center.y);
+    }
+
+    if y_min == i64::MAX {
+        return None;
+    }
+
+    let left_pos = WorldPos::new(left_pos.x, y_max);
+    let right_pos = WorldPos::new(right_pos.x, y_min);
+
+    Some((left_pos, right_pos))
+}
+
+/// Apply detail-level clamping to a raw column offset.
+///
+/// In `Truncated` mode, interior columns of long nodes map to the `...` region.
+fn clamp_col(col_raw: i64, block_seq_len: i64, detail_level: VisualDetail) -> i64 {
+    if detail_level == VisualDetail::Truncated && block_seq_len > 13 {
+        clamp_truncated_col(col_raw, block_seq_len)
+    } else {
+        col_raw
+    }
+}
+
+/// Map a sequence offset to a visual cell column inside a 13-cell truncated node.
+///
+/// Display layout: `AAAAA...BBBBB` — first 5 bases (cells 0-4), `...` (cells 5-7),
+/// last 5 bases (cells 8-12). Interior positions that fall in the `...` region clamp
+/// to cell 6 (the centre dot).
+fn clamp_truncated_col(value: i64, block_seq_len: i64) -> i64 {
+    if value < 5 {
+        value
+    } else if block_seq_len - value <= 5 {
+        13 - (block_seq_len - value)
+    } else {
+        6
+    }
+}
+
 /// Highlight only the matched bytes of a `GraphLocus`, using sub-rect tinting.
 ///
 /// - Start node: tinted from `start_offset` to its right edge.
 /// - Middle nodes: fully tinted.
 /// - End node: tinted from its left edge to `end_offset` (exclusive).
-pub fn highlight_match_range(
-    controller: &mut GraphController<GenGraph, GenGraphNodeSizer>,
+///
+/// In `Truncated` detail level the column offsets are clamped so that interior
+/// positions map to the `...` cell rather than a precise (wrong) location.
+pub fn highlight_match_range<S: NodeSizer<GenGraph>>(
+    controller: &mut GraphController<GenGraph, S>,
     m: &GraphLocus,
     style: PathStyle,
 ) {
+    let detail_level = controller.get_detail_level();
+
     let path_len = m.blocks.len();
     for (i, &node) in m.blocks.iter().enumerate() {
-        let col_start = if i == 0 { m.start_offset as i64 } else { 0 };
-        // br is inclusive, so end_offset (exclusive) - 1; saturate to avoid underflow on empty match
-        let col_end = if i == path_len - 1 {
+        let block_seq_len = node.length();
+        let col_start_raw = if i == 0 { m.start_offset as i64 } else { 0 };
+        let col_end_raw = if i == path_len - 1 {
             m.end_offset.saturating_sub(1) as i64
         } else {
-            node.length() - 1
+            block_seq_len - 1
         };
+        let (col_start, col_end) = (
+            clamp_col(col_start_raw, block_seq_len, detail_level),
+            clamp_col(col_end_raw, block_seq_len, detail_level),
+        );
         controller.set_cell_highlight(node, (col_start, 0), (col_end, 0), style);
     }
+
     for (&src, &dst) in m.blocks.iter().zip(m.blocks.iter().skip(1)) {
         controller.set_edge_highlight((src, dst), style);
     }

--- a/src/views/inline_label_placement.rs
+++ b/src/views/inline_label_placement.rs
@@ -1,0 +1,221 @@
+use gen_tui::{ViewportState, WorldPos};
+use ratatui::{
+    buffer::Buffer,
+    layout::Rect,
+    style::{Color, Style},
+};
+
+fn truncations(label: &str) -> impl Iterator<Item = String> {
+    let chars: Vec<char> = label.chars().collect();
+    let full_len = chars.len();
+
+    // For labels shorter than 4 chars, just return the full label.
+    if full_len < 4 {
+        vec![label.to_string()].into_iter()
+    } else {
+        let mut candidates = Vec::with_capacity(full_len - 1);
+
+        candidates.push(label.to_string());
+
+        // Keep at least 2 body characters before the ellipsis.
+        // TODO: this is char-based, not display-width-based.
+        for body_len in (2..full_len).rev() {
+            let body: String = chars[..body_len].iter().collect();
+            candidates.push(format!("{body}…"));
+        }
+
+        candidates.into_iter()
+    }
+}
+
+/// All top-left positions where a label of `label_width` fits inside `search`,
+/// ordered by Manhattan distance from `preferred`.
+///
+/// Ties prefer positions below `preferred` before positions above it, then smaller
+/// horizontal offsets.
+fn nearby_candidates(preferred: (u16, u16), search: Rect, label_width: u16) -> Vec<(u16, u16)> {
+    let (px, py) = (preferred.0 as i32, preferred.1 as i32);
+
+    let x_lo = search.x as i32;
+    let x_hi = search.right() as i32 - label_width as i32;
+    let y_lo = search.y as i32;
+    let y_hi = search.bottom() as i32;
+
+    if x_hi < x_lo {
+        return Vec::new();
+    }
+
+    let mut out = Vec::new();
+
+    for y in y_lo..y_hi {
+        for x in x_lo..=x_hi {
+            let dx = x - px;
+            let dy = y - py;
+            let dist = dx.abs() + dy.abs();
+
+            // Sort lower/equal rows before upper rows when distance ties.
+            let above = (dy < 0) as u8;
+
+            out.push(((x as u16, y as u16), (dist, above, dx.abs())));
+        }
+    }
+
+    out.sort_by_key(|&(_, key)| key);
+    out.into_iter().map(|(pos, _)| pos).collect()
+}
+
+/// Try to place `label` near `annotation`.
+///
+/// For each text form, this tries:
+///
+/// 1. centered below the annotation rectangle
+/// 2. centered above the annotation rectangle
+/// 3. nearby positions inside the bounded search rectangle
+///
+/// The full label is tried first. Shorter ellipsis forms are only tried after
+/// all positions have failed for the current text.
+fn try_draw_label_at(
+    buf: &mut Buffer,
+    area: Rect,
+    x: u16,
+    y: u16,
+    text: &str,
+    color: Color,
+) -> bool {
+    if y < area.y || y >= area.bottom() {
+        return false;
+    }
+
+    let width = text.chars().count() as u16;
+    let x_start = x.max(area.x);
+    let visible_width = (area.right() - x_start).min(width) as usize;
+    let skip_chars = (x_start - x) as usize;
+
+    if visible_width == 0 {
+        return false;
+    }
+
+    let visible_text: String = text.chars().skip(skip_chars).take(visible_width).collect();
+
+    if !(x_start..x_start + visible_width as u16)
+        .all(|col| buf.cell((col, y)).is_some_and(|cell| cell.symbol() == " "))
+    {
+        return false;
+    }
+
+    buf.set_string(x_start, y, visible_text, Style::default().fg(color));
+    true
+}
+
+/// Draw a label near a world-space position on the canvas.
+///
+/// `area_of_interest` is a tuple of (left_pos, right_pos) world-space corners of the annotation span.
+/// - left_pos.x and right_pos.x define the x range (first to last block)
+/// - left_pos.y and right_pos.y define the y range (min to max y across all blocks)
+///   `max_distance` is the maximum Manhattan distance from the annotation to search for label placement.
+///
+/// For each text form, this tries:
+/// 1. centered below the annotation rectangle
+/// 2. centered above the annotation rectangle
+/// 3. nearby positions inside the bounded search rectangle
+///
+/// The full label is tried first. Shorter ellipsis forms are only tried after
+/// all positions have failed for the current text.
+pub fn draw_label_near_pos(
+    buf: &mut Buffer,
+    area: Rect,
+    area_of_interest: (WorldPos, WorldPos),
+    label: &str,
+    color: Color,
+    viewport_state: &ViewportState,
+    max_distance: u16,
+) -> Option<(u16, u16)> {
+    if area.width == 0 || area.height == 0 {
+        return None;
+    }
+
+    let (left_pos, right_pos) = area_of_interest;
+    let (term_x_a, term_y_a) = viewport_state.world_to_terminal(left_pos)?;
+    let (term_x_b, term_y_b) = viewport_state.world_to_terminal(right_pos)?;
+
+    let x_min = term_x_a.min(term_x_b);
+    let x_max = term_x_a.max(term_x_b);
+    let y_min = term_y_a.min(term_y_b);
+    let y_max = term_y_a.max(term_y_b);
+
+    if y_max < area.y || y_min >= area.bottom() || x_max < area.x || x_min >= area.right() {
+        return None;
+    }
+
+    let annotation_width = x_max - x_min + 1;
+    let label_width = label.chars().count() as u16;
+    let x_margin = (annotation_width / 2).saturating_add(label_width / 2);
+
+    let annotation = Rect {
+        x: x_min,
+        y: y_min,
+        width: x_max - x_min + 1,
+        height: y_max - y_min + 1,
+    };
+
+    let center_x = annotation.x + annotation.width / 2;
+    let annotation_top = annotation.y;
+    let annotation_bottom = annotation.bottom();
+
+    let search_left = annotation.x.saturating_sub(x_margin).max(area.x);
+    let search_right = annotation
+        .right()
+        .saturating_add(x_margin)
+        .min(area.right());
+
+    let search_top = annotation.y.saturating_sub(max_distance).max(area.y);
+    let search_bottom = annotation
+        .bottom()
+        .saturating_add(max_distance)
+        .min(area.bottom());
+
+    if search_right <= search_left || search_bottom <= search_top {
+        return None;
+    }
+
+    let search = Rect {
+        x: search_left,
+        y: search_top,
+        width: search_right - search_left,
+        height: search_bottom - search_top,
+    };
+
+    for text in truncations(label) {
+        let width = text.chars().count() as u16;
+
+        let below = (
+            center_x.saturating_sub(width / 2),
+            annotation_bottom.saturating_add(1),
+        );
+
+        if try_draw_label_at(buf, area, below.0, below.1, &text, color) {
+            return Some(below);
+        }
+
+        let above = (
+            center_x.saturating_sub(width / 2),
+            annotation_top.saturating_sub(1),
+        );
+
+        if try_draw_label_at(buf, area, above.0, above.1, &text, color) {
+            return Some(above);
+        }
+
+        for (x, y) in nearby_candidates(below, search, width) {
+            if (x, y) == below || (x, y) == above {
+                continue;
+            }
+
+            if try_draw_label_at(buf, area, x, y, &text, color) {
+                return Some((x, y));
+            }
+        }
+    }
+
+    None
+}


### PR DESCRIPTION
## Summary

This PR adds two distinct annotation systems to the graph viewer.

### Track-based annotations

Track-based annotations appear below the graph as a dedicated panel (technically an overlay, not a panel). We extended the packing algorithm to support labels and strand indicators alongside the existing interval rendering. The panel expands automatically as tracks are added, so callers don't need to manage layout dimensions manually.

### Inline annotations

Inline annotations are rendered directly on the graph nodes. This mode is primarily intended for use in Python notebooks (see follow-up PR), where it has proven useful for displaying search results and variant-specific annotations in libraries — a use case that is significantly harder to express cleanly in a track-based layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (partially, he's really running with the credit here)