### PR TITLE
Accession based updates

### DIFF
--- a/gen-annotations/src/gff.rs
+++ b/gen-annotations/src/gff.rs
@@ -240,7 +240,6 @@ mod tests {
         .expect("should create child block group")[0]
             .id;
         let sample_path = BlockGroup::get_current_path(conn, &sample_bg_id);
-        let tree = sample_path.intervaltree(conn).unwrap();
         let replacement_sequence = "AA";
 
         let replacement = Sequence::new()
@@ -260,7 +259,7 @@ mod tests {
         .unwrap();
         let change = PathChange {
             block_group_id: sample_bg_id,
-            path: sample_path.clone(),
+            intervaltree_source: sample_path.clone(),
             path_accession: None,
             start: 15,
             end: 25,
@@ -278,8 +277,7 @@ mod tests {
             preserve_edge: true,
         };
 
-        BlockGroup::insert_change(conn, &change, &tree)
-            .expect("should apply AA update to child sample");
+        BlockGroup::insert_change(conn, &change).expect("should apply AA update to child sample");
 
         let edge_to_insert = Edge::query(
             conn,

--- a/gen-annotations/src/test_helpers.rs
+++ b/gen-annotations/src/test_helpers.rs
@@ -140,8 +140,6 @@ pub fn setup_test_data(conn: &GraphConnection) {
     .expect("should create child block group")[0]
         .id;
     let sample_path = BlockGroup::get_current_path(conn, &sample_bg_id);
-    let tree = sample_path.intervaltree(conn).unwrap();
-
     let alt_seq = "C";
 
     let sequence = Sequence::new()
@@ -161,7 +159,7 @@ pub fn setup_test_data(conn: &GraphConnection) {
     .unwrap();
     let change = PathChange {
         block_group_id: sample_bg_id,
-        path: sample_path,
+        intervaltree_source: sample_path,
         path_accession: None,
         start: 3,
         end: 4,
@@ -179,5 +177,5 @@ pub fn setup_test_data(conn: &GraphConnection) {
         preserve_edge: false,
     };
 
-    BlockGroup::insert_change(conn, &change, &tree).expect("should apply variant change");
+    BlockGroup::insert_change(conn, &change).expect("should apply variant change");
 }

--- a/gen-models/src/accession.rs
+++ b/gen-models/src/accession.rs
@@ -31,6 +31,8 @@ pub enum AccessionError {
     DatabaseError(#[from] rusqlite::Error),
     #[error("Duplicate entry with uuid: {0}")]
     Duplicate(String),
+    #[error("Accession {0} has no edges in accession_paths")]
+    MissingPath(HashId),
 }
 
 impl<'a> Capnp<'a> for Accession {
@@ -347,13 +349,14 @@ impl Accession {
         AccessionEdge::query(conn, query, params![accession_id])
     }
 
-    pub fn intervaltree(&self, conn: &GraphConnection) -> IntervalTree<i64, NodeIntervalBlock> {
+    pub fn intervaltree(
+        &self,
+        conn: &GraphConnection,
+    ) -> Result<IntervalTree<i64, NodeIntervalBlock>, AccessionError> {
         let edges = Self::get_edges_by_id(conn, &self.id);
-        assert!(
-            !edges.is_empty(),
-            "Accession {} has no edges in accession_paths",
-            self.id
-        );
+        if edges.is_empty() {
+            return Err(AccessionError::MissingPath(self.id));
+        }
 
         let mut offset = 0;
         let mut blocks = vec![NodeIntervalBlock {
@@ -387,10 +390,10 @@ impl Accession {
             strand: Strand::Forward,
         });
 
-        blocks
+        Ok(blocks
             .into_iter()
             .map(|block| (block.start..block.end, block))
-            .collect()
+            .collect())
     }
 }
 
@@ -696,7 +699,7 @@ mod tests {
         let accession =
             BlockGroup::add_accession(conn, &path, "test", 5, 35, &mut path_cache).unwrap();
 
-        let tree = accession.intervaltree(conn);
+        let tree = accession.intervaltree(conn).unwrap();
         interval_tree_verify(
             &tree,
             0,

--- a/gen-models/src/accession.rs
+++ b/gen-models/src/accession.rs
@@ -694,16 +694,28 @@ mod tests {
         let (_bg, path) = setup_block_group(conn);
         let mut path_cache = PathCache::new(conn);
         let accession =
-            BlockGroup::add_accession(conn, &path, "test", 10, 30, &mut path_cache).unwrap();
+            BlockGroup::add_accession(conn, &path, "test", 5, 35, &mut path_cache).unwrap();
 
         let tree = accession.intervaltree(conn);
         interval_tree_verify(
             &tree,
             0,
             &[NodeIntervalBlock {
-                node_id: HashId::convert_str("test-t-node"),
+                node_id: HashId::convert_str("test-a-node"),
                 start: 0,
-                end: 10,
+                end: 5,
+                sequence_start: 5,
+                sequence_end: 10,
+                strand: Strand::Forward,
+            }],
+        );
+        interval_tree_verify(
+            &tree,
+            5,
+            &[NodeIntervalBlock {
+                node_id: HashId::convert_str("test-t-node"),
+                start: 5,
+                end: 15,
                 sequence_start: 0,
                 sequence_end: 10,
                 strand: Strand::Forward,
@@ -711,13 +723,25 @@ mod tests {
         );
         interval_tree_verify(
             &tree,
-            10,
+            15,
             &[NodeIntervalBlock {
                 node_id: HashId::convert_str("test-c-node"),
-                start: 10,
-                end: 20,
+                start: 15,
+                end: 25,
                 sequence_start: 0,
                 sequence_end: 10,
+                strand: Strand::Forward,
+            }],
+        );
+        interval_tree_verify(
+            &tree,
+            25,
+            &[NodeIntervalBlock {
+                node_id: HashId::convert_str("test-g-node"),
+                start: 25,
+                end: 30,
+                sequence_start: 0,
+                sequence_end: 5,
                 strand: Strand::Forward,
             }],
         );

--- a/gen-models/src/accession.rs
+++ b/gen-models/src/accession.rs
@@ -1,6 +1,10 @@
 use std::collections::HashSet;
 
-use gen_core::{HashId, Strand, calculate_hash, traits::Capnp};
+use gen_core::{
+    HashId, NodeIntervalBlock, PATH_END_NODE_ID, PATH_START_NODE_ID, Strand, calculate_hash,
+    traits::Capnp,
+};
+use intervaltree::IntervalTree;
 use itertools::Itertools;
 use rusqlite::{Row, params};
 use serde::{Deserialize, Serialize};
@@ -13,7 +17,7 @@ use crate::{
     traits::*,
 };
 
-#[derive(Deserialize, Serialize, Debug, Eq, PartialEq)]
+#[derive(Clone, Deserialize, Serialize, Debug, Eq, PartialEq)]
 pub struct Accession {
     pub id: HashId,
     pub name: String,
@@ -342,6 +346,52 @@ impl Accession {
             order by ap.index_in_path;";
         AccessionEdge::query(conn, query, params![accession_id])
     }
+
+    pub fn intervaltree(&self, conn: &GraphConnection) -> IntervalTree<i64, NodeIntervalBlock> {
+        let edges = Self::get_edges_by_id(conn, &self.id);
+        assert!(
+            !edges.is_empty(),
+            "Accession {} has no edges in accession_paths",
+            self.id
+        );
+
+        let mut offset = 0;
+        let mut blocks = vec![NodeIntervalBlock {
+            node_id: PATH_START_NODE_ID,
+            start: i64::MIN + 1,
+            end: 0,
+            sequence_start: 0,
+            sequence_end: 0,
+            strand: Strand::Forward,
+        }];
+
+        for (into, out_of) in edges.iter().tuple_windows() {
+            let block_len = out_of.source_coordinate - into.target_coordinate;
+            blocks.push(NodeIntervalBlock {
+                node_id: into.target_node_id,
+                start: offset,
+                end: offset + block_len,
+                sequence_start: into.target_coordinate,
+                sequence_end: out_of.source_coordinate,
+                strand: into.target_strand,
+            });
+            offset += block_len;
+        }
+
+        blocks.push(NodeIntervalBlock {
+            node_id: PATH_END_NODE_ID,
+            start: offset,
+            end: i64::MAX - 1,
+            sequence_start: 0,
+            sequence_end: 0,
+            strand: Strand::Forward,
+        });
+
+        blocks
+            .into_iter()
+            .map(|block| (block.start..block.end, block))
+            .collect()
+    }
 }
 
 impl Query for Accession {
@@ -540,9 +590,13 @@ impl Query for AccessionPath {
 #[cfg(test)]
 mod tests {
     use capnp::message::TypedBuilder;
+    use gen_core::HashId;
 
     use super::*;
-    use crate::test_helpers::{get_connection, setup_block_group};
+    use crate::{
+        block_group::{BlockGroup, PathCache},
+        test_helpers::{get_connection, interval_tree_verify, setup_block_group},
+    };
 
     #[test]
     fn test_accession_capnp_serialization() {
@@ -631,6 +685,41 @@ mod tests {
                 block_group_id,
                 parent_accession_id: None,
             }]
+        );
+    }
+
+    #[test]
+    fn test_intervaltree() {
+        let conn = &get_connection(None).unwrap();
+        let (_bg, path) = setup_block_group(conn);
+        let mut path_cache = PathCache::new(conn);
+        let accession =
+            BlockGroup::add_accession(conn, &path, "test", 10, 30, &mut path_cache).unwrap();
+
+        let tree = accession.intervaltree(conn);
+        interval_tree_verify(
+            &tree,
+            0,
+            &[NodeIntervalBlock {
+                node_id: HashId::convert_str("test-t-node"),
+                start: 0,
+                end: 10,
+                sequence_start: 0,
+                sequence_end: 10,
+                strand: Strand::Forward,
+            }],
+        );
+        interval_tree_verify(
+            &tree,
+            10,
+            &[NodeIntervalBlock {
+                node_id: HashId::convert_str("test-c-node"),
+                start: 10,
+                end: 20,
+                sequence_start: 0,
+                sequence_end: 10,
+                strand: Strand::Forward,
+            }],
         );
     }
 }

--- a/gen-models/src/annotations.rs
+++ b/gen-models/src/annotations.rs
@@ -5,12 +5,16 @@ use std::{
 };
 
 use anyhow::anyhow;
-use gen_core::{HashId, calculate_hash, config::Workspace, region::Region, traits::Capnp};
+use gen_core::{
+    HashId, NodeIntervalBlock, calculate_hash, config::Workspace, region::Region, traits::Capnp,
+};
+use intervaltree::IntervalTree;
 use rusqlite::{Row, params, types::Value};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::{
+    accession::Accession,
     block_group::{BlockGroup, PathCache},
     changesets::{ChangesetModels, DatabaseChangeset, write_changeset},
     db::{DbContext, GraphConnection, OperationsConnection},
@@ -368,6 +372,17 @@ impl Annotation {
     ) -> Result<Vec<Annotation>, AnnotationError> {
         let query = "select * from annotations where annotation_group = ?1";
         Ok(Annotation::query(conn, query, params![group]))
+    }
+
+    pub fn intervaltree(&self, conn: &GraphConnection) -> IntervalTree<i64, NodeIntervalBlock> {
+        Accession::get_by_id(conn, &self.accession_id)
+            .unwrap_or_else(|| {
+                panic!(
+                    "Missing accession {} for annotation {}",
+                    self.accession_id, self.id
+                )
+            })
+            .intervaltree(conn)
     }
 }
 

--- a/gen-models/src/annotations.rs
+++ b/gen-models/src/annotations.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::{
-    accession::Accession,
+    accession::{Accession, AccessionError},
     block_group::{BlockGroup, PathCache},
     changesets::{ChangesetModels, DatabaseChangeset, write_changeset},
     db::{DbContext, GraphConnection, OperationsConnection},
@@ -258,6 +258,8 @@ pub enum AnnotationError {
     DatabaseError(#[from] rusqlite::Error),
     #[error("Annotation group error: {0}")]
     AnnotationGroupError(#[from] AnnotationGroupError),
+    #[error("Accession error: {0}")]
+    AccessionError(#[from] AccessionError),
     #[error("Annotation extra serialization error: {0}")]
     SerializationError(String),
 }
@@ -374,15 +376,16 @@ impl Annotation {
         Ok(Annotation::query(conn, query, params![group]))
     }
 
-    pub fn intervaltree(&self, conn: &GraphConnection) -> IntervalTree<i64, NodeIntervalBlock> {
-        Accession::get_by_id(conn, &self.accession_id)
-            .unwrap_or_else(|| {
-                panic!(
-                    "Missing accession {} for annotation {}",
-                    self.accession_id, self.id
-                )
-            })
-            .intervaltree(conn)
+    pub fn intervaltree(
+        &self,
+        conn: &GraphConnection,
+    ) -> Result<IntervalTree<i64, NodeIntervalBlock>, AnnotationError> {
+        let accession = Accession::get(
+            conn,
+            "select * from accessions where id = ?1",
+            params![self.accession_id],
+        )?;
+        accession.intervaltree(conn).map_err(Into::into)
     }
 }
 

--- a/gen-models/src/block_group.rs
+++ b/gen-models/src/block_group.rs
@@ -20,6 +20,7 @@ use thiserror::Error;
 
 use crate::{
     accession::{Accession, AccessionEdge, AccessionEdgeData, AccessionPath},
+    annotations::{Annotation as AccessionAnnotation, AnnotationError},
     block_group_edge::{AugmentedEdgeData, BlockGroupEdge, BlockGroupEdgeData},
     db::GraphConnection,
     edge::{Edge, EdgeData, GroupBlock},
@@ -60,6 +61,8 @@ pub enum BlockGroupError {
     AccessionError(#[from] AccessionError),
     #[error("Accession path creation error: {0}")]
     AccessionPathError(#[from] AccessionPathError),
+    #[error("Annotation error: {0}")]
+    AnnotationError(#[from] AnnotationError),
     #[error("Query error: {0}")]
     QueryError(#[from] QueryError),
     #[error("Change error: {0}")]
@@ -165,6 +168,130 @@ pub struct PathChange {
     pub chromosome_index: i64,
     pub phased: i64,
     pub preserve_edge: bool,
+}
+
+pub trait BlockGroupChange {
+    fn block_group_id(&self) -> HashId;
+    fn start(&self) -> i64;
+    fn end(&self) -> i64;
+    fn block(&self) -> &PathBlock;
+    fn chromosome_index(&self) -> i64;
+    fn phased(&self) -> i64;
+    fn preserve_edge(&self) -> bool;
+}
+
+#[derive(Clone, Debug)]
+pub struct AccessionChange {
+    pub block_group_id: HashId,
+    pub accession: Accession,
+    pub start: i64,
+    pub end: i64,
+    pub block: PathBlock,
+    pub chromosome_index: i64,
+    pub phased: i64,
+    pub preserve_edge: bool,
+}
+
+#[derive(Clone, Debug)]
+pub struct AnnotationChange {
+    pub block_group_id: HashId,
+    pub annotation: AccessionAnnotation,
+    pub start: i64,
+    pub end: i64,
+    pub block: PathBlock,
+    pub chromosome_index: i64,
+    pub phased: i64,
+    pub preserve_edge: bool,
+}
+
+impl BlockGroupChange for PathChange {
+    fn block_group_id(&self) -> HashId {
+        self.block_group_id
+    }
+
+    fn start(&self) -> i64 {
+        self.start
+    }
+
+    fn end(&self) -> i64 {
+        self.end
+    }
+
+    fn block(&self) -> &PathBlock {
+        &self.block
+    }
+
+    fn chromosome_index(&self) -> i64 {
+        self.chromosome_index
+    }
+
+    fn phased(&self) -> i64 {
+        self.phased
+    }
+
+    fn preserve_edge(&self) -> bool {
+        self.preserve_edge
+    }
+}
+
+impl BlockGroupChange for AccessionChange {
+    fn block_group_id(&self) -> HashId {
+        self.block_group_id
+    }
+
+    fn start(&self) -> i64 {
+        self.start
+    }
+
+    fn end(&self) -> i64 {
+        self.end
+    }
+
+    fn block(&self) -> &PathBlock {
+        &self.block
+    }
+
+    fn chromosome_index(&self) -> i64 {
+        self.chromosome_index
+    }
+
+    fn phased(&self) -> i64 {
+        self.phased
+    }
+
+    fn preserve_edge(&self) -> bool {
+        self.preserve_edge
+    }
+}
+
+impl BlockGroupChange for AnnotationChange {
+    fn block_group_id(&self) -> HashId {
+        self.block_group_id
+    }
+
+    fn start(&self) -> i64 {
+        self.start
+    }
+
+    fn end(&self) -> i64 {
+        self.end
+    }
+
+    fn block(&self) -> &PathBlock {
+        &self.block
+    }
+
+    fn chromosome_index(&self) -> i64 {
+        self.chromosome_index
+    }
+
+    fn phased(&self) -> i64 {
+        self.phased
+    }
+
+    fn preserve_edge(&self) -> bool {
+        self.preserve_edge
+    }
 }
 
 pub struct PathCache<'a> {
@@ -772,9 +899,9 @@ impl BlockGroup {
 
     #[allow(clippy::ptr_arg)]
     #[allow(clippy::needless_late_init)]
-    pub fn insert_change(
+    pub fn insert_change<C: BlockGroupChange>(
         conn: &GraphConnection,
-        change: &PathChange,
+        change: &C,
         tree: &IntervalTree<i64, NodeIntervalBlock>,
     ) -> Result<(), BlockGroupError> {
         let new_augmented_edges = BlockGroup::set_up_new_edges(change, tree)?;
@@ -787,7 +914,7 @@ impl BlockGroup {
             .iter()
             .enumerate()
             .map(|(i, edge_id)| BlockGroupEdgeData {
-                block_group_id: change.block_group_id,
+                block_group_id: change.block_group_id(),
                 edge_id: *edge_id,
                 chromosome_index: new_augmented_edges[i].chromosome_index,
                 phased: new_augmented_edges[i].phased,
@@ -797,21 +924,37 @@ impl BlockGroup {
         Ok(())
     }
 
-    fn set_up_new_edges(
-        change: &PathChange,
+    pub fn insert_accession_change(
+        conn: &GraphConnection,
+        change: &AccessionChange,
+    ) -> Result<(), BlockGroupError> {
+        let tree = change.accession.intervaltree(conn);
+        Self::insert_change(conn, change, &tree)
+    }
+
+    pub fn insert_annotation_change(
+        conn: &GraphConnection,
+        change: &AnnotationChange,
+    ) -> Result<(), BlockGroupError> {
+        let tree = change.annotation.intervaltree(conn);
+        Self::insert_change(conn, change, &tree)
+    }
+
+    fn set_up_new_edges<C: BlockGroupChange>(
+        change: &C,
         tree: &IntervalTree<i64, NodeIntervalBlock>,
     ) -> Result<Vec<AugmentedEdgeData>, BlockGroupError> {
         let start_blocks: Vec<&NodeIntervalBlock> =
-            tree.query_point(change.start).map(|x| &x.value).collect();
+            tree.query_point(change.start()).map(|x| &x.value).collect();
         assert_eq!(start_blocks.len(), 1);
         // NOTE: This may not be used but needs to be initialized here instead of inside the if
         // statement that uses it, so that the borrow checker is happy
         let previous_start_blocks: Vec<&NodeIntervalBlock> = tree
-            .query_point(change.start - 1)
+            .query_point(change.start() - 1)
             .map(|x| &x.value)
             .collect();
         assert_eq!(previous_start_blocks.len(), 1);
-        let start_block = if start_blocks[0].start == change.start {
+        let start_block = if start_blocks[0].start == change.start() {
             // First part of this block will be replaced/deleted, need to get previous block to add
             // edge including it
             previous_start_blocks[0]
@@ -825,32 +968,32 @@ impl BlockGroup {
         // interval tree. So while it's ok to have a start/end block be the start/end block (for
         // changes at the extremes, it's not ok for the change to start beyond the current
         // boundaries.
-        if is_start_node(start_block.node_id) && change.start < start_block.end {
+        if is_start_node(start_block.node_id) && change.start() < start_block.end {
             return Err(BlockGroupError::ChangeOutOfBounds(format!(
                 "Invalid change specified. Coordinate {pos} is before start of path range ({path_pos}).",
-                pos = change.start,
+                pos = change.start(),
                 path_pos = start_block.end
             )));
         }
         let end_blocks: Vec<&NodeIntervalBlock> =
-            tree.query_point(change.end).map(|x| &x.value).collect();
+            tree.query_point(change.end()).map(|x| &x.value).collect();
         assert_eq!(end_blocks.len(), 1);
         let end_block = end_blocks[0];
 
-        if is_end_node(end_block.node_id) && change.end > end_block.start {
+        if is_end_node(end_block.node_id) && change.end() > end_block.start {
             return Err(BlockGroupError::ChangeOutOfBounds(format!(
                 "Invalid change specified. Coordinate {pos} is before start of path range ({path_pos}).",
-                pos = change.end,
+                pos = change.end(),
                 path_pos = end_block.start
             )));
         }
 
         let mut new_edges = vec![];
 
-        if change.block.sequence_start == change.block.sequence_end {
+        if change.block().sequence_start == change.block().sequence_end {
             // Deletion
-            let source_coordinate = change.start - start_block.start + start_block.sequence_start;
-            let target_coordinate = change.end - end_block.start + end_block.sequence_start;
+            let source_coordinate = change.start() - start_block.start + start_block.sequence_start;
+            let target_coordinate = change.end() - end_block.start + end_block.sequence_start;
             let mut aug_edges = vec![];
             let new_edge = EdgeData {
                 source_node_id: start_block.node_id,
@@ -862,15 +1005,15 @@ impl BlockGroup {
             };
             aug_edges.push(AugmentedEdgeData {
                 edge_data: new_edge,
-                chromosome_index: change.chromosome_index,
-                phased: change.phased,
+                chromosome_index: change.chromosome_index(),
+                phased: change.phased(),
             });
 
             // NOTE: If the deletion is happening at the very beginning of a path, we need to add
             // an edge from the dedicated start node to the end of the deletion, to indicate it's
             // another start point in the block group DAG.
-            if change.start == 0 {
-                let target_coordinate = change.end - end_block.start + end_block.sequence_start;
+            if change.start() == 0 {
+                let target_coordinate = change.end() - end_block.start + end_block.sequence_start;
                 let new_beginning_edge = EdgeData {
                     source_node_id: PATH_START_NODE_ID,
                     source_coordinate: 0,
@@ -881,8 +1024,8 @@ impl BlockGroup {
                 };
                 aug_edges.push(AugmentedEdgeData {
                     edge_data: new_beginning_edge,
-                    chromosome_index: change.chromosome_index,
-                    phased: change.phased,
+                    chromosome_index: change.chromosome_index(),
+                    phased: change.phased(),
                 });
                 if !is_terminal(end_block.node_id) {
                     new_edges.push(AugmentedEdgeData {
@@ -894,7 +1037,7 @@ impl BlockGroup {
                             target_coordinate,
                             target_strand: Strand::Forward,
                         },
-                        chromosome_index: if change.preserve_edge {
+                        chromosome_index: if change.preserve_edge() {
                             0
                         } else {
                             PRESERVE_EDIT_SITE_CHROMOSOME_INDEX
@@ -913,7 +1056,7 @@ impl BlockGroup {
                             target_coordinate: source_coordinate,
                             target_strand: Strand::Forward,
                         },
-                        chromosome_index: if change.preserve_edge {
+                        chromosome_index: if change.preserve_edge() {
                             0
                         } else {
                             PRESERVE_EDIT_SITE_CHROMOSOME_INDEX
@@ -931,7 +1074,7 @@ impl BlockGroup {
                             target_coordinate,
                             target_strand: Strand::Forward,
                         },
-                        chromosome_index: if change.preserve_edge {
+                        chromosome_index: if change.preserve_edge() {
                             0
                         } else {
                             PRESERVE_EDIT_SITE_CHROMOSOME_INDEX
@@ -941,30 +1084,31 @@ impl BlockGroup {
                 }
             }
             new_edges.extend(aug_edges);
-        // NOTE: If the deletion is happening at the very end of a path, we might add an edge
-        // from the beginning of the deletion to the dedicated end node, but in practice it
-        // doesn't affect sequence readouts, so it may not be worth it.
+            // NOTE: If the deletion is happening at the very end of a path, we might add an edge
+            // from the beginning of the deletion to the dedicated end node, but in practice it
+            // doesn't affect sequence readouts, so it may not be worth it.
         } else {
             // Insertion/replacement
             let insertion_start_coordinate =
-                change.start - start_block.start + start_block.sequence_start;
+                change.start() - start_block.start + start_block.sequence_start;
             let new_start_edge = EdgeData {
                 source_node_id: start_block.node_id,
                 source_coordinate: insertion_start_coordinate,
                 source_strand: Strand::Forward,
-                target_node_id: change.block.node_id,
-                target_coordinate: change.block.sequence_start,
+                target_node_id: change.block().node_id,
+                target_coordinate: change.block().sequence_start,
                 target_strand: Strand::Forward,
             };
             let new_augmented_start_edge = AugmentedEdgeData {
                 edge_data: new_start_edge,
-                chromosome_index: change.chromosome_index,
-                phased: change.phased,
+                chromosome_index: change.chromosome_index(),
+                phased: change.phased(),
             };
-            let insertion_end_coordinate = change.end - end_block.start + end_block.sequence_start;
+            let insertion_end_coordinate =
+                change.end() - end_block.start + end_block.sequence_start;
             let new_end_edge = EdgeData {
-                source_node_id: change.block.node_id,
-                source_coordinate: change.block.sequence_end,
+                source_node_id: change.block().node_id,
+                source_coordinate: change.block().sequence_end,
                 source_strand: Strand::Forward,
                 target_node_id: end_block.node_id,
                 target_coordinate: insertion_end_coordinate,
@@ -972,21 +1116,21 @@ impl BlockGroup {
             };
             let new_augmented_end_edge = AugmentedEdgeData {
                 edge_data: new_end_edge,
-                chromosome_index: change.chromosome_index,
-                phased: change.phased,
+                chromosome_index: change.chromosome_index(),
+                phased: change.phased(),
             };
 
-            if change.start == 0 {
+            if change.start() == 0 {
                 new_edges.push(AugmentedEdgeData {
                     edge_data: EdgeData {
                         source_node_id: PATH_START_NODE_ID,
                         source_coordinate: 0,
                         source_strand: Strand::Forward,
-                        target_node_id: change.block.node_id,
-                        target_coordinate: change.block.sequence_start,
+                        target_node_id: change.block().node_id,
+                        target_coordinate: change.block().sequence_start,
                         target_strand: Strand::Forward,
                     },
-                    chromosome_index: change.chromosome_index,
+                    chromosome_index: change.chromosome_index(),
                     phased: 0,
                 });
             }
@@ -1001,7 +1145,7 @@ impl BlockGroup {
                         target_coordinate: insertion_start_coordinate,
                         target_strand: Strand::Forward,
                     },
-                    chromosome_index: if change.preserve_edge {
+                    chromosome_index: if change.preserve_edge() {
                         0
                     } else {
                         PRESERVE_EDIT_SITE_CHROMOSOME_INDEX
@@ -1019,7 +1163,7 @@ impl BlockGroup {
                         target_coordinate: insertion_end_coordinate,
                         target_strand: Strand::Forward,
                     },
-                    chromosome_index: if change.preserve_edge {
+                    chromosome_index: if change.preserve_edge() {
                         0
                     } else {
                         PRESERVE_EDIT_SITE_CHROMOSOME_INDEX
@@ -1313,6 +1457,7 @@ mod tests {
 
     use super::*;
     use crate::{
+        annotations::Annotation as ModelAnnotation,
         collection::Collection,
         node::Node,
         sample::Sample,
@@ -1894,6 +2039,109 @@ mod tests {
             )
             .len(),
             2
+        );
+    }
+
+    #[test]
+    fn insert_accession_change_get_all() {
+        let conn = get_connection(None).unwrap();
+        let (block_group_id, path) = setup_block_group(&conn);
+        let mut path_cache = PathCache::new(&conn);
+        let accession =
+            BlockGroup::add_accession(&conn, &path, "test-accession", 10, 30, &mut path_cache)
+                .unwrap();
+        let insert_sequence = Sequence::new()
+            .sequence_type("DNA")
+            .sequence("NNNN")
+            .save(&conn)
+            .unwrap();
+        let insert_node_id = Node::create(
+            &conn,
+            &insert_sequence.hash,
+            &HashId::convert_str("acc-insert-node"),
+        )
+        .unwrap();
+        let insert = PathBlock {
+            node_id: insert_node_id,
+            block_sequence: insert_sequence.get_sequence(0, 4).unwrap(),
+            sequence_start: 0,
+            sequence_end: 4,
+            path_start: 5,
+            path_end: 15,
+            strand: Strand::Forward,
+        };
+        let change = AccessionChange {
+            block_group_id,
+            accession,
+            start: 5,
+            end: 15,
+            block: insert,
+            chromosome_index: 1,
+            phased: 0,
+            preserve_edge: true,
+        };
+
+        BlockGroup::insert_accession_change(&conn, &change).unwrap();
+        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
+        assert_eq!(
+            all_sequences,
+            HashSet::from_iter(vec![
+                "AAAAAAAAAATTTTTTTTTTCCCCCCCCCCGGGGGGGGGG".to_string(),
+                "AAAAAAAAAATTTTTNNNNCCCCCGGGGGGGGGG".to_string(),
+            ])
+        );
+    }
+
+    #[test]
+    fn insert_annotation_change_get_all() {
+        let conn = get_connection(None).unwrap();
+        let (block_group_id, path) = setup_block_group(&conn);
+        let mut path_cache = PathCache::new(&conn);
+        let accession =
+            BlockGroup::add_accession(&conn, &path, "test-accession", 10, 30, &mut path_cache)
+                .unwrap();
+        let annotation =
+            ModelAnnotation::get_or_create(&conn, "gene-1", "track-1", &accession.id, None)
+                .unwrap();
+        let deletion_sequence = Sequence::new()
+            .sequence_type("DNA")
+            .sequence("")
+            .save(&conn)
+            .unwrap();
+        let deletion_node_id = Node::create(
+            &conn,
+            &deletion_sequence.hash,
+            &HashId::convert_str("annotation-delete-node"),
+        )
+        .unwrap();
+        let deletion = PathBlock {
+            node_id: deletion_node_id,
+            block_sequence: deletion_sequence.get_sequence(None, None).unwrap(),
+            sequence_start: 0,
+            sequence_end: 0,
+            path_start: 5,
+            path_end: 15,
+            strand: Strand::Forward,
+        };
+        let change = AnnotationChange {
+            block_group_id,
+            annotation,
+            start: 5,
+            end: 15,
+            block: deletion,
+            chromosome_index: 1,
+            phased: 0,
+            preserve_edge: true,
+        };
+
+        BlockGroup::insert_annotation_change(&conn, &change).unwrap();
+        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
+        assert_eq!(
+            all_sequences,
+            HashSet::from_iter(vec![
+                "AAAAAAAAAATTTTTTTTTTCCCCCCCCCCGGGGGGGGGG".to_string(),
+                "AAAAAAAAAATTTTTCCCCCGGGGGGGGGG".to_string(),
+            ])
         );
     }
 

--- a/gen-models/src/block_group.rs
+++ b/gen-models/src/block_group.rs
@@ -158,9 +158,9 @@ pub struct NewBlockGroup<'a> {
 }
 
 #[derive(Clone, Debug)]
-pub struct PathChange {
+pub struct BlockGroupChange<T: IntervalTreeSource> {
     pub block_group_id: HashId,
-    pub path: Path,
+    pub intervaltree_source: T,
     pub path_accession: Option<String>,
     pub start: i64,
     pub end: i64,
@@ -170,127 +170,60 @@ pub struct PathChange {
     pub preserve_edge: bool,
 }
 
-pub trait BlockGroupChange {
-    fn block_group_id(&self) -> HashId;
-    fn start(&self) -> i64;
-    fn end(&self) -> i64;
-    fn block(&self) -> &PathBlock;
-    fn chromosome_index(&self) -> i64;
-    fn phased(&self) -> i64;
-    fn preserve_edge(&self) -> bool;
-}
+pub type PathChange = BlockGroupChange<Path>;
+pub type AccessionChange = BlockGroupChange<Accession>;
+pub type AnnotationChange = BlockGroupChange<AccessionAnnotation>;
 
-#[derive(Clone, Debug)]
-pub struct AccessionChange {
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct BlockGroupTreeSource {
     pub block_group_id: HashId,
-    pub accession: Accession,
-    pub start: i64,
-    pub end: i64,
-    pub block: PathBlock,
-    pub chromosome_index: i64,
-    pub phased: i64,
-    pub preserve_edge: bool,
+    pub remove_ambiguous_positions: bool,
 }
 
-#[derive(Clone, Debug)]
-pub struct AnnotationChange {
-    pub block_group_id: HashId,
-    pub annotation: AccessionAnnotation,
-    pub start: i64,
-    pub end: i64,
-    pub block: PathBlock,
-    pub chromosome_index: i64,
-    pub phased: i64,
-    pub preserve_edge: bool,
+pub trait IntervalTreeSource {
+    fn intervaltree(
+        &self,
+        conn: &GraphConnection,
+    ) -> Result<IntervalTree<i64, NodeIntervalBlock>, BlockGroupError>;
 }
 
-impl BlockGroupChange for PathChange {
-    fn block_group_id(&self) -> HashId {
-        self.block_group_id
-    }
-
-    fn start(&self) -> i64 {
-        self.start
-    }
-
-    fn end(&self) -> i64 {
-        self.end
-    }
-
-    fn block(&self) -> &PathBlock {
-        &self.block
-    }
-
-    fn chromosome_index(&self) -> i64 {
-        self.chromosome_index
-    }
-
-    fn phased(&self) -> i64 {
-        self.phased
-    }
-
-    fn preserve_edge(&self) -> bool {
-        self.preserve_edge
+impl IntervalTreeSource for Path {
+    fn intervaltree(
+        &self,
+        conn: &GraphConnection,
+    ) -> Result<IntervalTree<i64, NodeIntervalBlock>, BlockGroupError> {
+        self.intervaltree(conn).map_err(Into::into)
     }
 }
 
-impl BlockGroupChange for AccessionChange {
-    fn block_group_id(&self) -> HashId {
-        self.block_group_id
-    }
-
-    fn start(&self) -> i64 {
-        self.start
-    }
-
-    fn end(&self) -> i64 {
-        self.end
-    }
-
-    fn block(&self) -> &PathBlock {
-        &self.block
-    }
-
-    fn chromosome_index(&self) -> i64 {
-        self.chromosome_index
-    }
-
-    fn phased(&self) -> i64 {
-        self.phased
-    }
-
-    fn preserve_edge(&self) -> bool {
-        self.preserve_edge
+impl IntervalTreeSource for Accession {
+    fn intervaltree(
+        &self,
+        conn: &GraphConnection,
+    ) -> Result<IntervalTree<i64, NodeIntervalBlock>, BlockGroupError> {
+        Ok(self.intervaltree(conn))
     }
 }
 
-impl BlockGroupChange for AnnotationChange {
-    fn block_group_id(&self) -> HashId {
-        self.block_group_id
+impl IntervalTreeSource for AccessionAnnotation {
+    fn intervaltree(
+        &self,
+        conn: &GraphConnection,
+    ) -> Result<IntervalTree<i64, NodeIntervalBlock>, BlockGroupError> {
+        Ok(self.intervaltree(conn))
     }
+}
 
-    fn start(&self) -> i64 {
-        self.start
-    }
-
-    fn end(&self) -> i64 {
-        self.end
-    }
-
-    fn block(&self) -> &PathBlock {
-        &self.block
-    }
-
-    fn chromosome_index(&self) -> i64 {
-        self.chromosome_index
-    }
-
-    fn phased(&self) -> i64 {
-        self.phased
-    }
-
-    fn preserve_edge(&self) -> bool {
-        self.preserve_edge
+impl IntervalTreeSource for BlockGroupTreeSource {
+    fn intervaltree(
+        &self,
+        conn: &GraphConnection,
+    ) -> Result<IntervalTree<i64, NodeIntervalBlock>, BlockGroupError> {
+        Ok(BlockGroup::intervaltree_for(
+            conn,
+            &self.block_group_id,
+            self.remove_ambiguous_positions,
+        ))
     }
 }
 
@@ -814,7 +747,7 @@ impl BlockGroup {
 
     pub fn insert_changes(
         conn: &GraphConnection,
-        changes: &[PathChange],
+        changes: &[BlockGroupChange<Path>],
         cache: &mut PathCache,
         modify_blockgroup: bool,
     ) -> Result<(), BlockGroupError> {
@@ -828,7 +761,7 @@ impl BlockGroup {
                     BlockGroup::intervaltree_for(conn, &change.block_group_id, true)
                 })
             } else {
-                PathCache::get_intervaltree(cache, &change.path)?
+                PathCache::get_intervaltree(cache, &change.intervaltree_source)?
             };
             let new_augmented_edges = BlockGroup::set_up_new_edges(change, tree)?;
             new_augmented_edges_by_block_group
@@ -837,7 +770,7 @@ impl BlockGroup {
                 .or_insert_with(|| new_augmented_edges.clone());
             if let Some(accession) = &change.path_accession {
                 new_accession_edges
-                    .entry((&change.path, accession))
+                    .entry((&change.intervaltree_source, accession))
                     .and_modify(|new_edge_data: &mut Vec<AugmentedEdgeData>| {
                         new_edge_data.extend(new_augmented_edges.clone())
                     })
@@ -899,12 +832,12 @@ impl BlockGroup {
 
     #[allow(clippy::ptr_arg)]
     #[allow(clippy::needless_late_init)]
-    pub fn insert_change<C: BlockGroupChange>(
+    pub fn insert_change<T: IntervalTreeSource>(
         conn: &GraphConnection,
-        change: &C,
-        tree: &IntervalTree<i64, NodeIntervalBlock>,
+        change: &BlockGroupChange<T>,
     ) -> Result<(), BlockGroupError> {
-        let new_augmented_edges = BlockGroup::set_up_new_edges(change, tree)?;
+        let tree = change.intervaltree_source.intervaltree(conn)?;
+        let new_augmented_edges = BlockGroup::set_up_new_edges(change, &tree)?;
         let new_edges = new_augmented_edges
             .iter()
             .map(|augmented_edge| augmented_edge.edge_data)
@@ -914,7 +847,7 @@ impl BlockGroup {
             .iter()
             .enumerate()
             .map(|(i, edge_id)| BlockGroupEdgeData {
-                block_group_id: change.block_group_id(),
+                block_group_id: change.block_group_id,
                 edge_id: *edge_id,
                 chromosome_index: new_augmented_edges[i].chromosome_index,
                 phased: new_augmented_edges[i].phased,
@@ -924,37 +857,21 @@ impl BlockGroup {
         Ok(())
     }
 
-    pub fn insert_accession_change(
-        conn: &GraphConnection,
-        change: &AccessionChange,
-    ) -> Result<(), BlockGroupError> {
-        let tree = change.accession.intervaltree(conn);
-        Self::insert_change(conn, change, &tree)
-    }
-
-    pub fn insert_annotation_change(
-        conn: &GraphConnection,
-        change: &AnnotationChange,
-    ) -> Result<(), BlockGroupError> {
-        let tree = change.annotation.intervaltree(conn);
-        Self::insert_change(conn, change, &tree)
-    }
-
-    fn set_up_new_edges<C: BlockGroupChange>(
-        change: &C,
+    fn set_up_new_edges<T: IntervalTreeSource>(
+        change: &BlockGroupChange<T>,
         tree: &IntervalTree<i64, NodeIntervalBlock>,
     ) -> Result<Vec<AugmentedEdgeData>, BlockGroupError> {
         let start_blocks: Vec<&NodeIntervalBlock> =
-            tree.query_point(change.start()).map(|x| &x.value).collect();
+            tree.query_point(change.start).map(|x| &x.value).collect();
         assert_eq!(start_blocks.len(), 1);
         // NOTE: This may not be used but needs to be initialized here instead of inside the if
         // statement that uses it, so that the borrow checker is happy
         let previous_start_blocks: Vec<&NodeIntervalBlock> = tree
-            .query_point(change.start() - 1)
+            .query_point(change.start - 1)
             .map(|x| &x.value)
             .collect();
         assert_eq!(previous_start_blocks.len(), 1);
-        let start_block = if start_blocks[0].start == change.start() {
+        let start_block = if start_blocks[0].start == change.start {
             // First part of this block will be replaced/deleted, need to get previous block to add
             // edge including it
             previous_start_blocks[0]
@@ -968,32 +885,32 @@ impl BlockGroup {
         // interval tree. So while it's ok to have a start/end block be the start/end block (for
         // changes at the extremes, it's not ok for the change to start beyond the current
         // boundaries.
-        if is_start_node(start_block.node_id) && change.start() < start_block.end {
+        if is_start_node(start_block.node_id) && change.start < start_block.end {
             return Err(BlockGroupError::ChangeOutOfBounds(format!(
                 "Invalid change specified. Coordinate {pos} is before start of path range ({path_pos}).",
-                pos = change.start(),
+                pos = change.start,
                 path_pos = start_block.end
             )));
         }
         let end_blocks: Vec<&NodeIntervalBlock> =
-            tree.query_point(change.end()).map(|x| &x.value).collect();
+            tree.query_point(change.end).map(|x| &x.value).collect();
         assert_eq!(end_blocks.len(), 1);
         let end_block = end_blocks[0];
 
-        if is_end_node(end_block.node_id) && change.end() > end_block.start {
+        if is_end_node(end_block.node_id) && change.end > end_block.start {
             return Err(BlockGroupError::ChangeOutOfBounds(format!(
                 "Invalid change specified. Coordinate {pos} is before start of path range ({path_pos}).",
-                pos = change.end(),
+                pos = change.end,
                 path_pos = end_block.start
             )));
         }
 
         let mut new_edges = vec![];
 
-        if change.block().sequence_start == change.block().sequence_end {
+        if change.block.sequence_start == change.block.sequence_end {
             // Deletion
-            let source_coordinate = change.start() - start_block.start + start_block.sequence_start;
-            let target_coordinate = change.end() - end_block.start + end_block.sequence_start;
+            let source_coordinate = change.start - start_block.start + start_block.sequence_start;
+            let target_coordinate = change.end - end_block.start + end_block.sequence_start;
             let mut aug_edges = vec![];
             let new_edge = EdgeData {
                 source_node_id: start_block.node_id,
@@ -1005,15 +922,15 @@ impl BlockGroup {
             };
             aug_edges.push(AugmentedEdgeData {
                 edge_data: new_edge,
-                chromosome_index: change.chromosome_index(),
-                phased: change.phased(),
+                chromosome_index: change.chromosome_index,
+                phased: change.phased,
             });
 
             // NOTE: If the deletion is happening at the very beginning of a path, we need to add
             // an edge from the dedicated start node to the end of the deletion, to indicate it's
             // another start point in the block group DAG.
-            if change.start() == 0 {
-                let target_coordinate = change.end() - end_block.start + end_block.sequence_start;
+            if change.start == 0 {
+                let target_coordinate = change.end - end_block.start + end_block.sequence_start;
                 let new_beginning_edge = EdgeData {
                     source_node_id: PATH_START_NODE_ID,
                     source_coordinate: 0,
@@ -1024,8 +941,8 @@ impl BlockGroup {
                 };
                 aug_edges.push(AugmentedEdgeData {
                     edge_data: new_beginning_edge,
-                    chromosome_index: change.chromosome_index(),
-                    phased: change.phased(),
+                    chromosome_index: change.chromosome_index,
+                    phased: change.phased,
                 });
                 if !is_terminal(end_block.node_id) {
                     new_edges.push(AugmentedEdgeData {
@@ -1037,7 +954,7 @@ impl BlockGroup {
                             target_coordinate,
                             target_strand: Strand::Forward,
                         },
-                        chromosome_index: if change.preserve_edge() {
+                        chromosome_index: if change.preserve_edge {
                             0
                         } else {
                             PRESERVE_EDIT_SITE_CHROMOSOME_INDEX
@@ -1056,7 +973,7 @@ impl BlockGroup {
                             target_coordinate: source_coordinate,
                             target_strand: Strand::Forward,
                         },
-                        chromosome_index: if change.preserve_edge() {
+                        chromosome_index: if change.preserve_edge {
                             0
                         } else {
                             PRESERVE_EDIT_SITE_CHROMOSOME_INDEX
@@ -1074,7 +991,7 @@ impl BlockGroup {
                             target_coordinate,
                             target_strand: Strand::Forward,
                         },
-                        chromosome_index: if change.preserve_edge() {
+                        chromosome_index: if change.preserve_edge {
                             0
                         } else {
                             PRESERVE_EDIT_SITE_CHROMOSOME_INDEX
@@ -1090,25 +1007,24 @@ impl BlockGroup {
         } else {
             // Insertion/replacement
             let insertion_start_coordinate =
-                change.start() - start_block.start + start_block.sequence_start;
+                change.start - start_block.start + start_block.sequence_start;
             let new_start_edge = EdgeData {
                 source_node_id: start_block.node_id,
                 source_coordinate: insertion_start_coordinate,
                 source_strand: Strand::Forward,
-                target_node_id: change.block().node_id,
-                target_coordinate: change.block().sequence_start,
+                target_node_id: change.block.node_id,
+                target_coordinate: change.block.sequence_start,
                 target_strand: Strand::Forward,
             };
             let new_augmented_start_edge = AugmentedEdgeData {
                 edge_data: new_start_edge,
-                chromosome_index: change.chromosome_index(),
-                phased: change.phased(),
+                chromosome_index: change.chromosome_index,
+                phased: change.phased,
             };
-            let insertion_end_coordinate =
-                change.end() - end_block.start + end_block.sequence_start;
+            let insertion_end_coordinate = change.end - end_block.start + end_block.sequence_start;
             let new_end_edge = EdgeData {
-                source_node_id: change.block().node_id,
-                source_coordinate: change.block().sequence_end,
+                source_node_id: change.block.node_id,
+                source_coordinate: change.block.sequence_end,
                 source_strand: Strand::Forward,
                 target_node_id: end_block.node_id,
                 target_coordinate: insertion_end_coordinate,
@@ -1116,21 +1032,21 @@ impl BlockGroup {
             };
             let new_augmented_end_edge = AugmentedEdgeData {
                 edge_data: new_end_edge,
-                chromosome_index: change.chromosome_index(),
-                phased: change.phased(),
+                chromosome_index: change.chromosome_index,
+                phased: change.phased,
             };
 
-            if change.start() == 0 {
+            if change.start == 0 {
                 new_edges.push(AugmentedEdgeData {
                     edge_data: EdgeData {
                         source_node_id: PATH_START_NODE_ID,
                         source_coordinate: 0,
                         source_strand: Strand::Forward,
-                        target_node_id: change.block().node_id,
-                        target_coordinate: change.block().sequence_start,
+                        target_node_id: change.block.node_id,
+                        target_coordinate: change.block.sequence_start,
                         target_strand: Strand::Forward,
                     },
-                    chromosome_index: change.chromosome_index(),
+                    chromosome_index: change.chromosome_index,
                     phased: 0,
                 });
             }
@@ -1145,7 +1061,7 @@ impl BlockGroup {
                         target_coordinate: insertion_start_coordinate,
                         target_strand: Strand::Forward,
                     },
-                    chromosome_index: if change.preserve_edge() {
+                    chromosome_index: if change.preserve_edge {
                         0
                     } else {
                         PRESERVE_EDIT_SITE_CHROMOSOME_INDEX
@@ -1163,7 +1079,7 @@ impl BlockGroup {
                         target_coordinate: insertion_end_coordinate,
                         target_strand: Strand::Forward,
                     },
-                    chromosome_index: if change.preserve_edge() {
+                    chromosome_index: if change.preserve_edge {
                         0
                     } else {
                         PRESERVE_EDIT_SITE_CHROMOSOME_INDEX
@@ -2072,7 +1988,8 @@ mod tests {
         };
         let change = AccessionChange {
             block_group_id,
-            accession,
+            intervaltree_source: accession,
+            path_accession: None,
             start: 5,
             end: 15,
             block: insert,
@@ -2081,7 +1998,7 @@ mod tests {
             preserve_edge: true,
         };
 
-        BlockGroup::insert_accession_change(&conn, &change).unwrap();
+        BlockGroup::insert_change(&conn, &change).unwrap();
         let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
         assert_eq!(
             all_sequences,
@@ -2125,7 +2042,8 @@ mod tests {
         };
         let change = AnnotationChange {
             block_group_id,
-            annotation,
+            intervaltree_source: annotation,
+            path_accession: None,
             start: 5,
             end: 15,
             block: deletion,
@@ -2134,7 +2052,7 @@ mod tests {
             preserve_edge: true,
         };
 
-        BlockGroup::insert_annotation_change(&conn, &change).unwrap();
+        BlockGroup::insert_change(&conn, &change).unwrap();
         let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
         assert_eq!(
             all_sequences,
@@ -2167,7 +2085,7 @@ mod tests {
         };
         let change = PathChange {
             block_group_id,
-            path: path.clone(),
+            intervaltree_source: path.clone(),
             path_accession: None,
             start: 7,
             end: 15,
@@ -2176,8 +2094,7 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        let tree = path.intervaltree(&conn).unwrap();
-        BlockGroup::insert_change(&conn, &change, &tree).unwrap();
+        BlockGroup::insert_change(&conn, &change).unwrap();
 
         let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
         assert_eq!(
@@ -2207,7 +2124,7 @@ mod tests {
 
         let change = PathChange {
             block_group_id,
-            path: path.clone(),
+            intervaltree_source: path.clone(),
             path_accession: None,
             start: 19,
             end: 31,
@@ -2217,8 +2134,7 @@ mod tests {
             preserve_edge: true,
         };
         // take out an entire block.
-        let tree = path.intervaltree(&conn).unwrap();
-        BlockGroup::insert_change(&conn, &change, &tree).unwrap();
+        BlockGroup::insert_change(&conn, &change).unwrap();
         let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
         assert_eq!(
             all_sequences,
@@ -2253,7 +2169,7 @@ mod tests {
         };
         let change = PathChange {
             block_group_id,
-            path: path.clone(),
+            intervaltree_source: path.clone(),
             path_accession: None,
             start: 7,
             end: 15,
@@ -2262,8 +2178,7 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        let tree = path.intervaltree(&conn).unwrap();
-        BlockGroup::insert_change(&conn, &change, &tree).unwrap();
+        BlockGroup::insert_change(&conn, &change).unwrap();
 
         let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
         assert_eq!(
@@ -2297,7 +2212,7 @@ mod tests {
         };
         let change = PathChange {
             block_group_id,
-            path: path.clone(),
+            intervaltree_source: path.clone(),
             path_accession: None,
             start: 15,
             end: 15,
@@ -2306,8 +2221,7 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        let tree = path.intervaltree(&conn).unwrap();
-        BlockGroup::insert_change(&conn, &change, &tree).unwrap();
+        BlockGroup::insert_change(&conn, &change).unwrap();
 
         let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
         assert_eq!(
@@ -2341,7 +2255,7 @@ mod tests {
         };
         let change = PathChange {
             block_group_id,
-            path: path.clone(),
+            intervaltree_source: path.clone(),
             path_accession: None,
             start: 12,
             end: 17,
@@ -2350,8 +2264,7 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        let tree = path.intervaltree(&conn).unwrap();
-        BlockGroup::insert_change(&conn, &change, &tree).unwrap();
+        BlockGroup::insert_change(&conn, &change).unwrap();
 
         let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
         assert_eq!(
@@ -2385,7 +2298,7 @@ mod tests {
         };
         let change = PathChange {
             block_group_id,
-            path: path.clone(),
+            intervaltree_source: path.clone(),
             path_accession: None,
             start: 10,
             end: 10,
@@ -2394,8 +2307,7 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        let tree = path.intervaltree(&conn).unwrap();
-        BlockGroup::insert_change(&conn, &change, &tree).unwrap();
+        BlockGroup::insert_change(&conn, &change).unwrap();
 
         let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
         assert_eq!(
@@ -2429,7 +2341,7 @@ mod tests {
         };
         let change = PathChange {
             block_group_id,
-            path: path.clone(),
+            intervaltree_source: path.clone(),
             path_accession: None,
             start: 9,
             end: 9,
@@ -2438,8 +2350,7 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        let tree = path.intervaltree(&conn).unwrap();
-        BlockGroup::insert_change(&conn, &change, &tree).unwrap();
+        BlockGroup::insert_change(&conn, &change).unwrap();
 
         let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
         assert_eq!(
@@ -2473,7 +2384,7 @@ mod tests {
         };
         let change = PathChange {
             block_group_id,
-            path: path.clone(),
+            intervaltree_source: path.clone(),
             path_accession: None,
             start: 10,
             end: 20,
@@ -2482,8 +2393,7 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        let tree = path.intervaltree(&conn).unwrap();
-        BlockGroup::insert_change(&conn, &change, &tree).unwrap();
+        BlockGroup::insert_change(&conn, &change).unwrap();
 
         let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
         assert_eq!(
@@ -2517,7 +2427,7 @@ mod tests {
         };
         let change = PathChange {
             block_group_id,
-            path: path.clone(),
+            intervaltree_source: path.clone(),
             path_accession: None,
             start: 15,
             end: 25,
@@ -2526,8 +2436,7 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        let tree = path.intervaltree(&conn).unwrap();
-        BlockGroup::insert_change(&conn, &change, &tree).unwrap();
+        BlockGroup::insert_change(&conn, &change).unwrap();
 
         let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
         assert_eq!(
@@ -2561,7 +2470,7 @@ mod tests {
         };
         let change = PathChange {
             block_group_id,
-            path: path.clone(),
+            intervaltree_source: path.clone(),
             path_accession: None,
             start: 5,
             end: 35,
@@ -2570,8 +2479,7 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        let tree = path.intervaltree(&conn).unwrap();
-        BlockGroup::insert_change(&conn, &change, &tree).unwrap();
+        BlockGroup::insert_change(&conn, &change).unwrap();
 
         let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
         assert_eq!(
@@ -2606,7 +2514,7 @@ mod tests {
 
         let change = PathChange {
             block_group_id,
-            path: path.clone(),
+            intervaltree_source: path.clone(),
             path_accession: None,
             start: 19,
             end: 31,
@@ -2617,8 +2525,7 @@ mod tests {
         };
 
         // take out an entire block.
-        let tree = path.intervaltree(&conn).unwrap();
-        BlockGroup::insert_change(&conn, &change, &tree).unwrap();
+        BlockGroup::insert_change(&conn, &change).unwrap();
         let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
         assert_eq!(
             all_sequences,
@@ -2651,7 +2558,7 @@ mod tests {
         };
         let change = PathChange {
             block_group_id,
-            path: path.clone(),
+            intervaltree_source: path.clone(),
             path_accession: None,
             start: 7,
             end: 15,
@@ -2660,8 +2567,7 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        let tree = path.intervaltree(&conn).unwrap();
-        BlockGroup::insert_change(&conn, &change, &tree).unwrap();
+        BlockGroup::insert_change(&conn, &change).unwrap();
 
         let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
         assert_eq!(
@@ -2671,9 +2577,7 @@ mod tests {
                 "AAAAAAANNNNTTTTTCCCCCCCCCCGGGGGGGGGG".to_string()
             ])
         );
-
-        let tree = path.intervaltree(&conn).unwrap();
-        BlockGroup::insert_change(&conn, &change, &tree).unwrap();
+        BlockGroup::insert_change(&conn, &change).unwrap();
 
         let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
         assert_eq!(
@@ -2707,7 +2611,7 @@ mod tests {
         };
         let change = PathChange {
             block_group_id,
-            path: path.clone(),
+            intervaltree_source: path.clone(),
             path_accession: None,
             start: 0,
             end: 0,
@@ -2716,8 +2620,7 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        let tree = path.intervaltree(&conn).unwrap();
-        BlockGroup::insert_change(&conn, &change, &tree).unwrap();
+        BlockGroup::insert_change(&conn, &change).unwrap();
 
         let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
         assert_eq!(
@@ -2751,7 +2654,7 @@ mod tests {
         };
         let change = PathChange {
             block_group_id,
-            path: path.clone(),
+            intervaltree_source: path.clone(),
             path_accession: None,
             start: 0,
             end: 0,
@@ -2760,8 +2663,7 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        let tree = path.intervaltree(&conn).unwrap();
-        BlockGroup::insert_change(&conn, &change, &tree).unwrap();
+        BlockGroup::insert_change(&conn, &change).unwrap();
 
         let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
         assert_eq!(
@@ -2795,7 +2697,7 @@ mod tests {
         };
         let change = PathChange {
             block_group_id,
-            path: path.clone(),
+            intervaltree_source: path.clone(),
             path_accession: None,
             start: 40,
             end: 40,
@@ -2804,8 +2706,7 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        let tree = path.intervaltree(&conn).unwrap();
-        BlockGroup::insert_change(&conn, &change, &tree).unwrap();
+        BlockGroup::insert_change(&conn, &change).unwrap();
 
         let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
         assert_eq!(
@@ -2839,7 +2740,7 @@ mod tests {
         };
         let change = PathChange {
             block_group_id,
-            path: path.clone(),
+            intervaltree_source: path.clone(),
             path_accession: None,
             start: 10,
             end: 11,
@@ -2848,8 +2749,7 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        let tree = path.intervaltree(&conn).unwrap();
-        BlockGroup::insert_change(&conn, &change, &tree).unwrap();
+        BlockGroup::insert_change(&conn, &change).unwrap();
 
         let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
         assert_eq!(
@@ -2883,7 +2783,7 @@ mod tests {
         };
         let change = PathChange {
             block_group_id,
-            path: path.clone(),
+            intervaltree_source: path.clone(),
             path_accession: None,
             start: 19,
             end: 20,
@@ -2892,8 +2792,7 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        let tree = path.intervaltree(&conn).unwrap();
-        BlockGroup::insert_change(&conn, &change, &tree).unwrap();
+        BlockGroup::insert_change(&conn, &change).unwrap();
 
         let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
         assert_eq!(
@@ -2927,7 +2826,7 @@ mod tests {
         };
         let change = PathChange {
             block_group_id,
-            path: path.clone(),
+            intervaltree_source: path.clone(),
             path_accession: None,
             start: 0,
             end: 1,
@@ -2936,8 +2835,7 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        let tree = path.intervaltree(&conn).unwrap();
-        BlockGroup::insert_change(&conn, &change, &tree).unwrap();
+        BlockGroup::insert_change(&conn, &change).unwrap();
 
         let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
         assert_eq!(
@@ -2971,7 +2869,7 @@ mod tests {
         };
         let change = PathChange {
             block_group_id,
-            path: path.clone(),
+            intervaltree_source: path.clone(),
             path_accession: None,
             start: 35,
             end: 40,
@@ -2980,8 +2878,7 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        let tree = path.intervaltree(&conn).unwrap();
-        BlockGroup::insert_change(&conn, &change, &tree).unwrap();
+        BlockGroup::insert_change(&conn, &change).unwrap();
 
         let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
         assert_eq!(
@@ -3015,7 +2912,7 @@ mod tests {
         };
         let after_end_change = PathChange {
             block_group_id,
-            path: path.clone(),
+            intervaltree_source: path.clone(),
             path_accession: None,
             start: 350,
             end: 400,
@@ -3026,7 +2923,7 @@ mod tests {
         };
         let before_start_change = PathChange {
             block_group_id,
-            path: path.clone(),
+            intervaltree_source: path.clone(),
             path_accession: None,
             start: -300,
             end: 400,
@@ -3035,10 +2932,9 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        let tree = path.intervaltree(&conn).unwrap();
-        let res = BlockGroup::insert_change(&conn, &after_end_change, &tree);
+        let res = BlockGroup::insert_change(&conn, &after_end_change);
         assert!(matches!(res, Err(BlockGroupError::ChangeOutOfBounds(_))));
-        let res = BlockGroup::insert_change(&conn, &before_start_change, &tree);
+        let res = BlockGroup::insert_change(&conn, &before_start_change);
         assert!(matches!(res, Err(BlockGroupError::ChangeOutOfBounds(_))));
     }
 
@@ -3064,7 +2960,7 @@ mod tests {
         };
         let change = PathChange {
             block_group_id,
-            path: path.clone(),
+            intervaltree_source: path.clone(),
             path_accession: None,
             start: 10,
             end: 12,
@@ -3073,8 +2969,7 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        let tree = path.intervaltree(&conn).unwrap();
-        BlockGroup::insert_change(&conn, &change, &tree).unwrap();
+        BlockGroup::insert_change(&conn, &change).unwrap();
 
         let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
         assert_eq!(
@@ -3108,7 +3003,7 @@ mod tests {
         };
         let change = PathChange {
             block_group_id,
-            path: path.clone(),
+            intervaltree_source: path.clone(),
             path_accession: None,
             start: 18,
             end: 20,
@@ -3117,8 +3012,7 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        let tree = path.intervaltree(&conn).unwrap();
-        BlockGroup::insert_change(&conn, &change, &tree).unwrap();
+        BlockGroup::insert_change(&conn, &change).unwrap();
 
         let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
         assert_eq!(
@@ -3133,10 +3027,10 @@ mod tests {
     #[test]
     fn test_blockgroup_interval_tree() {
         let conn = &get_connection(None).unwrap();
-        let (block_group_id, path) = setup_block_group(conn);
+        let (block_group_id, _path) = setup_block_group(conn);
         let _new_sample = Sample::get_or_create(conn, "child").unwrap();
         let new_bg_id = get_single_bg_id(conn, "test", "child", "chr1", vec!["test".to_string()]);
-        let new_path = Path::query(
+        let _new_path = Path::query(
             conn,
             "select * from paths where block_group_id = ?1",
             params![new_bg_id],
@@ -3161,9 +3055,12 @@ mod tests {
             path_end: 15,
             strand: Strand::Forward,
         };
-        let change = PathChange {
+        let change = BlockGroupChange {
             block_group_id: new_bg_id,
-            path: new_path[0].clone(),
+            intervaltree_source: BlockGroupTreeSource {
+                block_group_id: new_bg_id,
+                remove_ambiguous_positions: true,
+            },
             path_accession: None,
             start: 7,
             end: 15,
@@ -3172,8 +3069,7 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        let tree = path.intervaltree(conn).unwrap();
-        BlockGroup::insert_change(conn, &change, &tree).unwrap();
+        BlockGroup::insert_change(conn, &change).unwrap();
 
         let tree = BlockGroup::intervaltree_for(conn, &block_group_id, false);
         let tree2 = BlockGroup::intervaltree_for(conn, &block_group_id, true);
@@ -3331,7 +3227,7 @@ mod tests {
         };
         let change = PathChange {
             block_group_id: new_bg_id,
-            path: new_path[0].clone(),
+            intervaltree_source: new_path[0].clone(),
             path_accession: None,
             start: 7,
             end: 15,
@@ -3341,8 +3237,7 @@ mod tests {
             preserve_edge: false,
         };
         // note we are making our change against the new blockgroup, and not the parent blockgroup
-        let tree = BlockGroup::intervaltree_for(conn, &new_bg_id, true);
-        BlockGroup::insert_change(conn, &change, &tree).unwrap();
+        BlockGroup::insert_change(conn, &change).unwrap();
         let all_sequences = BlockGroup::get_all_sequences(conn, &new_bg_id, true);
         assert_eq!(
             all_sequences,
@@ -3358,7 +3253,7 @@ mod tests {
             "chr1",
             vec!["child".to_string()],
         );
-        let new_path = Path::query(
+        let _new_path = Path::query(
             conn,
             "select * from paths where block_group_id = ?1",
             rusqlite::params!(SQLValue::from(gc_bg_id)),
@@ -3373,9 +3268,12 @@ mod tests {
             path_end: 15,
             strand: Strand::Forward,
         };
-        let change = PathChange {
+        let change = BlockGroupChange {
             block_group_id: gc_bg_id,
-            path: new_path[0].clone(),
+            intervaltree_source: BlockGroupTreeSource {
+                block_group_id: gc_bg_id,
+                remove_ambiguous_positions: true,
+            },
             path_accession: None,
             start: 7,
             end: 15,
@@ -3385,8 +3283,7 @@ mod tests {
             preserve_edge: false,
         };
         // take out an entire block.
-        let tree = BlockGroup::intervaltree_for(conn, &gc_bg_id, true);
-        BlockGroup::insert_change(conn, &change, &tree).unwrap();
+        BlockGroup::insert_change(conn, &change).unwrap();
         let all_sequences = BlockGroup::get_all_sequences(conn, &gc_bg_id, true);
         assert_eq!(
             all_sequences,
@@ -3402,7 +3299,7 @@ mod tests {
         let (_block_group_id, _path) = setup_block_group(conn);
         let _new_sample = Sample::get_or_create(conn, "child").unwrap();
         let new_bg_id = get_single_bg_id(conn, "test", "child", "chr1", vec!["test".to_string()]);
-        let new_path = Path::query(
+        let _new_path = Path::query(
             conn,
             "select * from paths where block_group_id = ?1",
             params![new_bg_id],
@@ -3423,9 +3320,12 @@ mod tests {
             path_end: 11,
             strand: Strand::Forward,
         };
-        let change = PathChange {
+        let change = BlockGroupChange {
             block_group_id: new_bg_id,
-            path: new_path[0].clone(),
+            intervaltree_source: BlockGroupTreeSource {
+                block_group_id: new_bg_id,
+                remove_ambiguous_positions: true,
+            },
             path_accession: None,
             start: 7,
             end: 11,
@@ -3435,8 +3335,7 @@ mod tests {
             preserve_edge: true,
         };
         // note we are making our change against the new blockgroup, and not the parent blockgroup
-        let tree = BlockGroup::intervaltree_for(conn, &new_bg_id, true);
-        BlockGroup::insert_change(conn, &change, &tree).unwrap();
+        BlockGroup::insert_change(conn, &change).unwrap();
         let all_sequences = BlockGroup::get_all_sequences(conn, &new_bg_id, true);
         assert_eq!(
             all_sequences,
@@ -3455,7 +3354,7 @@ mod tests {
             "chr1",
             vec!["child".to_string()],
         );
-        let new_path = Path::query(
+        let _new_path = Path::query(
             conn,
             "select * from paths where block_group_id = ?1",
             params![gc_bg_id],
@@ -3482,9 +3381,12 @@ mod tests {
             path_end: 24,
             strand: Strand::Forward,
         };
-        let change = PathChange {
+        let change = BlockGroupChange {
             block_group_id: gc_bg_id,
-            path: new_path[0].clone(),
+            intervaltree_source: BlockGroupTreeSource {
+                block_group_id: gc_bg_id,
+                remove_ambiguous_positions: true,
+            },
             path_accession: None,
             start: 20,
             end: 24,
@@ -3494,8 +3396,7 @@ mod tests {
             preserve_edge: true,
         };
         // take out an entire block.
-        let tree = BlockGroup::intervaltree_for(conn, &gc_bg_id, true);
-        BlockGroup::insert_change(conn, &change, &tree).unwrap();
+        BlockGroup::insert_change(conn, &change).unwrap();
         let all_sequences = BlockGroup::get_all_sequences(conn, &gc_bg_id, true);
         assert_eq!(
             all_sequences,
@@ -3516,7 +3417,7 @@ mod tests {
         let (_block_group_id, _path) = setup_block_group(conn);
         let _new_sample = Sample::get_or_create(conn, "child").unwrap();
         let new_bg_id = get_single_bg_id(conn, "test", "child", "chr1", vec!["test".to_string()]);
-        let new_path = Path::query(
+        let _new_path = Path::query(
             conn,
             "select * from paths where block_group_id = ?1",
             rusqlite::params!(SQLValue::from(new_bg_id)),
@@ -3539,9 +3440,12 @@ mod tests {
             path_end: 12,
             strand: Strand::Forward,
         };
-        let change = PathChange {
+        let change = BlockGroupChange {
             block_group_id: new_bg_id,
-            path: new_path[0].clone(),
+            intervaltree_source: BlockGroupTreeSource {
+                block_group_id: new_bg_id,
+                remove_ambiguous_positions: true,
+            },
             path_accession: None,
             start: 7,
             end: 12,
@@ -3551,8 +3455,7 @@ mod tests {
             preserve_edge: true,
         };
         // note we are making our change against the new blockgroup, and not the parent blockgroup
-        let tree = BlockGroup::intervaltree_for(conn, &new_bg_id, true);
-        BlockGroup::insert_change(conn, &change, &tree).unwrap();
+        BlockGroup::insert_change(conn, &change).unwrap();
         let all_sequences = BlockGroup::get_all_sequences(conn, &new_bg_id, true);
         assert_eq!(
             all_sequences,
@@ -3571,7 +3474,7 @@ mod tests {
             "chr1",
             vec!["child".to_string()],
         );
-        let new_path = Path::query(
+        let _new_path = Path::query(
             conn,
             "select * from paths where block_group_id = ?1",
             rusqlite::params!(SQLValue::from(gc_bg_id)),
@@ -3594,9 +3497,12 @@ mod tests {
             path_end: 24,
             strand: Strand::Forward,
         };
-        let change = PathChange {
+        let change = BlockGroupChange {
             block_group_id: gc_bg_id,
-            path: new_path[0].clone(),
+            intervaltree_source: BlockGroupTreeSource {
+                block_group_id: gc_bg_id,
+                remove_ambiguous_positions: true,
+            },
             path_accession: None,
             start: 20,
             end: 24,
@@ -3606,8 +3512,7 @@ mod tests {
             preserve_edge: true,
         };
         // take out an entire block.
-        let tree = BlockGroup::intervaltree_for(conn, &gc_bg_id, true);
-        BlockGroup::insert_change(conn, &change, &tree).unwrap();
+        BlockGroup::insert_change(conn, &change).unwrap();
     }
 
     mod test_derive_subgraph {

--- a/gen-models/src/block_group.rs
+++ b/gen-models/src/block_group.rs
@@ -683,8 +683,6 @@ impl BlockGroup {
         let end_blocks: Vec<&NodeIntervalBlock> = tree.query_point(end).map(|x| &x.value).collect();
         assert_eq!(end_blocks.len(), 1);
         let end_block = end_blocks[0];
-        // we make a start/end edge for the accession start/end, then fill in the middle
-        // with any existing edges
         let start_edge = AccessionEdgeData {
             source_node_id: PATH_START_NODE_ID,
             source_coordinate: -1,
@@ -723,7 +721,6 @@ impl BlockGroup {
                     in_range
                 })
                 .collect::<Vec<_>>();
-            // if start and end block are not the same, we will always have at least 2 elements in path_blocks
             for (block, next_block) in path_blocks.iter().zip(path_blocks[1..].iter()) {
                 path_edges.push(AccessionEdgeData {
                     source_node_id: block.node_id,
@@ -745,39 +742,48 @@ impl BlockGroup {
         Ok(accession)
     }
 
-    pub fn insert_changes(
+    pub fn insert_changes<T: IntervalTreeSource + Clone + Eq + Hash>(
         conn: &GraphConnection,
-        changes: &[BlockGroupChange<Path>],
-        cache: &mut PathCache,
-        modify_blockgroup: bool,
+        changes: &[BlockGroupChange<T>],
     ) -> Result<(), BlockGroupError> {
         let mut new_augmented_edges_by_block_group =
-            HashMap::<&HashId, Vec<AugmentedEdgeData>>::new();
-        let mut new_accession_edges = HashMap::new();
+            HashMap::<HashId, Vec<AugmentedEdgeData>>::new();
+        let mut new_accession_edges = HashMap::<(HashId, String), Vec<AugmentedEdgeData>>::new();
         let mut tree_map = HashMap::new();
         for change in changes {
-            let tree = if modify_blockgroup {
-                tree_map.entry(change.block_group_id).or_insert_with(|| {
-                    BlockGroup::intervaltree_for(conn, &change.block_group_id, true)
-                })
-            } else {
-                PathCache::get_intervaltree(cache, &change.intervaltree_source)?
-            };
+            if !tree_map.contains_key(&change.intervaltree_source) {
+                tree_map.insert(
+                    change.intervaltree_source.clone(),
+                    change.intervaltree_source.intervaltree(conn)?,
+                );
+            }
+            let tree = tree_map.get(&change.intervaltree_source).unwrap();
             let new_augmented_edges = BlockGroup::set_up_new_edges(change, tree)?;
             new_augmented_edges_by_block_group
-                .entry(&change.block_group_id)
+                .entry(change.block_group_id)
                 .and_modify(|new_edge_data| new_edge_data.extend(new_augmented_edges.clone()))
                 .or_insert_with(|| new_augmented_edges.clone());
             if let Some(accession) = &change.path_accession {
                 new_accession_edges
-                    .entry((&change.intervaltree_source, accession))
+                    .entry((change.block_group_id, accession.clone()))
                     .and_modify(|new_edge_data: &mut Vec<AugmentedEdgeData>| {
                         new_edge_data.extend(new_augmented_edges.clone())
                     })
                     .or_insert_with(|| new_augmented_edges.clone());
             }
         }
+        Self::persist_insert_changes(
+            conn,
+            new_augmented_edges_by_block_group,
+            new_accession_edges,
+        )
+    }
 
+    fn persist_insert_changes(
+        conn: &GraphConnection,
+        new_augmented_edges_by_block_group: HashMap<HashId, Vec<AugmentedEdgeData>>,
+        new_accession_edges: HashMap<(HashId, String), Vec<AugmentedEdgeData>>,
+    ) -> Result<(), BlockGroupError> {
         let mut edge_data_map = HashMap::new();
 
         for (block_group_id, new_augmented_edges) in new_augmented_edges_by_block_group {
@@ -793,7 +799,7 @@ impl BlockGroup {
                 .iter()
                 .enumerate()
                 .map(|(i, edge_id)| BlockGroupEdgeData {
-                    block_group_id: *block_group_id,
+                    block_group_id,
                     edge_id: *edge_id,
                     chromosome_index: new_augmented_edges[i].chromosome_index,
                     phased: new_augmented_edges[i].phased,
@@ -802,11 +808,11 @@ impl BlockGroup {
             BlockGroupEdge::bulk_create(conn, &new_block_group_edges);
         }
 
-        for ((path, accession_name), path_edges) in new_accession_edges {
+        for ((block_group_id, accession_name), path_edges) in new_accession_edges {
             match Accession::get(
                 conn,
                 "select * from accessions where name = ?1 AND block_group_id = ?2",
-                params![accession_name, path.block_group_id],
+                params![accession_name, block_group_id],
             ) {
                 Ok(_) => {
                     println!(
@@ -821,7 +827,7 @@ impl BlockGroup {
                             .map(AccessionEdgeData::from)
                             .collect::<Vec<_>>(),
                     );
-                    let acc = Accession::create(conn, accession_name, &path.block_group_id, None)
+                    let acc = Accession::create(conn, &accession_name, &block_group_id, None)
                         .expect("Accession could not be created.");
                     AccessionPath::create(conn, &acc.id, &acc_edges)?;
                 }
@@ -838,23 +844,21 @@ impl BlockGroup {
     ) -> Result<(), BlockGroupError> {
         let tree = change.intervaltree_source.intervaltree(conn)?;
         let new_augmented_edges = BlockGroup::set_up_new_edges(change, &tree)?;
-        let new_edges = new_augmented_edges
-            .iter()
-            .map(|augmented_edge| augmented_edge.edge_data)
-            .collect::<Vec<_>>();
-        let edge_ids = Edge::bulk_create(conn, &new_edges);
-        let new_block_group_edges = edge_ids
-            .iter()
-            .enumerate()
-            .map(|(i, edge_id)| BlockGroupEdgeData {
-                block_group_id: change.block_group_id,
-                edge_id: *edge_id,
-                chromosome_index: new_augmented_edges[i].chromosome_index,
-                phased: new_augmented_edges[i].phased,
-            })
-            .collect::<Vec<_>>();
-        BlockGroupEdge::bulk_create(conn, &new_block_group_edges);
-        Ok(())
+        let mut new_augmented_edges_by_block_group = HashMap::new();
+        new_augmented_edges_by_block_group
+            .insert(change.block_group_id, new_augmented_edges.clone());
+        let mut new_accession_edges = HashMap::new();
+        if let Some(accession) = &change.path_accession {
+            new_accession_edges.insert(
+                (change.block_group_id, accession.clone()),
+                new_augmented_edges,
+            );
+        }
+        Self::persist_insert_changes(
+            conn,
+            new_augmented_edges_by_block_group,
+            new_accession_edges,
+        )
     }
 
     fn set_up_new_edges<T: IntervalTreeSource>(

--- a/gen-models/src/block_group.rs
+++ b/gen-models/src/block_group.rs
@@ -201,7 +201,7 @@ impl IntervalTreeSource for Accession {
         &self,
         conn: &GraphConnection,
     ) -> Result<IntervalTree<i64, NodeIntervalBlock>, BlockGroupError> {
-        Ok(self.intervaltree(conn))
+        self.intervaltree(conn).map_err(Into::into)
     }
 }
 
@@ -210,7 +210,7 @@ impl IntervalTreeSource for AccessionAnnotation {
         &self,
         conn: &GraphConnection,
     ) -> Result<IntervalTree<i64, NodeIntervalBlock>, BlockGroupError> {
-        Ok(self.intervaltree(conn))
+        self.intervaltree(conn).map_err(Into::into)
     }
 }
 

--- a/gen-models/src/block_group.rs
+++ b/gen-models/src/block_group.rs
@@ -745,11 +745,16 @@ impl BlockGroup {
     pub fn insert_changes<T: IntervalTreeSource + Clone + Eq + Hash>(
         conn: &GraphConnection,
         changes: &[BlockGroupChange<T>],
+        tree_map: Option<&mut HashMap<T, IntervalTree<i64, NodeIntervalBlock>>>,
     ) -> Result<(), BlockGroupError> {
         let mut new_augmented_edges_by_block_group =
             HashMap::<HashId, Vec<AugmentedEdgeData>>::new();
         let mut new_accession_edges = HashMap::<(HashId, String), Vec<AugmentedEdgeData>>::new();
-        let mut tree_map = HashMap::new();
+        let mut local_tree_map = HashMap::new();
+        let tree_map = match tree_map {
+            Some(tree_map) => tree_map,
+            None => &mut local_tree_map,
+        };
         for change in changes {
             if !tree_map.contains_key(&change.intervaltree_source) {
                 tree_map.insert(

--- a/gen-models/src/changesets.rs
+++ b/gen-models/src/changesets.rs
@@ -1017,6 +1017,12 @@ pub fn apply_changeset(
             AnnotationError::AnnotationGroupError(AnnotationGroupError::DatabaseError(inner)) => {
                 ChangesetError::SqliteError(inner)
             }
+            AnnotationError::AccessionError(crate::accession::AccessionError::DatabaseError(
+                inner,
+            )) => ChangesetError::SqliteError(inner),
+            AnnotationError::AccessionError(err) => {
+                ChangesetError::SerializationError(err.to_string())
+            }
             AnnotationError::SerializationError(message) => {
                 ChangesetError::SerializationError(message)
             }
@@ -1033,6 +1039,12 @@ pub fn apply_changeset(
             AnnotationError::DatabaseError(inner) => ChangesetError::SqliteError(inner),
             AnnotationError::AnnotationGroupError(AnnotationGroupError::DatabaseError(inner)) => {
                 ChangesetError::SqliteError(inner)
+            }
+            AnnotationError::AccessionError(crate::accession::AccessionError::DatabaseError(
+                inner,
+            )) => ChangesetError::SqliteError(inner),
+            AnnotationError::AccessionError(err) => {
+                ChangesetError::SerializationError(err.to_string())
             }
             AnnotationError::SerializationError(message) => {
                 ChangesetError::SerializationError(message)
@@ -1063,6 +1075,12 @@ pub fn revert_changeset(
             AnnotationError::DatabaseError(inner) => ChangesetError::SqliteError(inner),
             AnnotationError::AnnotationGroupError(AnnotationGroupError::DatabaseError(inner)) => {
                 ChangesetError::SqliteError(inner)
+            }
+            AnnotationError::AccessionError(crate::accession::AccessionError::DatabaseError(
+                inner,
+            )) => ChangesetError::SqliteError(inner),
+            AnnotationError::AccessionError(err) => {
+                ChangesetError::SerializationError(err.to_string())
             }
             AnnotationError::SerializationError(message) => {
                 ChangesetError::SerializationError(message)

--- a/gen-models/src/edge.rs
+++ b/gen-models/src/edge.rs
@@ -753,7 +753,7 @@ mod tests {
         };
         let change = PathChange {
             block_group_id,
-            path: path.clone(),
+            intervaltree_source: path.clone(),
             path_accession: None,
             start: 7,
             end: 15,
@@ -762,8 +762,7 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        let tree = path.intervaltree(&conn).unwrap();
-        BlockGroup::insert_change(&conn, &change, &tree).unwrap();
+        BlockGroup::insert_change(&conn, &change).unwrap();
         let mut edges = BlockGroupEdge::edges_for_block_group(&conn, &block_group_id);
 
         let blocks = Edge::blocks_from_edges(&conn, &edges);

--- a/src/exports/gfa.rs
+++ b/src/exports/gfa.rs
@@ -734,7 +734,7 @@ mod tests {
         };
         let change = PathChange {
             block_group_id,
-            path: path.clone(),
+            intervaltree_source: path.clone(),
             path_accession: None,
             start: 7,
             end: 15,
@@ -743,8 +743,7 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        let tree = path.intervaltree(conn).unwrap();
-        BlockGroup::insert_change(conn, &change, &tree).unwrap();
+        BlockGroup::insert_change(conn, &change).unwrap();
 
         let augmented_edges = BlockGroupEdge::edges_for_block_group(conn, &block_group_id);
         let mut node_ids = HashSet::new();

--- a/src/imports/genbank.rs
+++ b/src/imports/genbank.rs
@@ -609,7 +609,7 @@ where
                             )?;
                             PathChange {
                                 block_group_id: block_group.id,
-                                path: path.clone(),
+                                intervaltree_source: path.clone(),
                                 path_accession: None,
                                 start,
                                 end,
@@ -629,7 +629,7 @@ where
                         }
                         EditType::Deletion => PathChange {
                             block_group_id: block_group.id,
-                            path: path.clone(),
+                            intervaltree_source: path.clone(),
                             path_accession: None,
                             start,
                             end,
@@ -647,8 +647,7 @@ where
                             preserve_edge: true,
                         },
                     };
-                    let tree = path.intervaltree(conn)?;
-                    BlockGroup::insert_change(conn, &change, &tree).unwrap();
+                    BlockGroup::insert_change(conn, &change).unwrap();
                     applied_changes.push((edit, change_node_id));
                 }
 

--- a/src/updates/fasta.rs
+++ b/src/updates/fasta.rs
@@ -59,7 +59,6 @@ pub fn update_with_fasta(
     struct TargetBlockGroupState {
         block_group_id: HashId,
         path: gen_models::path::Path,
-        interval_tree: intervaltree::IntervalTree<i64, gen_core::NodeIntervalBlock>,
         first_node: Option<HashId>,
     }
 
@@ -67,11 +66,9 @@ pub fn update_with_fasta(
         .iter()
         .map(|target_block_group| -> Result<_, FastaError> {
             let path = BlockGroup::get_current_path(conn, &target_block_group.id);
-            let interval_tree = path.intervaltree(conn)?;
             Ok(TargetBlockGroupState {
                 block_group_id: target_block_group.id,
                 path,
-                interval_tree,
                 first_node: None,
             })
         })
@@ -98,7 +95,7 @@ pub fn update_with_fasta(
 
                 let path_change = PathChange {
                     block_group_id: state.block_group_id,
-                    path: state.path.clone(),
+                    intervaltree_source: state.path.clone(),
                     path_accession: None,
                     start: start_coordinate,
                     end: end_coordinate,
@@ -108,7 +105,7 @@ pub fn update_with_fasta(
                     preserve_edge: true,
                 };
 
-                BlockGroup::insert_change(conn, &path_change, &state.interval_tree).unwrap();
+                BlockGroup::insert_change(conn, &path_change).unwrap();
                 if index == 0 {
                     state.first_node = Some(node_id);
                 } else if state.first_node.is_some() {
@@ -143,7 +140,7 @@ pub fn update_with_fasta(
 
                 let path_change = PathChange {
                     block_group_id: state.block_group_id,
-                    path: state.path.clone(),
+                    intervaltree_source: state.path.clone(),
                     path_accession: None,
                     start: start_coordinate,
                     end: end_coordinate,
@@ -153,7 +150,7 @@ pub fn update_with_fasta(
                     preserve_edge: true,
                 };
 
-                BlockGroup::insert_change(conn, &path_change, &state.interval_tree).unwrap();
+                BlockGroup::insert_change(conn, &path_change).unwrap();
                 if index == 0 {
                     state.first_node = Some(node_id);
                 } else if state.first_node.is_some() {

--- a/src/updates/genbank.rs
+++ b/src/updates/genbank.rs
@@ -181,7 +181,7 @@ where
                             )?;
                             PathChange {
                                 block_group_id: block_group.id,
-                                path: path.clone(),
+                                intervaltree_source: path.clone(),
                                 path_accession: None,
                                 start,
                                 end,
@@ -201,7 +201,7 @@ where
                         }
                         EditType::Deletion => PathChange {
                             block_group_id: block_group.id,
-                            path: path.clone(),
+                            intervaltree_source: path.clone(),
                             path_accession: None,
                             start,
                             end,
@@ -219,8 +219,7 @@ where
                             preserve_edge: true,
                         },
                     };
-                    let tree = path.intervaltree(conn)?;
-                    BlockGroup::insert_change(conn, &change, &tree).unwrap();
+                    BlockGroup::insert_change(conn, &change).unwrap();
                 }
             }
             Err(e) => return Err(GenBankError::ParseError(format!("Failed to parse {e}"))),

--- a/src/updates/sequence.rs
+++ b/src/updates/sequence.rs
@@ -54,7 +54,6 @@ pub fn update_with_sequence(
 
     for target_block_group in &target_block_groups {
         let path = BlockGroup::get_current_path(conn, &target_block_group.id);
-        let interval_tree = path.intervaltree(conn)?;
         let node_id = if sequence.is_empty() {
             let node_id = HashId::convert_str("");
             let path_block = PathBlock {
@@ -69,7 +68,7 @@ pub fn update_with_sequence(
 
             let path_change = PathChange {
                 block_group_id: target_block_group.id,
-                path: path.clone(),
+                intervaltree_source: path.clone(),
                 path_accession: None,
                 start: start_coordinate,
                 end: end_coordinate,
@@ -79,7 +78,7 @@ pub fn update_with_sequence(
                 preserve_edge: true,
             };
 
-            BlockGroup::insert_change(conn, &path_change, &interval_tree).unwrap();
+            BlockGroup::insert_change(conn, &path_change).unwrap();
             node_id
         } else {
             let seq = Sequence::new()
@@ -110,7 +109,7 @@ pub fn update_with_sequence(
 
             let path_change = PathChange {
                 block_group_id: target_block_group.id,
-                path: path.clone(),
+                intervaltree_source: path.clone(),
                 path_accession: None,
                 start: start_coordinate,
                 end: end_coordinate,
@@ -120,7 +119,7 @@ pub fn update_with_sequence(
                 preserve_edge: true,
             };
 
-            BlockGroup::insert_change(conn, &path_change, &interval_tree).unwrap();
+            BlockGroup::insert_change(conn, &path_change).unwrap();
             node_id
         };
 

--- a/src/updates/vcf.rs
+++ b/src/updates/vcf.rs
@@ -605,6 +605,8 @@ pub fn update_with_vcf(
     ));
     bar.set_message("Changes applied");
     let mut summary: HashMap<String, HashMap<String, i64>> = HashMap::new();
+    let mut path_tree_cache = HashMap::new();
+    let mut block_group_tree_cache = HashMap::new();
     for ((path, sample_name), path_changes) in changes {
         for chunk in path_changes.chunks(1000) {
             if in_place {
@@ -625,9 +627,14 @@ pub fn update_with_vcf(
                         preserve_edge: change.preserve_edge,
                     })
                     .collect::<Vec<_>>();
-                BlockGroup::insert_changes(conn, &in_place_changes).unwrap();
+                BlockGroup::insert_changes(
+                    conn,
+                    &in_place_changes,
+                    Some(&mut block_group_tree_cache),
+                )
+                .unwrap();
             } else {
-                BlockGroup::insert_changes(conn, chunk).unwrap();
+                BlockGroup::insert_changes(conn, chunk, Some(&mut path_tree_cache)).unwrap();
             }
             bar.inc(chunk.len() as u64);
         }

--- a/src/updates/vcf.rs
+++ b/src/updates/vcf.rs
@@ -6,7 +6,9 @@ use std::{
 
 use gen_core::{HashId, PathBlock, Strand};
 use gen_models::{
-    block_group::{BlockGroup, BlockGroupData, PathCache, PathChange},
+    block_group::{
+        BlockGroup, BlockGroupChange, BlockGroupData, BlockGroupTreeSource, PathCache, PathChange,
+    },
     db::{DbContext, GraphConnection},
     errors::{BlockGroupError, NodeError, OperationError, PathError, SampleError, SequenceError},
     file_types::FileTypes,
@@ -162,7 +164,7 @@ fn prepare_change(
     };
     PathChange {
         block_group_id: *sample_bg_id,
-        path: sample_path.clone(),
+        intervaltree_source: sample_path.clone(),
         path_accession: ids,
         start: ref_start,
         end: ref_end,
@@ -605,7 +607,28 @@ pub fn update_with_vcf(
     let mut summary: HashMap<String, HashMap<String, i64>> = HashMap::new();
     for ((path, sample_name), path_changes) in changes {
         for chunk in path_changes.chunks(1000) {
-            BlockGroup::insert_changes(conn, chunk, &mut path_cache, in_place).unwrap();
+            if in_place {
+                let in_place_changes = chunk
+                    .iter()
+                    .map(|change| BlockGroupChange {
+                        block_group_id: change.block_group_id,
+                        intervaltree_source: BlockGroupTreeSource {
+                            block_group_id: change.block_group_id,
+                            remove_ambiguous_positions: true,
+                        },
+                        path_accession: change.path_accession.clone(),
+                        start: change.start,
+                        end: change.end,
+                        block: change.block.clone(),
+                        chromosome_index: change.chromosome_index,
+                        phased: change.phased,
+                        preserve_edge: change.preserve_edge,
+                    })
+                    .collect::<Vec<_>>();
+                BlockGroup::insert_changes(conn, &in_place_changes).unwrap();
+            } else {
+                BlockGroup::insert_changes(conn, chunk).unwrap();
+            }
             bar.inc(chunk.len() as u64);
         }
         summary


### PR DESCRIPTION
Update a blockgroup based on accessions/annotations. The core of this is a new trait for creating an intervaltree and using that intervaltree in the new struct, BlockGroupChange. So we have a trait defining how a path/accession/etc. can make an intervaltree and provide the nodes that are going to be impacted by a change.