### PR TITLE
Remove path from accession

### DIFF
--- a/gen-capnp-schemas/gen-models.capnp
+++ b/gen-capnp-schemas/gen-models.capnp
@@ -104,7 +104,7 @@ struct PathEdge {
 struct Accession {
   id @0 :List(UInt8);
   name @1 :Text;
-  pathId @2 :List(UInt8);
+  blockGroupId @2 :List(UInt8);
   parentAccessionId :union {
     none @3 :Void;
     some @4 :List(UInt8);

--- a/gen-models/migrations/core/01-initial/up.sql
+++ b/gen-models/migrations/core/01-initial/up.sql
@@ -48,14 +48,13 @@ CREATE UNIQUE INDEX path_uidx ON paths(block_group_id, name);
 CREATE TABLE accessions (
   id BLOB PRIMARY KEY NOT NULL,
   name TEXT NOT NULL,
---  path accessions can reference other path accessions
-  path_id BLOB NOT NULL,
+  block_group_id BLOB NOT NULL,
   parent_accession_id BLOB,
-  FOREIGN KEY(path_id) REFERENCES paths(id),
+  FOREIGN KEY(block_group_id) REFERENCES block_groups(id),
   FOREIGN KEY(parent_accession_id) REFERENCES accessions(id)
 ) STRICT;
-CREATE UNIQUE INDEX accession_uidx ON accessions(path_id, parent_accession_id, name) WHERE parent_accession_id is not null;
-CREATE UNIQUE INDEX accession_null_aid_uidx ON accessions(path_id, name) WHERE parent_accession_id is null;
+CREATE UNIQUE INDEX accession_uidx ON accessions(block_group_id, parent_accession_id, name) WHERE parent_accession_id is not null;
+CREATE UNIQUE INDEX accession_null_aid_uidx ON accessions(block_group_id, name) WHERE parent_accession_id is null;
 
 CREATE TABLE accession_edges (
   id BLOB PRIMARY KEY NOT NULL,

--- a/gen-models/src/accession.rs
+++ b/gen-models/src/accession.rs
@@ -17,7 +17,7 @@ use crate::{
 pub struct Accession {
     pub id: HashId,
     pub name: String,
-    pub path_id: HashId,
+    pub block_group_id: HashId,
     pub parent_accession_id: Option<HashId>,
 }
 
@@ -36,7 +36,7 @@ impl<'a> Capnp<'a> for Accession {
     fn write_capnp(&self, builder: &mut Self::Builder) {
         builder.set_id(&self.id.0).unwrap();
         builder.set_name(&self.name);
-        builder.set_path_id(&self.path_id.0).unwrap();
+        builder.set_block_group_id(&self.block_group_id.0).unwrap();
         match &self.parent_accession_id {
             None => {
                 builder.reborrow().get_parent_accession_id().set_none(());
@@ -60,8 +60,8 @@ impl<'a> Capnp<'a> for Accession {
             .try_into()
             .unwrap();
         let name = reader.get_name().unwrap().to_string().unwrap();
-        let path_id = reader
-            .get_path_id()
+        let block_group_id = reader
+            .get_block_group_id()
             .unwrap()
             .as_slice()
             .unwrap()
@@ -78,7 +78,7 @@ impl<'a> Capnp<'a> for Accession {
         Accession {
             id,
             name,
-            path_id,
+            block_group_id,
             parent_accession_id,
         }
     }
@@ -271,37 +271,41 @@ impl From<&AugmentedEdgeData> for AccessionEdgeData {
 }
 
 impl Accession {
-    fn id_hash(path_id: &HashId, parent_accession_id: Option<&HashId>, name: &str) -> HashId {
+    fn id_hash(
+        block_group_id: &HashId,
+        parent_accession_id: Option<&HashId>,
+        name: &str,
+    ) -> HashId {
         HashId(calculate_hash(&format!(
-            "{path_id}:{parent_accession_id:?}:{name}"
+            "{block_group_id}:{parent_accession_id:?}:{name}"
         )))
     }
 
     pub fn create(
         conn: &GraphConnection,
         name: &str,
-        path_id: &HashId,
+        block_group_id: &HashId,
         parent_accession_id: Option<&HashId>,
     ) -> Result<Accession, AccessionError> {
-        let query = "INSERT INTO accessions (id, name, path_id, parent_accession_id) VALUES (?1, ?2, ?3, ?4);";
+        let query = "INSERT INTO accessions (id, name, block_group_id, parent_accession_id) VALUES (?1, ?2, ?3, ?4);";
         let mut stmt = match conn.prepare(query) {
             Ok(s) => s,
             Err(e) => return Err(AccessionError::DatabaseError(e)),
         };
 
-        let hash = Accession::id_hash(path_id, parent_accession_id, name);
-        match stmt.execute((hash, name, path_id, parent_accession_id)) {
+        let hash = Accession::id_hash(block_group_id, parent_accession_id, name);
+        match stmt.execute((hash, name, block_group_id, parent_accession_id)) {
             Ok(_) => Ok(Accession {
                 id: hash,
                 name: name.to_string(),
-                path_id: *path_id,
+                block_group_id: *block_group_id,
                 parent_accession_id: parent_accession_id.copied(),
             }),
             Err(rusqlite::Error::SqliteFailure(err, _details))
                 if err.code == rusqlite::ErrorCode::ConstraintViolation =>
             {
                 Err(AccessionError::Duplicate(format!(
-                    "An accession with the same name, path_id, and parent_accession_id already exists. name: {name}, path_id: {path_id}, parent_accession_id: {parent_accession_id:?}"
+                    "An accession with the same name, block_group_id, and parent_accession_id already exists. name: {name}, block_group_id: {block_group_id}, parent_accession_id: {parent_accession_id:?}"
                 )))
             }
             Err(e) => Err(AccessionError::DatabaseError(e)),
@@ -311,17 +315,17 @@ impl Accession {
     pub fn get_or_create(
         conn: &GraphConnection,
         name: &str,
-        path_id: &HashId,
+        block_group_id: &HashId,
         parent_accession_id: Option<&HashId>,
     ) -> Result<Accession, AccessionError> {
-        match Accession::create(conn, name, path_id, parent_accession_id) {
+        match Accession::create(conn, name, block_group_id, parent_accession_id) {
             Ok(accession) => Ok(accession),
             Err(AccessionError::Duplicate(_)) => {
-                let hash = Accession::id_hash(path_id, parent_accession_id, name);
+                let hash = Accession::id_hash(block_group_id, parent_accession_id, name);
                 Ok(Accession {
                     id: hash,
                     name: name.to_string(),
-                    path_id: *path_id,
+                    block_group_id: *block_group_id,
                     parent_accession_id: parent_accession_id.copied(),
                 })
             }
@@ -349,7 +353,7 @@ impl Query for Accession {
         Accession {
             id: row.get(0).unwrap(),
             name: row.get(1).unwrap(),
-            path_id: row.get(2).unwrap(),
+            block_group_id: row.get(2).unwrap(),
             parent_accession_id: row.get(3).unwrap(),
         }
     }
@@ -547,7 +551,7 @@ mod tests {
                 .try_into()
                 .unwrap(),
             name: "test_accession".to_string(),
-            path_id: "0000000000000000000000000000000000000000000000000000000000000150"
+            block_group_id: "0000000000000000000000000000000000000000000000000000000000000150"
                 .try_into()
                 .unwrap(),
             parent_accession_id: Some(
@@ -572,7 +576,7 @@ mod tests {
                 .try_into()
                 .unwrap(),
             name: "test_accession_2".to_string(),
-            path_id: "0000000000000000000000000000000000000000000000000000000000000151"
+            block_group_id: "0000000000000000000000000000000000000000000000000000000000000151"
                 .try_into()
                 .unwrap(),
             parent_accession_id: None,
@@ -612,9 +616,9 @@ mod tests {
     #[test]
     fn test_accession_create_query() {
         let conn = &get_connection(None).unwrap();
-        let (_bg, path) = setup_block_group(conn);
-        let accession = Accession::create(conn, "test", &path.id, None).unwrap();
-        let _accession_2 = Accession::create(conn, "test2", &path.id, None).unwrap();
+        let (block_group_id, _path) = setup_block_group(conn);
+        let accession = Accession::create(conn, "test", &block_group_id, None).unwrap();
+        let _accession_2 = Accession::create(conn, "test2", &block_group_id, None).unwrap();
         assert_eq!(
             Accession::query(
                 conn,
@@ -624,7 +628,7 @@ mod tests {
             vec![Accession {
                 id: accession.id,
                 name: "test".to_string(),
-                path_id: path.id,
+                block_group_id,
                 parent_accession_id: None,
             }]
         );

--- a/gen-models/src/block_group.rs
+++ b/gen-models/src/block_group.rs
@@ -329,26 +329,21 @@ impl BlockGroup {
             path_map.insert(path.id, new_path.id);
         }
 
+        let source_block_group_id = existing_paths[0].block_group_id;
         for accession in Accession::query(
             conn,
-            "select * from accessions where path_id IN rarray(?1);",
-            rusqlite::params!(Rc::new(
-                existing_paths
-                    .iter()
-                    .map(|path| SQLValue::from(path.id))
-                    .collect::<Vec<SQLValue>>()
-            )),
+            "select * from accessions where block_group_id = ?1;",
+            params![source_block_group_id],
         ) {
             let edges = AccessionPath::query(
                 conn,
                 "Select * from accession_paths where accession_id = ?1 order by index_in_path ASC;",
                 rusqlite::params!(SQLValue::from(accession.id)),
             );
-            let new_path_id = path_map.get(&accession.path_id).unwrap();
             let obj = Accession::get_or_create(
                 conn,
                 &accession.name,
-                new_path_id,
+                target_block_group_id,
                 accession.parent_accession_id.as_ref(),
             )?;
             AccessionPath::create(
@@ -649,8 +644,8 @@ impl BlockGroup {
             target_strand: Strand::Forward,
             chromosome_index: 0,
         };
-        let accession =
-            Accession::create(conn, name, &path.id, None).expect("Unable to create accession.");
+        let accession = Accession::create(conn, name, &path.block_group_id, None)
+            .expect("Unable to create accession.");
         let mut path_edges = vec![start_edge];
         if start_block == end_block {
             path_edges.push(end_edge);
@@ -751,8 +746,8 @@ impl BlockGroup {
         for ((path, accession_name), path_edges) in new_accession_edges {
             match Accession::get(
                 conn,
-                "select * from accessions where name = ?1 AND path_id = ?2",
-                params![accession_name, path.id],
+                "select * from accessions where name = ?1 AND block_group_id = ?2",
+                params![accession_name, path.block_group_id],
             ) {
                 Ok(_) => {
                     println!(
@@ -767,7 +762,7 @@ impl BlockGroup {
                             .map(AccessionEdgeData::from)
                             .collect::<Vec<_>>(),
                     );
-                    let acc = Accession::create(conn, accession_name, &path.id, None)
+                    let acc = Accession::create(conn, accession_name, &path.block_group_id, None)
                         .expect("Accession could not be created.");
                     AccessionPath::create(conn, &acc.id, &acc_edges)?;
                 }
@@ -1845,7 +1840,7 @@ mod tests {
 
         let child_a_accessions = Accession::query(
             conn,
-            "select accessions.* from accessions join paths on accessions.path_id = paths.id where paths.block_group_id = ?1 order by accessions.name",
+            "select * from accessions where block_group_id = ?1 order by name",
             params![child_a.id],
         );
         assert_eq!(
@@ -1858,7 +1853,7 @@ mod tests {
 
         let child_b_accessions = Accession::query(
             conn,
-            "select accessions.* from accessions join paths on accessions.path_id = paths.id where paths.block_group_id = ?1 order by accessions.name",
+            "select * from accessions where block_group_id = ?1 order by name",
             params![child_b.id],
         );
         assert_eq!(
@@ -1885,7 +1880,7 @@ mod tests {
             vec![Accession {
                 id: acc_1.id,
                 name: "test".to_string(),
-                path_id: path.id,
+                block_group_id: path.block_group_id,
                 parent_accession_id: None,
             }]
         );

--- a/gen-models/src/block_group.rs
+++ b/gen-models/src/block_group.rs
@@ -329,11 +329,10 @@ impl BlockGroup {
             path_map.insert(path.id, new_path.id);
         }
 
-        let source_block_group_id = existing_paths[0].block_group_id;
         for accession in Accession::query(
             conn,
             "select * from accessions where block_group_id = ?1;",
-            params![source_block_group_id],
+            params![self.id],
         ) {
             let edges = AccessionPath::query(
                 conn,

--- a/gen-models/src/changesets.rs
+++ b/gen-models/src/changesets.rs
@@ -657,19 +657,19 @@ pub fn process_changesetiter(
                 }
                 "accessions" => {
                     let accession_id = HashId(parse_blob(item, pk_column));
-                    let path_id = HashId(parse_blob(item, 2));
+                    let block_group_id = HashId(parse_blob(item, 2));
                     let parent_accession_id = parse_maybe_hashid(item, 3);
 
                     created_accessions.push(Accession {
                         id: accession_id,
                         name: parse_string(item, 1),
-                        path_id,
+                        block_group_id,
                         parent_accession_id,
                     });
 
                     created_accessions_set.insert(accession_id);
-                    if !created_paths_set.contains(&path_id) {
-                        previous_paths.insert(path_id);
+                    if !created_block_groups_set.contains(&block_group_id) {
+                        previous_block_groups.insert(block_group_id);
                     }
                     if let Some(id) = parent_accession_id
                         && !created_accessions_set.contains(&id)
@@ -893,7 +893,7 @@ pub fn apply_changeset(
         Accession::get_or_create(
             conn,
             &accession.name,
-            &accession.path_id,
+            &accession.block_group_id,
             accession.parent_accession_id.as_ref(),
         )?;
     }
@@ -971,7 +971,7 @@ pub fn apply_changeset(
         Accession::get_or_create(
             conn,
             &accession.name,
-            &accession.path_id,
+            &accession.block_group_id,
             accession.parent_accession_id.as_ref(),
         )?;
         let edges = changeset
@@ -1349,7 +1349,7 @@ mod tests {
             accessions: vec![Accession {
                 id: HashId::pad_str(1),
                 name: "test_accession".to_string(),
-                path_id: HashId::pad_str(1),
+                block_group_id: HashId::pad_str(1),
                 parent_accession_id: None,
             }],
             accession_edges: vec![AccessionEdge {
@@ -1515,7 +1515,7 @@ mod tests {
             accessions: vec![Accession {
                 id: HashId::pad_str(1),
                 name: "test_accession".to_string(),
-                path_id: HashId::pad_str(1),
+                block_group_id: HashId::pad_str(1),
                 parent_accession_id: None,
             }],
             accession_edges: vec![AccessionEdge {

--- a/gen-models/src/session_operations.rs
+++ b/gen-models/src/session_operations.rs
@@ -379,7 +379,7 @@ mod tests {
             accessions: vec![Accession {
                 id: HashId::pad_str(1),
                 name: "test_accession".to_string(),
-                path_id: HashId::pad_str(1),
+                block_group_id: HashId::pad_str(1),
                 parent_accession_id: None,
             }],
             accession_edges: vec![AccessionEdge {

--- a/gen-python/src/python_api/jupyter_widget.rs
+++ b/gen-python/src/python_api/jupyter_widget.rs
@@ -9,8 +9,9 @@ use r#gen::{
     get_connection,
     graphs::graph_search::GraphLocus,
     views::{
+        annotation_groups::load_annotation_group_entries,
         annotation_track::{AnnotationSpan, AnnotationTrack},
-        annotations::load_annotations_for_group,
+        annotations::{AnnotationGroupTrackRequest, load_annotations_for_group},
         gen_graph_widget::{
             GenGraphNodeRenderer, GenGraphNodeSizer, center_on_node_offset, highlight_match_range,
             locus_label_bounds, viewport_pos_map,
@@ -270,8 +271,22 @@ impl PyGraphController {
         conn: &GraphConnection,
         group: &str,
     ) -> Result<AnnotationTrack, AnnotationError> {
+        let block_group_id = self
+            .block_group_id
+            .expect("block group id should be set for track loading");
+        let current_block_group =
+            BlockGroup::get_by_id(conn, &block_group_id).expect("current block group should exist");
+        let entry = load_annotation_group_entries(conn, &current_block_group)
+            .into_iter()
+            .find(|entry| entry.name == group)
+            .ok_or_else(|| AnnotationError::DatabaseError(rusqlite::Error::QueryReturnedNoRows))?;
         let ranges = self.all_node_ranges();
-        let spans = load_annotations_for_group(conn, group, &ranges)?;
+        let spans = load_annotations_for_group(&AnnotationGroupTrackRequest {
+            conn,
+            current_block_group: &current_block_group,
+            entry: &entry,
+            visible_ranges_by_node: &ranges,
+        })?;
         Ok(AnnotationTrack::new(group.to_string(), spans))
     }
 }

--- a/src/exports/genbank.rs
+++ b/src/exports/genbank.rs
@@ -95,7 +95,7 @@ fn export_annotations(
         let Some(accession) = Accession::get_by_id(conn, &annotation.accession_id) else {
             continue;
         };
-        if accession.path_id != path.id {
+        if accession.block_group_id != path.block_group_id {
             continue;
         }
 
@@ -578,7 +578,7 @@ mod tests {
             chromosome_index: 0,
         });
 
-        let accession = Accession::get_or_create(conn, name, &path.id, None).unwrap();
+        let accession = Accession::get_or_create(conn, name, &path.block_group_id, None).unwrap();
         let edge_ids = AccessionEdge::bulk_create(conn, &edges);
         AccessionPath::create(conn, &accession.id, &edge_ids);
         Annotation::create_with_samples(

--- a/src/imports/genbank.rs
+++ b/src/imports/genbank.rs
@@ -332,7 +332,8 @@ fn create_accession_for_segments(
     accession_name: &str,
     segments: &[AnnotationSegment],
 ) -> Result<HashId, GenBankError> {
-    let accession = match Accession::get_or_create(conn, accession_name, &path.id, None) {
+    let accession = match Accession::get_or_create(conn, accession_name, &path.block_group_id, None)
+    {
         Ok(accession) => accession,
         Err(err) => return Err(GenBankError::AccessionError(err)),
     };


### PR DESCRIPTION
Drops paths for block_group for accessions. We don't even need block_groups to be honest but we can do that if it ever makes sense. This is so we can label parts outside of paths