### PR TITLE
feat(gen-python): make collection optional and last in all PyO3 bindings

### DIFF
--- a/gen-python/examples/repository_api.ipynb
+++ b/gen-python/examples/repository_api.ipynb
@@ -1,0 +1,4740 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "01-header",
+   "metadata": {},
+   "source": [
+    "# Repository API\n\nDemonstrates imports, exports, updates, and graph operations.\nAll functions accept an optional `collection` parameter (see Section 5)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "02-setup",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Repository at: /var/folders/f8/8zf8xczs0pxf9_vfnlmqlx9h0000gn/T/gen-demo-hqpn37zr\n"
+     ]
+    }
+   ],
+   "source": [
+    "import gen\n",
+    "import pathlib\n",
+    "import tempfile\n",
+    "\n",
+    "# Fixture files bundled with the repo\n",
+    "REPO_ROOT = pathlib.Path(gen.__file__).parents[3]\n",
+    "FX = REPO_ROOT / \"fixtures\"\n",
+    "\n",
+    "# Fresh temporary repo for each run\n",
+    "WORK_DIR = pathlib.Path(tempfile.mkdtemp(prefix=\"gen-demo-\"))\n",
+    "repo = gen.Repository(str(WORK_DIR))\n",
+    "print(f\"Repository at: {WORK_DIR}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "03-imports-header",
+   "metadata": {},
+   "source": [
+    "## 1. Imports\n",
+    "\n",
+    "All import functions share the signature `(filename, sample=None, ...)`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "04-fasta-header",
+   "metadata": {},
+   "source": [
+    "### 1.1 `import_fasta`\n",
+    "\n",
+    "Imports one or more sequences from a FASTA file.  `shallow=True` skips storing sequence bytes and is useful for large references."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "05-import-fasta",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Block groups after FASTA imports: 10\n",
+      "  reference / m123\n",
+      "  parts_sample / p1\n",
+      "  parts_sample / p2\n",
+      "  parts_sample / p3\n",
+      "  parts_sample / cds1\n",
+      "  parts_sample / cds2\n",
+      "  parts_sample / cds3\n",
+      "  multi / m1\n",
+      "  multi / m2\n",
+      "  multi / m3\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Minimal: only the filename is required\n",
+    "repo.import_fasta(str(FX / \"simple.fa\"))\n",
+    "\n",
+    "# With an explicit sample name\n",
+    "repo.import_fasta(str(FX / \"parts.fa\"), sample=\"parts_sample\")\n",
+    "\n",
+    "repo.import_fasta(str(FX / \"multiseq.fa\"), sample=\"multi\")\n",
+    "\n",
+    "bgs = repo.get_block_groups()\n",
+    "print(f\"Block groups after FASTA imports: {len(bgs)}\")\n",
+    "for bg in bgs:\n",
+    "    print(f\"  {bg.sample_name} / {bg.name}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "06-gfa-header",
+   "metadata": {},
+   "source": [
+    "### 1.2 `import_gfa`\n",
+    "\n",
+    "Imports a sequence graph from a GFA (Graph Fragment Assembly) file, preserving branch structure."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "07-import-gfa",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Block groups after GFA import: 11\n",
+      "  m123 (sample=reference)\n",
+      "  p1 (sample=parts_sample)\n",
+      "  p2 (sample=parts_sample)\n",
+      "  p3 (sample=parts_sample)\n",
+      "  cds1 (sample=parts_sample)\n",
+      "  cds2 (sample=parts_sample)\n",
+      "  cds3 (sample=parts_sample)\n",
+      "  m1 (sample=multi)\n",
+      "  m2 (sample=multi)\n",
+      "  m3 (sample=multi)\n",
+      "   (sample=gfa_sample)\n"
+     ]
+    }
+   ],
+   "source": [
+    "repo.import_gfa(str(FX / \"anderson_promoters.gfa\"), sample=\"gfa_sample\")\n",
+    "\n",
+    "bgs = repo.get_block_groups()\n",
+    "print(f\"Block groups after GFA import: {len(bgs)}\")\n",
+    "for bg in bgs:\n",
+    "    print(f\"  {bg.name} (sample={bg.sample_name})\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "08-plot-gfa",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "305988e518924d51b7a96a0ed38a936b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "<gen.jupyter_widget.GenGraphWidget object at 0x1089e1be0>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Visualise the imported GFA graph\n",
+    "bg_gfa = bgs[0]\n",
+    "bg_gfa.plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "09-genbank-header",
+   "metadata": {},
+   "source": [
+    "### 1.3 `import_genbank`\n",
+    "\n",
+    "Imports a GenBank (.gb) file, including feature annotations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "10-import-genbank",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Block groups after GenBank import: 12\n",
+      "  m123\n",
+      "  p1\n",
+      "  p2\n",
+      "  p3\n",
+      "  cds1\n",
+      "  cds2\n",
+      "  cds3\n",
+      "  m1\n",
+      "  m2\n",
+      "  m3\n",
+      "  \n",
+      "  sequence-222046-\n"
+     ]
+    }
+   ],
+   "source": [
+    "repo.import_genbank(str(FX / \"puc19.gb\"), sample=\"genbank_sample\")\n",
+    "\n",
+    "bgs_gb = repo.get_block_groups()\n",
+    "print(f\"Block groups after GenBank import: {len(bgs_gb)}\")\n",
+    "for bg in bgs_gb:\n",
+    "    print(f\"  {bg.name}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "11-library-header",
+   "metadata": {},
+   "source": [
+    "### 1.4 `import_library` / `import_library_files`\n",
+    "\n",
+    "`import_library` takes combinatorial part definitions directly as Python objects.\n",
+    "`import_library_files` reads the same information from CSV files on disk."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "12-import-library",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Block groups after library import: 13\n"
+     ]
+    }
+   ],
+   "source": [
+    "# import_library: build parts programmatically\n",
+    "parts_list = [\n",
+    "    [gen.SequencePart(\"p1\", \"AAAA\"), gen.SequencePart(\"cds1\", \"ATGATAA\")],\n",
+    "    [gen.SequencePart(\"p2\", \"TAAT\"), gen.SequencePart(\"cds2\", \"ATGTTAA\")],\n",
+    "    [gen.SequencePart(\"p3\", \"CAAC\"), gen.SequencePart(\"cds3\", \"ATGCTAA\")],\n",
+    "]\n",
+    "\n",
+    "repo.import_library(\"my_library\", parts_list)\n",
+    "\n",
+    "bgs_lib = repo.get_block_groups()\n",
+    "print(f\"Block groups after library import: {len(bgs_lib)}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "13-import-library-files",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Block groups after library-files import: 14\n"
+     ]
+    }
+   ],
+   "source": [
+    "# import_library_files: read parts and layout from CSV files\n",
+    "PARTS_CSV   = FX / \"parts.fa\"\n",
+    "LAYOUT_CSV  = FX / \"combinatorial_design.csv\"\n",
+    "\n",
+    "repo.import_library_files(\"csv_library\", str(PARTS_CSV), str(LAYOUT_CSV))\n",
+    "\n",
+    "bgs_lib2 = repo.get_block_groups()\n",
+    "print(f\"Block groups after library-files import: {len(bgs_lib2)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "14-exports-header",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 2. Exports\n",
+    "\n",
+    "Export functions write a sample to disk."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "15-export-setup",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Use the \"demo\" collection (multiseq.fa) as source for all exports\n",
+    "OUT = WORK_DIR / \"exports\"\n",
+    "OUT.mkdir(exist_ok=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "16-export-fasta-header",
+   "metadata": {},
+   "source": [
+    "### 2.1 `export_fasta`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "17-export-fasta",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exported to file /var/folders/f8/8zf8xczs0pxf9_vfnlmqlx9h0000gn/T/gen-demo-hqpn37zr/exports/demo.fa\n",
+      ">m1\n",
+      "ATGC\n",
+      ">m2\n",
+      "GCAT\n",
+      ">m3\n",
+      "A\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "out_fa = OUT / \"demo.fa\"\n",
+    "repo.export_fasta(str(out_fa), sample=\"multi\")\n",
+    "print(out_fa.read_text())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "18-export-gfa-header",
+   "metadata": {},
+   "source": [
+    "### 2.2 `export_gfa`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "19-export-gfa",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "S\t019e27d1bf897b43a413a59e9ef4237200000000000000000000000000000000.0.1\tA\n",
+      "S\t019e27d1bf897b43a413a5cec60b5eae00000000000000000000000000000000.0.1\tA\n",
+      "S\t019e27d1bf897b43a413a62fd6f5f97100000000000000000000000000000000.0.1\tA\n",
+      "S\t019e27d1bf897b43a413a67cc5764e7d00000000000000000000000000000000.0.1\tA\n",
+      "S\t019e27d1bf897b43a413a6a2f34c320200000000000000000000000000000000.0.1\tA\n",
+      "... (78 more lines)\n"
+     ]
+    }
+   ],
+   "source": [
+    "out_gfa = OUT / \"demo.gfa\"\n",
+    "repo.export_gfa(str(out_gfa), sample=\"gfa_sample\")\n",
+    "lines = out_gfa.read_text().splitlines()\n",
+    "print(\"\\n\".join(lines[:5]))\n",
+    "if len(lines) > 5:\n",
+    "    print(f\"... ({len(lines) - 5} more lines)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "20-export-genbank-header",
+   "metadata": {},
+   "source": [
+    "### 2.3 `export_genbank`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "21-export-genbank",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "LOCUS       sequence-222046-        2686 bp            linear UNK 01-JAN-1970\n",
+      "FEATURES             Location/Qualifiers\n",
+      "     source          1..2686\n",
+      "                     /mol_type=\"other DNA\"\n",
+      "                     /organism=\"synthetic DNA construct\"\n",
+      "     primer_bind     118..137\n",
+      "                     /label=\"pBR322ori-F\"\n",
+      "                     /note=\"pBR322 origin, forward primer\"\n",
+      "     primer_bind     371..388\n",
+      "                     /label=\"L4440\"\n",
+      "                     /note=\"L4440 vector, forward primer\"\n",
+      "     protein_bind    505..526\n",
+      "                     /label=\"CAP binding site\"\n",
+      "                     /bound_moiety=\"E. coli catabolite activator protein\"\n",
+      "                     /note=\"CAP binding activates transcription in the presence\n",
+      "                     of cAMP.\"\n",
+      "     promoter        join(541..546, ...\n"
+     ]
+    }
+   ],
+   "source": [
+    "out_gb = OUT / \"demo.gb\"\n",
+    "repo.export_genbank(str(out_gb), sample=\"genbank_sample\")\n",
+    "print(out_gb.read_text()[:800], \"...\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "22-updates-header",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 3. Updates\n",
+    "\n",
+    "Updates graft new variants or sequences onto an existing graph, creating a new sample that branches off the original."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "23-update-fasta-header",
+   "metadata": {},
+   "source": [
+    "### 3.1 `update_with_fasta`\n",
+    "\n",
+    "Replaces a region `[start, end)` of a block group with sequences from a FASTA file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "24-update-fasta",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Block groups after update: 2Updated with fasta file: /Users/bvh/git/worktree-2/fixtures/parts.fa\n",
+      "\n",
+      "  ref / m123\n",
+      "  fasta_updated / m123\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Work on a fresh repo so the updates have a clean baseline\n",
+    "update_repo = gen.Repository(str(WORK_DIR / \"updates\"))\n",
+    "update_repo.import_fasta(str(FX / \"simple.fa\"), sample=\"ref\")\n",
+    "\n",
+    "update_repo.update_with_fasta(\n",
+    "    str(FX / \"parts.fa\"),\n",
+    "    sample=\"ref\",\n",
+    "    new_sample=\"fasta_updated\",\n",
+    "    region_name=\"m123\",\n",
+    "    start=3,\n",
+    "    end=10,\n",
+    ")\n",
+    "\n",
+    "bgs = update_repo.get_block_groups()\n",
+    "print(f\"Block groups after update: {len(bgs)}\")\n",
+    "for bg in bgs:\n",
+    "    print(f\"  {bg.sample_name} / {bg.name}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "25-plot-updated",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "03f20394de264fa089b8dbab5d4d0615",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "<gen.jupyter_widget.GenGraphWidget object at 0x108ad3890>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# The updated block group now has multiple paths; show_path highlights the edited one\n",
+    "updated_bg = [bg for bg in bgs if bg.name == \"m123\"][0]\n",
+    "w = updated_bg.plot()\n",
+    "w.show_path()\n",
+    "w"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "26-update-sequence-header",
+   "metadata": {},
+   "source": [
+    "### 3.2 `update_with_sequence`\n",
+    "\n",
+    "Inline variant: replace a region with a literal sequence string."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "27-update-sequence",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Updated with sequence.\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7c4d347f93df4f8b9af643d9e1c67a74",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "<gen.jupyter_widget.GenGraphWidget object at 0x108bc0190>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "update_repo.update_with_sequence(\n",
+    "    \"TTTTTTTT\",\n",
+    "    sample=\"ref\",\n",
+    "    new_sample=\"seq_updated\",\n",
+    "    region_name=\"m123\",\n",
+    "    start=5,\n",
+    "    end=15,\n",
+    ")\n",
+    "\n",
+    "bg_seq = [bg for bg in update_repo.get_block_groups() if bg.sample_name == \"seq_updated\"][0]\n",
+    "w = bg_seq.plot()\n",
+    "w.show_path()\n",
+    "w"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "28-update-vcf-header",
+   "metadata": {},
+   "source": [
+    "### 3.3 `update_with_vcf`\n",
+    "\n",
+    "Applies variants from a VCF file.  Supports genotype filtering and multi-sample VCFs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "29-update-vcf",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Block groups after VCF update: 4\n",
+      "  ref / m123\n",
+      "  unknown / m123\n",
+      "  G1 / m123\n",
+      "  foo / m123\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "2003e3cf12f14b1eb4b920df70cc0ee7",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "<gen.jupyter_widget.GenGraphWidget object at 0x108acac40>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Use a dedicated repo so state is clean\n",
+    "vcf_repo = gen.Repository(str(WORK_DIR / \"vcf_simple\"))\n",
+    "vcf_repo.import_fasta(str(FX / \"simple.fa\"), sample=\"ref\")\n",
+    "\n",
+    "# parent_samples points to the base sample to update from\n",
+    "# genotype= fixes a specific GT to apply (e.g. \"1/1\" = hom alt only)\n",
+    "# sample=  selects a VCF sample column for genotype info\n",
+    "vcf_repo.update_with_vcf(\n",
+    "    str(FX / \"simple.vcf\"),\n",
+    "    parent_samples=[\"ref\"],\n",
+    ")\n",
+    "\n",
+    "bgs = vcf_repo.get_block_groups()\n",
+    "print(f\"Block groups after VCF update: {len(bgs)}\")\n",
+    "for bg in bgs:\n",
+    "    print(f\"  {bg.sample_name} / {bg.name}\")\n",
+    "\n",
+    "updated_bg = [bg for bg in bgs if bg.sample_name != \"ref\"][0]\n",
+    "w = updated_bg.plot()\n",
+    "w.show_path()\n",
+    "w"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "31-update-gfa-header",
+   "metadata": {},
+   "source": [
+    "### 3.4 `update_with_gfa`\n",
+    "\n",
+    "Merges an additional GFA graph into an existing block group."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "32-update-gfa",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Block groups after GFA update: 2Warning: No path found that matches path 291344 from input GFA, skipping\n",
+      "\n",
+      "  ref / \n",
+      "  gfa_merged / \n",
+      "Updated with GFA file: /Users/bvh/git/worktree-2/fixtures/walk.gfa\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "154e50c9e1b2487cb5c44c5ed75eef96",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "<gen.jupyter_widget.GenGraphWidget object at 0x108acb5c0>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "gfa_update_repo = gen.Repository(str(WORK_DIR / \"gfa_update\"))\n",
+    "gfa_update_repo.import_gfa(str(FX / \"simple.gfa\"), sample=\"ref\")\n",
+    "\n",
+    "gfa_update_repo.update_with_gfa(\n",
+    "    str(FX / \"walk.gfa\"),\n",
+    "    sample=\"ref\",\n",
+    "    new_sample=\"gfa_merged\",\n",
+    ")\n",
+    "\n",
+    "merged_bgs = gfa_update_repo.get_block_groups()\n",
+    "print(f\"Block groups after GFA update: {len(merged_bgs)}\")\n",
+    "for bg in merged_bgs:\n",
+    "    print(f\"  {bg.sample_name} / {bg.name}\")\n",
+    "\n",
+    "merged_bg = [bg for bg in merged_bgs if bg.sample_name == \"gfa_merged\"][0]\n",
+    "w = merged_bg.plot()\n",
+    "w.show_path()\n",
+    "w"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "35-update-gaf-header",
+   "metadata": {},
+   "source": [
+    "### 3.6 `update_with_gaf`\n",
+    "\n",
+    "Aligns reads from a GAF file onto an existing graph, recording observed paths as new samples."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "36-update-gaf",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Block groups after GAF update: 3\n",
+      "  ref / test_left\n",
+      "  ref / test_right\n",
+      "  ref / \n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "a8d03fc2d27347f08064d601a6665b21",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "<gen.jupyter_widget.GenGraphWidget object at 0x108b169f0>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "gaf_repo = gen.Repository(str(WORK_DIR / \"gaf_demo\"))\n",
+    "gaf_repo.import_fasta(str(FX / \"chr22_het.fa\"), sample=\"ref\")\n",
+    "gaf_repo.import_gfa(str(FX / \"chr22_het.gfa\"), sample=\"ref\")\n",
+    "\n",
+    "# csv: path to the insert-flanks CSV that describes insertions in the GAF\n",
+    "gaf_repo.update_with_gaf(\n",
+    "    str(FX / \"chr22_het.gaf\"),\n",
+    "    csv=str(FX / \"chr22_insert.csv\"),\n",
+    "    sample=\"gaf_sample\",\n",
+    ")\n",
+    "\n",
+    "bgs = gaf_repo.get_block_groups()\n",
+    "print(f\"Block groups after GAF update: {len(bgs)}\")\n",
+    "for bg in bgs:\n",
+    "    print(f\"  {bg.sample_name} / {bg.name}\")\n",
+    "\n",
+    "w = bgs[0].plot()\n",
+    "w.show_path()\n",
+    "w"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "37-update-library-header",
+   "metadata": {},
+   "source": [
+    "### 3.7 `update_with_library` / `update_with_library_files`\n",
+    "\n",
+    "Replaces a region with a combinatorial library, producing one path per design."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "38-update-library",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Block groups after library update: 2\n",
+      "  ref / m123\n",
+      "  lib_updated / lib_updated\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "797bc198a9dc46158de08c3ea117d4c1",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "<gen.jupyter_widget.GenGraphWidget object at 0x108b3e8b0>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "lib_update_repo = gen.Repository(str(WORK_DIR / \"lib_update\"))\n",
+    "lib_update_repo.import_fasta(str(FX / \"simple.fa\"), sample=\"ref\")\n",
+    "\n",
+    "# Build the replacement library inline\n",
+    "parts_list = [\n",
+    "    [gen.SequencePart(\"p1\", \"AAAA\"), gen.SequencePart(\"cds1\", \"ATGATAA\")],\n",
+    "    [gen.SequencePart(\"p2\", \"TAAT\"), gen.SequencePart(\"cds2\", \"ATGTTAA\")],\n",
+    "]\n",
+    "\n",
+    "lib_update_repo.update_with_library(\n",
+    "    sample=\"ref\",\n",
+    "    new_sample_name=\"lib_updated\",\n",
+    "    path_name=\"m123\",\n",
+    "    start=5,\n",
+    "    end=20,\n",
+    "    parts_list=parts_list,\n",
+    ")\n",
+    "\n",
+    "bgs = lib_update_repo.get_block_groups()\n",
+    "print(f\"Block groups after library update: {len(bgs)}\")\n",
+    "for bg in bgs:\n",
+    "    print(f\"  {bg.sample_name} / {bg.name}\")\n",
+    "\n",
+    "updated_bg = [bg for bg in bgs if bg.sample_name == \"lib_updated\"][0]\n",
+    "w = updated_bg.plot()\n",
+    "w.show_path()\n",
+    "w"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "39-update-library-files",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Block groups after library-files update: 3\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Same operation, but reading parts from CSV files\n",
+    "lib_update_repo.update_with_library_files(\n",
+    "    sample=\"ref\",\n",
+    "    new_sample=\"lib_file_updated\",\n",
+    "    path_name=\"m123\",\n",
+    "    start=5,\n",
+    "    end=20,\n",
+    "    library=str(FX / \"combinatorial_design.csv\"),\n",
+    "    parts=str(FX / \"parts.fa\"),\n",
+    ")\n",
+    "\n",
+    "bgs = lib_update_repo.get_block_groups()\n",
+    "print(f\"Block groups after library-files update: {len(bgs)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "40-graph-ops-header",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 4. Graph Operations\n",
+    "\n",
+    "Graph operations derive new samples by slicing, chunking, or concatenating existing graphs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "41-graph-ops-setup",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Base block groups: 2\n",
+      "  test_left (ref)\n",
+      "  test_right (ref)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# chr22_het.fa has several linear ~50bp sequences \u2014 good for subgraph and chunk demos\n",
+    "ops_repo = gen.Repository(str(WORK_DIR / \"graph_ops\"))\n",
+    "ops_repo.import_fasta(str(FX / \"chr22_het.fa\"), sample=\"ref\")\n",
+    "\n",
+    "bgs = ops_repo.get_block_groups()\n",
+    "print(f\"Base block groups: {len(bgs)}\")\n",
+    "for bg in bgs:\n",
+    "    print(f\"  {bg.name} ({bg.sample_name})\")\n",
+    "\n",
+    "region_name = bgs[0].name"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "42-derive-subgraph-header",
+   "metadata": {},
+   "source": [
+    "### 4.1 `derive_subgraph`\n",
+    "\n",
+    "Extracts the subgraph covering a genomic region into a new sample."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "43-derive-subgraph",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Derived subgraph block groups: 1Derive subgraph succeeded.\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "539fd50d87344128a3f8e0b0b733937b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "<gen.jupyter_widget.GenGraphWidget object at 0x108b3ecf0>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "ops_repo.derive_subgraph(\n",
+    "    sample=\"ref\",\n",
+    "    new_sample=\"subgraph_sample\",\n",
+    "    region=f\"{region_name}:0-25\",\n",
+    ")\n",
+    "\n",
+    "sub_bgs = [bg for bg in ops_repo.get_block_groups() if bg.sample_name == \"subgraph_sample\"]\n",
+    "print(f\"Derived subgraph block groups: {len(sub_bgs)}\")\n",
+    "sub_bgs[0].plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "44-derive-chunks-header",
+   "metadata": {},
+   "source": [
+    "### 4.2 `derive_chunks`\n",
+    "\n",
+    "Splits a block group into fixed-size chunks using explicit breakpoint coordinates."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "45-derive-chunks",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Chunks created: 2Derive chunks succeeded.\n",
+      "\n",
+      "  test_left.1\n",
+      "  test_left.2\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "73c8827b43424c24b6f88e0023b82d50",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "<gen.jupyter_widget.GenGraphWidget object at 0x108b35c50>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# breakpoints is a list of integer coordinates along the path\n",
+    "ops_repo.derive_chunks(\n",
+    "    sample=\"ref\",\n",
+    "    new_sample=\"chunks_sample\",\n",
+    "    region=region_name,\n",
+    "    breakpoints=[25],   # split at position 25 \u2192 two chunks [0,25] and [25,end]\n",
+    ")\n",
+    "\n",
+    "chunk_bgs = [bg for bg in ops_repo.get_block_groups() if bg.sample_name == \"chunks_sample\"]\n",
+    "print(f\"Chunks created: {len(chunk_bgs)}\")\n",
+    "for bg in chunk_bgs:\n",
+    "    print(f\"  {bg.name}\")\n",
+    "\n",
+    "chunk_bgs[0].plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "46-make-stitch-header",
+   "metadata": {},
+   "source": [
+    "### 4.3 `make_stitch`\n",
+    "\n",
+    "Joins a comma-separated list of existing block groups end-to-end into a single new block group."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "47-make-stitch",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Stitched block groups: 1Stitched chunks successfully into new region stitched_region in sample stitched_sample.\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7d33055f144148129e7d4ffba1a87683",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "<gen.jupyter_widget.GenGraphWidget object at 0x108b36e50>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Stitch the first three chunks back into one region\n",
+    "stitch_names = \",\".join(bg.name for bg in chunk_bgs[:3])\n",
+    "\n",
+    "ops_repo.make_stitch(\n",
+    "    sample=\"chunks_sample\",\n",
+    "    new_sample=\"stitched_sample\",\n",
+    "    regions=stitch_names,\n",
+    "    new_region=\"stitched_region\",\n",
+    ")\n",
+    "\n",
+    "stitched = [bg for bg in ops_repo.get_block_groups() if bg.sample_name == \"stitched_sample\"]\n",
+    "print(f\"Stitched block groups: {len(stitched)}\")\n",
+    "stitched[0].plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "48-stitch-header",
+   "metadata": {},
+   "source": [
+    "### 4.4 `stitch` (typed helper)\n",
+    "\n",
+    "Same as `make_stitch` but accepts `BlockGroup` objects directly instead of name strings."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "49-stitch",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Stitched: typed_region in sample 'stitch_typed'Stitched chunks successfully into new region typed_region in sample stitch_typed.\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9f6976b9aacf42bd9ada50a3c750998a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "<gen.jupyter_widget.GenGraphWidget object at 0x108c04050>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "result_bg = ops_repo.stitch(\n",
+    "    bgs=chunk_bgs[:3],\n",
+    "    new_sample=\"stitch_typed\",\n",
+    "    new_region=\"typed_region\",\n",
+    ")\n",
+    "\n",
+    "print(f\"Stitched: {result_bg.name} in sample '{result_bg.sample_name}'\")\n",
+    "result_bg.plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "50-collection-header",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 5. Using the `collection` parameter\n",
+    "\n",
+    "A single `gen` repository can hold data from multiple analyses on the same organism.\n",
+    "Collections let you organise block groups by analysis type while still sharing the same samples \u2014\n",
+    "for example, genomics, transcriptomics, and proteomics data can all live in one repo and\n",
+    "be queried independently or jointly.\n",
+    "\n",
+    "Pass `collection=` to any import/export/update call to tag block groups, then retrieve them\n",
+    "with `get_block_groups_by_collection`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "51-collection-demo",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "genomics:        4 block group(s)\n",
+      "transcriptomics: 6 block group(s)\n",
+      "proteomics:      3 block group(s)\n",
+      "\n",
+      "  [genomics] wt / m123\n",
+      "  [genomics] mut / m1\n",
+      "  [genomics] mut / m2\n",
+      "  [genomics] mut / m3\n"
+     ]
+    }
+   ],
+   "source": [
+    "multi_repo = gen.Repository(str(WORK_DIR / \"multi_omics\"))\n",
+    "\n",
+    "# Each analysis type gets its own collection \u2014 same repo, same samples\n",
+    "multi_repo.import_fasta(str(FX / \"simple.fa\"),   sample=\"wt\", collection=\"genomics\")\n",
+    "multi_repo.import_fasta(str(FX / \"parts.fa\"),    sample=\"wt\", collection=\"transcriptomics\")\n",
+    "multi_repo.import_fasta(str(FX / \"multiseq.fa\"), sample=\"wt\", collection=\"proteomics\")\n",
+    "multi_repo.import_fasta(str(FX / \"multiseq.fa\"), sample=\"mut\", collection=\"genomics\")\n",
+    "\n",
+    "genomics      = multi_repo.get_block_groups_by_collection(\"genomics\")\n",
+    "transcriptomics = multi_repo.get_block_groups_by_collection(\"transcriptomics\")\n",
+    "proteomics    = multi_repo.get_block_groups_by_collection(\"proteomics\")\n",
+    "\n",
+    "print(f\"genomics:        {len(genomics)} block group(s)\")\n",
+    "print(f\"transcriptomics: {len(transcriptomics)} block group(s)\")\n",
+    "print(f\"proteomics:      {len(proteomics)} block group(s)\")\n",
+    "print()\n",
+    "for bg in genomics:\n",
+    "    print(f\"  [genomics] {bg.sample_name} / {bg.name}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.3"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {
+     "1b402e83572c457986b6f53c6452966f": {
+      "model_module": "anywidget",
+      "model_module_version": "~0.9.*",
+      "model_name": "AnyModel",
+      "state": {
+       "_anywidget_id": "gen.jupyter_widget.GenGraphWidget",
+       "_dom_classes": [],
+       "_esm": "// Generated from js/index.ts by `npm run build` / `make jupyter`. Edit TypeScript sources, not this file.\n\n// js/grid.ts\nvar TEXT_SIZE = 14;\nvar CELL_SIZE = Math.round(TEXT_SIZE / 0.875);\nvar BOX_SCALE = 1.15;\nvar FONT_FAMILY = \"monospace\";\nvar BOX_FONT = `${CELL_SIZE}px ${FONT_FAMILY}`;\nvar TEXT_FONT = `${TEXT_SIZE}px ${FONT_FAMILY}`;\nfunction cellFont(size, cell) {\n  const style = cell.bold && cell.italic ? \"bold italic\" : cell.bold ? \"bold\" : cell.italic ? \"italic\" : \"\";\n  return style ? `${style} ${size}px ${FONT_FAMILY}` : `${size}px ${FONT_FAMILY}`;\n}\nfunction measure(ctx, font, text) {\n  ctx.font = font;\n  ctx.textAlign = \"left\";\n  ctx.textBaseline = \"alphabetic\";\n  return ctx.measureText(text);\n}\nfunction isBoxLike(ch) {\n  if (!ch || ch === \" \") return false;\n  const cp = ch.codePointAt(0);\n  return cp >= 9472 && cp <= 9599 || // box drawing\n  cp >= 9600 && cp <= 9631 || // block elements\n  cp >= 10240 && cp <= 10495;\n}\nfunction makeGridMetrics(ctx) {\n  const block = measure(ctx, BOX_FONT, \"\\u2588\");\n  const cellW = Math.ceil(block.actualBoundingBoxLeft + block.actualBoundingBoxRight);\n  const cellH = Math.ceil(block.actualBoundingBoxAscent + block.actualBoundingBoxDescent);\n  const boxDrawX = block.actualBoundingBoxLeft;\n  const boxDrawY = block.actualBoundingBoxAscent;\n  const textProbe = measure(ctx, TEXT_FONT, \"Mg\");\n  const textMono = measure(ctx, TEXT_FONT, \"M\");\n  const textAscent = textProbe.emHeightAscent ?? textProbe.fontBoundingBoxAscent ?? textProbe.actualBoundingBoxAscent;\n  const textDescent = textProbe.emHeightDescent ?? textProbe.fontBoundingBoxDescent ?? textProbe.actualBoundingBoxDescent;\n  const textX = Math.round((cellW - textMono.width) / 2);\n  const textBaseline = Math.round((cellH + textAscent - textDescent) / 2) + 1;\n  return { cellW, cellH, boxDrawX, boxDrawY, textX, textBaseline };\n}\n\n// js/glyphs.ts\nvar GLYPH_SPLIT = /* @__PURE__ */ new Map([\n  // Pure-heavy lines and half-lines: map to their light/rounded equivalents\n  [9473, [9472, void 0]],\n  [9475, [9474, void 0]],\n  [9477, [9476, void 0]],\n  [9479, [9478, void 0]],\n  [9481, [9480, void 0]],\n  [9483, [9482, void 0]],\n  [9592, [9588, void 0]],\n  [9593, [9589, void 0]],\n  [9594, [9590, void 0]],\n  [9595, [9591, void 0]],\n  // Pure-heavy corners\n  [9487, [9581, void 0]],\n  [9491, [9582, void 0]],\n  [9495, [9584, void 0]],\n  [9499, [9583, void 0]],\n  // Pure-heavy tees and cross\n  [9507, [9500, void 0]],\n  [9515, [9508, void 0]],\n  [9523, [9516, void 0]],\n  [9531, [9524, void 0]],\n  [9547, [9532, void 0]],\n  // Mixed-weight corners (one heavy arm, one light arm)\n  [9485, [9590, 9591]],\n  [9486, [9591, 9590]],\n  [9489, [9588, 9591]],\n  [9490, [9591, 9588]],\n  [9493, [9590, 9589]],\n  [9494, [9589, 9590]],\n  [9497, [9588, 9589]],\n  [9498, [9589, 9588]],\n  // Mixed-weight tees (heavy stem, mixed crossbar)\n  [9501, [9590, 9474]],\n  [9502, [9589, 9484]],\n  [9503, [9591, 9492]],\n  [9504, [9474, 9590]],\n  [9505, [9492, 9591]],\n  [9506, [9484, 9589]],\n  [9509, [9588, 9474]],\n  [9510, [9589, 9488]],\n  [9511, [9591, 9496]],\n  [9512, [9474, 9588]],\n  [9513, [9496, 9591]],\n  [9514, [9488, 9589]],\n  [9517, [9588, 9484]],\n  [9518, [9590, 9488]],\n  [9519, [9472, 9591]],\n  [9520, [9591, 9472]],\n  [9521, [9488, 9590]],\n  [9522, [9484, 9588]],\n  [9525, [9588, 9492]],\n  [9526, [9590, 9496]],\n  [9527, [9472, 9589]],\n  [9528, [9589, 9472]],\n  [9529, [9496, 9590]],\n  [9530, [9492, 9588]],\n  // Mixed-weight crosses\n  [9533, [9588, 9500]],\n  [9534, [9590, 9508]],\n  [9535, [9472, 9474]],\n  [9536, [9589, 9516]],\n  [9537, [9591, 9524]],\n  [9538, [9474, 9472]],\n  [9539, [9496, 9484]],\n  [9540, [9492, 9488]],\n  [9541, [9488, 9492]],\n  [9542, [9484, 9496]],\n  [9543, [9524, 9591]],\n  [9544, [9516, 9589]],\n  [9545, [9508, 9590]],\n  [9546, [9500, 9588]]\n]);\nvar NODE_GLYPH_CP = 9679;\n\n// js/renderer.ts\nfunction drawSplitGlyph(ctx, heavyCp, lightCp, px, py, cellW, cellH, boxDrawX, boxDrawY, fg, neutral_fg, boxFont) {\n  ctx.save();\n  ctx.beginPath();\n  ctx.rect(px, py, cellW, cellH);\n  ctx.clip();\n  if (lightCp !== void 0) {\n    ctx.fillStyle = neutral_fg;\n    ctx.font = boxFont;\n    ctx.save();\n    ctx.translate(px + cellW / 2, py + cellH / 2);\n    ctx.scale(BOX_SCALE, BOX_SCALE);\n    ctx.fillText(String.fromCodePoint(lightCp), boxDrawX - cellW / 2, boxDrawY - cellH / 2);\n    ctx.restore();\n  }\n  ctx.fillStyle = fg;\n  ctx.font = boxFont;\n  ctx.save();\n  ctx.translate(px + cellW / 2, py + cellH / 2);\n  ctx.scale(BOX_SCALE, BOX_SCALE);\n  ctx.fillText(String.fromCodePoint(heavyCp), boxDrawX - cellW / 2, boxDrawY - cellH / 2);\n  ctx.restore();\n  ctx.restore();\n}\nfunction paintFrame(ctx, canvas, grid, frame) {\n  const nodeCells = /* @__PURE__ */ new Set();\n  if (!frame?.cells) return nodeCells;\n  const { cellW, cellH, boxDrawX, boxDrawY, textX, textBaseline } = grid;\n  const { cols, rows, cells, neutral_fg = \"#cdd6f4\", neutral_bg = \"#1e1e2e\" } = frame;\n  canvas.width = cols * cellW;\n  canvas.height = rows * cellH;\n  ctx.fillStyle = neutral_bg;\n  ctx.fillRect(0, 0, canvas.width, canvas.height);\n  ctx.textAlign = \"left\";\n  ctx.textBaseline = \"alphabetic\";\n  for (const cell of cells) {\n    const { x: c, y: r, text } = cell;\n    const fg = cell.fg ?? neutral_fg;\n    const bg = cell.bg ?? neutral_bg;\n    const px = c * cellW;\n    const py = r * cellH;\n    if (!text || text === \" \") continue;\n    const cp = text.codePointAt(0);\n    if (!isBoxLike(text)) nodeCells.add(`${c},${r}`);\n    if (cp === NODE_GLYPH_CP) {\n      if (bg !== neutral_bg) {\n        ctx.fillStyle = bg;\n        ctx.fillRect(px, py, cellW, cellH);\n      }\n      ctx.fillStyle = fg;\n      ctx.beginPath();\n      ctx.arc(px + cellW / 2, py + cellH / 2, cellW / 2, 0, Math.PI * 2);\n      ctx.fill();\n      continue;\n    }\n    if (bg !== neutral_bg) {\n      ctx.fillStyle = bg;\n      ctx.fillRect(px, py, cellW, cellH);\n    }\n    const split = GLYPH_SPLIT.get(cp);\n    if (split !== void 0) {\n      const [heavyCp, lightCp] = split;\n      const boxFont = cellFont(CELL_SIZE, { bold: false, italic: !!cell.italic });\n      drawSplitGlyph(ctx, heavyCp, lightCp, px, py, cellW, cellH, boxDrawX, boxDrawY, fg, neutral_fg, boxFont);\n    } else if (isBoxLike(text)) {\n      ctx.fillStyle = fg;\n      ctx.font = cellFont(CELL_SIZE, cell);\n      ctx.save();\n      ctx.beginPath();\n      ctx.rect(px, py, cellW, cellH);\n      ctx.clip();\n      ctx.translate(px + cellW / 2, py + cellH / 2);\n      ctx.scale(BOX_SCALE, BOX_SCALE);\n      ctx.fillText(text, boxDrawX - cellW / 2, boxDrawY - cellH / 2);\n      ctx.restore();\n    } else {\n      ctx.fillStyle = fg;\n      ctx.font = cellFont(TEXT_SIZE, cell);\n      ctx.fillText(text, px + textX, py + textBaseline);\n    }\n    if (cell.underline) {\n      ctx.fillStyle = fg;\n      const underlineY = Math.min(py + cellH - 1, py + textBaseline + 1);\n      ctx.fillRect(px, underlineY, cellW, 1);\n    }\n  }\n  return nodeCells;\n}\n\n// js/interaction.ts\nvar DRAG_THRESHOLD = 4;\nfunction attachInteraction(canvas, model, grid, getNodeCells, isFrozen) {\n  const { cellW, cellH } = grid;\n  canvas.addEventListener(\"mousemove\", (e) => {\n    if (isFrozen()) return;\n    if (pointerDown) return;\n    const rect = canvas.getBoundingClientRect();\n    const col = Math.floor((e.clientX - rect.left) / cellW);\n    const row = Math.floor((e.clientY - rect.top) / cellH);\n    canvas.style.cursor = getNodeCells().has(`${col},${row}`) ? \"pointer\" : \"grab\";\n  });\n  let pointerDown = false;\n  let isDragging = false;\n  let dragStartX = 0;\n  let dragStartY = 0;\n  let lastDragX = 0;\n  let lastDragY = 0;\n  let dragRemX = 0;\n  let dragRemY = 0;\n  canvas.addEventListener(\"mousedown\", (e) => {\n    if (isFrozen() || e.button !== 0) return;\n    pointerDown = true;\n    isDragging = false;\n    dragStartX = lastDragX = e.clientX;\n    dragStartY = lastDragY = e.clientY;\n    dragRemX = 0;\n    dragRemY = 0;\n    e.preventDefault();\n  });\n  window.addEventListener(\"mousemove\", (e) => {\n    if (!pointerDown) return;\n    const totalDx = e.clientX - dragStartX;\n    const totalDy = e.clientY - dragStartY;\n    if (!isDragging && (Math.abs(totalDx) > DRAG_THRESHOLD || Math.abs(totalDy) > DRAG_THRESHOLD)) {\n      isDragging = true;\n      canvas.style.cursor = \"grabbing\";\n    }\n    if (isDragging) {\n      dragRemX += e.clientX - lastDragX;\n      dragRemY += e.clientY - lastDragY;\n      const termDx = Math.trunc(dragRemX / cellW);\n      const termDy = Math.trunc(dragRemY / cellH);\n      if (termDx !== 0 || termDy !== 0) {\n        model.send({ type: \"pan\", dx: termDx, dy: termDy });\n        dragRemX -= termDx * cellW;\n        dragRemY -= termDy * cellH;\n      }\n    }\n    lastDragX = e.clientX;\n    lastDragY = e.clientY;\n  });\n  window.addEventListener(\"mouseup\", (e) => {\n    if (!pointerDown || e.button !== 0) return;\n    if (!isDragging) {\n      const rect = canvas.getBoundingClientRect();\n      const col = Math.floor((e.clientX - rect.left) / cellW);\n      const row = Math.floor((e.clientY - rect.top) / cellH);\n      model.send({ type: \"mouse_click\", col, row, button: e.button });\n    }\n    pointerDown = false;\n    isDragging = false;\n    canvas.style.cursor = \"grab\";\n  });\n}\n\n// js/index.ts\nfunction render({ model, el }) {\n  const scratch = document.createElement(\"canvas\");\n  const scratchCtx = scratch.getContext(\"2d\");\n  const grid = makeGridMetrics(scratchCtx);\n  const wrapper = document.createElement(\"div\");\n  wrapper.style.cssText = \"position: relative; display: inline-block; line-height: 0;\";\n  const canvas = document.createElement(\"canvas\");\n  canvas.style.cssText = \"display: block; cursor: grab; border: 2px solid #45475a;\";\n  const sharedBtnStyle = [\n    \"width: 24px\",\n    \"height: 24px\",\n    \"font-size: 16px\",\n    \"line-height: 1\",\n    \"cursor: pointer\",\n    \"background: rgba(30,30,46,0.85)\",\n    \"color: #cdd6f4\",\n    \"border: 1px solid #45475a\",\n    \"border-radius: 4px\",\n    \"display: flex\",\n    \"align-items: center\",\n    \"justify-content: center\",\n    \"user-select: none\",\n    \"padding: 0\"\n  ].join(\"; \");\n  const btnContainer = document.createElement(\"div\");\n  btnContainer.style.cssText = \"position: absolute; bottom: 8px; right: 8px; display: flex; flex-direction: column; gap: 4px; z-index: 1;\";\n  const zoomInBtn = document.createElement(\"button\");\n  zoomInBtn.textContent = \"+\";\n  zoomInBtn.setAttribute(\"style\", sharedBtnStyle);\n  zoomInBtn.title = \"Zoom in (+)\";\n  const zoomOutBtn = document.createElement(\"button\");\n  zoomOutBtn.textContent = \"\\u2212\";\n  zoomOutBtn.setAttribute(\"style\", sharedBtnStyle);\n  zoomOutBtn.title = \"Zoom out (-)\";\n  btnContainer.appendChild(zoomInBtn);\n  btnContainer.appendChild(zoomOutBtn);\n  wrapper.appendChild(canvas);\n  wrapper.appendChild(btnContainer);\n  el.appendChild(wrapper);\n  const ctx = canvas.getContext(\"2d\");\n  let nodeCells = /* @__PURE__ */ new Set();\n  let frozen = false;\n  function repaint(frame) {\n    nodeCells = paintFrame(ctx, canvas, grid, frame);\n  }\n  repaint(model.get(\"frame\"));\n  model.on(\"change:frame\", () => repaint(model.get(\"frame\")));\n  model.on(\"msg:custom\", (msg) => {\n    if (msg.type !== \"freeze\") return;\n    frozen = true;\n    btnContainer.style.display = \"none\";\n    canvas.style.cursor = \"default\";\n    wrapper.style.border = \"none\";\n    const dataUrl = canvas.toDataURL(\"image/png\");\n    const img = document.createElement(\"img\");\n    img.src = dataUrl;\n    img.width = canvas.width;\n    img.height = canvas.height;\n    img.style.cssText = \"display:block;cursor:default;font-family:monospace\";\n    el.replaceChild(img, wrapper);\n    model.send({ type: \"snapshot\", data: dataUrl });\n  });\n  zoomInBtn.addEventListener(\"mousedown\", (e) => e.preventDefault());\n  zoomOutBtn.addEventListener(\"mousedown\", (e) => e.preventDefault());\n  zoomInBtn.addEventListener(\"click\", () => model.send({ type: \"zoom\", direction: \"in\" }));\n  zoomOutBtn.addEventListener(\"click\", () => model.send({ type: \"zoom\", direction: \"out\" }));\n  attachInteraction(canvas, model, grid, () => nodeCells, () => frozen);\n}\nvar index_default = { render };\nexport {\n  index_default as default\n};\n//# sourceMappingURL=jupyter_widget.js.map\n",
+       "_model_module": "anywidget",
+       "_model_module_version": "~0.9.*",
+       "_model_name": "AnyModel",
+       "_view_count": null,
+       "_view_module": "anywidget",
+       "_view_module_version": "~0.9.*",
+       "_view_name": "AnyView",
+       "cols": 60,
+       "frame": {
+        "cells": [
+         {
+          "text": "\u255f",
+          "x": 5,
+          "y": 5
+         },
+         {
+          "text": "\u2500",
+          "x": 6,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "a",
+          "x": 7,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "t",
+          "x": 8,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "g",
+          "x": 9,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "g",
+          "x": 10,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "g",
+          "x": 11,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": ".",
+          "x": 12,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": ".",
+          "x": 13,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": ".",
+          "x": 14,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "c",
+          "x": 15,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "a",
+          "x": 16,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "c",
+          "x": 17,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "a",
+          "x": 18,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "t",
+          "x": 19,
+          "y": 5
+         },
+         {
+          "text": "\u2500",
+          "x": 20,
+          "y": 5
+         },
+         {
+          "text": "\u2562",
+          "x": 21,
+          "y": 5
+         }
+        ],
+        "cols": 60,
+        "neutral_bg": "#1e1e2e",
+        "neutral_fg": "#cdd6f4",
+        "rows": 12
+       },
+       "layout": "IPY_MODEL_eeec5f0194204ac0a168890d3ca0a13b",
+       "rows": 12,
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "1f9ac0f2edc541fbbb6517b52ef2373a": {
+      "model_module": "anywidget",
+      "model_module_version": "~0.9.*",
+      "model_name": "AnyModel",
+      "state": {
+       "_anywidget_id": "gen.jupyter_widget.GenGraphWidget",
+       "_dom_classes": [],
+       "_esm": "// Generated from js/index.ts by `npm run build` / `make jupyter`. Edit TypeScript sources, not this file.\n\n// js/grid.ts\nvar TEXT_SIZE = 14;\nvar CELL_SIZE = Math.round(TEXT_SIZE / 0.875);\nvar BOX_SCALE = 1.15;\nvar FONT_FAMILY = \"monospace\";\nvar BOX_FONT = `${CELL_SIZE}px ${FONT_FAMILY}`;\nvar TEXT_FONT = `${TEXT_SIZE}px ${FONT_FAMILY}`;\nfunction cellFont(size, cell) {\n  const style = cell.bold && cell.italic ? \"bold italic\" : cell.bold ? \"bold\" : cell.italic ? \"italic\" : \"\";\n  return style ? `${style} ${size}px ${FONT_FAMILY}` : `${size}px ${FONT_FAMILY}`;\n}\nfunction measure(ctx, font, text) {\n  ctx.font = font;\n  ctx.textAlign = \"left\";\n  ctx.textBaseline = \"alphabetic\";\n  return ctx.measureText(text);\n}\nfunction isBoxLike(ch) {\n  if (!ch || ch === \" \") return false;\n  const cp = ch.codePointAt(0);\n  return cp >= 9472 && cp <= 9599 || // box drawing\n  cp >= 9600 && cp <= 9631 || // block elements\n  cp >= 10240 && cp <= 10495;\n}\nfunction makeGridMetrics(ctx) {\n  const block = measure(ctx, BOX_FONT, \"\\u2588\");\n  const cellW = Math.ceil(block.actualBoundingBoxLeft + block.actualBoundingBoxRight);\n  const cellH = Math.ceil(block.actualBoundingBoxAscent + block.actualBoundingBoxDescent);\n  const boxDrawX = block.actualBoundingBoxLeft;\n  const boxDrawY = block.actualBoundingBoxAscent;\n  const textProbe = measure(ctx, TEXT_FONT, \"Mg\");\n  const textMono = measure(ctx, TEXT_FONT, \"M\");\n  const textAscent = textProbe.emHeightAscent ?? textProbe.fontBoundingBoxAscent ?? textProbe.actualBoundingBoxAscent;\n  const textDescent = textProbe.emHeightDescent ?? textProbe.fontBoundingBoxDescent ?? textProbe.actualBoundingBoxDescent;\n  const textX = Math.round((cellW - textMono.width) / 2);\n  const textBaseline = Math.round((cellH + textAscent - textDescent) / 2) + 1;\n  return { cellW, cellH, boxDrawX, boxDrawY, textX, textBaseline };\n}\n\n// js/glyphs.ts\nvar GLYPH_SPLIT = /* @__PURE__ */ new Map([\n  // Pure-heavy lines and half-lines: map to their light/rounded equivalents\n  [9473, [9472, void 0]],\n  [9475, [9474, void 0]],\n  [9477, [9476, void 0]],\n  [9479, [9478, void 0]],\n  [9481, [9480, void 0]],\n  [9483, [9482, void 0]],\n  [9592, [9588, void 0]],\n  [9593, [9589, void 0]],\n  [9594, [9590, void 0]],\n  [9595, [9591, void 0]],\n  // Pure-heavy corners\n  [9487, [9581, void 0]],\n  [9491, [9582, void 0]],\n  [9495, [9584, void 0]],\n  [9499, [9583, void 0]],\n  // Pure-heavy tees and cross\n  [9507, [9500, void 0]],\n  [9515, [9508, void 0]],\n  [9523, [9516, void 0]],\n  [9531, [9524, void 0]],\n  [9547, [9532, void 0]],\n  // Mixed-weight corners (one heavy arm, one light arm)\n  [9485, [9590, 9591]],\n  [9486, [9591, 9590]],\n  [9489, [9588, 9591]],\n  [9490, [9591, 9588]],\n  [9493, [9590, 9589]],\n  [9494, [9589, 9590]],\n  [9497, [9588, 9589]],\n  [9498, [9589, 9588]],\n  // Mixed-weight tees (heavy stem, mixed crossbar)\n  [9501, [9590, 9474]],\n  [9502, [9589, 9484]],\n  [9503, [9591, 9492]],\n  [9504, [9474, 9590]],\n  [9505, [9492, 9591]],\n  [9506, [9484, 9589]],\n  [9509, [9588, 9474]],\n  [9510, [9589, 9488]],\n  [9511, [9591, 9496]],\n  [9512, [9474, 9588]],\n  [9513, [9496, 9591]],\n  [9514, [9488, 9589]],\n  [9517, [9588, 9484]],\n  [9518, [9590, 9488]],\n  [9519, [9472, 9591]],\n  [9520, [9591, 9472]],\n  [9521, [9488, 9590]],\n  [9522, [9484, 9588]],\n  [9525, [9588, 9492]],\n  [9526, [9590, 9496]],\n  [9527, [9472, 9589]],\n  [9528, [9589, 9472]],\n  [9529, [9496, 9590]],\n  [9530, [9492, 9588]],\n  // Mixed-weight crosses\n  [9533, [9588, 9500]],\n  [9534, [9590, 9508]],\n  [9535, [9472, 9474]],\n  [9536, [9589, 9516]],\n  [9537, [9591, 9524]],\n  [9538, [9474, 9472]],\n  [9539, [9496, 9484]],\n  [9540, [9492, 9488]],\n  [9541, [9488, 9492]],\n  [9542, [9484, 9496]],\n  [9543, [9524, 9591]],\n  [9544, [9516, 9589]],\n  [9545, [9508, 9590]],\n  [9546, [9500, 9588]]\n]);\nvar NODE_GLYPH_CP = 9679;\n\n// js/renderer.ts\nfunction drawSplitGlyph(ctx, heavyCp, lightCp, px, py, cellW, cellH, boxDrawX, boxDrawY, fg, neutral_fg, boxFont) {\n  ctx.save();\n  ctx.beginPath();\n  ctx.rect(px, py, cellW, cellH);\n  ctx.clip();\n  if (lightCp !== void 0) {\n    ctx.fillStyle = neutral_fg;\n    ctx.font = boxFont;\n    ctx.save();\n    ctx.translate(px + cellW / 2, py + cellH / 2);\n    ctx.scale(BOX_SCALE, BOX_SCALE);\n    ctx.fillText(String.fromCodePoint(lightCp), boxDrawX - cellW / 2, boxDrawY - cellH / 2);\n    ctx.restore();\n  }\n  ctx.fillStyle = fg;\n  ctx.font = boxFont;\n  ctx.save();\n  ctx.translate(px + cellW / 2, py + cellH / 2);\n  ctx.scale(BOX_SCALE, BOX_SCALE);\n  ctx.fillText(String.fromCodePoint(heavyCp), boxDrawX - cellW / 2, boxDrawY - cellH / 2);\n  ctx.restore();\n  ctx.restore();\n}\nfunction paintFrame(ctx, canvas, grid, frame) {\n  const nodeCells = /* @__PURE__ */ new Set();\n  if (!frame?.cells) return nodeCells;\n  const { cellW, cellH, boxDrawX, boxDrawY, textX, textBaseline } = grid;\n  const { cols, rows, cells, neutral_fg = \"#cdd6f4\", neutral_bg = \"#1e1e2e\" } = frame;\n  canvas.width = cols * cellW;\n  canvas.height = rows * cellH;\n  ctx.fillStyle = neutral_bg;\n  ctx.fillRect(0, 0, canvas.width, canvas.height);\n  ctx.textAlign = \"left\";\n  ctx.textBaseline = \"alphabetic\";\n  for (const cell of cells) {\n    const { x: c, y: r, text } = cell;\n    const fg = cell.fg ?? neutral_fg;\n    const bg = cell.bg ?? neutral_bg;\n    const px = c * cellW;\n    const py = r * cellH;\n    if (!text || text === \" \") continue;\n    const cp = text.codePointAt(0);\n    if (!isBoxLike(text)) nodeCells.add(`${c},${r}`);\n    if (cp === NODE_GLYPH_CP) {\n      if (bg !== neutral_bg) {\n        ctx.fillStyle = bg;\n        ctx.fillRect(px, py, cellW, cellH);\n      }\n      ctx.fillStyle = fg;\n      ctx.beginPath();\n      ctx.arc(px + cellW / 2, py + cellH / 2, cellW / 2, 0, Math.PI * 2);\n      ctx.fill();\n      continue;\n    }\n    if (bg !== neutral_bg) {\n      ctx.fillStyle = bg;\n      ctx.fillRect(px, py, cellW, cellH);\n    }\n    const split = GLYPH_SPLIT.get(cp);\n    if (split !== void 0) {\n      const [heavyCp, lightCp] = split;\n      const boxFont = cellFont(CELL_SIZE, { bold: false, italic: !!cell.italic });\n      drawSplitGlyph(ctx, heavyCp, lightCp, px, py, cellW, cellH, boxDrawX, boxDrawY, fg, neutral_fg, boxFont);\n    } else if (isBoxLike(text)) {\n      ctx.fillStyle = fg;\n      ctx.font = cellFont(CELL_SIZE, cell);\n      ctx.save();\n      ctx.beginPath();\n      ctx.rect(px, py, cellW, cellH);\n      ctx.clip();\n      ctx.translate(px + cellW / 2, py + cellH / 2);\n      ctx.scale(BOX_SCALE, BOX_SCALE);\n      ctx.fillText(text, boxDrawX - cellW / 2, boxDrawY - cellH / 2);\n      ctx.restore();\n    } else {\n      ctx.fillStyle = fg;\n      ctx.font = cellFont(TEXT_SIZE, cell);\n      ctx.fillText(text, px + textX, py + textBaseline);\n    }\n    if (cell.underline) {\n      ctx.fillStyle = fg;\n      const underlineY = Math.min(py + cellH - 1, py + textBaseline + 1);\n      ctx.fillRect(px, underlineY, cellW, 1);\n    }\n  }\n  return nodeCells;\n}\n\n// js/interaction.ts\nvar DRAG_THRESHOLD = 4;\nfunction attachInteraction(canvas, model, grid, getNodeCells, isFrozen) {\n  const { cellW, cellH } = grid;\n  canvas.addEventListener(\"mousemove\", (e) => {\n    if (isFrozen()) return;\n    if (pointerDown) return;\n    const rect = canvas.getBoundingClientRect();\n    const col = Math.floor((e.clientX - rect.left) / cellW);\n    const row = Math.floor((e.clientY - rect.top) / cellH);\n    canvas.style.cursor = getNodeCells().has(`${col},${row}`) ? \"pointer\" : \"grab\";\n  });\n  let pointerDown = false;\n  let isDragging = false;\n  let dragStartX = 0;\n  let dragStartY = 0;\n  let lastDragX = 0;\n  let lastDragY = 0;\n  let dragRemX = 0;\n  let dragRemY = 0;\n  canvas.addEventListener(\"mousedown\", (e) => {\n    if (isFrozen() || e.button !== 0) return;\n    pointerDown = true;\n    isDragging = false;\n    dragStartX = lastDragX = e.clientX;\n    dragStartY = lastDragY = e.clientY;\n    dragRemX = 0;\n    dragRemY = 0;\n    e.preventDefault();\n  });\n  window.addEventListener(\"mousemove\", (e) => {\n    if (!pointerDown) return;\n    const totalDx = e.clientX - dragStartX;\n    const totalDy = e.clientY - dragStartY;\n    if (!isDragging && (Math.abs(totalDx) > DRAG_THRESHOLD || Math.abs(totalDy) > DRAG_THRESHOLD)) {\n      isDragging = true;\n      canvas.style.cursor = \"grabbing\";\n    }\n    if (isDragging) {\n      dragRemX += e.clientX - lastDragX;\n      dragRemY += e.clientY - lastDragY;\n      const termDx = Math.trunc(dragRemX / cellW);\n      const termDy = Math.trunc(dragRemY / cellH);\n      if (termDx !== 0 || termDy !== 0) {\n        model.send({ type: \"pan\", dx: termDx, dy: termDy });\n        dragRemX -= termDx * cellW;\n        dragRemY -= termDy * cellH;\n      }\n    }\n    lastDragX = e.clientX;\n    lastDragY = e.clientY;\n  });\n  window.addEventListener(\"mouseup\", (e) => {\n    if (!pointerDown || e.button !== 0) return;\n    if (!isDragging) {\n      const rect = canvas.getBoundingClientRect();\n      const col = Math.floor((e.clientX - rect.left) / cellW);\n      const row = Math.floor((e.clientY - rect.top) / cellH);\n      model.send({ type: \"mouse_click\", col, row, button: e.button });\n    }\n    pointerDown = false;\n    isDragging = false;\n    canvas.style.cursor = \"grab\";\n  });\n}\n\n// js/index.ts\nfunction render({ model, el }) {\n  const scratch = document.createElement(\"canvas\");\n  const scratchCtx = scratch.getContext(\"2d\");\n  const grid = makeGridMetrics(scratchCtx);\n  const wrapper = document.createElement(\"div\");\n  wrapper.style.cssText = \"position: relative; display: inline-block; line-height: 0;\";\n  const canvas = document.createElement(\"canvas\");\n  canvas.style.cssText = \"display: block; cursor: grab; border: 2px solid #45475a;\";\n  const sharedBtnStyle = [\n    \"width: 24px\",\n    \"height: 24px\",\n    \"font-size: 16px\",\n    \"line-height: 1\",\n    \"cursor: pointer\",\n    \"background: rgba(30,30,46,0.85)\",\n    \"color: #cdd6f4\",\n    \"border: 1px solid #45475a\",\n    \"border-radius: 4px\",\n    \"display: flex\",\n    \"align-items: center\",\n    \"justify-content: center\",\n    \"user-select: none\",\n    \"padding: 0\"\n  ].join(\"; \");\n  const btnContainer = document.createElement(\"div\");\n  btnContainer.style.cssText = \"position: absolute; bottom: 8px; right: 8px; display: flex; flex-direction: column; gap: 4px; z-index: 1;\";\n  const zoomInBtn = document.createElement(\"button\");\n  zoomInBtn.textContent = \"+\";\n  zoomInBtn.setAttribute(\"style\", sharedBtnStyle);\n  zoomInBtn.title = \"Zoom in (+)\";\n  const zoomOutBtn = document.createElement(\"button\");\n  zoomOutBtn.textContent = \"\\u2212\";\n  zoomOutBtn.setAttribute(\"style\", sharedBtnStyle);\n  zoomOutBtn.title = \"Zoom out (-)\";\n  btnContainer.appendChild(zoomInBtn);\n  btnContainer.appendChild(zoomOutBtn);\n  wrapper.appendChild(canvas);\n  wrapper.appendChild(btnContainer);\n  el.appendChild(wrapper);\n  const ctx = canvas.getContext(\"2d\");\n  let nodeCells = /* @__PURE__ */ new Set();\n  let frozen = false;\n  function repaint(frame) {\n    nodeCells = paintFrame(ctx, canvas, grid, frame);\n  }\n  repaint(model.get(\"frame\"));\n  model.on(\"change:frame\", () => repaint(model.get(\"frame\")));\n  model.on(\"msg:custom\", (msg) => {\n    if (msg.type !== \"freeze\") return;\n    frozen = true;\n    btnContainer.style.display = \"none\";\n    canvas.style.cursor = \"default\";\n    wrapper.style.border = \"none\";\n    const dataUrl = canvas.toDataURL(\"image/png\");\n    const img = document.createElement(\"img\");\n    img.src = dataUrl;\n    img.width = canvas.width;\n    img.height = canvas.height;\n    img.style.cssText = \"display:block;cursor:default;font-family:monospace\";\n    el.replaceChild(img, wrapper);\n    model.send({ type: \"snapshot\", data: dataUrl });\n  });\n  zoomInBtn.addEventListener(\"mousedown\", (e) => e.preventDefault());\n  zoomOutBtn.addEventListener(\"mousedown\", (e) => e.preventDefault());\n  zoomInBtn.addEventListener(\"click\", () => model.send({ type: \"zoom\", direction: \"in\" }));\n  zoomOutBtn.addEventListener(\"click\", () => model.send({ type: \"zoom\", direction: \"out\" }));\n  attachInteraction(canvas, model, grid, () => nodeCells, () => frozen);\n}\nvar index_default = { render };\nexport {\n  index_default as default\n};\n//# sourceMappingURL=jupyter_widget.js.map\n",
+       "_model_module": "anywidget",
+       "_model_module_version": "~0.9.*",
+       "_model_name": "AnyModel",
+       "_view_count": null,
+       "_view_module": "anywidget",
+       "_view_module_version": "~0.9.*",
+       "_view_name": "AnyView",
+       "cols": 60,
+       "frame": {
+        "cells": [
+         {
+          "text": "\u255f",
+          "x": 5,
+          "y": 5
+         },
+         {
+          "text": "\u2500",
+          "x": 6,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "a",
+          "x": 7,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "t",
+          "x": 8,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "g",
+          "x": 9,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "g",
+          "x": 10,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "g",
+          "x": 11,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": ".",
+          "x": 12,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": ".",
+          "x": 13,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": ".",
+          "x": 14,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "a",
+          "x": 15,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "g",
+          "x": 16,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "t",
+          "x": 17,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "g",
+          "x": 18,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "a",
+          "x": 19,
+          "y": 5
+         },
+         {
+          "text": "\u2500",
+          "x": 20,
+          "y": 5
+         },
+         {
+          "text": "\u2562",
+          "x": 21,
+          "y": 5
+         }
+        ],
+        "cols": 60,
+        "neutral_bg": "#1e1e2e",
+        "neutral_fg": "#cdd6f4",
+        "rows": 12
+       },
+       "layout": "IPY_MODEL_fd212e1357a94d29a2da8cce3041dae4",
+       "rows": 12,
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "2a31b0c0b5ed43b2803ab2e8c4b9aad2": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "2a69ad50bdb04f0587a4c9bb6a70e2c3": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "4b8493bc98fe45deb44bf6f2cd09c1b8": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "61656055a2d649dd82aef552e81ca4c1": {
+      "model_module": "anywidget",
+      "model_module_version": "~0.9.*",
+      "model_name": "AnyModel",
+      "state": {
+       "_anywidget_id": "gen.jupyter_widget.GenGraphWidget",
+       "_dom_classes": [],
+       "_esm": "// Generated from js/index.ts by `npm run build` / `make jupyter`. Edit TypeScript sources, not this file.\n\n// js/grid.ts\nvar TEXT_SIZE = 14;\nvar CELL_SIZE = Math.round(TEXT_SIZE / 0.875);\nvar BOX_SCALE = 1.15;\nvar FONT_FAMILY = \"monospace\";\nvar BOX_FONT = `${CELL_SIZE}px ${FONT_FAMILY}`;\nvar TEXT_FONT = `${TEXT_SIZE}px ${FONT_FAMILY}`;\nfunction cellFont(size, cell) {\n  const style = cell.bold && cell.italic ? \"bold italic\" : cell.bold ? \"bold\" : cell.italic ? \"italic\" : \"\";\n  return style ? `${style} ${size}px ${FONT_FAMILY}` : `${size}px ${FONT_FAMILY}`;\n}\nfunction measure(ctx, font, text) {\n  ctx.font = font;\n  ctx.textAlign = \"left\";\n  ctx.textBaseline = \"alphabetic\";\n  return ctx.measureText(text);\n}\nfunction isBoxLike(ch) {\n  if (!ch || ch === \" \") return false;\n  const cp = ch.codePointAt(0);\n  return cp >= 9472 && cp <= 9599 || // box drawing\n  cp >= 9600 && cp <= 9631 || // block elements\n  cp >= 10240 && cp <= 10495;\n}\nfunction makeGridMetrics(ctx) {\n  const block = measure(ctx, BOX_FONT, \"\\u2588\");\n  const cellW = Math.ceil(block.actualBoundingBoxLeft + block.actualBoundingBoxRight);\n  const cellH = Math.ceil(block.actualBoundingBoxAscent + block.actualBoundingBoxDescent);\n  const boxDrawX = block.actualBoundingBoxLeft;\n  const boxDrawY = block.actualBoundingBoxAscent;\n  const textProbe = measure(ctx, TEXT_FONT, \"Mg\");\n  const textMono = measure(ctx, TEXT_FONT, \"M\");\n  const textAscent = textProbe.emHeightAscent ?? textProbe.fontBoundingBoxAscent ?? textProbe.actualBoundingBoxAscent;\n  const textDescent = textProbe.emHeightDescent ?? textProbe.fontBoundingBoxDescent ?? textProbe.actualBoundingBoxDescent;\n  const textX = Math.round((cellW - textMono.width) / 2);\n  const textBaseline = Math.round((cellH + textAscent - textDescent) / 2) + 1;\n  return { cellW, cellH, boxDrawX, boxDrawY, textX, textBaseline };\n}\n\n// js/glyphs.ts\nvar GLYPH_SPLIT = /* @__PURE__ */ new Map([\n  // Pure-heavy lines and half-lines: map to their light/rounded equivalents\n  [9473, [9472, void 0]],\n  [9475, [9474, void 0]],\n  [9477, [9476, void 0]],\n  [9479, [9478, void 0]],\n  [9481, [9480, void 0]],\n  [9483, [9482, void 0]],\n  [9592, [9588, void 0]],\n  [9593, [9589, void 0]],\n  [9594, [9590, void 0]],\n  [9595, [9591, void 0]],\n  // Pure-heavy corners\n  [9487, [9581, void 0]],\n  [9491, [9582, void 0]],\n  [9495, [9584, void 0]],\n  [9499, [9583, void 0]],\n  // Pure-heavy tees and cross\n  [9507, [9500, void 0]],\n  [9515, [9508, void 0]],\n  [9523, [9516, void 0]],\n  [9531, [9524, void 0]],\n  [9547, [9532, void 0]],\n  // Mixed-weight corners (one heavy arm, one light arm)\n  [9485, [9590, 9591]],\n  [9486, [9591, 9590]],\n  [9489, [9588, 9591]],\n  [9490, [9591, 9588]],\n  [9493, [9590, 9589]],\n  [9494, [9589, 9590]],\n  [9497, [9588, 9589]],\n  [9498, [9589, 9588]],\n  // Mixed-weight tees (heavy stem, mixed crossbar)\n  [9501, [9590, 9474]],\n  [9502, [9589, 9484]],\n  [9503, [9591, 9492]],\n  [9504, [9474, 9590]],\n  [9505, [9492, 9591]],\n  [9506, [9484, 9589]],\n  [9509, [9588, 9474]],\n  [9510, [9589, 9488]],\n  [9511, [9591, 9496]],\n  [9512, [9474, 9588]],\n  [9513, [9496, 9591]],\n  [9514, [9488, 9589]],\n  [9517, [9588, 9484]],\n  [9518, [9590, 9488]],\n  [9519, [9472, 9591]],\n  [9520, [9591, 9472]],\n  [9521, [9488, 9590]],\n  [9522, [9484, 9588]],\n  [9525, [9588, 9492]],\n  [9526, [9590, 9496]],\n  [9527, [9472, 9589]],\n  [9528, [9589, 9472]],\n  [9529, [9496, 9590]],\n  [9530, [9492, 9588]],\n  // Mixed-weight crosses\n  [9533, [9588, 9500]],\n  [9534, [9590, 9508]],\n  [9535, [9472, 9474]],\n  [9536, [9589, 9516]],\n  [9537, [9591, 9524]],\n  [9538, [9474, 9472]],\n  [9539, [9496, 9484]],\n  [9540, [9492, 9488]],\n  [9541, [9488, 9492]],\n  [9542, [9484, 9496]],\n  [9543, [9524, 9591]],\n  [9544, [9516, 9589]],\n  [9545, [9508, 9590]],\n  [9546, [9500, 9588]]\n]);\nvar NODE_GLYPH_CP = 9679;\n\n// js/renderer.ts\nfunction drawSplitGlyph(ctx, heavyCp, lightCp, px, py, cellW, cellH, boxDrawX, boxDrawY, fg, neutral_fg, boxFont) {\n  ctx.save();\n  ctx.beginPath();\n  ctx.rect(px, py, cellW, cellH);\n  ctx.clip();\n  if (lightCp !== void 0) {\n    ctx.fillStyle = neutral_fg;\n    ctx.font = boxFont;\n    ctx.save();\n    ctx.translate(px + cellW / 2, py + cellH / 2);\n    ctx.scale(BOX_SCALE, BOX_SCALE);\n    ctx.fillText(String.fromCodePoint(lightCp), boxDrawX - cellW / 2, boxDrawY - cellH / 2);\n    ctx.restore();\n  }\n  ctx.fillStyle = fg;\n  ctx.font = boxFont;\n  ctx.save();\n  ctx.translate(px + cellW / 2, py + cellH / 2);\n  ctx.scale(BOX_SCALE, BOX_SCALE);\n  ctx.fillText(String.fromCodePoint(heavyCp), boxDrawX - cellW / 2, boxDrawY - cellH / 2);\n  ctx.restore();\n  ctx.restore();\n}\nfunction paintFrame(ctx, canvas, grid, frame) {\n  const nodeCells = /* @__PURE__ */ new Set();\n  if (!frame?.cells) return nodeCells;\n  const { cellW, cellH, boxDrawX, boxDrawY, textX, textBaseline } = grid;\n  const { cols, rows, cells, neutral_fg = \"#cdd6f4\", neutral_bg = \"#1e1e2e\" } = frame;\n  canvas.width = cols * cellW;\n  canvas.height = rows * cellH;\n  ctx.fillStyle = neutral_bg;\n  ctx.fillRect(0, 0, canvas.width, canvas.height);\n  ctx.textAlign = \"left\";\n  ctx.textBaseline = \"alphabetic\";\n  for (const cell of cells) {\n    const { x: c, y: r, text } = cell;\n    const fg = cell.fg ?? neutral_fg;\n    const bg = cell.bg ?? neutral_bg;\n    const px = c * cellW;\n    const py = r * cellH;\n    if (!text || text === \" \") continue;\n    const cp = text.codePointAt(0);\n    if (!isBoxLike(text)) nodeCells.add(`${c},${r}`);\n    if (cp === NODE_GLYPH_CP) {\n      if (bg !== neutral_bg) {\n        ctx.fillStyle = bg;\n        ctx.fillRect(px, py, cellW, cellH);\n      }\n      ctx.fillStyle = fg;\n      ctx.beginPath();\n      ctx.arc(px + cellW / 2, py + cellH / 2, cellW / 2, 0, Math.PI * 2);\n      ctx.fill();\n      continue;\n    }\n    if (bg !== neutral_bg) {\n      ctx.fillStyle = bg;\n      ctx.fillRect(px, py, cellW, cellH);\n    }\n    const split = GLYPH_SPLIT.get(cp);\n    if (split !== void 0) {\n      const [heavyCp, lightCp] = split;\n      const boxFont = cellFont(CELL_SIZE, { bold: false, italic: !!cell.italic });\n      drawSplitGlyph(ctx, heavyCp, lightCp, px, py, cellW, cellH, boxDrawX, boxDrawY, fg, neutral_fg, boxFont);\n    } else if (isBoxLike(text)) {\n      ctx.fillStyle = fg;\n      ctx.font = cellFont(CELL_SIZE, cell);\n      ctx.save();\n      ctx.beginPath();\n      ctx.rect(px, py, cellW, cellH);\n      ctx.clip();\n      ctx.translate(px + cellW / 2, py + cellH / 2);\n      ctx.scale(BOX_SCALE, BOX_SCALE);\n      ctx.fillText(text, boxDrawX - cellW / 2, boxDrawY - cellH / 2);\n      ctx.restore();\n    } else {\n      ctx.fillStyle = fg;\n      ctx.font = cellFont(TEXT_SIZE, cell);\n      ctx.fillText(text, px + textX, py + textBaseline);\n    }\n    if (cell.underline) {\n      ctx.fillStyle = fg;\n      const underlineY = Math.min(py + cellH - 1, py + textBaseline + 1);\n      ctx.fillRect(px, underlineY, cellW, 1);\n    }\n  }\n  return nodeCells;\n}\n\n// js/interaction.ts\nvar DRAG_THRESHOLD = 4;\nfunction attachInteraction(canvas, model, grid, getNodeCells, isFrozen) {\n  const { cellW, cellH } = grid;\n  canvas.addEventListener(\"mousemove\", (e) => {\n    if (isFrozen()) return;\n    if (pointerDown) return;\n    const rect = canvas.getBoundingClientRect();\n    const col = Math.floor((e.clientX - rect.left) / cellW);\n    const row = Math.floor((e.clientY - rect.top) / cellH);\n    canvas.style.cursor = getNodeCells().has(`${col},${row}`) ? \"pointer\" : \"grab\";\n  });\n  let pointerDown = false;\n  let isDragging = false;\n  let dragStartX = 0;\n  let dragStartY = 0;\n  let lastDragX = 0;\n  let lastDragY = 0;\n  let dragRemX = 0;\n  let dragRemY = 0;\n  canvas.addEventListener(\"mousedown\", (e) => {\n    if (isFrozen() || e.button !== 0) return;\n    pointerDown = true;\n    isDragging = false;\n    dragStartX = lastDragX = e.clientX;\n    dragStartY = lastDragY = e.clientY;\n    dragRemX = 0;\n    dragRemY = 0;\n    e.preventDefault();\n  });\n  window.addEventListener(\"mousemove\", (e) => {\n    if (!pointerDown) return;\n    const totalDx = e.clientX - dragStartX;\n    const totalDy = e.clientY - dragStartY;\n    if (!isDragging && (Math.abs(totalDx) > DRAG_THRESHOLD || Math.abs(totalDy) > DRAG_THRESHOLD)) {\n      isDragging = true;\n      canvas.style.cursor = \"grabbing\";\n    }\n    if (isDragging) {\n      dragRemX += e.clientX - lastDragX;\n      dragRemY += e.clientY - lastDragY;\n      const termDx = Math.trunc(dragRemX / cellW);\n      const termDy = Math.trunc(dragRemY / cellH);\n      if (termDx !== 0 || termDy !== 0) {\n        model.send({ type: \"pan\", dx: termDx, dy: termDy });\n        dragRemX -= termDx * cellW;\n        dragRemY -= termDy * cellH;\n      }\n    }\n    lastDragX = e.clientX;\n    lastDragY = e.clientY;\n  });\n  window.addEventListener(\"mouseup\", (e) => {\n    if (!pointerDown || e.button !== 0) return;\n    if (!isDragging) {\n      const rect = canvas.getBoundingClientRect();\n      const col = Math.floor((e.clientX - rect.left) / cellW);\n      const row = Math.floor((e.clientY - rect.top) / cellH);\n      model.send({ type: \"mouse_click\", col, row, button: e.button });\n    }\n    pointerDown = false;\n    isDragging = false;\n    canvas.style.cursor = \"grab\";\n  });\n}\n\n// js/index.ts\nfunction render({ model, el }) {\n  const scratch = document.createElement(\"canvas\");\n  const scratchCtx = scratch.getContext(\"2d\");\n  const grid = makeGridMetrics(scratchCtx);\n  const wrapper = document.createElement(\"div\");\n  wrapper.style.cssText = \"position: relative; display: inline-block; line-height: 0;\";\n  const canvas = document.createElement(\"canvas\");\n  canvas.style.cssText = \"display: block; cursor: grab; border: 2px solid #45475a;\";\n  const sharedBtnStyle = [\n    \"width: 24px\",\n    \"height: 24px\",\n    \"font-size: 16px\",\n    \"line-height: 1\",\n    \"cursor: pointer\",\n    \"background: rgba(30,30,46,0.85)\",\n    \"color: #cdd6f4\",\n    \"border: 1px solid #45475a\",\n    \"border-radius: 4px\",\n    \"display: flex\",\n    \"align-items: center\",\n    \"justify-content: center\",\n    \"user-select: none\",\n    \"padding: 0\"\n  ].join(\"; \");\n  const btnContainer = document.createElement(\"div\");\n  btnContainer.style.cssText = \"position: absolute; bottom: 8px; right: 8px; display: flex; flex-direction: column; gap: 4px; z-index: 1;\";\n  const zoomInBtn = document.createElement(\"button\");\n  zoomInBtn.textContent = \"+\";\n  zoomInBtn.setAttribute(\"style\", sharedBtnStyle);\n  zoomInBtn.title = \"Zoom in (+)\";\n  const zoomOutBtn = document.createElement(\"button\");\n  zoomOutBtn.textContent = \"\\u2212\";\n  zoomOutBtn.setAttribute(\"style\", sharedBtnStyle);\n  zoomOutBtn.title = \"Zoom out (-)\";\n  btnContainer.appendChild(zoomInBtn);\n  btnContainer.appendChild(zoomOutBtn);\n  wrapper.appendChild(canvas);\n  wrapper.appendChild(btnContainer);\n  el.appendChild(wrapper);\n  const ctx = canvas.getContext(\"2d\");\n  let nodeCells = /* @__PURE__ */ new Set();\n  let frozen = false;\n  function repaint(frame) {\n    nodeCells = paintFrame(ctx, canvas, grid, frame);\n  }\n  repaint(model.get(\"frame\"));\n  model.on(\"change:frame\", () => repaint(model.get(\"frame\")));\n  model.on(\"msg:custom\", (msg) => {\n    if (msg.type !== \"freeze\") return;\n    frozen = true;\n    btnContainer.style.display = \"none\";\n    canvas.style.cursor = \"default\";\n    wrapper.style.border = \"none\";\n    const dataUrl = canvas.toDataURL(\"image/png\");\n    const img = document.createElement(\"img\");\n    img.src = dataUrl;\n    img.width = canvas.width;\n    img.height = canvas.height;\n    img.style.cssText = \"display:block;cursor:default;font-family:monospace\";\n    el.replaceChild(img, wrapper);\n    model.send({ type: \"snapshot\", data: dataUrl });\n  });\n  zoomInBtn.addEventListener(\"mousedown\", (e) => e.preventDefault());\n  zoomOutBtn.addEventListener(\"mousedown\", (e) => e.preventDefault());\n  zoomInBtn.addEventListener(\"click\", () => model.send({ type: \"zoom\", direction: \"in\" }));\n  zoomOutBtn.addEventListener(\"click\", () => model.send({ type: \"zoom\", direction: \"out\" }));\n  attachInteraction(canvas, model, grid, () => nodeCells, () => frozen);\n}\nvar index_default = { render };\nexport {\n  index_default as default\n};\n//# sourceMappingURL=jupyter_widget.js.map\n",
+       "_model_module": "anywidget",
+       "_model_module_version": "~0.9.*",
+       "_model_name": "AnyModel",
+       "_view_count": null,
+       "_view_module": "anywidget",
+       "_view_module_version": "~0.9.*",
+       "_view_name": "AnyView",
+       "cols": 60,
+       "frame": {
+        "cells": [
+         {
+          "text": "\u255f",
+          "x": 5,
+          "y": 5
+         },
+         {
+          "text": "\u2500",
+          "x": 6,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "a",
+          "x": 7,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "t",
+          "x": 8,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "g",
+          "x": 9,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "g",
+          "x": 10,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "g",
+          "x": 11,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": ".",
+          "x": 12,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": ".",
+          "x": 13,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": ".",
+          "x": 14,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "a",
+          "x": 15,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "g",
+          "x": 16,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "t",
+          "x": 17,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "g",
+          "x": 18,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "a",
+          "x": 19,
+          "y": 5
+         },
+         {
+          "text": "\u2500",
+          "x": 20,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "a",
+          "x": 21,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "g",
+          "x": 22,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "a",
+          "x": 23,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "t",
+          "x": 24,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "t",
+          "x": 25,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": ".",
+          "x": 26,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": ".",
+          "x": 27,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": ".",
+          "x": 28,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "c",
+          "x": 29,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "a",
+          "x": 30,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "c",
+          "x": 31,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "a",
+          "x": 32,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "t",
+          "x": 33,
+          "y": 5
+         },
+         {
+          "text": "\u2500",
+          "x": 34,
+          "y": 5
+         },
+         {
+          "text": "\u2562",
+          "x": 35,
+          "y": 5
+         }
+        ],
+        "cols": 60,
+        "neutral_bg": "#1e1e2e",
+        "neutral_fg": "#cdd6f4",
+        "rows": 12
+       },
+       "layout": "IPY_MODEL_2a69ad50bdb04f0587a4c9bb6a70e2c3",
+       "rows": 12,
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "786e10cfd60a4f89b0c020d205002964": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "821afd01aa55407b8f2fff75bdac8efd": {
+      "model_module": "anywidget",
+      "model_module_version": "~0.9.*",
+      "model_name": "AnyModel",
+      "state": {
+       "_anywidget_id": "gen.jupyter_widget.GenGraphWidget",
+       "_dom_classes": [],
+       "_esm": "// Generated from js/index.ts by `npm run build` / `make jupyter`. Edit TypeScript sources, not this file.\n\n// js/grid.ts\nvar TEXT_SIZE = 14;\nvar CELL_SIZE = Math.round(TEXT_SIZE / 0.875);\nvar BOX_SCALE = 1.15;\nvar FONT_FAMILY = \"monospace\";\nvar BOX_FONT = `${CELL_SIZE}px ${FONT_FAMILY}`;\nvar TEXT_FONT = `${TEXT_SIZE}px ${FONT_FAMILY}`;\nfunction cellFont(size, cell) {\n  const style = cell.bold && cell.italic ? \"bold italic\" : cell.bold ? \"bold\" : cell.italic ? \"italic\" : \"\";\n  return style ? `${style} ${size}px ${FONT_FAMILY}` : `${size}px ${FONT_FAMILY}`;\n}\nfunction measure(ctx, font, text) {\n  ctx.font = font;\n  ctx.textAlign = \"left\";\n  ctx.textBaseline = \"alphabetic\";\n  return ctx.measureText(text);\n}\nfunction isBoxLike(ch) {\n  if (!ch || ch === \" \") return false;\n  const cp = ch.codePointAt(0);\n  return cp >= 9472 && cp <= 9599 || // box drawing\n  cp >= 9600 && cp <= 9631 || // block elements\n  cp >= 10240 && cp <= 10495;\n}\nfunction makeGridMetrics(ctx) {\n  const block = measure(ctx, BOX_FONT, \"\\u2588\");\n  const cellW = Math.ceil(block.actualBoundingBoxLeft + block.actualBoundingBoxRight);\n  const cellH = Math.ceil(block.actualBoundingBoxAscent + block.actualBoundingBoxDescent);\n  const boxDrawX = block.actualBoundingBoxLeft;\n  const boxDrawY = block.actualBoundingBoxAscent;\n  const textProbe = measure(ctx, TEXT_FONT, \"Mg\");\n  const textMono = measure(ctx, TEXT_FONT, \"M\");\n  const textAscent = textProbe.emHeightAscent ?? textProbe.fontBoundingBoxAscent ?? textProbe.actualBoundingBoxAscent;\n  const textDescent = textProbe.emHeightDescent ?? textProbe.fontBoundingBoxDescent ?? textProbe.actualBoundingBoxDescent;\n  const textX = Math.round((cellW - textMono.width) / 2);\n  const textBaseline = Math.round((cellH + textAscent - textDescent) / 2) + 1;\n  return { cellW, cellH, boxDrawX, boxDrawY, textX, textBaseline };\n}\n\n// js/glyphs.ts\nvar GLYPH_SPLIT = /* @__PURE__ */ new Map([\n  // Pure-heavy lines and half-lines: map to their light/rounded equivalents\n  [9473, [9472, void 0]],\n  [9475, [9474, void 0]],\n  [9477, [9476, void 0]],\n  [9479, [9478, void 0]],\n  [9481, [9480, void 0]],\n  [9483, [9482, void 0]],\n  [9592, [9588, void 0]],\n  [9593, [9589, void 0]],\n  [9594, [9590, void 0]],\n  [9595, [9591, void 0]],\n  // Pure-heavy corners\n  [9487, [9581, void 0]],\n  [9491, [9582, void 0]],\n  [9495, [9584, void 0]],\n  [9499, [9583, void 0]],\n  // Pure-heavy tees and cross\n  [9507, [9500, void 0]],\n  [9515, [9508, void 0]],\n  [9523, [9516, void 0]],\n  [9531, [9524, void 0]],\n  [9547, [9532, void 0]],\n  // Mixed-weight corners (one heavy arm, one light arm)\n  [9485, [9590, 9591]],\n  [9486, [9591, 9590]],\n  [9489, [9588, 9591]],\n  [9490, [9591, 9588]],\n  [9493, [9590, 9589]],\n  [9494, [9589, 9590]],\n  [9497, [9588, 9589]],\n  [9498, [9589, 9588]],\n  // Mixed-weight tees (heavy stem, mixed crossbar)\n  [9501, [9590, 9474]],\n  [9502, [9589, 9484]],\n  [9503, [9591, 9492]],\n  [9504, [9474, 9590]],\n  [9505, [9492, 9591]],\n  [9506, [9484, 9589]],\n  [9509, [9588, 9474]],\n  [9510, [9589, 9488]],\n  [9511, [9591, 9496]],\n  [9512, [9474, 9588]],\n  [9513, [9496, 9591]],\n  [9514, [9488, 9589]],\n  [9517, [9588, 9484]],\n  [9518, [9590, 9488]],\n  [9519, [9472, 9591]],\n  [9520, [9591, 9472]],\n  [9521, [9488, 9590]],\n  [9522, [9484, 9588]],\n  [9525, [9588, 9492]],\n  [9526, [9590, 9496]],\n  [9527, [9472, 9589]],\n  [9528, [9589, 9472]],\n  [9529, [9496, 9590]],\n  [9530, [9492, 9588]],\n  // Mixed-weight crosses\n  [9533, [9588, 9500]],\n  [9534, [9590, 9508]],\n  [9535, [9472, 9474]],\n  [9536, [9589, 9516]],\n  [9537, [9591, 9524]],\n  [9538, [9474, 9472]],\n  [9539, [9496, 9484]],\n  [9540, [9492, 9488]],\n  [9541, [9488, 9492]],\n  [9542, [9484, 9496]],\n  [9543, [9524, 9591]],\n  [9544, [9516, 9589]],\n  [9545, [9508, 9590]],\n  [9546, [9500, 9588]]\n]);\nvar NODE_GLYPH_CP = 9679;\n\n// js/renderer.ts\nfunction drawSplitGlyph(ctx, heavyCp, lightCp, px, py, cellW, cellH, boxDrawX, boxDrawY, fg, neutral_fg, boxFont) {\n  ctx.save();\n  ctx.beginPath();\n  ctx.rect(px, py, cellW, cellH);\n  ctx.clip();\n  if (lightCp !== void 0) {\n    ctx.fillStyle = neutral_fg;\n    ctx.font = boxFont;\n    ctx.save();\n    ctx.translate(px + cellW / 2, py + cellH / 2);\n    ctx.scale(BOX_SCALE, BOX_SCALE);\n    ctx.fillText(String.fromCodePoint(lightCp), boxDrawX - cellW / 2, boxDrawY - cellH / 2);\n    ctx.restore();\n  }\n  ctx.fillStyle = fg;\n  ctx.font = boxFont;\n  ctx.save();\n  ctx.translate(px + cellW / 2, py + cellH / 2);\n  ctx.scale(BOX_SCALE, BOX_SCALE);\n  ctx.fillText(String.fromCodePoint(heavyCp), boxDrawX - cellW / 2, boxDrawY - cellH / 2);\n  ctx.restore();\n  ctx.restore();\n}\nfunction paintFrame(ctx, canvas, grid, frame) {\n  const nodeCells = /* @__PURE__ */ new Set();\n  if (!frame?.cells) return nodeCells;\n  const { cellW, cellH, boxDrawX, boxDrawY, textX, textBaseline } = grid;\n  const { cols, rows, cells, neutral_fg = \"#cdd6f4\", neutral_bg = \"#1e1e2e\" } = frame;\n  canvas.width = cols * cellW;\n  canvas.height = rows * cellH;\n  ctx.fillStyle = neutral_bg;\n  ctx.fillRect(0, 0, canvas.width, canvas.height);\n  ctx.textAlign = \"left\";\n  ctx.textBaseline = \"alphabetic\";\n  for (const cell of cells) {\n    const { x: c, y: r, text } = cell;\n    const fg = cell.fg ?? neutral_fg;\n    const bg = cell.bg ?? neutral_bg;\n    const px = c * cellW;\n    const py = r * cellH;\n    if (!text || text === \" \") continue;\n    const cp = text.codePointAt(0);\n    if (!isBoxLike(text)) nodeCells.add(`${c},${r}`);\n    if (cp === NODE_GLYPH_CP) {\n      if (bg !== neutral_bg) {\n        ctx.fillStyle = bg;\n        ctx.fillRect(px, py, cellW, cellH);\n      }\n      ctx.fillStyle = fg;\n      ctx.beginPath();\n      ctx.arc(px + cellW / 2, py + cellH / 2, cellW / 2, 0, Math.PI * 2);\n      ctx.fill();\n      continue;\n    }\n    if (bg !== neutral_bg) {\n      ctx.fillStyle = bg;\n      ctx.fillRect(px, py, cellW, cellH);\n    }\n    const split = GLYPH_SPLIT.get(cp);\n    if (split !== void 0) {\n      const [heavyCp, lightCp] = split;\n      const boxFont = cellFont(CELL_SIZE, { bold: false, italic: !!cell.italic });\n      drawSplitGlyph(ctx, heavyCp, lightCp, px, py, cellW, cellH, boxDrawX, boxDrawY, fg, neutral_fg, boxFont);\n    } else if (isBoxLike(text)) {\n      ctx.fillStyle = fg;\n      ctx.font = cellFont(CELL_SIZE, cell);\n      ctx.save();\n      ctx.beginPath();\n      ctx.rect(px, py, cellW, cellH);\n      ctx.clip();\n      ctx.translate(px + cellW / 2, py + cellH / 2);\n      ctx.scale(BOX_SCALE, BOX_SCALE);\n      ctx.fillText(text, boxDrawX - cellW / 2, boxDrawY - cellH / 2);\n      ctx.restore();\n    } else {\n      ctx.fillStyle = fg;\n      ctx.font = cellFont(TEXT_SIZE, cell);\n      ctx.fillText(text, px + textX, py + textBaseline);\n    }\n    if (cell.underline) {\n      ctx.fillStyle = fg;\n      const underlineY = Math.min(py + cellH - 1, py + textBaseline + 1);\n      ctx.fillRect(px, underlineY, cellW, 1);\n    }\n  }\n  return nodeCells;\n}\n\n// js/interaction.ts\nvar DRAG_THRESHOLD = 4;\nfunction attachInteraction(canvas, model, grid, getNodeCells, isFrozen) {\n  const { cellW, cellH } = grid;\n  canvas.addEventListener(\"mousemove\", (e) => {\n    if (isFrozen()) return;\n    if (pointerDown) return;\n    const rect = canvas.getBoundingClientRect();\n    const col = Math.floor((e.clientX - rect.left) / cellW);\n    const row = Math.floor((e.clientY - rect.top) / cellH);\n    canvas.style.cursor = getNodeCells().has(`${col},${row}`) ? \"pointer\" : \"grab\";\n  });\n  let pointerDown = false;\n  let isDragging = false;\n  let dragStartX = 0;\n  let dragStartY = 0;\n  let lastDragX = 0;\n  let lastDragY = 0;\n  let dragRemX = 0;\n  let dragRemY = 0;\n  canvas.addEventListener(\"mousedown\", (e) => {\n    if (isFrozen() || e.button !== 0) return;\n    pointerDown = true;\n    isDragging = false;\n    dragStartX = lastDragX = e.clientX;\n    dragStartY = lastDragY = e.clientY;\n    dragRemX = 0;\n    dragRemY = 0;\n    e.preventDefault();\n  });\n  window.addEventListener(\"mousemove\", (e) => {\n    if (!pointerDown) return;\n    const totalDx = e.clientX - dragStartX;\n    const totalDy = e.clientY - dragStartY;\n    if (!isDragging && (Math.abs(totalDx) > DRAG_THRESHOLD || Math.abs(totalDy) > DRAG_THRESHOLD)) {\n      isDragging = true;\n      canvas.style.cursor = \"grabbing\";\n    }\n    if (isDragging) {\n      dragRemX += e.clientX - lastDragX;\n      dragRemY += e.clientY - lastDragY;\n      const termDx = Math.trunc(dragRemX / cellW);\n      const termDy = Math.trunc(dragRemY / cellH);\n      if (termDx !== 0 || termDy !== 0) {\n        model.send({ type: \"pan\", dx: termDx, dy: termDy });\n        dragRemX -= termDx * cellW;\n        dragRemY -= termDy * cellH;\n      }\n    }\n    lastDragX = e.clientX;\n    lastDragY = e.clientY;\n  });\n  window.addEventListener(\"mouseup\", (e) => {\n    if (!pointerDown || e.button !== 0) return;\n    if (!isDragging) {\n      const rect = canvas.getBoundingClientRect();\n      const col = Math.floor((e.clientX - rect.left) / cellW);\n      const row = Math.floor((e.clientY - rect.top) / cellH);\n      model.send({ type: \"mouse_click\", col, row, button: e.button });\n    }\n    pointerDown = false;\n    isDragging = false;\n    canvas.style.cursor = \"grab\";\n  });\n}\n\n// js/index.ts\nfunction render({ model, el }) {\n  const scratch = document.createElement(\"canvas\");\n  const scratchCtx = scratch.getContext(\"2d\");\n  const grid = makeGridMetrics(scratchCtx);\n  const wrapper = document.createElement(\"div\");\n  wrapper.style.cssText = \"position: relative; display: inline-block; line-height: 0;\";\n  const canvas = document.createElement(\"canvas\");\n  canvas.style.cssText = \"display: block; cursor: grab; border: 2px solid #45475a;\";\n  const sharedBtnStyle = [\n    \"width: 24px\",\n    \"height: 24px\",\n    \"font-size: 16px\",\n    \"line-height: 1\",\n    \"cursor: pointer\",\n    \"background: rgba(30,30,46,0.85)\",\n    \"color: #cdd6f4\",\n    \"border: 1px solid #45475a\",\n    \"border-radius: 4px\",\n    \"display: flex\",\n    \"align-items: center\",\n    \"justify-content: center\",\n    \"user-select: none\",\n    \"padding: 0\"\n  ].join(\"; \");\n  const btnContainer = document.createElement(\"div\");\n  btnContainer.style.cssText = \"position: absolute; bottom: 8px; right: 8px; display: flex; flex-direction: column; gap: 4px; z-index: 1;\";\n  const zoomInBtn = document.createElement(\"button\");\n  zoomInBtn.textContent = \"+\";\n  zoomInBtn.setAttribute(\"style\", sharedBtnStyle);\n  zoomInBtn.title = \"Zoom in (+)\";\n  const zoomOutBtn = document.createElement(\"button\");\n  zoomOutBtn.textContent = \"\\u2212\";\n  zoomOutBtn.setAttribute(\"style\", sharedBtnStyle);\n  zoomOutBtn.title = \"Zoom out (-)\";\n  btnContainer.appendChild(zoomInBtn);\n  btnContainer.appendChild(zoomOutBtn);\n  wrapper.appendChild(canvas);\n  wrapper.appendChild(btnContainer);\n  el.appendChild(wrapper);\n  const ctx = canvas.getContext(\"2d\");\n  let nodeCells = /* @__PURE__ */ new Set();\n  let frozen = false;\n  function repaint(frame) {\n    nodeCells = paintFrame(ctx, canvas, grid, frame);\n  }\n  repaint(model.get(\"frame\"));\n  model.on(\"change:frame\", () => repaint(model.get(\"frame\")));\n  model.on(\"msg:custom\", (msg) => {\n    if (msg.type !== \"freeze\") return;\n    frozen = true;\n    btnContainer.style.display = \"none\";\n    canvas.style.cursor = \"default\";\n    wrapper.style.border = \"none\";\n    const dataUrl = canvas.toDataURL(\"image/png\");\n    const img = document.createElement(\"img\");\n    img.src = dataUrl;\n    img.width = canvas.width;\n    img.height = canvas.height;\n    img.style.cssText = \"display:block;cursor:default;font-family:monospace\";\n    el.replaceChild(img, wrapper);\n    model.send({ type: \"snapshot\", data: dataUrl });\n  });\n  zoomInBtn.addEventListener(\"mousedown\", (e) => e.preventDefault());\n  zoomOutBtn.addEventListener(\"mousedown\", (e) => e.preventDefault());\n  zoomInBtn.addEventListener(\"click\", () => model.send({ type: \"zoom\", direction: \"in\" }));\n  zoomOutBtn.addEventListener(\"click\", () => model.send({ type: \"zoom\", direction: \"out\" }));\n  attachInteraction(canvas, model, grid, () => nodeCells, () => frozen);\n}\nvar index_default = { render };\nexport {\n  index_default as default\n};\n//# sourceMappingURL=jupyter_widget.js.map\n",
+       "_model_module": "anywidget",
+       "_model_module_version": "~0.9.*",
+       "_model_name": "AnyModel",
+       "_view_count": null,
+       "_view_module": "anywidget",
+       "_view_module_version": "~0.9.*",
+       "_view_name": "AnyView",
+       "cols": 60,
+       "frame": {
+        "cells": [
+         {
+          "text": "\u255f",
+          "x": 5,
+          "y": 5
+         },
+         {
+          "text": "\u2500",
+          "x": 6,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "A",
+          "x": 7,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "T",
+          "x": 8,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "C",
+          "x": 9,
+          "y": 5
+         },
+         {
+          "fg": "#f38ba8",
+          "text": "\u2501",
+          "x": 10,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "G",
+          "x": 11,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "A",
+          "x": 12,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "T",
+          "x": 13,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "C",
+          "x": 14,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "G",
+          "x": 15,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "A",
+          "x": 16,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "T",
+          "x": 17,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "C",
+          "x": 18,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "G",
+          "x": 19,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "A",
+          "x": 20,
+          "y": 5
+         },
+         {
+          "fg": "#f38ba8",
+          "text": "\u2501",
+          "x": 21,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "T",
+          "x": 22,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "C",
+          "x": 23,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "G",
+          "x": 24,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "A",
+          "x": 25,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "T",
+          "x": 26,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "C",
+          "x": 27,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "G",
+          "x": 28,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "G",
+          "x": 29,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "G",
+          "x": 30,
+          "y": 5
+         },
+         {
+          "fg": "#f38ba8",
+          "text": "\u2501",
+          "x": 31,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "A",
+          "x": 32,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "A",
+          "x": 33,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "C",
+          "x": 34,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "A",
+          "x": 35,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "C",
+          "x": 36,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "A",
+          "x": 37,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "C",
+          "x": 38,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "A",
+          "x": 39,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "G",
+          "x": 40,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "A",
+          "x": 41,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "G",
+          "x": 42,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "A",
+          "x": 43,
+          "y": 5
+         },
+         {
+          "text": "\u2500",
+          "x": 44,
+          "y": 5
+         },
+         {
+          "text": "\u2562",
+          "x": 45,
+          "y": 5
+         }
+        ],
+        "cols": 60,
+        "neutral_bg": "#1e1e2e",
+        "neutral_fg": "#cdd6f4",
+        "rows": 12
+       },
+       "layout": "IPY_MODEL_9b899ea4de2a45b3bab1ab446138a65a",
+       "rows": 12,
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "851c21ddcae14e649069a949bfe25ed3": {
+      "model_module": "anywidget",
+      "model_module_version": "~0.9.*",
+      "model_name": "AnyModel",
+      "state": {
+       "_anywidget_id": "gen.jupyter_widget.GenGraphWidget",
+       "_dom_classes": [],
+       "_esm": "// Generated from js/index.ts by `npm run build` / `make jupyter`. Edit TypeScript sources, not this file.\n\n// js/grid.ts\nvar TEXT_SIZE = 14;\nvar CELL_SIZE = Math.round(TEXT_SIZE / 0.875);\nvar BOX_SCALE = 1.15;\nvar FONT_FAMILY = \"monospace\";\nvar BOX_FONT = `${CELL_SIZE}px ${FONT_FAMILY}`;\nvar TEXT_FONT = `${TEXT_SIZE}px ${FONT_FAMILY}`;\nfunction cellFont(size, cell) {\n  const style = cell.bold && cell.italic ? \"bold italic\" : cell.bold ? \"bold\" : cell.italic ? \"italic\" : \"\";\n  return style ? `${style} ${size}px ${FONT_FAMILY}` : `${size}px ${FONT_FAMILY}`;\n}\nfunction measure(ctx, font, text) {\n  ctx.font = font;\n  ctx.textAlign = \"left\";\n  ctx.textBaseline = \"alphabetic\";\n  return ctx.measureText(text);\n}\nfunction isBoxLike(ch) {\n  if (!ch || ch === \" \") return false;\n  const cp = ch.codePointAt(0);\n  return cp >= 9472 && cp <= 9599 || // box drawing\n  cp >= 9600 && cp <= 9631 || // block elements\n  cp >= 10240 && cp <= 10495;\n}\nfunction makeGridMetrics(ctx) {\n  const block = measure(ctx, BOX_FONT, \"\\u2588\");\n  const cellW = Math.ceil(block.actualBoundingBoxLeft + block.actualBoundingBoxRight);\n  const cellH = Math.ceil(block.actualBoundingBoxAscent + block.actualBoundingBoxDescent);\n  const boxDrawX = block.actualBoundingBoxLeft;\n  const boxDrawY = block.actualBoundingBoxAscent;\n  const textProbe = measure(ctx, TEXT_FONT, \"Mg\");\n  const textMono = measure(ctx, TEXT_FONT, \"M\");\n  const textAscent = textProbe.emHeightAscent ?? textProbe.fontBoundingBoxAscent ?? textProbe.actualBoundingBoxAscent;\n  const textDescent = textProbe.emHeightDescent ?? textProbe.fontBoundingBoxDescent ?? textProbe.actualBoundingBoxDescent;\n  const textX = Math.round((cellW - textMono.width) / 2);\n  const textBaseline = Math.round((cellH + textAscent - textDescent) / 2) + 1;\n  return { cellW, cellH, boxDrawX, boxDrawY, textX, textBaseline };\n}\n\n// js/glyphs.ts\nvar GLYPH_SPLIT = /* @__PURE__ */ new Map([\n  // Pure-heavy lines and half-lines: map to their light/rounded equivalents\n  [9473, [9472, void 0]],\n  [9475, [9474, void 0]],\n  [9477, [9476, void 0]],\n  [9479, [9478, void 0]],\n  [9481, [9480, void 0]],\n  [9483, [9482, void 0]],\n  [9592, [9588, void 0]],\n  [9593, [9589, void 0]],\n  [9594, [9590, void 0]],\n  [9595, [9591, void 0]],\n  // Pure-heavy corners\n  [9487, [9581, void 0]],\n  [9491, [9582, void 0]],\n  [9495, [9584, void 0]],\n  [9499, [9583, void 0]],\n  // Pure-heavy tees and cross\n  [9507, [9500, void 0]],\n  [9515, [9508, void 0]],\n  [9523, [9516, void 0]],\n  [9531, [9524, void 0]],\n  [9547, [9532, void 0]],\n  // Mixed-weight corners (one heavy arm, one light arm)\n  [9485, [9590, 9591]],\n  [9486, [9591, 9590]],\n  [9489, [9588, 9591]],\n  [9490, [9591, 9588]],\n  [9493, [9590, 9589]],\n  [9494, [9589, 9590]],\n  [9497, [9588, 9589]],\n  [9498, [9589, 9588]],\n  // Mixed-weight tees (heavy stem, mixed crossbar)\n  [9501, [9590, 9474]],\n  [9502, [9589, 9484]],\n  [9503, [9591, 9492]],\n  [9504, [9474, 9590]],\n  [9505, [9492, 9591]],\n  [9506, [9484, 9589]],\n  [9509, [9588, 9474]],\n  [9510, [9589, 9488]],\n  [9511, [9591, 9496]],\n  [9512, [9474, 9588]],\n  [9513, [9496, 9591]],\n  [9514, [9488, 9589]],\n  [9517, [9588, 9484]],\n  [9518, [9590, 9488]],\n  [9519, [9472, 9591]],\n  [9520, [9591, 9472]],\n  [9521, [9488, 9590]],\n  [9522, [9484, 9588]],\n  [9525, [9588, 9492]],\n  [9526, [9590, 9496]],\n  [9527, [9472, 9589]],\n  [9528, [9589, 9472]],\n  [9529, [9496, 9590]],\n  [9530, [9492, 9588]],\n  // Mixed-weight crosses\n  [9533, [9588, 9500]],\n  [9534, [9590, 9508]],\n  [9535, [9472, 9474]],\n  [9536, [9589, 9516]],\n  [9537, [9591, 9524]],\n  [9538, [9474, 9472]],\n  [9539, [9496, 9484]],\n  [9540, [9492, 9488]],\n  [9541, [9488, 9492]],\n  [9542, [9484, 9496]],\n  [9543, [9524, 9591]],\n  [9544, [9516, 9589]],\n  [9545, [9508, 9590]],\n  [9546, [9500, 9588]]\n]);\nvar NODE_GLYPH_CP = 9679;\n\n// js/renderer.ts\nfunction drawSplitGlyph(ctx, heavyCp, lightCp, px, py, cellW, cellH, boxDrawX, boxDrawY, fg, neutral_fg, boxFont) {\n  ctx.save();\n  ctx.beginPath();\n  ctx.rect(px, py, cellW, cellH);\n  ctx.clip();\n  if (lightCp !== void 0) {\n    ctx.fillStyle = neutral_fg;\n    ctx.font = boxFont;\n    ctx.save();\n    ctx.translate(px + cellW / 2, py + cellH / 2);\n    ctx.scale(BOX_SCALE, BOX_SCALE);\n    ctx.fillText(String.fromCodePoint(lightCp), boxDrawX - cellW / 2, boxDrawY - cellH / 2);\n    ctx.restore();\n  }\n  ctx.fillStyle = fg;\n  ctx.font = boxFont;\n  ctx.save();\n  ctx.translate(px + cellW / 2, py + cellH / 2);\n  ctx.scale(BOX_SCALE, BOX_SCALE);\n  ctx.fillText(String.fromCodePoint(heavyCp), boxDrawX - cellW / 2, boxDrawY - cellH / 2);\n  ctx.restore();\n  ctx.restore();\n}\nfunction paintFrame(ctx, canvas, grid, frame) {\n  const nodeCells = /* @__PURE__ */ new Set();\n  if (!frame?.cells) return nodeCells;\n  const { cellW, cellH, boxDrawX, boxDrawY, textX, textBaseline } = grid;\n  const { cols, rows, cells, neutral_fg = \"#cdd6f4\", neutral_bg = \"#1e1e2e\" } = frame;\n  canvas.width = cols * cellW;\n  canvas.height = rows * cellH;\n  ctx.fillStyle = neutral_bg;\n  ctx.fillRect(0, 0, canvas.width, canvas.height);\n  ctx.textAlign = \"left\";\n  ctx.textBaseline = \"alphabetic\";\n  for (const cell of cells) {\n    const { x: c, y: r, text } = cell;\n    const fg = cell.fg ?? neutral_fg;\n    const bg = cell.bg ?? neutral_bg;\n    const px = c * cellW;\n    const py = r * cellH;\n    if (!text || text === \" \") continue;\n    const cp = text.codePointAt(0);\n    if (!isBoxLike(text)) nodeCells.add(`${c},${r}`);\n    if (cp === NODE_GLYPH_CP) {\n      if (bg !== neutral_bg) {\n        ctx.fillStyle = bg;\n        ctx.fillRect(px, py, cellW, cellH);\n      }\n      ctx.fillStyle = fg;\n      ctx.beginPath();\n      ctx.arc(px + cellW / 2, py + cellH / 2, cellW / 2, 0, Math.PI * 2);\n      ctx.fill();\n      continue;\n    }\n    if (bg !== neutral_bg) {\n      ctx.fillStyle = bg;\n      ctx.fillRect(px, py, cellW, cellH);\n    }\n    const split = GLYPH_SPLIT.get(cp);\n    if (split !== void 0) {\n      const [heavyCp, lightCp] = split;\n      const boxFont = cellFont(CELL_SIZE, { bold: false, italic: !!cell.italic });\n      drawSplitGlyph(ctx, heavyCp, lightCp, px, py, cellW, cellH, boxDrawX, boxDrawY, fg, neutral_fg, boxFont);\n    } else if (isBoxLike(text)) {\n      ctx.fillStyle = fg;\n      ctx.font = cellFont(CELL_SIZE, cell);\n      ctx.save();\n      ctx.beginPath();\n      ctx.rect(px, py, cellW, cellH);\n      ctx.clip();\n      ctx.translate(px + cellW / 2, py + cellH / 2);\n      ctx.scale(BOX_SCALE, BOX_SCALE);\n      ctx.fillText(text, boxDrawX - cellW / 2, boxDrawY - cellH / 2);\n      ctx.restore();\n    } else {\n      ctx.fillStyle = fg;\n      ctx.font = cellFont(TEXT_SIZE, cell);\n      ctx.fillText(text, px + textX, py + textBaseline);\n    }\n    if (cell.underline) {\n      ctx.fillStyle = fg;\n      const underlineY = Math.min(py + cellH - 1, py + textBaseline + 1);\n      ctx.fillRect(px, underlineY, cellW, 1);\n    }\n  }\n  return nodeCells;\n}\n\n// js/interaction.ts\nvar DRAG_THRESHOLD = 4;\nfunction attachInteraction(canvas, model, grid, getNodeCells, isFrozen) {\n  const { cellW, cellH } = grid;\n  canvas.addEventListener(\"mousemove\", (e) => {\n    if (isFrozen()) return;\n    if (pointerDown) return;\n    const rect = canvas.getBoundingClientRect();\n    const col = Math.floor((e.clientX - rect.left) / cellW);\n    const row = Math.floor((e.clientY - rect.top) / cellH);\n    canvas.style.cursor = getNodeCells().has(`${col},${row}`) ? \"pointer\" : \"grab\";\n  });\n  let pointerDown = false;\n  let isDragging = false;\n  let dragStartX = 0;\n  let dragStartY = 0;\n  let lastDragX = 0;\n  let lastDragY = 0;\n  let dragRemX = 0;\n  let dragRemY = 0;\n  canvas.addEventListener(\"mousedown\", (e) => {\n    if (isFrozen() || e.button !== 0) return;\n    pointerDown = true;\n    isDragging = false;\n    dragStartX = lastDragX = e.clientX;\n    dragStartY = lastDragY = e.clientY;\n    dragRemX = 0;\n    dragRemY = 0;\n    e.preventDefault();\n  });\n  window.addEventListener(\"mousemove\", (e) => {\n    if (!pointerDown) return;\n    const totalDx = e.clientX - dragStartX;\n    const totalDy = e.clientY - dragStartY;\n    if (!isDragging && (Math.abs(totalDx) > DRAG_THRESHOLD || Math.abs(totalDy) > DRAG_THRESHOLD)) {\n      isDragging = true;\n      canvas.style.cursor = \"grabbing\";\n    }\n    if (isDragging) {\n      dragRemX += e.clientX - lastDragX;\n      dragRemY += e.clientY - lastDragY;\n      const termDx = Math.trunc(dragRemX / cellW);\n      const termDy = Math.trunc(dragRemY / cellH);\n      if (termDx !== 0 || termDy !== 0) {\n        model.send({ type: \"pan\", dx: termDx, dy: termDy });\n        dragRemX -= termDx * cellW;\n        dragRemY -= termDy * cellH;\n      }\n    }\n    lastDragX = e.clientX;\n    lastDragY = e.clientY;\n  });\n  window.addEventListener(\"mouseup\", (e) => {\n    if (!pointerDown || e.button !== 0) return;\n    if (!isDragging) {\n      const rect = canvas.getBoundingClientRect();\n      const col = Math.floor((e.clientX - rect.left) / cellW);\n      const row = Math.floor((e.clientY - rect.top) / cellH);\n      model.send({ type: \"mouse_click\", col, row, button: e.button });\n    }\n    pointerDown = false;\n    isDragging = false;\n    canvas.style.cursor = \"grab\";\n  });\n}\n\n// js/index.ts\nfunction render({ model, el }) {\n  const scratch = document.createElement(\"canvas\");\n  const scratchCtx = scratch.getContext(\"2d\");\n  const grid = makeGridMetrics(scratchCtx);\n  const wrapper = document.createElement(\"div\");\n  wrapper.style.cssText = \"position: relative; display: inline-block; line-height: 0;\";\n  const canvas = document.createElement(\"canvas\");\n  canvas.style.cssText = \"display: block; cursor: grab; border: 2px solid #45475a;\";\n  const sharedBtnStyle = [\n    \"width: 24px\",\n    \"height: 24px\",\n    \"font-size: 16px\",\n    \"line-height: 1\",\n    \"cursor: pointer\",\n    \"background: rgba(30,30,46,0.85)\",\n    \"color: #cdd6f4\",\n    \"border: 1px solid #45475a\",\n    \"border-radius: 4px\",\n    \"display: flex\",\n    \"align-items: center\",\n    \"justify-content: center\",\n    \"user-select: none\",\n    \"padding: 0\"\n  ].join(\"; \");\n  const btnContainer = document.createElement(\"div\");\n  btnContainer.style.cssText = \"position: absolute; bottom: 8px; right: 8px; display: flex; flex-direction: column; gap: 4px; z-index: 1;\";\n  const zoomInBtn = document.createElement(\"button\");\n  zoomInBtn.textContent = \"+\";\n  zoomInBtn.setAttribute(\"style\", sharedBtnStyle);\n  zoomInBtn.title = \"Zoom in (+)\";\n  const zoomOutBtn = document.createElement(\"button\");\n  zoomOutBtn.textContent = \"\\u2212\";\n  zoomOutBtn.setAttribute(\"style\", sharedBtnStyle);\n  zoomOutBtn.title = \"Zoom out (-)\";\n  btnContainer.appendChild(zoomInBtn);\n  btnContainer.appendChild(zoomOutBtn);\n  wrapper.appendChild(canvas);\n  wrapper.appendChild(btnContainer);\n  el.appendChild(wrapper);\n  const ctx = canvas.getContext(\"2d\");\n  let nodeCells = /* @__PURE__ */ new Set();\n  let frozen = false;\n  function repaint(frame) {\n    nodeCells = paintFrame(ctx, canvas, grid, frame);\n  }\n  repaint(model.get(\"frame\"));\n  model.on(\"change:frame\", () => repaint(model.get(\"frame\")));\n  model.on(\"msg:custom\", (msg) => {\n    if (msg.type !== \"freeze\") return;\n    frozen = true;\n    btnContainer.style.display = \"none\";\n    canvas.style.cursor = \"default\";\n    wrapper.style.border = \"none\";\n    const dataUrl = canvas.toDataURL(\"image/png\");\n    const img = document.createElement(\"img\");\n    img.src = dataUrl;\n    img.width = canvas.width;\n    img.height = canvas.height;\n    img.style.cssText = \"display:block;cursor:default;font-family:monospace\";\n    el.replaceChild(img, wrapper);\n    model.send({ type: \"snapshot\", data: dataUrl });\n  });\n  zoomInBtn.addEventListener(\"mousedown\", (e) => e.preventDefault());\n  zoomOutBtn.addEventListener(\"mousedown\", (e) => e.preventDefault());\n  zoomInBtn.addEventListener(\"click\", () => model.send({ type: \"zoom\", direction: \"in\" }));\n  zoomOutBtn.addEventListener(\"click\", () => model.send({ type: \"zoom\", direction: \"out\" }));\n  attachInteraction(canvas, model, grid, () => nodeCells, () => frozen);\n}\nvar index_default = { render };\nexport {\n  index_default as default\n};\n//# sourceMappingURL=jupyter_widget.js.map\n",
+       "_model_module": "anywidget",
+       "_model_module_version": "~0.9.*",
+       "_model_name": "AnyModel",
+       "_view_count": null,
+       "_view_module": "anywidget",
+       "_view_module_version": "~0.9.*",
+       "_view_name": "AnyView",
+       "cols": 60,
+       "frame": {
+        "cells": [
+         {
+          "text": "\u255f",
+          "x": 5,
+          "y": 5
+         },
+         {
+          "text": "\u2500",
+          "x": 6,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "a",
+          "x": 7,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "t",
+          "x": 8,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "g",
+          "x": 9,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "g",
+          "x": 10,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "g",
+          "x": 11,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": ".",
+          "x": 12,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": ".",
+          "x": 13,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": ".",
+          "x": 14,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "a",
+          "x": 15,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "g",
+          "x": 16,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "t",
+          "x": 17,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "g",
+          "x": 18,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "a",
+          "x": 19,
+          "y": 5
+         },
+         {
+          "text": "\u2500",
+          "x": 20,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "a",
+          "x": 21,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "g",
+          "x": 22,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "a",
+          "x": 23,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "t",
+          "x": 24,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "t",
+          "x": 25,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": ".",
+          "x": 26,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": ".",
+          "x": 27,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": ".",
+          "x": 28,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "c",
+          "x": 29,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "a",
+          "x": 30,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "c",
+          "x": 31,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "a",
+          "x": 32,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "t",
+          "x": 33,
+          "y": 5
+         },
+         {
+          "text": "\u2500",
+          "x": 34,
+          "y": 5
+         },
+         {
+          "text": "\u2562",
+          "x": 35,
+          "y": 5
+         }
+        ],
+        "cols": 60,
+        "neutral_bg": "#1e1e2e",
+        "neutral_fg": "#cdd6f4",
+        "rows": 12
+       },
+       "layout": "IPY_MODEL_a457b58968174354b4d47c55ab8b6e1d",
+       "rows": 12,
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "9b899ea4de2a45b3bab1ab446138a65a": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "9f28cfb8fee64b7bb35cd16c294a9d5f": {
+      "model_module": "anywidget",
+      "model_module_version": "~0.9.*",
+      "model_name": "AnyModel",
+      "state": {
+       "_anywidget_id": "gen.jupyter_widget.GenGraphWidget",
+       "_dom_classes": [],
+       "_esm": "// Generated from js/index.ts by `npm run build` / `make jupyter`. Edit TypeScript sources, not this file.\n\n// js/grid.ts\nvar TEXT_SIZE = 14;\nvar CELL_SIZE = Math.round(TEXT_SIZE / 0.875);\nvar BOX_SCALE = 1.15;\nvar FONT_FAMILY = \"monospace\";\nvar BOX_FONT = `${CELL_SIZE}px ${FONT_FAMILY}`;\nvar TEXT_FONT = `${TEXT_SIZE}px ${FONT_FAMILY}`;\nfunction cellFont(size, cell) {\n  const style = cell.bold && cell.italic ? \"bold italic\" : cell.bold ? \"bold\" : cell.italic ? \"italic\" : \"\";\n  return style ? `${style} ${size}px ${FONT_FAMILY}` : `${size}px ${FONT_FAMILY}`;\n}\nfunction measure(ctx, font, text) {\n  ctx.font = font;\n  ctx.textAlign = \"left\";\n  ctx.textBaseline = \"alphabetic\";\n  return ctx.measureText(text);\n}\nfunction isBoxLike(ch) {\n  if (!ch || ch === \" \") return false;\n  const cp = ch.codePointAt(0);\n  return cp >= 9472 && cp <= 9599 || // box drawing\n  cp >= 9600 && cp <= 9631 || // block elements\n  cp >= 10240 && cp <= 10495;\n}\nfunction makeGridMetrics(ctx) {\n  const block = measure(ctx, BOX_FONT, \"\\u2588\");\n  const cellW = Math.ceil(block.actualBoundingBoxLeft + block.actualBoundingBoxRight);\n  const cellH = Math.ceil(block.actualBoundingBoxAscent + block.actualBoundingBoxDescent);\n  const boxDrawX = block.actualBoundingBoxLeft;\n  const boxDrawY = block.actualBoundingBoxAscent;\n  const textProbe = measure(ctx, TEXT_FONT, \"Mg\");\n  const textMono = measure(ctx, TEXT_FONT, \"M\");\n  const textAscent = textProbe.emHeightAscent ?? textProbe.fontBoundingBoxAscent ?? textProbe.actualBoundingBoxAscent;\n  const textDescent = textProbe.emHeightDescent ?? textProbe.fontBoundingBoxDescent ?? textProbe.actualBoundingBoxDescent;\n  const textX = Math.round((cellW - textMono.width) / 2);\n  const textBaseline = Math.round((cellH + textAscent - textDescent) / 2) + 1;\n  return { cellW, cellH, boxDrawX, boxDrawY, textX, textBaseline };\n}\n\n// js/glyphs.ts\nvar GLYPH_SPLIT = /* @__PURE__ */ new Map([\n  // Pure-heavy lines and half-lines: map to their light/rounded equivalents\n  [9473, [9472, void 0]],\n  [9475, [9474, void 0]],\n  [9477, [9476, void 0]],\n  [9479, [9478, void 0]],\n  [9481, [9480, void 0]],\n  [9483, [9482, void 0]],\n  [9592, [9588, void 0]],\n  [9593, [9589, void 0]],\n  [9594, [9590, void 0]],\n  [9595, [9591, void 0]],\n  // Pure-heavy corners\n  [9487, [9581, void 0]],\n  [9491, [9582, void 0]],\n  [9495, [9584, void 0]],\n  [9499, [9583, void 0]],\n  // Pure-heavy tees and cross\n  [9507, [9500, void 0]],\n  [9515, [9508, void 0]],\n  [9523, [9516, void 0]],\n  [9531, [9524, void 0]],\n  [9547, [9532, void 0]],\n  // Mixed-weight corners (one heavy arm, one light arm)\n  [9485, [9590, 9591]],\n  [9486, [9591, 9590]],\n  [9489, [9588, 9591]],\n  [9490, [9591, 9588]],\n  [9493, [9590, 9589]],\n  [9494, [9589, 9590]],\n  [9497, [9588, 9589]],\n  [9498, [9589, 9588]],\n  // Mixed-weight tees (heavy stem, mixed crossbar)\n  [9501, [9590, 9474]],\n  [9502, [9589, 9484]],\n  [9503, [9591, 9492]],\n  [9504, [9474, 9590]],\n  [9505, [9492, 9591]],\n  [9506, [9484, 9589]],\n  [9509, [9588, 9474]],\n  [9510, [9589, 9488]],\n  [9511, [9591, 9496]],\n  [9512, [9474, 9588]],\n  [9513, [9496, 9591]],\n  [9514, [9488, 9589]],\n  [9517, [9588, 9484]],\n  [9518, [9590, 9488]],\n  [9519, [9472, 9591]],\n  [9520, [9591, 9472]],\n  [9521, [9488, 9590]],\n  [9522, [9484, 9588]],\n  [9525, [9588, 9492]],\n  [9526, [9590, 9496]],\n  [9527, [9472, 9589]],\n  [9528, [9589, 9472]],\n  [9529, [9496, 9590]],\n  [9530, [9492, 9588]],\n  // Mixed-weight crosses\n  [9533, [9588, 9500]],\n  [9534, [9590, 9508]],\n  [9535, [9472, 9474]],\n  [9536, [9589, 9516]],\n  [9537, [9591, 9524]],\n  [9538, [9474, 9472]],\n  [9539, [9496, 9484]],\n  [9540, [9492, 9488]],\n  [9541, [9488, 9492]],\n  [9542, [9484, 9496]],\n  [9543, [9524, 9591]],\n  [9544, [9516, 9589]],\n  [9545, [9508, 9590]],\n  [9546, [9500, 9588]]\n]);\nvar NODE_GLYPH_CP = 9679;\n\n// js/renderer.ts\nfunction drawSplitGlyph(ctx, heavyCp, lightCp, px, py, cellW, cellH, boxDrawX, boxDrawY, fg, neutral_fg, boxFont) {\n  ctx.save();\n  ctx.beginPath();\n  ctx.rect(px, py, cellW, cellH);\n  ctx.clip();\n  if (lightCp !== void 0) {\n    ctx.fillStyle = neutral_fg;\n    ctx.font = boxFont;\n    ctx.save();\n    ctx.translate(px + cellW / 2, py + cellH / 2);\n    ctx.scale(BOX_SCALE, BOX_SCALE);\n    ctx.fillText(String.fromCodePoint(lightCp), boxDrawX - cellW / 2, boxDrawY - cellH / 2);\n    ctx.restore();\n  }\n  ctx.fillStyle = fg;\n  ctx.font = boxFont;\n  ctx.save();\n  ctx.translate(px + cellW / 2, py + cellH / 2);\n  ctx.scale(BOX_SCALE, BOX_SCALE);\n  ctx.fillText(String.fromCodePoint(heavyCp), boxDrawX - cellW / 2, boxDrawY - cellH / 2);\n  ctx.restore();\n  ctx.restore();\n}\nfunction paintFrame(ctx, canvas, grid, frame) {\n  const nodeCells = /* @__PURE__ */ new Set();\n  if (!frame?.cells) return nodeCells;\n  const { cellW, cellH, boxDrawX, boxDrawY, textX, textBaseline } = grid;\n  const { cols, rows, cells, neutral_fg = \"#cdd6f4\", neutral_bg = \"#1e1e2e\" } = frame;\n  canvas.width = cols * cellW;\n  canvas.height = rows * cellH;\n  ctx.fillStyle = neutral_bg;\n  ctx.fillRect(0, 0, canvas.width, canvas.height);\n  ctx.textAlign = \"left\";\n  ctx.textBaseline = \"alphabetic\";\n  for (const cell of cells) {\n    const { x: c, y: r, text } = cell;\n    const fg = cell.fg ?? neutral_fg;\n    const bg = cell.bg ?? neutral_bg;\n    const px = c * cellW;\n    const py = r * cellH;\n    if (!text || text === \" \") continue;\n    const cp = text.codePointAt(0);\n    if (!isBoxLike(text)) nodeCells.add(`${c},${r}`);\n    if (cp === NODE_GLYPH_CP) {\n      if (bg !== neutral_bg) {\n        ctx.fillStyle = bg;\n        ctx.fillRect(px, py, cellW, cellH);\n      }\n      ctx.fillStyle = fg;\n      ctx.beginPath();\n      ctx.arc(px + cellW / 2, py + cellH / 2, cellW / 2, 0, Math.PI * 2);\n      ctx.fill();\n      continue;\n    }\n    if (bg !== neutral_bg) {\n      ctx.fillStyle = bg;\n      ctx.fillRect(px, py, cellW, cellH);\n    }\n    const split = GLYPH_SPLIT.get(cp);\n    if (split !== void 0) {\n      const [heavyCp, lightCp] = split;\n      const boxFont = cellFont(CELL_SIZE, { bold: false, italic: !!cell.italic });\n      drawSplitGlyph(ctx, heavyCp, lightCp, px, py, cellW, cellH, boxDrawX, boxDrawY, fg, neutral_fg, boxFont);\n    } else if (isBoxLike(text)) {\n      ctx.fillStyle = fg;\n      ctx.font = cellFont(CELL_SIZE, cell);\n      ctx.save();\n      ctx.beginPath();\n      ctx.rect(px, py, cellW, cellH);\n      ctx.clip();\n      ctx.translate(px + cellW / 2, py + cellH / 2);\n      ctx.scale(BOX_SCALE, BOX_SCALE);\n      ctx.fillText(text, boxDrawX - cellW / 2, boxDrawY - cellH / 2);\n      ctx.restore();\n    } else {\n      ctx.fillStyle = fg;\n      ctx.font = cellFont(TEXT_SIZE, cell);\n      ctx.fillText(text, px + textX, py + textBaseline);\n    }\n    if (cell.underline) {\n      ctx.fillStyle = fg;\n      const underlineY = Math.min(py + cellH - 1, py + textBaseline + 1);\n      ctx.fillRect(px, underlineY, cellW, 1);\n    }\n  }\n  return nodeCells;\n}\n\n// js/interaction.ts\nvar DRAG_THRESHOLD = 4;\nfunction attachInteraction(canvas, model, grid, getNodeCells, isFrozen) {\n  const { cellW, cellH } = grid;\n  canvas.addEventListener(\"mousemove\", (e) => {\n    if (isFrozen()) return;\n    if (pointerDown) return;\n    const rect = canvas.getBoundingClientRect();\n    const col = Math.floor((e.clientX - rect.left) / cellW);\n    const row = Math.floor((e.clientY - rect.top) / cellH);\n    canvas.style.cursor = getNodeCells().has(`${col},${row}`) ? \"pointer\" : \"grab\";\n  });\n  let pointerDown = false;\n  let isDragging = false;\n  let dragStartX = 0;\n  let dragStartY = 0;\n  let lastDragX = 0;\n  let lastDragY = 0;\n  let dragRemX = 0;\n  let dragRemY = 0;\n  canvas.addEventListener(\"mousedown\", (e) => {\n    if (isFrozen() || e.button !== 0) return;\n    pointerDown = true;\n    isDragging = false;\n    dragStartX = lastDragX = e.clientX;\n    dragStartY = lastDragY = e.clientY;\n    dragRemX = 0;\n    dragRemY = 0;\n    e.preventDefault();\n  });\n  window.addEventListener(\"mousemove\", (e) => {\n    if (!pointerDown) return;\n    const totalDx = e.clientX - dragStartX;\n    const totalDy = e.clientY - dragStartY;\n    if (!isDragging && (Math.abs(totalDx) > DRAG_THRESHOLD || Math.abs(totalDy) > DRAG_THRESHOLD)) {\n      isDragging = true;\n      canvas.style.cursor = \"grabbing\";\n    }\n    if (isDragging) {\n      dragRemX += e.clientX - lastDragX;\n      dragRemY += e.clientY - lastDragY;\n      const termDx = Math.trunc(dragRemX / cellW);\n      const termDy = Math.trunc(dragRemY / cellH);\n      if (termDx !== 0 || termDy !== 0) {\n        model.send({ type: \"pan\", dx: termDx, dy: termDy });\n        dragRemX -= termDx * cellW;\n        dragRemY -= termDy * cellH;\n      }\n    }\n    lastDragX = e.clientX;\n    lastDragY = e.clientY;\n  });\n  window.addEventListener(\"mouseup\", (e) => {\n    if (!pointerDown || e.button !== 0) return;\n    if (!isDragging) {\n      const rect = canvas.getBoundingClientRect();\n      const col = Math.floor((e.clientX - rect.left) / cellW);\n      const row = Math.floor((e.clientY - rect.top) / cellH);\n      model.send({ type: \"mouse_click\", col, row, button: e.button });\n    }\n    pointerDown = false;\n    isDragging = false;\n    canvas.style.cursor = \"grab\";\n  });\n}\n\n// js/index.ts\nfunction render({ model, el }) {\n  const scratch = document.createElement(\"canvas\");\n  const scratchCtx = scratch.getContext(\"2d\");\n  const grid = makeGridMetrics(scratchCtx);\n  const wrapper = document.createElement(\"div\");\n  wrapper.style.cssText = \"position: relative; display: inline-block; line-height: 0;\";\n  const canvas = document.createElement(\"canvas\");\n  canvas.style.cssText = \"display: block; cursor: grab; border: 2px solid #45475a;\";\n  const sharedBtnStyle = [\n    \"width: 24px\",\n    \"height: 24px\",\n    \"font-size: 16px\",\n    \"line-height: 1\",\n    \"cursor: pointer\",\n    \"background: rgba(30,30,46,0.85)\",\n    \"color: #cdd6f4\",\n    \"border: 1px solid #45475a\",\n    \"border-radius: 4px\",\n    \"display: flex\",\n    \"align-items: center\",\n    \"justify-content: center\",\n    \"user-select: none\",\n    \"padding: 0\"\n  ].join(\"; \");\n  const btnContainer = document.createElement(\"div\");\n  btnContainer.style.cssText = \"position: absolute; bottom: 8px; right: 8px; display: flex; flex-direction: column; gap: 4px; z-index: 1;\";\n  const zoomInBtn = document.createElement(\"button\");\n  zoomInBtn.textContent = \"+\";\n  zoomInBtn.setAttribute(\"style\", sharedBtnStyle);\n  zoomInBtn.title = \"Zoom in (+)\";\n  const zoomOutBtn = document.createElement(\"button\");\n  zoomOutBtn.textContent = \"\\u2212\";\n  zoomOutBtn.setAttribute(\"style\", sharedBtnStyle);\n  zoomOutBtn.title = \"Zoom out (-)\";\n  btnContainer.appendChild(zoomInBtn);\n  btnContainer.appendChild(zoomOutBtn);\n  wrapper.appendChild(canvas);\n  wrapper.appendChild(btnContainer);\n  el.appendChild(wrapper);\n  const ctx = canvas.getContext(\"2d\");\n  let nodeCells = /* @__PURE__ */ new Set();\n  let frozen = false;\n  function repaint(frame) {\n    nodeCells = paintFrame(ctx, canvas, grid, frame);\n  }\n  repaint(model.get(\"frame\"));\n  model.on(\"change:frame\", () => repaint(model.get(\"frame\")));\n  model.on(\"msg:custom\", (msg) => {\n    if (msg.type !== \"freeze\") return;\n    frozen = true;\n    btnContainer.style.display = \"none\";\n    canvas.style.cursor = \"default\";\n    wrapper.style.border = \"none\";\n    const dataUrl = canvas.toDataURL(\"image/png\");\n    const img = document.createElement(\"img\");\n    img.src = dataUrl;\n    img.width = canvas.width;\n    img.height = canvas.height;\n    img.style.cssText = \"display:block;cursor:default;font-family:monospace\";\n    el.replaceChild(img, wrapper);\n    model.send({ type: \"snapshot\", data: dataUrl });\n  });\n  zoomInBtn.addEventListener(\"mousedown\", (e) => e.preventDefault());\n  zoomOutBtn.addEventListener(\"mousedown\", (e) => e.preventDefault());\n  zoomInBtn.addEventListener(\"click\", () => model.send({ type: \"zoom\", direction: \"in\" }));\n  zoomOutBtn.addEventListener(\"click\", () => model.send({ type: \"zoom\", direction: \"out\" }));\n  attachInteraction(canvas, model, grid, () => nodeCells, () => frozen);\n}\nvar index_default = { render };\nexport {\n  index_default as default\n};\n//# sourceMappingURL=jupyter_widget.js.map\n",
+       "_model_module": "anywidget",
+       "_model_module_version": "~0.9.*",
+       "_model_name": "AnyModel",
+       "_view_count": null,
+       "_view_module": "anywidget",
+       "_view_module_version": "~0.9.*",
+       "_view_name": "AnyView",
+       "cols": 60,
+       "frame": {
+        "cells": [
+         {
+          "fg": "#f38ba8",
+          "text": "\u250f",
+          "x": 11,
+          "y": 4
+         },
+         {
+          "fg": "#f38ba8",
+          "text": "\u2501",
+          "x": 12,
+          "y": 4
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "G",
+          "x": 13,
+          "y": 4
+         },
+         {
+          "fg": "#f38ba8",
+          "text": "\u2501",
+          "x": 14,
+          "y": 4
+         },
+         {
+          "fg": "#f38ba8",
+          "text": "\u2513",
+          "x": 15,
+          "y": 4
+         },
+         {
+          "text": "\u256d",
+          "x": 24,
+          "y": 4
+         },
+         {
+          "text": "\u2500",
+          "x": 25,
+          "y": 4
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "A",
+          "x": 26,
+          "y": 4
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "G",
+          "x": 27,
+          "y": 4
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "A",
+          "x": 28,
+          "y": 4
+         },
+         {
+          "text": "\u2500",
+          "x": 29,
+          "y": 4
+         },
+         {
+          "text": "\u256e",
+          "x": 30,
+          "y": 4
+         },
+         {
+          "text": "\u255f",
+          "x": 5,
+          "y": 5
+         },
+         {
+          "text": "\u2500",
+          "x": 6,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "A",
+          "x": 7,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "T",
+          "x": 8,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "C",
+          "x": 9,
+          "y": 5
+         },
+         {
+          "fg": "#f38ba8",
+          "text": "\u2501",
+          "x": 10,
+          "y": 5
+         },
+         {
+          "fg": "#f38ba8",
+          "text": "\u2529",
+          "x": 11,
+          "y": 5
+         },
+         {
+          "fg": "#f38ba8",
+          "text": "\u2521",
+          "x": 15,
+          "y": 5
+         },
+         {
+          "fg": "#f38ba8",
+          "text": "\u2501",
+          "x": 16,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "A",
+          "x": 17,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "T",
+          "x": 18,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "C",
+          "x": 19,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "G",
+          "x": 20,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "A",
+          "x": 21,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "T",
+          "x": 22,
+          "y": 5
+         },
+         {
+          "fg": "#f38ba8",
+          "text": "\u2501",
+          "x": 23,
+          "y": 5
+         },
+         {
+          "fg": "#f38ba8",
+          "text": "\u252a",
+          "x": 24,
+          "y": 5
+         },
+         {
+          "fg": "#f38ba8",
+          "text": "\u2522",
+          "x": 30,
+          "y": 5
+         },
+         {
+          "fg": "#f38ba8",
+          "text": "\u2501",
+          "x": 31,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "C",
+          "x": 32,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "G",
+          "x": 33,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "A",
+          "x": 34,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "T",
+          "x": 35,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "C",
+          "x": 36,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": ".",
+          "x": 37,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": ".",
+          "x": 38,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": ".",
+          "x": 39,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "A",
+          "x": 40,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "G",
+          "x": 41,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "A",
+          "x": 42,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "G",
+          "x": 43,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "A",
+          "x": 44,
+          "y": 5
+         },
+         {
+          "text": "\u2500",
+          "x": 45,
+          "y": 5
+         },
+         {
+          "text": "\u2562",
+          "x": 46,
+          "y": 5
+         },
+         {
+          "text": "\u2570",
+          "x": 11,
+          "y": 6
+         },
+         {
+          "text": "\u2500",
+          "x": 12,
+          "y": 6
+         },
+         {
+          "text": "\u2500",
+          "x": 13,
+          "y": 6
+         },
+         {
+          "text": "\u2500",
+          "x": 14,
+          "y": 6
+         },
+         {
+          "text": "\u256f",
+          "x": 15,
+          "y": 6
+         },
+         {
+          "fg": "#f38ba8",
+          "text": "\u2517",
+          "x": 24,
+          "y": 6
+         },
+         {
+          "fg": "#f38ba8",
+          "text": "\u2501",
+          "x": 25,
+          "y": 6
+         },
+         {
+          "fg": "#f38ba8",
+          "text": "\u2501",
+          "x": 26,
+          "y": 6
+         },
+         {
+          "fg": "#f38ba8",
+          "text": "\u2501",
+          "x": 27,
+          "y": 6
+         },
+         {
+          "fg": "#f38ba8",
+          "text": "\u2501",
+          "x": 28,
+          "y": 6
+         },
+         {
+          "fg": "#f38ba8",
+          "text": "\u2501",
+          "x": 29,
+          "y": 6
+         },
+         {
+          "fg": "#f38ba8",
+          "text": "\u251b",
+          "x": 30,
+          "y": 6
+         }
+        ],
+        "cols": 60,
+        "neutral_bg": "#1e1e2e",
+        "neutral_fg": "#cdd6f4",
+        "rows": 12
+       },
+       "layout": "IPY_MODEL_2a31b0c0b5ed43b2803ab2e8c4b9aad2",
+       "rows": 12,
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "a457b58968174354b4d47c55ab8b6e1d": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "a45b6aaaa2c3403491ad6a6b06352a40": {
+      "model_module": "anywidget",
+      "model_module_version": "~0.9.*",
+      "model_name": "AnyModel",
+      "state": {
+       "_anywidget_id": "gen.jupyter_widget.GenGraphWidget",
+       "_dom_classes": [],
+       "_esm": "// Generated from js/index.ts by `npm run build` / `make jupyter`. Edit TypeScript sources, not this file.\n\n// js/grid.ts\nvar TEXT_SIZE = 14;\nvar CELL_SIZE = Math.round(TEXT_SIZE / 0.875);\nvar BOX_SCALE = 1.15;\nvar FONT_FAMILY = \"monospace\";\nvar BOX_FONT = `${CELL_SIZE}px ${FONT_FAMILY}`;\nvar TEXT_FONT = `${TEXT_SIZE}px ${FONT_FAMILY}`;\nfunction cellFont(size, cell) {\n  const style = cell.bold && cell.italic ? \"bold italic\" : cell.bold ? \"bold\" : cell.italic ? \"italic\" : \"\";\n  return style ? `${style} ${size}px ${FONT_FAMILY}` : `${size}px ${FONT_FAMILY}`;\n}\nfunction measure(ctx, font, text) {\n  ctx.font = font;\n  ctx.textAlign = \"left\";\n  ctx.textBaseline = \"alphabetic\";\n  return ctx.measureText(text);\n}\nfunction isBoxLike(ch) {\n  if (!ch || ch === \" \") return false;\n  const cp = ch.codePointAt(0);\n  return cp >= 9472 && cp <= 9599 || // box drawing\n  cp >= 9600 && cp <= 9631 || // block elements\n  cp >= 10240 && cp <= 10495;\n}\nfunction makeGridMetrics(ctx) {\n  const block = measure(ctx, BOX_FONT, \"\\u2588\");\n  const cellW = Math.ceil(block.actualBoundingBoxLeft + block.actualBoundingBoxRight);\n  const cellH = Math.ceil(block.actualBoundingBoxAscent + block.actualBoundingBoxDescent);\n  const boxDrawX = block.actualBoundingBoxLeft;\n  const boxDrawY = block.actualBoundingBoxAscent;\n  const textProbe = measure(ctx, TEXT_FONT, \"Mg\");\n  const textMono = measure(ctx, TEXT_FONT, \"M\");\n  const textAscent = textProbe.emHeightAscent ?? textProbe.fontBoundingBoxAscent ?? textProbe.actualBoundingBoxAscent;\n  const textDescent = textProbe.emHeightDescent ?? textProbe.fontBoundingBoxDescent ?? textProbe.actualBoundingBoxDescent;\n  const textX = Math.round((cellW - textMono.width) / 2);\n  const textBaseline = Math.round((cellH + textAscent - textDescent) / 2) + 1;\n  return { cellW, cellH, boxDrawX, boxDrawY, textX, textBaseline };\n}\n\n// js/glyphs.ts\nvar GLYPH_SPLIT = /* @__PURE__ */ new Map([\n  // Pure-heavy lines and half-lines: map to their light/rounded equivalents\n  [9473, [9472, void 0]],\n  [9475, [9474, void 0]],\n  [9477, [9476, void 0]],\n  [9479, [9478, void 0]],\n  [9481, [9480, void 0]],\n  [9483, [9482, void 0]],\n  [9592, [9588, void 0]],\n  [9593, [9589, void 0]],\n  [9594, [9590, void 0]],\n  [9595, [9591, void 0]],\n  // Pure-heavy corners\n  [9487, [9581, void 0]],\n  [9491, [9582, void 0]],\n  [9495, [9584, void 0]],\n  [9499, [9583, void 0]],\n  // Pure-heavy tees and cross\n  [9507, [9500, void 0]],\n  [9515, [9508, void 0]],\n  [9523, [9516, void 0]],\n  [9531, [9524, void 0]],\n  [9547, [9532, void 0]],\n  // Mixed-weight corners (one heavy arm, one light arm)\n  [9485, [9590, 9591]],\n  [9486, [9591, 9590]],\n  [9489, [9588, 9591]],\n  [9490, [9591, 9588]],\n  [9493, [9590, 9589]],\n  [9494, [9589, 9590]],\n  [9497, [9588, 9589]],\n  [9498, [9589, 9588]],\n  // Mixed-weight tees (heavy stem, mixed crossbar)\n  [9501, [9590, 9474]],\n  [9502, [9589, 9484]],\n  [9503, [9591, 9492]],\n  [9504, [9474, 9590]],\n  [9505, [9492, 9591]],\n  [9506, [9484, 9589]],\n  [9509, [9588, 9474]],\n  [9510, [9589, 9488]],\n  [9511, [9591, 9496]],\n  [9512, [9474, 9588]],\n  [9513, [9496, 9591]],\n  [9514, [9488, 9589]],\n  [9517, [9588, 9484]],\n  [9518, [9590, 9488]],\n  [9519, [9472, 9591]],\n  [9520, [9591, 9472]],\n  [9521, [9488, 9590]],\n  [9522, [9484, 9588]],\n  [9525, [9588, 9492]],\n  [9526, [9590, 9496]],\n  [9527, [9472, 9589]],\n  [9528, [9589, 9472]],\n  [9529, [9496, 9590]],\n  [9530, [9492, 9588]],\n  // Mixed-weight crosses\n  [9533, [9588, 9500]],\n  [9534, [9590, 9508]],\n  [9535, [9472, 9474]],\n  [9536, [9589, 9516]],\n  [9537, [9591, 9524]],\n  [9538, [9474, 9472]],\n  [9539, [9496, 9484]],\n  [9540, [9492, 9488]],\n  [9541, [9488, 9492]],\n  [9542, [9484, 9496]],\n  [9543, [9524, 9591]],\n  [9544, [9516, 9589]],\n  [9545, [9508, 9590]],\n  [9546, [9500, 9588]]\n]);\nvar NODE_GLYPH_CP = 9679;\n\n// js/renderer.ts\nfunction drawSplitGlyph(ctx, heavyCp, lightCp, px, py, cellW, cellH, boxDrawX, boxDrawY, fg, neutral_fg, boxFont) {\n  ctx.save();\n  ctx.beginPath();\n  ctx.rect(px, py, cellW, cellH);\n  ctx.clip();\n  if (lightCp !== void 0) {\n    ctx.fillStyle = neutral_fg;\n    ctx.font = boxFont;\n    ctx.save();\n    ctx.translate(px + cellW / 2, py + cellH / 2);\n    ctx.scale(BOX_SCALE, BOX_SCALE);\n    ctx.fillText(String.fromCodePoint(lightCp), boxDrawX - cellW / 2, boxDrawY - cellH / 2);\n    ctx.restore();\n  }\n  ctx.fillStyle = fg;\n  ctx.font = boxFont;\n  ctx.save();\n  ctx.translate(px + cellW / 2, py + cellH / 2);\n  ctx.scale(BOX_SCALE, BOX_SCALE);\n  ctx.fillText(String.fromCodePoint(heavyCp), boxDrawX - cellW / 2, boxDrawY - cellH / 2);\n  ctx.restore();\n  ctx.restore();\n}\nfunction paintFrame(ctx, canvas, grid, frame) {\n  const nodeCells = /* @__PURE__ */ new Set();\n  if (!frame?.cells) return nodeCells;\n  const { cellW, cellH, boxDrawX, boxDrawY, textX, textBaseline } = grid;\n  const { cols, rows, cells, neutral_fg = \"#cdd6f4\", neutral_bg = \"#1e1e2e\" } = frame;\n  canvas.width = cols * cellW;\n  canvas.height = rows * cellH;\n  ctx.fillStyle = neutral_bg;\n  ctx.fillRect(0, 0, canvas.width, canvas.height);\n  ctx.textAlign = \"left\";\n  ctx.textBaseline = \"alphabetic\";\n  for (const cell of cells) {\n    const { x: c, y: r, text } = cell;\n    const fg = cell.fg ?? neutral_fg;\n    const bg = cell.bg ?? neutral_bg;\n    const px = c * cellW;\n    const py = r * cellH;\n    if (!text || text === \" \") continue;\n    const cp = text.codePointAt(0);\n    if (!isBoxLike(text)) nodeCells.add(`${c},${r}`);\n    if (cp === NODE_GLYPH_CP) {\n      if (bg !== neutral_bg) {\n        ctx.fillStyle = bg;\n        ctx.fillRect(px, py, cellW, cellH);\n      }\n      ctx.fillStyle = fg;\n      ctx.beginPath();\n      ctx.arc(px + cellW / 2, py + cellH / 2, cellW / 2, 0, Math.PI * 2);\n      ctx.fill();\n      continue;\n    }\n    if (bg !== neutral_bg) {\n      ctx.fillStyle = bg;\n      ctx.fillRect(px, py, cellW, cellH);\n    }\n    const split = GLYPH_SPLIT.get(cp);\n    if (split !== void 0) {\n      const [heavyCp, lightCp] = split;\n      const boxFont = cellFont(CELL_SIZE, { bold: false, italic: !!cell.italic });\n      drawSplitGlyph(ctx, heavyCp, lightCp, px, py, cellW, cellH, boxDrawX, boxDrawY, fg, neutral_fg, boxFont);\n    } else if (isBoxLike(text)) {\n      ctx.fillStyle = fg;\n      ctx.font = cellFont(CELL_SIZE, cell);\n      ctx.save();\n      ctx.beginPath();\n      ctx.rect(px, py, cellW, cellH);\n      ctx.clip();\n      ctx.translate(px + cellW / 2, py + cellH / 2);\n      ctx.scale(BOX_SCALE, BOX_SCALE);\n      ctx.fillText(text, boxDrawX - cellW / 2, boxDrawY - cellH / 2);\n      ctx.restore();\n    } else {\n      ctx.fillStyle = fg;\n      ctx.font = cellFont(TEXT_SIZE, cell);\n      ctx.fillText(text, px + textX, py + textBaseline);\n    }\n    if (cell.underline) {\n      ctx.fillStyle = fg;\n      const underlineY = Math.min(py + cellH - 1, py + textBaseline + 1);\n      ctx.fillRect(px, underlineY, cellW, 1);\n    }\n  }\n  return nodeCells;\n}\n\n// js/interaction.ts\nvar DRAG_THRESHOLD = 4;\nfunction attachInteraction(canvas, model, grid, getNodeCells, isFrozen) {\n  const { cellW, cellH } = grid;\n  canvas.addEventListener(\"mousemove\", (e) => {\n    if (isFrozen()) return;\n    if (pointerDown) return;\n    const rect = canvas.getBoundingClientRect();\n    const col = Math.floor((e.clientX - rect.left) / cellW);\n    const row = Math.floor((e.clientY - rect.top) / cellH);\n    canvas.style.cursor = getNodeCells().has(`${col},${row}`) ? \"pointer\" : \"grab\";\n  });\n  let pointerDown = false;\n  let isDragging = false;\n  let dragStartX = 0;\n  let dragStartY = 0;\n  let lastDragX = 0;\n  let lastDragY = 0;\n  let dragRemX = 0;\n  let dragRemY = 0;\n  canvas.addEventListener(\"mousedown\", (e) => {\n    if (isFrozen() || e.button !== 0) return;\n    pointerDown = true;\n    isDragging = false;\n    dragStartX = lastDragX = e.clientX;\n    dragStartY = lastDragY = e.clientY;\n    dragRemX = 0;\n    dragRemY = 0;\n    e.preventDefault();\n  });\n  window.addEventListener(\"mousemove\", (e) => {\n    if (!pointerDown) return;\n    const totalDx = e.clientX - dragStartX;\n    const totalDy = e.clientY - dragStartY;\n    if (!isDragging && (Math.abs(totalDx) > DRAG_THRESHOLD || Math.abs(totalDy) > DRAG_THRESHOLD)) {\n      isDragging = true;\n      canvas.style.cursor = \"grabbing\";\n    }\n    if (isDragging) {\n      dragRemX += e.clientX - lastDragX;\n      dragRemY += e.clientY - lastDragY;\n      const termDx = Math.trunc(dragRemX / cellW);\n      const termDy = Math.trunc(dragRemY / cellH);\n      if (termDx !== 0 || termDy !== 0) {\n        model.send({ type: \"pan\", dx: termDx, dy: termDy });\n        dragRemX -= termDx * cellW;\n        dragRemY -= termDy * cellH;\n      }\n    }\n    lastDragX = e.clientX;\n    lastDragY = e.clientY;\n  });\n  window.addEventListener(\"mouseup\", (e) => {\n    if (!pointerDown || e.button !== 0) return;\n    if (!isDragging) {\n      const rect = canvas.getBoundingClientRect();\n      const col = Math.floor((e.clientX - rect.left) / cellW);\n      const row = Math.floor((e.clientY - rect.top) / cellH);\n      model.send({ type: \"mouse_click\", col, row, button: e.button });\n    }\n    pointerDown = false;\n    isDragging = false;\n    canvas.style.cursor = \"grab\";\n  });\n}\n\n// js/index.ts\nfunction render({ model, el }) {\n  const scratch = document.createElement(\"canvas\");\n  const scratchCtx = scratch.getContext(\"2d\");\n  const grid = makeGridMetrics(scratchCtx);\n  const wrapper = document.createElement(\"div\");\n  wrapper.style.cssText = \"position: relative; display: inline-block; line-height: 0;\";\n  const canvas = document.createElement(\"canvas\");\n  canvas.style.cssText = \"display: block; cursor: grab; border: 2px solid #45475a;\";\n  const sharedBtnStyle = [\n    \"width: 24px\",\n    \"height: 24px\",\n    \"font-size: 16px\",\n    \"line-height: 1\",\n    \"cursor: pointer\",\n    \"background: rgba(30,30,46,0.85)\",\n    \"color: #cdd6f4\",\n    \"border: 1px solid #45475a\",\n    \"border-radius: 4px\",\n    \"display: flex\",\n    \"align-items: center\",\n    \"justify-content: center\",\n    \"user-select: none\",\n    \"padding: 0\"\n  ].join(\"; \");\n  const btnContainer = document.createElement(\"div\");\n  btnContainer.style.cssText = \"position: absolute; bottom: 8px; right: 8px; display: flex; flex-direction: column; gap: 4px; z-index: 1;\";\n  const zoomInBtn = document.createElement(\"button\");\n  zoomInBtn.textContent = \"+\";\n  zoomInBtn.setAttribute(\"style\", sharedBtnStyle);\n  zoomInBtn.title = \"Zoom in (+)\";\n  const zoomOutBtn = document.createElement(\"button\");\n  zoomOutBtn.textContent = \"\\u2212\";\n  zoomOutBtn.setAttribute(\"style\", sharedBtnStyle);\n  zoomOutBtn.title = \"Zoom out (-)\";\n  btnContainer.appendChild(zoomInBtn);\n  btnContainer.appendChild(zoomOutBtn);\n  wrapper.appendChild(canvas);\n  wrapper.appendChild(btnContainer);\n  el.appendChild(wrapper);\n  const ctx = canvas.getContext(\"2d\");\n  let nodeCells = /* @__PURE__ */ new Set();\n  let frozen = false;\n  function repaint(frame) {\n    nodeCells = paintFrame(ctx, canvas, grid, frame);\n  }\n  repaint(model.get(\"frame\"));\n  model.on(\"change:frame\", () => repaint(model.get(\"frame\")));\n  model.on(\"msg:custom\", (msg) => {\n    if (msg.type !== \"freeze\") return;\n    frozen = true;\n    btnContainer.style.display = \"none\";\n    canvas.style.cursor = \"default\";\n    wrapper.style.border = \"none\";\n    const dataUrl = canvas.toDataURL(\"image/png\");\n    const img = document.createElement(\"img\");\n    img.src = dataUrl;\n    img.width = canvas.width;\n    img.height = canvas.height;\n    img.style.cssText = \"display:block;cursor:default;font-family:monospace\";\n    el.replaceChild(img, wrapper);\n    model.send({ type: \"snapshot\", data: dataUrl });\n  });\n  zoomInBtn.addEventListener(\"mousedown\", (e) => e.preventDefault());\n  zoomOutBtn.addEventListener(\"mousedown\", (e) => e.preventDefault());\n  zoomInBtn.addEventListener(\"click\", () => model.send({ type: \"zoom\", direction: \"in\" }));\n  zoomOutBtn.addEventListener(\"click\", () => model.send({ type: \"zoom\", direction: \"out\" }));\n  attachInteraction(canvas, model, grid, () => nodeCells, () => frozen);\n}\nvar index_default = { render };\nexport {\n  index_default as default\n};\n//# sourceMappingURL=jupyter_widget.js.map\n",
+       "_model_module": "anywidget",
+       "_model_module_version": "~0.9.*",
+       "_model_name": "AnyModel",
+       "_view_count": null,
+       "_view_module": "anywidget",
+       "_view_module_version": "~0.9.*",
+       "_view_name": "AnyView",
+       "cols": 60,
+       "frame": {
+        "cells": [
+         {
+          "text": "\u255f",
+          "x": 5,
+          "y": 5
+         },
+         {
+          "text": "\u2500",
+          "x": 6,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "A",
+          "x": 7,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "T",
+          "x": 8,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "C",
+          "x": 9,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "G",
+          "x": 10,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "A",
+          "x": 11,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": ".",
+          "x": 12,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": ".",
+          "x": 13,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": ".",
+          "x": 14,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "A",
+          "x": 15,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "G",
+          "x": 16,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "A",
+          "x": 17,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "G",
+          "x": 18,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "A",
+          "x": 19,
+          "y": 5
+         },
+         {
+          "text": "\u2500",
+          "x": 20,
+          "y": 5
+         },
+         {
+          "text": "\u2562",
+          "x": 21,
+          "y": 5
+         }
+        ],
+        "cols": 60,
+        "neutral_bg": "#1e1e2e",
+        "neutral_fg": "#cdd6f4",
+        "rows": 12
+       },
+       "layout": "IPY_MODEL_f27e08ca99fd47498d2c78eec8530679",
+       "rows": 12,
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "c1655b639c72468d959cfe1f5f5c7ecf": {
+      "model_module": "anywidget",
+      "model_module_version": "~0.9.*",
+      "model_name": "AnyModel",
+      "state": {
+       "_anywidget_id": "gen.jupyter_widget.GenGraphWidget",
+       "_dom_classes": [],
+       "_esm": "// Generated from js/index.ts by `npm run build` / `make jupyter`. Edit TypeScript sources, not this file.\n\n// js/grid.ts\nvar TEXT_SIZE = 14;\nvar CELL_SIZE = Math.round(TEXT_SIZE / 0.875);\nvar BOX_SCALE = 1.15;\nvar FONT_FAMILY = \"monospace\";\nvar BOX_FONT = `${CELL_SIZE}px ${FONT_FAMILY}`;\nvar TEXT_FONT = `${TEXT_SIZE}px ${FONT_FAMILY}`;\nfunction cellFont(size, cell) {\n  const style = cell.bold && cell.italic ? \"bold italic\" : cell.bold ? \"bold\" : cell.italic ? \"italic\" : \"\";\n  return style ? `${style} ${size}px ${FONT_FAMILY}` : `${size}px ${FONT_FAMILY}`;\n}\nfunction measure(ctx, font, text) {\n  ctx.font = font;\n  ctx.textAlign = \"left\";\n  ctx.textBaseline = \"alphabetic\";\n  return ctx.measureText(text);\n}\nfunction isBoxLike(ch) {\n  if (!ch || ch === \" \") return false;\n  const cp = ch.codePointAt(0);\n  return cp >= 9472 && cp <= 9599 || // box drawing\n  cp >= 9600 && cp <= 9631 || // block elements\n  cp >= 10240 && cp <= 10495;\n}\nfunction makeGridMetrics(ctx) {\n  const block = measure(ctx, BOX_FONT, \"\\u2588\");\n  const cellW = Math.ceil(block.actualBoundingBoxLeft + block.actualBoundingBoxRight);\n  const cellH = Math.ceil(block.actualBoundingBoxAscent + block.actualBoundingBoxDescent);\n  const boxDrawX = block.actualBoundingBoxLeft;\n  const boxDrawY = block.actualBoundingBoxAscent;\n  const textProbe = measure(ctx, TEXT_FONT, \"Mg\");\n  const textMono = measure(ctx, TEXT_FONT, \"M\");\n  const textAscent = textProbe.emHeightAscent ?? textProbe.fontBoundingBoxAscent ?? textProbe.actualBoundingBoxAscent;\n  const textDescent = textProbe.emHeightDescent ?? textProbe.fontBoundingBoxDescent ?? textProbe.actualBoundingBoxDescent;\n  const textX = Math.round((cellW - textMono.width) / 2);\n  const textBaseline = Math.round((cellH + textAscent - textDescent) / 2) + 1;\n  return { cellW, cellH, boxDrawX, boxDrawY, textX, textBaseline };\n}\n\n// js/glyphs.ts\nvar GLYPH_SPLIT = /* @__PURE__ */ new Map([\n  // Pure-heavy lines and half-lines: map to their light/rounded equivalents\n  [9473, [9472, void 0]],\n  [9475, [9474, void 0]],\n  [9477, [9476, void 0]],\n  [9479, [9478, void 0]],\n  [9481, [9480, void 0]],\n  [9483, [9482, void 0]],\n  [9592, [9588, void 0]],\n  [9593, [9589, void 0]],\n  [9594, [9590, void 0]],\n  [9595, [9591, void 0]],\n  // Pure-heavy corners\n  [9487, [9581, void 0]],\n  [9491, [9582, void 0]],\n  [9495, [9584, void 0]],\n  [9499, [9583, void 0]],\n  // Pure-heavy tees and cross\n  [9507, [9500, void 0]],\n  [9515, [9508, void 0]],\n  [9523, [9516, void 0]],\n  [9531, [9524, void 0]],\n  [9547, [9532, void 0]],\n  // Mixed-weight corners (one heavy arm, one light arm)\n  [9485, [9590, 9591]],\n  [9486, [9591, 9590]],\n  [9489, [9588, 9591]],\n  [9490, [9591, 9588]],\n  [9493, [9590, 9589]],\n  [9494, [9589, 9590]],\n  [9497, [9588, 9589]],\n  [9498, [9589, 9588]],\n  // Mixed-weight tees (heavy stem, mixed crossbar)\n  [9501, [9590, 9474]],\n  [9502, [9589, 9484]],\n  [9503, [9591, 9492]],\n  [9504, [9474, 9590]],\n  [9505, [9492, 9591]],\n  [9506, [9484, 9589]],\n  [9509, [9588, 9474]],\n  [9510, [9589, 9488]],\n  [9511, [9591, 9496]],\n  [9512, [9474, 9588]],\n  [9513, [9496, 9591]],\n  [9514, [9488, 9589]],\n  [9517, [9588, 9484]],\n  [9518, [9590, 9488]],\n  [9519, [9472, 9591]],\n  [9520, [9591, 9472]],\n  [9521, [9488, 9590]],\n  [9522, [9484, 9588]],\n  [9525, [9588, 9492]],\n  [9526, [9590, 9496]],\n  [9527, [9472, 9589]],\n  [9528, [9589, 9472]],\n  [9529, [9496, 9590]],\n  [9530, [9492, 9588]],\n  // Mixed-weight crosses\n  [9533, [9588, 9500]],\n  [9534, [9590, 9508]],\n  [9535, [9472, 9474]],\n  [9536, [9589, 9516]],\n  [9537, [9591, 9524]],\n  [9538, [9474, 9472]],\n  [9539, [9496, 9484]],\n  [9540, [9492, 9488]],\n  [9541, [9488, 9492]],\n  [9542, [9484, 9496]],\n  [9543, [9524, 9591]],\n  [9544, [9516, 9589]],\n  [9545, [9508, 9590]],\n  [9546, [9500, 9588]]\n]);\nvar NODE_GLYPH_CP = 9679;\n\n// js/renderer.ts\nfunction drawSplitGlyph(ctx, heavyCp, lightCp, px, py, cellW, cellH, boxDrawX, boxDrawY, fg, neutral_fg, boxFont) {\n  ctx.save();\n  ctx.beginPath();\n  ctx.rect(px, py, cellW, cellH);\n  ctx.clip();\n  if (lightCp !== void 0) {\n    ctx.fillStyle = neutral_fg;\n    ctx.font = boxFont;\n    ctx.save();\n    ctx.translate(px + cellW / 2, py + cellH / 2);\n    ctx.scale(BOX_SCALE, BOX_SCALE);\n    ctx.fillText(String.fromCodePoint(lightCp), boxDrawX - cellW / 2, boxDrawY - cellH / 2);\n    ctx.restore();\n  }\n  ctx.fillStyle = fg;\n  ctx.font = boxFont;\n  ctx.save();\n  ctx.translate(px + cellW / 2, py + cellH / 2);\n  ctx.scale(BOX_SCALE, BOX_SCALE);\n  ctx.fillText(String.fromCodePoint(heavyCp), boxDrawX - cellW / 2, boxDrawY - cellH / 2);\n  ctx.restore();\n  ctx.restore();\n}\nfunction paintFrame(ctx, canvas, grid, frame) {\n  const nodeCells = /* @__PURE__ */ new Set();\n  if (!frame?.cells) return nodeCells;\n  const { cellW, cellH, boxDrawX, boxDrawY, textX, textBaseline } = grid;\n  const { cols, rows, cells, neutral_fg = \"#cdd6f4\", neutral_bg = \"#1e1e2e\" } = frame;\n  canvas.width = cols * cellW;\n  canvas.height = rows * cellH;\n  ctx.fillStyle = neutral_bg;\n  ctx.fillRect(0, 0, canvas.width, canvas.height);\n  ctx.textAlign = \"left\";\n  ctx.textBaseline = \"alphabetic\";\n  for (const cell of cells) {\n    const { x: c, y: r, text } = cell;\n    const fg = cell.fg ?? neutral_fg;\n    const bg = cell.bg ?? neutral_bg;\n    const px = c * cellW;\n    const py = r * cellH;\n    if (!text || text === \" \") continue;\n    const cp = text.codePointAt(0);\n    if (!isBoxLike(text)) nodeCells.add(`${c},${r}`);\n    if (cp === NODE_GLYPH_CP) {\n      if (bg !== neutral_bg) {\n        ctx.fillStyle = bg;\n        ctx.fillRect(px, py, cellW, cellH);\n      }\n      ctx.fillStyle = fg;\n      ctx.beginPath();\n      ctx.arc(px + cellW / 2, py + cellH / 2, cellW / 2, 0, Math.PI * 2);\n      ctx.fill();\n      continue;\n    }\n    if (bg !== neutral_bg) {\n      ctx.fillStyle = bg;\n      ctx.fillRect(px, py, cellW, cellH);\n    }\n    const split = GLYPH_SPLIT.get(cp);\n    if (split !== void 0) {\n      const [heavyCp, lightCp] = split;\n      const boxFont = cellFont(CELL_SIZE, { bold: false, italic: !!cell.italic });\n      drawSplitGlyph(ctx, heavyCp, lightCp, px, py, cellW, cellH, boxDrawX, boxDrawY, fg, neutral_fg, boxFont);\n    } else if (isBoxLike(text)) {\n      ctx.fillStyle = fg;\n      ctx.font = cellFont(CELL_SIZE, cell);\n      ctx.save();\n      ctx.beginPath();\n      ctx.rect(px, py, cellW, cellH);\n      ctx.clip();\n      ctx.translate(px + cellW / 2, py + cellH / 2);\n      ctx.scale(BOX_SCALE, BOX_SCALE);\n      ctx.fillText(text, boxDrawX - cellW / 2, boxDrawY - cellH / 2);\n      ctx.restore();\n    } else {\n      ctx.fillStyle = fg;\n      ctx.font = cellFont(TEXT_SIZE, cell);\n      ctx.fillText(text, px + textX, py + textBaseline);\n    }\n    if (cell.underline) {\n      ctx.fillStyle = fg;\n      const underlineY = Math.min(py + cellH - 1, py + textBaseline + 1);\n      ctx.fillRect(px, underlineY, cellW, 1);\n    }\n  }\n  return nodeCells;\n}\n\n// js/interaction.ts\nvar DRAG_THRESHOLD = 4;\nfunction attachInteraction(canvas, model, grid, getNodeCells, isFrozen) {\n  const { cellW, cellH } = grid;\n  canvas.addEventListener(\"mousemove\", (e) => {\n    if (isFrozen()) return;\n    if (pointerDown) return;\n    const rect = canvas.getBoundingClientRect();\n    const col = Math.floor((e.clientX - rect.left) / cellW);\n    const row = Math.floor((e.clientY - rect.top) / cellH);\n    canvas.style.cursor = getNodeCells().has(`${col},${row}`) ? \"pointer\" : \"grab\";\n  });\n  let pointerDown = false;\n  let isDragging = false;\n  let dragStartX = 0;\n  let dragStartY = 0;\n  let lastDragX = 0;\n  let lastDragY = 0;\n  let dragRemX = 0;\n  let dragRemY = 0;\n  canvas.addEventListener(\"mousedown\", (e) => {\n    if (isFrozen() || e.button !== 0) return;\n    pointerDown = true;\n    isDragging = false;\n    dragStartX = lastDragX = e.clientX;\n    dragStartY = lastDragY = e.clientY;\n    dragRemX = 0;\n    dragRemY = 0;\n    e.preventDefault();\n  });\n  window.addEventListener(\"mousemove\", (e) => {\n    if (!pointerDown) return;\n    const totalDx = e.clientX - dragStartX;\n    const totalDy = e.clientY - dragStartY;\n    if (!isDragging && (Math.abs(totalDx) > DRAG_THRESHOLD || Math.abs(totalDy) > DRAG_THRESHOLD)) {\n      isDragging = true;\n      canvas.style.cursor = \"grabbing\";\n    }\n    if (isDragging) {\n      dragRemX += e.clientX - lastDragX;\n      dragRemY += e.clientY - lastDragY;\n      const termDx = Math.trunc(dragRemX / cellW);\n      const termDy = Math.trunc(dragRemY / cellH);\n      if (termDx !== 0 || termDy !== 0) {\n        model.send({ type: \"pan\", dx: termDx, dy: termDy });\n        dragRemX -= termDx * cellW;\n        dragRemY -= termDy * cellH;\n      }\n    }\n    lastDragX = e.clientX;\n    lastDragY = e.clientY;\n  });\n  window.addEventListener(\"mouseup\", (e) => {\n    if (!pointerDown || e.button !== 0) return;\n    if (!isDragging) {\n      const rect = canvas.getBoundingClientRect();\n      const col = Math.floor((e.clientX - rect.left) / cellW);\n      const row = Math.floor((e.clientY - rect.top) / cellH);\n      model.send({ type: \"mouse_click\", col, row, button: e.button });\n    }\n    pointerDown = false;\n    isDragging = false;\n    canvas.style.cursor = \"grab\";\n  });\n}\n\n// js/index.ts\nfunction render({ model, el }) {\n  const scratch = document.createElement(\"canvas\");\n  const scratchCtx = scratch.getContext(\"2d\");\n  const grid = makeGridMetrics(scratchCtx);\n  const wrapper = document.createElement(\"div\");\n  wrapper.style.cssText = \"position: relative; display: inline-block; line-height: 0;\";\n  const canvas = document.createElement(\"canvas\");\n  canvas.style.cssText = \"display: block; cursor: grab; border: 2px solid #45475a;\";\n  const sharedBtnStyle = [\n    \"width: 24px\",\n    \"height: 24px\",\n    \"font-size: 16px\",\n    \"line-height: 1\",\n    \"cursor: pointer\",\n    \"background: rgba(30,30,46,0.85)\",\n    \"color: #cdd6f4\",\n    \"border: 1px solid #45475a\",\n    \"border-radius: 4px\",\n    \"display: flex\",\n    \"align-items: center\",\n    \"justify-content: center\",\n    \"user-select: none\",\n    \"padding: 0\"\n  ].join(\"; \");\n  const btnContainer = document.createElement(\"div\");\n  btnContainer.style.cssText = \"position: absolute; bottom: 8px; right: 8px; display: flex; flex-direction: column; gap: 4px; z-index: 1;\";\n  const zoomInBtn = document.createElement(\"button\");\n  zoomInBtn.textContent = \"+\";\n  zoomInBtn.setAttribute(\"style\", sharedBtnStyle);\n  zoomInBtn.title = \"Zoom in (+)\";\n  const zoomOutBtn = document.createElement(\"button\");\n  zoomOutBtn.textContent = \"\\u2212\";\n  zoomOutBtn.setAttribute(\"style\", sharedBtnStyle);\n  zoomOutBtn.title = \"Zoom out (-)\";\n  btnContainer.appendChild(zoomInBtn);\n  btnContainer.appendChild(zoomOutBtn);\n  wrapper.appendChild(canvas);\n  wrapper.appendChild(btnContainer);\n  el.appendChild(wrapper);\n  const ctx = canvas.getContext(\"2d\");\n  let nodeCells = /* @__PURE__ */ new Set();\n  let frozen = false;\n  function repaint(frame) {\n    nodeCells = paintFrame(ctx, canvas, grid, frame);\n  }\n  repaint(model.get(\"frame\"));\n  model.on(\"change:frame\", () => repaint(model.get(\"frame\")));\n  model.on(\"msg:custom\", (msg) => {\n    if (msg.type !== \"freeze\") return;\n    frozen = true;\n    btnContainer.style.display = \"none\";\n    canvas.style.cursor = \"default\";\n    wrapper.style.border = \"none\";\n    const dataUrl = canvas.toDataURL(\"image/png\");\n    const img = document.createElement(\"img\");\n    img.src = dataUrl;\n    img.width = canvas.width;\n    img.height = canvas.height;\n    img.style.cssText = \"display:block;cursor:default;font-family:monospace\";\n    el.replaceChild(img, wrapper);\n    model.send({ type: \"snapshot\", data: dataUrl });\n  });\n  zoomInBtn.addEventListener(\"mousedown\", (e) => e.preventDefault());\n  zoomOutBtn.addEventListener(\"mousedown\", (e) => e.preventDefault());\n  zoomInBtn.addEventListener(\"click\", () => model.send({ type: \"zoom\", direction: \"in\" }));\n  zoomOutBtn.addEventListener(\"click\", () => model.send({ type: \"zoom\", direction: \"out\" }));\n  attachInteraction(canvas, model, grid, () => nodeCells, () => frozen);\n}\nvar index_default = { render };\nexport {\n  index_default as default\n};\n//# sourceMappingURL=jupyter_widget.js.map\n",
+       "_model_module": "anywidget",
+       "_model_module_version": "~0.9.*",
+       "_model_name": "AnyModel",
+       "_view_count": null,
+       "_view_module": "anywidget",
+       "_view_module_version": "~0.9.*",
+       "_view_name": "AnyView",
+       "cols": 60,
+       "frame": {
+        "cells": [
+         {
+          "text": "\u255f",
+          "x": 5,
+          "y": 5
+         },
+         {
+          "text": "\u2500",
+          "x": 6,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "a",
+          "x": 7,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "t",
+          "x": 8,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "g",
+          "x": 9,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "g",
+          "x": 10,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "g",
+          "x": 11,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": ".",
+          "x": 12,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": ".",
+          "x": 13,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": ".",
+          "x": 14,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "a",
+          "x": 15,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "g",
+          "x": 16,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "t",
+          "x": 17,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "g",
+          "x": 18,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "a",
+          "x": 19,
+          "y": 5
+         },
+         {
+          "text": "\u2500",
+          "x": 20,
+          "y": 5
+         },
+         {
+          "text": "\u2562",
+          "x": 21,
+          "y": 5
+         }
+        ],
+        "cols": 60,
+        "neutral_bg": "#1e1e2e",
+        "neutral_fg": "#cdd6f4",
+        "rows": 12
+       },
+       "layout": "IPY_MODEL_fb8e4870aacb4f5e8d00f1fbb2b86c54",
+       "rows": 12,
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "cf2ea6b44bad45449ea322bdeb120f1e": {
+      "model_module": "anywidget",
+      "model_module_version": "~0.9.*",
+      "model_name": "AnyModel",
+      "state": {
+       "_anywidget_id": "gen.jupyter_widget.GenGraphWidget",
+       "_dom_classes": [],
+       "_esm": "// Generated from js/index.ts by `npm run build` / `make jupyter`. Edit TypeScript sources, not this file.\n\n// js/grid.ts\nvar TEXT_SIZE = 14;\nvar CELL_SIZE = Math.round(TEXT_SIZE / 0.875);\nvar BOX_SCALE = 1.15;\nvar FONT_FAMILY = \"monospace\";\nvar BOX_FONT = `${CELL_SIZE}px ${FONT_FAMILY}`;\nvar TEXT_FONT = `${TEXT_SIZE}px ${FONT_FAMILY}`;\nfunction cellFont(size, cell) {\n  const style = cell.bold && cell.italic ? \"bold italic\" : cell.bold ? \"bold\" : cell.italic ? \"italic\" : \"\";\n  return style ? `${style} ${size}px ${FONT_FAMILY}` : `${size}px ${FONT_FAMILY}`;\n}\nfunction measure(ctx, font, text) {\n  ctx.font = font;\n  ctx.textAlign = \"left\";\n  ctx.textBaseline = \"alphabetic\";\n  return ctx.measureText(text);\n}\nfunction isBoxLike(ch) {\n  if (!ch || ch === \" \") return false;\n  const cp = ch.codePointAt(0);\n  return cp >= 9472 && cp <= 9599 || // box drawing\n  cp >= 9600 && cp <= 9631 || // block elements\n  cp >= 10240 && cp <= 10495;\n}\nfunction makeGridMetrics(ctx) {\n  const block = measure(ctx, BOX_FONT, \"\\u2588\");\n  const cellW = Math.ceil(block.actualBoundingBoxLeft + block.actualBoundingBoxRight);\n  const cellH = Math.ceil(block.actualBoundingBoxAscent + block.actualBoundingBoxDescent);\n  const boxDrawX = block.actualBoundingBoxLeft;\n  const boxDrawY = block.actualBoundingBoxAscent;\n  const textProbe = measure(ctx, TEXT_FONT, \"Mg\");\n  const textMono = measure(ctx, TEXT_FONT, \"M\");\n  const textAscent = textProbe.emHeightAscent ?? textProbe.fontBoundingBoxAscent ?? textProbe.actualBoundingBoxAscent;\n  const textDescent = textProbe.emHeightDescent ?? textProbe.fontBoundingBoxDescent ?? textProbe.actualBoundingBoxDescent;\n  const textX = Math.round((cellW - textMono.width) / 2);\n  const textBaseline = Math.round((cellH + textAscent - textDescent) / 2) + 1;\n  return { cellW, cellH, boxDrawX, boxDrawY, textX, textBaseline };\n}\n\n// js/glyphs.ts\nvar GLYPH_SPLIT = /* @__PURE__ */ new Map([\n  // Pure-heavy lines and half-lines: map to their light/rounded equivalents\n  [9473, [9472, void 0]],\n  [9475, [9474, void 0]],\n  [9477, [9476, void 0]],\n  [9479, [9478, void 0]],\n  [9481, [9480, void 0]],\n  [9483, [9482, void 0]],\n  [9592, [9588, void 0]],\n  [9593, [9589, void 0]],\n  [9594, [9590, void 0]],\n  [9595, [9591, void 0]],\n  // Pure-heavy corners\n  [9487, [9581, void 0]],\n  [9491, [9582, void 0]],\n  [9495, [9584, void 0]],\n  [9499, [9583, void 0]],\n  // Pure-heavy tees and cross\n  [9507, [9500, void 0]],\n  [9515, [9508, void 0]],\n  [9523, [9516, void 0]],\n  [9531, [9524, void 0]],\n  [9547, [9532, void 0]],\n  // Mixed-weight corners (one heavy arm, one light arm)\n  [9485, [9590, 9591]],\n  [9486, [9591, 9590]],\n  [9489, [9588, 9591]],\n  [9490, [9591, 9588]],\n  [9493, [9590, 9589]],\n  [9494, [9589, 9590]],\n  [9497, [9588, 9589]],\n  [9498, [9589, 9588]],\n  // Mixed-weight tees (heavy stem, mixed crossbar)\n  [9501, [9590, 9474]],\n  [9502, [9589, 9484]],\n  [9503, [9591, 9492]],\n  [9504, [9474, 9590]],\n  [9505, [9492, 9591]],\n  [9506, [9484, 9589]],\n  [9509, [9588, 9474]],\n  [9510, [9589, 9488]],\n  [9511, [9591, 9496]],\n  [9512, [9474, 9588]],\n  [9513, [9496, 9591]],\n  [9514, [9488, 9589]],\n  [9517, [9588, 9484]],\n  [9518, [9590, 9488]],\n  [9519, [9472, 9591]],\n  [9520, [9591, 9472]],\n  [9521, [9488, 9590]],\n  [9522, [9484, 9588]],\n  [9525, [9588, 9492]],\n  [9526, [9590, 9496]],\n  [9527, [9472, 9589]],\n  [9528, [9589, 9472]],\n  [9529, [9496, 9590]],\n  [9530, [9492, 9588]],\n  // Mixed-weight crosses\n  [9533, [9588, 9500]],\n  [9534, [9590, 9508]],\n  [9535, [9472, 9474]],\n  [9536, [9589, 9516]],\n  [9537, [9591, 9524]],\n  [9538, [9474, 9472]],\n  [9539, [9496, 9484]],\n  [9540, [9492, 9488]],\n  [9541, [9488, 9492]],\n  [9542, [9484, 9496]],\n  [9543, [9524, 9591]],\n  [9544, [9516, 9589]],\n  [9545, [9508, 9590]],\n  [9546, [9500, 9588]]\n]);\nvar NODE_GLYPH_CP = 9679;\n\n// js/renderer.ts\nfunction drawSplitGlyph(ctx, heavyCp, lightCp, px, py, cellW, cellH, boxDrawX, boxDrawY, fg, neutral_fg, boxFont) {\n  ctx.save();\n  ctx.beginPath();\n  ctx.rect(px, py, cellW, cellH);\n  ctx.clip();\n  if (lightCp !== void 0) {\n    ctx.fillStyle = neutral_fg;\n    ctx.font = boxFont;\n    ctx.save();\n    ctx.translate(px + cellW / 2, py + cellH / 2);\n    ctx.scale(BOX_SCALE, BOX_SCALE);\n    ctx.fillText(String.fromCodePoint(lightCp), boxDrawX - cellW / 2, boxDrawY - cellH / 2);\n    ctx.restore();\n  }\n  ctx.fillStyle = fg;\n  ctx.font = boxFont;\n  ctx.save();\n  ctx.translate(px + cellW / 2, py + cellH / 2);\n  ctx.scale(BOX_SCALE, BOX_SCALE);\n  ctx.fillText(String.fromCodePoint(heavyCp), boxDrawX - cellW / 2, boxDrawY - cellH / 2);\n  ctx.restore();\n  ctx.restore();\n}\nfunction paintFrame(ctx, canvas, grid, frame) {\n  const nodeCells = /* @__PURE__ */ new Set();\n  if (!frame?.cells) return nodeCells;\n  const { cellW, cellH, boxDrawX, boxDrawY, textX, textBaseline } = grid;\n  const { cols, rows, cells, neutral_fg = \"#cdd6f4\", neutral_bg = \"#1e1e2e\" } = frame;\n  canvas.width = cols * cellW;\n  canvas.height = rows * cellH;\n  ctx.fillStyle = neutral_bg;\n  ctx.fillRect(0, 0, canvas.width, canvas.height);\n  ctx.textAlign = \"left\";\n  ctx.textBaseline = \"alphabetic\";\n  for (const cell of cells) {\n    const { x: c, y: r, text } = cell;\n    const fg = cell.fg ?? neutral_fg;\n    const bg = cell.bg ?? neutral_bg;\n    const px = c * cellW;\n    const py = r * cellH;\n    if (!text || text === \" \") continue;\n    const cp = text.codePointAt(0);\n    if (!isBoxLike(text)) nodeCells.add(`${c},${r}`);\n    if (cp === NODE_GLYPH_CP) {\n      if (bg !== neutral_bg) {\n        ctx.fillStyle = bg;\n        ctx.fillRect(px, py, cellW, cellH);\n      }\n      ctx.fillStyle = fg;\n      ctx.beginPath();\n      ctx.arc(px + cellW / 2, py + cellH / 2, cellW / 2, 0, Math.PI * 2);\n      ctx.fill();\n      continue;\n    }\n    if (bg !== neutral_bg) {\n      ctx.fillStyle = bg;\n      ctx.fillRect(px, py, cellW, cellH);\n    }\n    const split = GLYPH_SPLIT.get(cp);\n    if (split !== void 0) {\n      const [heavyCp, lightCp] = split;\n      const boxFont = cellFont(CELL_SIZE, { bold: false, italic: !!cell.italic });\n      drawSplitGlyph(ctx, heavyCp, lightCp, px, py, cellW, cellH, boxDrawX, boxDrawY, fg, neutral_fg, boxFont);\n    } else if (isBoxLike(text)) {\n      ctx.fillStyle = fg;\n      ctx.font = cellFont(CELL_SIZE, cell);\n      ctx.save();\n      ctx.beginPath();\n      ctx.rect(px, py, cellW, cellH);\n      ctx.clip();\n      ctx.translate(px + cellW / 2, py + cellH / 2);\n      ctx.scale(BOX_SCALE, BOX_SCALE);\n      ctx.fillText(text, boxDrawX - cellW / 2, boxDrawY - cellH / 2);\n      ctx.restore();\n    } else {\n      ctx.fillStyle = fg;\n      ctx.font = cellFont(TEXT_SIZE, cell);\n      ctx.fillText(text, px + textX, py + textBaseline);\n    }\n    if (cell.underline) {\n      ctx.fillStyle = fg;\n      const underlineY = Math.min(py + cellH - 1, py + textBaseline + 1);\n      ctx.fillRect(px, underlineY, cellW, 1);\n    }\n  }\n  return nodeCells;\n}\n\n// js/interaction.ts\nvar DRAG_THRESHOLD = 4;\nfunction attachInteraction(canvas, model, grid, getNodeCells, isFrozen) {\n  const { cellW, cellH } = grid;\n  canvas.addEventListener(\"mousemove\", (e) => {\n    if (isFrozen()) return;\n    if (pointerDown) return;\n    const rect = canvas.getBoundingClientRect();\n    const col = Math.floor((e.clientX - rect.left) / cellW);\n    const row = Math.floor((e.clientY - rect.top) / cellH);\n    canvas.style.cursor = getNodeCells().has(`${col},${row}`) ? \"pointer\" : \"grab\";\n  });\n  let pointerDown = false;\n  let isDragging = false;\n  let dragStartX = 0;\n  let dragStartY = 0;\n  let lastDragX = 0;\n  let lastDragY = 0;\n  let dragRemX = 0;\n  let dragRemY = 0;\n  canvas.addEventListener(\"mousedown\", (e) => {\n    if (isFrozen() || e.button !== 0) return;\n    pointerDown = true;\n    isDragging = false;\n    dragStartX = lastDragX = e.clientX;\n    dragStartY = lastDragY = e.clientY;\n    dragRemX = 0;\n    dragRemY = 0;\n    e.preventDefault();\n  });\n  window.addEventListener(\"mousemove\", (e) => {\n    if (!pointerDown) return;\n    const totalDx = e.clientX - dragStartX;\n    const totalDy = e.clientY - dragStartY;\n    if (!isDragging && (Math.abs(totalDx) > DRAG_THRESHOLD || Math.abs(totalDy) > DRAG_THRESHOLD)) {\n      isDragging = true;\n      canvas.style.cursor = \"grabbing\";\n    }\n    if (isDragging) {\n      dragRemX += e.clientX - lastDragX;\n      dragRemY += e.clientY - lastDragY;\n      const termDx = Math.trunc(dragRemX / cellW);\n      const termDy = Math.trunc(dragRemY / cellH);\n      if (termDx !== 0 || termDy !== 0) {\n        model.send({ type: \"pan\", dx: termDx, dy: termDy });\n        dragRemX -= termDx * cellW;\n        dragRemY -= termDy * cellH;\n      }\n    }\n    lastDragX = e.clientX;\n    lastDragY = e.clientY;\n  });\n  window.addEventListener(\"mouseup\", (e) => {\n    if (!pointerDown || e.button !== 0) return;\n    if (!isDragging) {\n      const rect = canvas.getBoundingClientRect();\n      const col = Math.floor((e.clientX - rect.left) / cellW);\n      const row = Math.floor((e.clientY - rect.top) / cellH);\n      model.send({ type: \"mouse_click\", col, row, button: e.button });\n    }\n    pointerDown = false;\n    isDragging = false;\n    canvas.style.cursor = \"grab\";\n  });\n}\n\n// js/index.ts\nfunction render({ model, el }) {\n  const scratch = document.createElement(\"canvas\");\n  const scratchCtx = scratch.getContext(\"2d\");\n  const grid = makeGridMetrics(scratchCtx);\n  const wrapper = document.createElement(\"div\");\n  wrapper.style.cssText = \"position: relative; display: inline-block; line-height: 0;\";\n  const canvas = document.createElement(\"canvas\");\n  canvas.style.cssText = \"display: block; cursor: grab; border: 2px solid #45475a;\";\n  const sharedBtnStyle = [\n    \"width: 24px\",\n    \"height: 24px\",\n    \"font-size: 16px\",\n    \"line-height: 1\",\n    \"cursor: pointer\",\n    \"background: rgba(30,30,46,0.85)\",\n    \"color: #cdd6f4\",\n    \"border: 1px solid #45475a\",\n    \"border-radius: 4px\",\n    \"display: flex\",\n    \"align-items: center\",\n    \"justify-content: center\",\n    \"user-select: none\",\n    \"padding: 0\"\n  ].join(\"; \");\n  const btnContainer = document.createElement(\"div\");\n  btnContainer.style.cssText = \"position: absolute; bottom: 8px; right: 8px; display: flex; flex-direction: column; gap: 4px; z-index: 1;\";\n  const zoomInBtn = document.createElement(\"button\");\n  zoomInBtn.textContent = \"+\";\n  zoomInBtn.setAttribute(\"style\", sharedBtnStyle);\n  zoomInBtn.title = \"Zoom in (+)\";\n  const zoomOutBtn = document.createElement(\"button\");\n  zoomOutBtn.textContent = \"\\u2212\";\n  zoomOutBtn.setAttribute(\"style\", sharedBtnStyle);\n  zoomOutBtn.title = \"Zoom out (-)\";\n  btnContainer.appendChild(zoomInBtn);\n  btnContainer.appendChild(zoomOutBtn);\n  wrapper.appendChild(canvas);\n  wrapper.appendChild(btnContainer);\n  el.appendChild(wrapper);\n  const ctx = canvas.getContext(\"2d\");\n  let nodeCells = /* @__PURE__ */ new Set();\n  let frozen = false;\n  function repaint(frame) {\n    nodeCells = paintFrame(ctx, canvas, grid, frame);\n  }\n  repaint(model.get(\"frame\"));\n  model.on(\"change:frame\", () => repaint(model.get(\"frame\")));\n  model.on(\"msg:custom\", (msg) => {\n    if (msg.type !== \"freeze\") return;\n    frozen = true;\n    btnContainer.style.display = \"none\";\n    canvas.style.cursor = \"default\";\n    wrapper.style.border = \"none\";\n    const dataUrl = canvas.toDataURL(\"image/png\");\n    const img = document.createElement(\"img\");\n    img.src = dataUrl;\n    img.width = canvas.width;\n    img.height = canvas.height;\n    img.style.cssText = \"display:block;cursor:default;font-family:monospace\";\n    el.replaceChild(img, wrapper);\n    model.send({ type: \"snapshot\", data: dataUrl });\n  });\n  zoomInBtn.addEventListener(\"mousedown\", (e) => e.preventDefault());\n  zoomOutBtn.addEventListener(\"mousedown\", (e) => e.preventDefault());\n  zoomInBtn.addEventListener(\"click\", () => model.send({ type: \"zoom\", direction: \"in\" }));\n  zoomOutBtn.addEventListener(\"click\", () => model.send({ type: \"zoom\", direction: \"out\" }));\n  attachInteraction(canvas, model, grid, () => nodeCells, () => frozen);\n}\nvar index_default = { render };\nexport {\n  index_default as default\n};\n//# sourceMappingURL=jupyter_widget.js.map\n",
+       "_model_module": "anywidget",
+       "_model_module_version": "~0.9.*",
+       "_model_name": "AnyModel",
+       "_view_count": null,
+       "_view_module": "anywidget",
+       "_view_module_version": "~0.9.*",
+       "_view_name": "AnyView",
+       "cols": 60,
+       "frame": {
+        "cells": [
+         {
+          "text": "\u256d",
+          "x": 13,
+          "y": 4
+         },
+         {
+          "text": "\u2500",
+          "x": 14,
+          "y": 4
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "T",
+          "x": 15,
+          "y": 4
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "C",
+          "x": 16,
+          "y": 4
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "G",
+          "x": 17,
+          "y": 4
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "A",
+          "x": 18,
+          "y": 4
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "T",
+          "x": 19,
+          "y": 4
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "C",
+          "x": 20,
+          "y": 4
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "G",
+          "x": 21,
+          "y": 4
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "A",
+          "x": 22,
+          "y": 4
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "T",
+          "x": 23,
+          "y": 4
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "C",
+          "x": 24,
+          "y": 4
+         },
+         {
+          "text": "\u2500",
+          "x": 25,
+          "y": 4
+         },
+         {
+          "text": "\u256e",
+          "x": 26,
+          "y": 4
+         },
+         {
+          "text": "\u255f",
+          "x": 5,
+          "y": 5
+         },
+         {
+          "text": "\u2500",
+          "x": 6,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "A",
+          "x": 7,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "T",
+          "x": 8,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "C",
+          "x": 9,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "G",
+          "x": 10,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "A",
+          "x": 11,
+          "y": 5
+         },
+         {
+          "fg": "#f38ba8",
+          "text": "\u2501",
+          "x": 12,
+          "y": 5
+         },
+         {
+          "fg": "#f38ba8",
+          "text": "\u252a",
+          "x": 13,
+          "y": 5
+         },
+         {
+          "fg": "#f38ba8",
+          "text": "\u2522",
+          "x": 26,
+          "y": 5
+         },
+         {
+          "fg": "#f38ba8",
+          "text": "\u2501",
+          "x": 27,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "G",
+          "x": 28,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "A",
+          "x": 29,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "T",
+          "x": 30,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "C",
+          "x": 31,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "G",
+          "x": 32,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": ".",
+          "x": 33,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": ".",
+          "x": 34,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": ".",
+          "x": 35,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "A",
+          "x": 36,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "G",
+          "x": 37,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "A",
+          "x": 38,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "G",
+          "x": 39,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "A",
+          "x": 40,
+          "y": 5
+         },
+         {
+          "text": "\u2500",
+          "x": 41,
+          "y": 5
+         },
+         {
+          "text": "\u2562",
+          "x": 42,
+          "y": 5
+         },
+         {
+          "fg": "#f38ba8",
+          "text": "\u2517",
+          "x": 13,
+          "y": 6
+         },
+         {
+          "fg": "#f38ba8",
+          "text": "\u2501",
+          "x": 14,
+          "y": 6
+         },
+         {
+          "fg": "#f38ba8",
+          "text": "\u2501",
+          "x": 15,
+          "y": 6
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "T",
+          "x": 16,
+          "y": 6
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "T",
+          "x": 17,
+          "y": 6
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "T",
+          "x": 18,
+          "y": 6
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "T",
+          "x": 19,
+          "y": 6
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "T",
+          "x": 20,
+          "y": 6
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "T",
+          "x": 21,
+          "y": 6
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "T",
+          "x": 22,
+          "y": 6
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "T",
+          "x": 23,
+          "y": 6
+         },
+         {
+          "fg": "#f38ba8",
+          "text": "\u2501",
+          "x": 24,
+          "y": 6
+         },
+         {
+          "fg": "#f38ba8",
+          "text": "\u2501",
+          "x": 25,
+          "y": 6
+         },
+         {
+          "fg": "#f38ba8",
+          "text": "\u251b",
+          "x": 26,
+          "y": 6
+         }
+        ],
+        "cols": 60,
+        "neutral_bg": "#1e1e2e",
+        "neutral_fg": "#cdd6f4",
+        "rows": 12
+       },
+       "layout": "IPY_MODEL_786e10cfd60a4f89b0c020d205002964",
+       "rows": 12,
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "d780b166d202430aaf0d91bf21da2220": {
+      "model_module": "anywidget",
+      "model_module_version": "~0.9.*",
+      "model_name": "AnyModel",
+      "state": {
+       "_anywidget_id": "gen.jupyter_widget.GenGraphWidget",
+       "_dom_classes": [],
+       "_esm": "// Generated from js/index.ts by `npm run build` / `make jupyter`. Edit TypeScript sources, not this file.\n\n// js/grid.ts\nvar TEXT_SIZE = 14;\nvar CELL_SIZE = Math.round(TEXT_SIZE / 0.875);\nvar BOX_SCALE = 1.15;\nvar FONT_FAMILY = \"monospace\";\nvar BOX_FONT = `${CELL_SIZE}px ${FONT_FAMILY}`;\nvar TEXT_FONT = `${TEXT_SIZE}px ${FONT_FAMILY}`;\nfunction cellFont(size, cell) {\n  const style = cell.bold && cell.italic ? \"bold italic\" : cell.bold ? \"bold\" : cell.italic ? \"italic\" : \"\";\n  return style ? `${style} ${size}px ${FONT_FAMILY}` : `${size}px ${FONT_FAMILY}`;\n}\nfunction measure(ctx, font, text) {\n  ctx.font = font;\n  ctx.textAlign = \"left\";\n  ctx.textBaseline = \"alphabetic\";\n  return ctx.measureText(text);\n}\nfunction isBoxLike(ch) {\n  if (!ch || ch === \" \") return false;\n  const cp = ch.codePointAt(0);\n  return cp >= 9472 && cp <= 9599 || // box drawing\n  cp >= 9600 && cp <= 9631 || // block elements\n  cp >= 10240 && cp <= 10495;\n}\nfunction makeGridMetrics(ctx) {\n  const block = measure(ctx, BOX_FONT, \"\\u2588\");\n  const cellW = Math.ceil(block.actualBoundingBoxLeft + block.actualBoundingBoxRight);\n  const cellH = Math.ceil(block.actualBoundingBoxAscent + block.actualBoundingBoxDescent);\n  const boxDrawX = block.actualBoundingBoxLeft;\n  const boxDrawY = block.actualBoundingBoxAscent;\n  const textProbe = measure(ctx, TEXT_FONT, \"Mg\");\n  const textMono = measure(ctx, TEXT_FONT, \"M\");\n  const textAscent = textProbe.emHeightAscent ?? textProbe.fontBoundingBoxAscent ?? textProbe.actualBoundingBoxAscent;\n  const textDescent = textProbe.emHeightDescent ?? textProbe.fontBoundingBoxDescent ?? textProbe.actualBoundingBoxDescent;\n  const textX = Math.round((cellW - textMono.width) / 2);\n  const textBaseline = Math.round((cellH + textAscent - textDescent) / 2) + 1;\n  return { cellW, cellH, boxDrawX, boxDrawY, textX, textBaseline };\n}\n\n// js/glyphs.ts\nvar GLYPH_SPLIT = /* @__PURE__ */ new Map([\n  // Pure-heavy lines and half-lines: map to their light/rounded equivalents\n  [9473, [9472, void 0]],\n  [9475, [9474, void 0]],\n  [9477, [9476, void 0]],\n  [9479, [9478, void 0]],\n  [9481, [9480, void 0]],\n  [9483, [9482, void 0]],\n  [9592, [9588, void 0]],\n  [9593, [9589, void 0]],\n  [9594, [9590, void 0]],\n  [9595, [9591, void 0]],\n  // Pure-heavy corners\n  [9487, [9581, void 0]],\n  [9491, [9582, void 0]],\n  [9495, [9584, void 0]],\n  [9499, [9583, void 0]],\n  // Pure-heavy tees and cross\n  [9507, [9500, void 0]],\n  [9515, [9508, void 0]],\n  [9523, [9516, void 0]],\n  [9531, [9524, void 0]],\n  [9547, [9532, void 0]],\n  // Mixed-weight corners (one heavy arm, one light arm)\n  [9485, [9590, 9591]],\n  [9486, [9591, 9590]],\n  [9489, [9588, 9591]],\n  [9490, [9591, 9588]],\n  [9493, [9590, 9589]],\n  [9494, [9589, 9590]],\n  [9497, [9588, 9589]],\n  [9498, [9589, 9588]],\n  // Mixed-weight tees (heavy stem, mixed crossbar)\n  [9501, [9590, 9474]],\n  [9502, [9589, 9484]],\n  [9503, [9591, 9492]],\n  [9504, [9474, 9590]],\n  [9505, [9492, 9591]],\n  [9506, [9484, 9589]],\n  [9509, [9588, 9474]],\n  [9510, [9589, 9488]],\n  [9511, [9591, 9496]],\n  [9512, [9474, 9588]],\n  [9513, [9496, 9591]],\n  [9514, [9488, 9589]],\n  [9517, [9588, 9484]],\n  [9518, [9590, 9488]],\n  [9519, [9472, 9591]],\n  [9520, [9591, 9472]],\n  [9521, [9488, 9590]],\n  [9522, [9484, 9588]],\n  [9525, [9588, 9492]],\n  [9526, [9590, 9496]],\n  [9527, [9472, 9589]],\n  [9528, [9589, 9472]],\n  [9529, [9496, 9590]],\n  [9530, [9492, 9588]],\n  // Mixed-weight crosses\n  [9533, [9588, 9500]],\n  [9534, [9590, 9508]],\n  [9535, [9472, 9474]],\n  [9536, [9589, 9516]],\n  [9537, [9591, 9524]],\n  [9538, [9474, 9472]],\n  [9539, [9496, 9484]],\n  [9540, [9492, 9488]],\n  [9541, [9488, 9492]],\n  [9542, [9484, 9496]],\n  [9543, [9524, 9591]],\n  [9544, [9516, 9589]],\n  [9545, [9508, 9590]],\n  [9546, [9500, 9588]]\n]);\nvar NODE_GLYPH_CP = 9679;\n\n// js/renderer.ts\nfunction drawSplitGlyph(ctx, heavyCp, lightCp, px, py, cellW, cellH, boxDrawX, boxDrawY, fg, neutral_fg, boxFont) {\n  ctx.save();\n  ctx.beginPath();\n  ctx.rect(px, py, cellW, cellH);\n  ctx.clip();\n  if (lightCp !== void 0) {\n    ctx.fillStyle = neutral_fg;\n    ctx.font = boxFont;\n    ctx.save();\n    ctx.translate(px + cellW / 2, py + cellH / 2);\n    ctx.scale(BOX_SCALE, BOX_SCALE);\n    ctx.fillText(String.fromCodePoint(lightCp), boxDrawX - cellW / 2, boxDrawY - cellH / 2);\n    ctx.restore();\n  }\n  ctx.fillStyle = fg;\n  ctx.font = boxFont;\n  ctx.save();\n  ctx.translate(px + cellW / 2, py + cellH / 2);\n  ctx.scale(BOX_SCALE, BOX_SCALE);\n  ctx.fillText(String.fromCodePoint(heavyCp), boxDrawX - cellW / 2, boxDrawY - cellH / 2);\n  ctx.restore();\n  ctx.restore();\n}\nfunction paintFrame(ctx, canvas, grid, frame) {\n  const nodeCells = /* @__PURE__ */ new Set();\n  if (!frame?.cells) return nodeCells;\n  const { cellW, cellH, boxDrawX, boxDrawY, textX, textBaseline } = grid;\n  const { cols, rows, cells, neutral_fg = \"#cdd6f4\", neutral_bg = \"#1e1e2e\" } = frame;\n  canvas.width = cols * cellW;\n  canvas.height = rows * cellH;\n  ctx.fillStyle = neutral_bg;\n  ctx.fillRect(0, 0, canvas.width, canvas.height);\n  ctx.textAlign = \"left\";\n  ctx.textBaseline = \"alphabetic\";\n  for (const cell of cells) {\n    const { x: c, y: r, text } = cell;\n    const fg = cell.fg ?? neutral_fg;\n    const bg = cell.bg ?? neutral_bg;\n    const px = c * cellW;\n    const py = r * cellH;\n    if (!text || text === \" \") continue;\n    const cp = text.codePointAt(0);\n    if (!isBoxLike(text)) nodeCells.add(`${c},${r}`);\n    if (cp === NODE_GLYPH_CP) {\n      if (bg !== neutral_bg) {\n        ctx.fillStyle = bg;\n        ctx.fillRect(px, py, cellW, cellH);\n      }\n      ctx.fillStyle = fg;\n      ctx.beginPath();\n      ctx.arc(px + cellW / 2, py + cellH / 2, cellW / 2, 0, Math.PI * 2);\n      ctx.fill();\n      continue;\n    }\n    if (bg !== neutral_bg) {\n      ctx.fillStyle = bg;\n      ctx.fillRect(px, py, cellW, cellH);\n    }\n    const split = GLYPH_SPLIT.get(cp);\n    if (split !== void 0) {\n      const [heavyCp, lightCp] = split;\n      const boxFont = cellFont(CELL_SIZE, { bold: false, italic: !!cell.italic });\n      drawSplitGlyph(ctx, heavyCp, lightCp, px, py, cellW, cellH, boxDrawX, boxDrawY, fg, neutral_fg, boxFont);\n    } else if (isBoxLike(text)) {\n      ctx.fillStyle = fg;\n      ctx.font = cellFont(CELL_SIZE, cell);\n      ctx.save();\n      ctx.beginPath();\n      ctx.rect(px, py, cellW, cellH);\n      ctx.clip();\n      ctx.translate(px + cellW / 2, py + cellH / 2);\n      ctx.scale(BOX_SCALE, BOX_SCALE);\n      ctx.fillText(text, boxDrawX - cellW / 2, boxDrawY - cellH / 2);\n      ctx.restore();\n    } else {\n      ctx.fillStyle = fg;\n      ctx.font = cellFont(TEXT_SIZE, cell);\n      ctx.fillText(text, px + textX, py + textBaseline);\n    }\n    if (cell.underline) {\n      ctx.fillStyle = fg;\n      const underlineY = Math.min(py + cellH - 1, py + textBaseline + 1);\n      ctx.fillRect(px, underlineY, cellW, 1);\n    }\n  }\n  return nodeCells;\n}\n\n// js/interaction.ts\nvar DRAG_THRESHOLD = 4;\nfunction attachInteraction(canvas, model, grid, getNodeCells, isFrozen) {\n  const { cellW, cellH } = grid;\n  canvas.addEventListener(\"mousemove\", (e) => {\n    if (isFrozen()) return;\n    if (pointerDown) return;\n    const rect = canvas.getBoundingClientRect();\n    const col = Math.floor((e.clientX - rect.left) / cellW);\n    const row = Math.floor((e.clientY - rect.top) / cellH);\n    canvas.style.cursor = getNodeCells().has(`${col},${row}`) ? \"pointer\" : \"grab\";\n  });\n  let pointerDown = false;\n  let isDragging = false;\n  let dragStartX = 0;\n  let dragStartY = 0;\n  let lastDragX = 0;\n  let lastDragY = 0;\n  let dragRemX = 0;\n  let dragRemY = 0;\n  canvas.addEventListener(\"mousedown\", (e) => {\n    if (isFrozen() || e.button !== 0) return;\n    pointerDown = true;\n    isDragging = false;\n    dragStartX = lastDragX = e.clientX;\n    dragStartY = lastDragY = e.clientY;\n    dragRemX = 0;\n    dragRemY = 0;\n    e.preventDefault();\n  });\n  window.addEventListener(\"mousemove\", (e) => {\n    if (!pointerDown) return;\n    const totalDx = e.clientX - dragStartX;\n    const totalDy = e.clientY - dragStartY;\n    if (!isDragging && (Math.abs(totalDx) > DRAG_THRESHOLD || Math.abs(totalDy) > DRAG_THRESHOLD)) {\n      isDragging = true;\n      canvas.style.cursor = \"grabbing\";\n    }\n    if (isDragging) {\n      dragRemX += e.clientX - lastDragX;\n      dragRemY += e.clientY - lastDragY;\n      const termDx = Math.trunc(dragRemX / cellW);\n      const termDy = Math.trunc(dragRemY / cellH);\n      if (termDx !== 0 || termDy !== 0) {\n        model.send({ type: \"pan\", dx: termDx, dy: termDy });\n        dragRemX -= termDx * cellW;\n        dragRemY -= termDy * cellH;\n      }\n    }\n    lastDragX = e.clientX;\n    lastDragY = e.clientY;\n  });\n  window.addEventListener(\"mouseup\", (e) => {\n    if (!pointerDown || e.button !== 0) return;\n    if (!isDragging) {\n      const rect = canvas.getBoundingClientRect();\n      const col = Math.floor((e.clientX - rect.left) / cellW);\n      const row = Math.floor((e.clientY - rect.top) / cellH);\n      model.send({ type: \"mouse_click\", col, row, button: e.button });\n    }\n    pointerDown = false;\n    isDragging = false;\n    canvas.style.cursor = \"grab\";\n  });\n}\n\n// js/index.ts\nfunction render({ model, el }) {\n  const scratch = document.createElement(\"canvas\");\n  const scratchCtx = scratch.getContext(\"2d\");\n  const grid = makeGridMetrics(scratchCtx);\n  const wrapper = document.createElement(\"div\");\n  wrapper.style.cssText = \"position: relative; display: inline-block; line-height: 0;\";\n  const canvas = document.createElement(\"canvas\");\n  canvas.style.cssText = \"display: block; cursor: grab; border: 2px solid #45475a;\";\n  const sharedBtnStyle = [\n    \"width: 24px\",\n    \"height: 24px\",\n    \"font-size: 16px\",\n    \"line-height: 1\",\n    \"cursor: pointer\",\n    \"background: rgba(30,30,46,0.85)\",\n    \"color: #cdd6f4\",\n    \"border: 1px solid #45475a\",\n    \"border-radius: 4px\",\n    \"display: flex\",\n    \"align-items: center\",\n    \"justify-content: center\",\n    \"user-select: none\",\n    \"padding: 0\"\n  ].join(\"; \");\n  const btnContainer = document.createElement(\"div\");\n  btnContainer.style.cssText = \"position: absolute; bottom: 8px; right: 8px; display: flex; flex-direction: column; gap: 4px; z-index: 1;\";\n  const zoomInBtn = document.createElement(\"button\");\n  zoomInBtn.textContent = \"+\";\n  zoomInBtn.setAttribute(\"style\", sharedBtnStyle);\n  zoomInBtn.title = \"Zoom in (+)\";\n  const zoomOutBtn = document.createElement(\"button\");\n  zoomOutBtn.textContent = \"\\u2212\";\n  zoomOutBtn.setAttribute(\"style\", sharedBtnStyle);\n  zoomOutBtn.title = \"Zoom out (-)\";\n  btnContainer.appendChild(zoomInBtn);\n  btnContainer.appendChild(zoomOutBtn);\n  wrapper.appendChild(canvas);\n  wrapper.appendChild(btnContainer);\n  el.appendChild(wrapper);\n  const ctx = canvas.getContext(\"2d\");\n  let nodeCells = /* @__PURE__ */ new Set();\n  let frozen = false;\n  function repaint(frame) {\n    nodeCells = paintFrame(ctx, canvas, grid, frame);\n  }\n  repaint(model.get(\"frame\"));\n  model.on(\"change:frame\", () => repaint(model.get(\"frame\")));\n  model.on(\"msg:custom\", (msg) => {\n    if (msg.type !== \"freeze\") return;\n    frozen = true;\n    btnContainer.style.display = \"none\";\n    canvas.style.cursor = \"default\";\n    wrapper.style.border = \"none\";\n    const dataUrl = canvas.toDataURL(\"image/png\");\n    const img = document.createElement(\"img\");\n    img.src = dataUrl;\n    img.width = canvas.width;\n    img.height = canvas.height;\n    img.style.cssText = \"display:block;cursor:default;font-family:monospace\";\n    el.replaceChild(img, wrapper);\n    model.send({ type: \"snapshot\", data: dataUrl });\n  });\n  zoomInBtn.addEventListener(\"mousedown\", (e) => e.preventDefault());\n  zoomOutBtn.addEventListener(\"mousedown\", (e) => e.preventDefault());\n  zoomInBtn.addEventListener(\"click\", () => model.send({ type: \"zoom\", direction: \"in\" }));\n  zoomOutBtn.addEventListener(\"click\", () => model.send({ type: \"zoom\", direction: \"out\" }));\n  attachInteraction(canvas, model, grid, () => nodeCells, () => frozen);\n}\nvar index_default = { render };\nexport {\n  index_default as default\n};\n//# sourceMappingURL=jupyter_widget.js.map\n",
+       "_model_module": "anywidget",
+       "_model_module_version": "~0.9.*",
+       "_model_name": "AnyModel",
+       "_view_count": null,
+       "_view_module": "anywidget",
+       "_view_module_version": "~0.9.*",
+       "_view_name": "AnyView",
+       "cols": 60,
+       "frame": {
+        "cells": [
+         {
+          "text": "\u255f",
+          "x": 5,
+          "y": 5
+         },
+         {
+          "text": "\u2500",
+          "x": 6,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "A",
+          "x": 7,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "T",
+          "x": 8,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "C",
+          "x": 9,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "G",
+          "x": 10,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "A",
+          "x": 11,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": ".",
+          "x": 12,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": ".",
+          "x": 13,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": ".",
+          "x": 14,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "A",
+          "x": 15,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "G",
+          "x": 16,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "A",
+          "x": 17,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "G",
+          "x": 18,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "A",
+          "x": 19,
+          "y": 5
+         },
+         {
+          "text": "\u2500",
+          "x": 20,
+          "y": 5
+         },
+         {
+          "text": "\u2562",
+          "x": 21,
+          "y": 5
+         }
+        ],
+        "cols": 60,
+        "neutral_bg": "#1e1e2e",
+        "neutral_fg": "#cdd6f4",
+        "rows": 12
+       },
+       "layout": "IPY_MODEL_4b8493bc98fe45deb44bf6f2cd09c1b8",
+       "rows": 12,
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "eeec5f0194204ac0a168890d3ca0a13b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "efeba939e0ff4dbdaea76ead80317426": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "f27e08ca99fd47498d2c78eec8530679": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "fb8e4870aacb4f5e8d00f1fbb2b86c54": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "fd212e1357a94d29a2da8cce3041dae4": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "fee52d0c45d4446984b4d6750c18293f": {
+      "model_module": "anywidget",
+      "model_module_version": "~0.9.*",
+      "model_name": "AnyModel",
+      "state": {
+       "_anywidget_id": "gen.jupyter_widget.GenGraphWidget",
+       "_dom_classes": [],
+       "_esm": "// Generated from js/index.ts by `npm run build` / `make jupyter`. Edit TypeScript sources, not this file.\n\n// js/grid.ts\nvar TEXT_SIZE = 14;\nvar CELL_SIZE = Math.round(TEXT_SIZE / 0.875);\nvar BOX_SCALE = 1.15;\nvar FONT_FAMILY = \"monospace\";\nvar BOX_FONT = `${CELL_SIZE}px ${FONT_FAMILY}`;\nvar TEXT_FONT = `${TEXT_SIZE}px ${FONT_FAMILY}`;\nfunction cellFont(size, cell) {\n  const style = cell.bold && cell.italic ? \"bold italic\" : cell.bold ? \"bold\" : cell.italic ? \"italic\" : \"\";\n  return style ? `${style} ${size}px ${FONT_FAMILY}` : `${size}px ${FONT_FAMILY}`;\n}\nfunction measure(ctx, font, text) {\n  ctx.font = font;\n  ctx.textAlign = \"left\";\n  ctx.textBaseline = \"alphabetic\";\n  return ctx.measureText(text);\n}\nfunction isBoxLike(ch) {\n  if (!ch || ch === \" \") return false;\n  const cp = ch.codePointAt(0);\n  return cp >= 9472 && cp <= 9599 || // box drawing\n  cp >= 9600 && cp <= 9631 || // block elements\n  cp >= 10240 && cp <= 10495;\n}\nfunction makeGridMetrics(ctx) {\n  const block = measure(ctx, BOX_FONT, \"\\u2588\");\n  const cellW = Math.ceil(block.actualBoundingBoxLeft + block.actualBoundingBoxRight);\n  const cellH = Math.ceil(block.actualBoundingBoxAscent + block.actualBoundingBoxDescent);\n  const boxDrawX = block.actualBoundingBoxLeft;\n  const boxDrawY = block.actualBoundingBoxAscent;\n  const textProbe = measure(ctx, TEXT_FONT, \"Mg\");\n  const textMono = measure(ctx, TEXT_FONT, \"M\");\n  const textAscent = textProbe.emHeightAscent ?? textProbe.fontBoundingBoxAscent ?? textProbe.actualBoundingBoxAscent;\n  const textDescent = textProbe.emHeightDescent ?? textProbe.fontBoundingBoxDescent ?? textProbe.actualBoundingBoxDescent;\n  const textX = Math.round((cellW - textMono.width) / 2);\n  const textBaseline = Math.round((cellH + textAscent - textDescent) / 2) + 1;\n  return { cellW, cellH, boxDrawX, boxDrawY, textX, textBaseline };\n}\n\n// js/glyphs.ts\nvar GLYPH_SPLIT = /* @__PURE__ */ new Map([\n  // Pure-heavy lines and half-lines: map to their light/rounded equivalents\n  [9473, [9472, void 0]],\n  [9475, [9474, void 0]],\n  [9477, [9476, void 0]],\n  [9479, [9478, void 0]],\n  [9481, [9480, void 0]],\n  [9483, [9482, void 0]],\n  [9592, [9588, void 0]],\n  [9593, [9589, void 0]],\n  [9594, [9590, void 0]],\n  [9595, [9591, void 0]],\n  // Pure-heavy corners\n  [9487, [9581, void 0]],\n  [9491, [9582, void 0]],\n  [9495, [9584, void 0]],\n  [9499, [9583, void 0]],\n  // Pure-heavy tees and cross\n  [9507, [9500, void 0]],\n  [9515, [9508, void 0]],\n  [9523, [9516, void 0]],\n  [9531, [9524, void 0]],\n  [9547, [9532, void 0]],\n  // Mixed-weight corners (one heavy arm, one light arm)\n  [9485, [9590, 9591]],\n  [9486, [9591, 9590]],\n  [9489, [9588, 9591]],\n  [9490, [9591, 9588]],\n  [9493, [9590, 9589]],\n  [9494, [9589, 9590]],\n  [9497, [9588, 9589]],\n  [9498, [9589, 9588]],\n  // Mixed-weight tees (heavy stem, mixed crossbar)\n  [9501, [9590, 9474]],\n  [9502, [9589, 9484]],\n  [9503, [9591, 9492]],\n  [9504, [9474, 9590]],\n  [9505, [9492, 9591]],\n  [9506, [9484, 9589]],\n  [9509, [9588, 9474]],\n  [9510, [9589, 9488]],\n  [9511, [9591, 9496]],\n  [9512, [9474, 9588]],\n  [9513, [9496, 9591]],\n  [9514, [9488, 9589]],\n  [9517, [9588, 9484]],\n  [9518, [9590, 9488]],\n  [9519, [9472, 9591]],\n  [9520, [9591, 9472]],\n  [9521, [9488, 9590]],\n  [9522, [9484, 9588]],\n  [9525, [9588, 9492]],\n  [9526, [9590, 9496]],\n  [9527, [9472, 9589]],\n  [9528, [9589, 9472]],\n  [9529, [9496, 9590]],\n  [9530, [9492, 9588]],\n  // Mixed-weight crosses\n  [9533, [9588, 9500]],\n  [9534, [9590, 9508]],\n  [9535, [9472, 9474]],\n  [9536, [9589, 9516]],\n  [9537, [9591, 9524]],\n  [9538, [9474, 9472]],\n  [9539, [9496, 9484]],\n  [9540, [9492, 9488]],\n  [9541, [9488, 9492]],\n  [9542, [9484, 9496]],\n  [9543, [9524, 9591]],\n  [9544, [9516, 9589]],\n  [9545, [9508, 9590]],\n  [9546, [9500, 9588]]\n]);\nvar NODE_GLYPH_CP = 9679;\n\n// js/renderer.ts\nfunction drawSplitGlyph(ctx, heavyCp, lightCp, px, py, cellW, cellH, boxDrawX, boxDrawY, fg, neutral_fg, boxFont) {\n  ctx.save();\n  ctx.beginPath();\n  ctx.rect(px, py, cellW, cellH);\n  ctx.clip();\n  if (lightCp !== void 0) {\n    ctx.fillStyle = neutral_fg;\n    ctx.font = boxFont;\n    ctx.save();\n    ctx.translate(px + cellW / 2, py + cellH / 2);\n    ctx.scale(BOX_SCALE, BOX_SCALE);\n    ctx.fillText(String.fromCodePoint(lightCp), boxDrawX - cellW / 2, boxDrawY - cellH / 2);\n    ctx.restore();\n  }\n  ctx.fillStyle = fg;\n  ctx.font = boxFont;\n  ctx.save();\n  ctx.translate(px + cellW / 2, py + cellH / 2);\n  ctx.scale(BOX_SCALE, BOX_SCALE);\n  ctx.fillText(String.fromCodePoint(heavyCp), boxDrawX - cellW / 2, boxDrawY - cellH / 2);\n  ctx.restore();\n  ctx.restore();\n}\nfunction paintFrame(ctx, canvas, grid, frame) {\n  const nodeCells = /* @__PURE__ */ new Set();\n  if (!frame?.cells) return nodeCells;\n  const { cellW, cellH, boxDrawX, boxDrawY, textX, textBaseline } = grid;\n  const { cols, rows, cells, neutral_fg = \"#cdd6f4\", neutral_bg = \"#1e1e2e\" } = frame;\n  canvas.width = cols * cellW;\n  canvas.height = rows * cellH;\n  ctx.fillStyle = neutral_bg;\n  ctx.fillRect(0, 0, canvas.width, canvas.height);\n  ctx.textAlign = \"left\";\n  ctx.textBaseline = \"alphabetic\";\n  for (const cell of cells) {\n    const { x: c, y: r, text } = cell;\n    const fg = cell.fg ?? neutral_fg;\n    const bg = cell.bg ?? neutral_bg;\n    const px = c * cellW;\n    const py = r * cellH;\n    if (!text || text === \" \") continue;\n    const cp = text.codePointAt(0);\n    if (!isBoxLike(text)) nodeCells.add(`${c},${r}`);\n    if (cp === NODE_GLYPH_CP) {\n      if (bg !== neutral_bg) {\n        ctx.fillStyle = bg;\n        ctx.fillRect(px, py, cellW, cellH);\n      }\n      ctx.fillStyle = fg;\n      ctx.beginPath();\n      ctx.arc(px + cellW / 2, py + cellH / 2, cellW / 2, 0, Math.PI * 2);\n      ctx.fill();\n      continue;\n    }\n    if (bg !== neutral_bg) {\n      ctx.fillStyle = bg;\n      ctx.fillRect(px, py, cellW, cellH);\n    }\n    const split = GLYPH_SPLIT.get(cp);\n    if (split !== void 0) {\n      const [heavyCp, lightCp] = split;\n      const boxFont = cellFont(CELL_SIZE, { bold: false, italic: !!cell.italic });\n      drawSplitGlyph(ctx, heavyCp, lightCp, px, py, cellW, cellH, boxDrawX, boxDrawY, fg, neutral_fg, boxFont);\n    } else if (isBoxLike(text)) {\n      ctx.fillStyle = fg;\n      ctx.font = cellFont(CELL_SIZE, cell);\n      ctx.save();\n      ctx.beginPath();\n      ctx.rect(px, py, cellW, cellH);\n      ctx.clip();\n      ctx.translate(px + cellW / 2, py + cellH / 2);\n      ctx.scale(BOX_SCALE, BOX_SCALE);\n      ctx.fillText(text, boxDrawX - cellW / 2, boxDrawY - cellH / 2);\n      ctx.restore();\n    } else {\n      ctx.fillStyle = fg;\n      ctx.font = cellFont(TEXT_SIZE, cell);\n      ctx.fillText(text, px + textX, py + textBaseline);\n    }\n    if (cell.underline) {\n      ctx.fillStyle = fg;\n      const underlineY = Math.min(py + cellH - 1, py + textBaseline + 1);\n      ctx.fillRect(px, underlineY, cellW, 1);\n    }\n  }\n  return nodeCells;\n}\n\n// js/interaction.ts\nvar DRAG_THRESHOLD = 4;\nfunction attachInteraction(canvas, model, grid, getNodeCells, isFrozen) {\n  const { cellW, cellH } = grid;\n  canvas.addEventListener(\"mousemove\", (e) => {\n    if (isFrozen()) return;\n    if (pointerDown) return;\n    const rect = canvas.getBoundingClientRect();\n    const col = Math.floor((e.clientX - rect.left) / cellW);\n    const row = Math.floor((e.clientY - rect.top) / cellH);\n    canvas.style.cursor = getNodeCells().has(`${col},${row}`) ? \"pointer\" : \"grab\";\n  });\n  let pointerDown = false;\n  let isDragging = false;\n  let dragStartX = 0;\n  let dragStartY = 0;\n  let lastDragX = 0;\n  let lastDragY = 0;\n  let dragRemX = 0;\n  let dragRemY = 0;\n  canvas.addEventListener(\"mousedown\", (e) => {\n    if (isFrozen() || e.button !== 0) return;\n    pointerDown = true;\n    isDragging = false;\n    dragStartX = lastDragX = e.clientX;\n    dragStartY = lastDragY = e.clientY;\n    dragRemX = 0;\n    dragRemY = 0;\n    e.preventDefault();\n  });\n  window.addEventListener(\"mousemove\", (e) => {\n    if (!pointerDown) return;\n    const totalDx = e.clientX - dragStartX;\n    const totalDy = e.clientY - dragStartY;\n    if (!isDragging && (Math.abs(totalDx) > DRAG_THRESHOLD || Math.abs(totalDy) > DRAG_THRESHOLD)) {\n      isDragging = true;\n      canvas.style.cursor = \"grabbing\";\n    }\n    if (isDragging) {\n      dragRemX += e.clientX - lastDragX;\n      dragRemY += e.clientY - lastDragY;\n      const termDx = Math.trunc(dragRemX / cellW);\n      const termDy = Math.trunc(dragRemY / cellH);\n      if (termDx !== 0 || termDy !== 0) {\n        model.send({ type: \"pan\", dx: termDx, dy: termDy });\n        dragRemX -= termDx * cellW;\n        dragRemY -= termDy * cellH;\n      }\n    }\n    lastDragX = e.clientX;\n    lastDragY = e.clientY;\n  });\n  window.addEventListener(\"mouseup\", (e) => {\n    if (!pointerDown || e.button !== 0) return;\n    if (!isDragging) {\n      const rect = canvas.getBoundingClientRect();\n      const col = Math.floor((e.clientX - rect.left) / cellW);\n      const row = Math.floor((e.clientY - rect.top) / cellH);\n      model.send({ type: \"mouse_click\", col, row, button: e.button });\n    }\n    pointerDown = false;\n    isDragging = false;\n    canvas.style.cursor = \"grab\";\n  });\n}\n\n// js/index.ts\nfunction render({ model, el }) {\n  const scratch = document.createElement(\"canvas\");\n  const scratchCtx = scratch.getContext(\"2d\");\n  const grid = makeGridMetrics(scratchCtx);\n  const wrapper = document.createElement(\"div\");\n  wrapper.style.cssText = \"position: relative; display: inline-block; line-height: 0;\";\n  const canvas = document.createElement(\"canvas\");\n  canvas.style.cssText = \"display: block; cursor: grab; border: 2px solid #45475a;\";\n  const sharedBtnStyle = [\n    \"width: 24px\",\n    \"height: 24px\",\n    \"font-size: 16px\",\n    \"line-height: 1\",\n    \"cursor: pointer\",\n    \"background: rgba(30,30,46,0.85)\",\n    \"color: #cdd6f4\",\n    \"border: 1px solid #45475a\",\n    \"border-radius: 4px\",\n    \"display: flex\",\n    \"align-items: center\",\n    \"justify-content: center\",\n    \"user-select: none\",\n    \"padding: 0\"\n  ].join(\"; \");\n  const btnContainer = document.createElement(\"div\");\n  btnContainer.style.cssText = \"position: absolute; bottom: 8px; right: 8px; display: flex; flex-direction: column; gap: 4px; z-index: 1;\";\n  const zoomInBtn = document.createElement(\"button\");\n  zoomInBtn.textContent = \"+\";\n  zoomInBtn.setAttribute(\"style\", sharedBtnStyle);\n  zoomInBtn.title = \"Zoom in (+)\";\n  const zoomOutBtn = document.createElement(\"button\");\n  zoomOutBtn.textContent = \"\\u2212\";\n  zoomOutBtn.setAttribute(\"style\", sharedBtnStyle);\n  zoomOutBtn.title = \"Zoom out (-)\";\n  btnContainer.appendChild(zoomInBtn);\n  btnContainer.appendChild(zoomOutBtn);\n  wrapper.appendChild(canvas);\n  wrapper.appendChild(btnContainer);\n  el.appendChild(wrapper);\n  const ctx = canvas.getContext(\"2d\");\n  let nodeCells = /* @__PURE__ */ new Set();\n  let frozen = false;\n  function repaint(frame) {\n    nodeCells = paintFrame(ctx, canvas, grid, frame);\n  }\n  repaint(model.get(\"frame\"));\n  model.on(\"change:frame\", () => repaint(model.get(\"frame\")));\n  model.on(\"msg:custom\", (msg) => {\n    if (msg.type !== \"freeze\") return;\n    frozen = true;\n    btnContainer.style.display = \"none\";\n    canvas.style.cursor = \"default\";\n    wrapper.style.border = \"none\";\n    const dataUrl = canvas.toDataURL(\"image/png\");\n    const img = document.createElement(\"img\");\n    img.src = dataUrl;\n    img.width = canvas.width;\n    img.height = canvas.height;\n    img.style.cssText = \"display:block;cursor:default;font-family:monospace\";\n    el.replaceChild(img, wrapper);\n    model.send({ type: \"snapshot\", data: dataUrl });\n  });\n  zoomInBtn.addEventListener(\"mousedown\", (e) => e.preventDefault());\n  zoomOutBtn.addEventListener(\"mousedown\", (e) => e.preventDefault());\n  zoomInBtn.addEventListener(\"click\", () => model.send({ type: \"zoom\", direction: \"in\" }));\n  zoomOutBtn.addEventListener(\"click\", () => model.send({ type: \"zoom\", direction: \"out\" }));\n  attachInteraction(canvas, model, grid, () => nodeCells, () => frozen);\n}\nvar index_default = { render };\nexport {\n  index_default as default\n};\n//# sourceMappingURL=jupyter_widget.js.map\n",
+       "_model_module": "anywidget",
+       "_model_module_version": "~0.9.*",
+       "_model_name": "AnyModel",
+       "_view_count": null,
+       "_view_module": "anywidget",
+       "_view_module_version": "~0.9.*",
+       "_view_name": "AnyView",
+       "cols": 60,
+       "frame": {
+        "cells": [
+         {
+          "fg": "#f38ba8",
+          "text": "\u250f",
+          "x": 13,
+          "y": 3
+         },
+         {
+          "fg": "#f38ba8",
+          "text": "\u2501",
+          "x": 14,
+          "y": 3
+         },
+         {
+          "fg": "#f38ba8",
+          "text": "\u2501",
+          "x": 15,
+          "y": 3
+         },
+         {
+          "fg": "#f38ba8",
+          "text": "\u2501",
+          "x": 16,
+          "y": 3
+         },
+         {
+          "fg": "#f38ba8",
+          "text": "\u2501",
+          "x": 17,
+          "y": 3
+         },
+         {
+          "fg": "#f38ba8",
+          "text": "\u2501",
+          "x": 18,
+          "y": 3
+         },
+         {
+          "fg": "#f38ba8",
+          "text": "\u2501",
+          "x": 19,
+          "y": 3
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "T",
+          "x": 20,
+          "y": 3
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "C",
+          "x": 21,
+          "y": 3
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "G",
+          "x": 22,
+          "y": 3
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "A",
+          "x": 23,
+          "y": 3
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "T",
+          "x": 24,
+          "y": 3
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": ".",
+          "x": 25,
+          "y": 3
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": ".",
+          "x": 26,
+          "y": 3
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": ".",
+          "x": 27,
+          "y": 3
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "G",
+          "x": 28,
+          "y": 3
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "A",
+          "x": 29,
+          "y": 3
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "T",
+          "x": 30,
+          "y": 3
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "C",
+          "x": 31,
+          "y": 3
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "G",
+          "x": 32,
+          "y": 3
+         },
+         {
+          "fg": "#f38ba8",
+          "text": "\u2501",
+          "x": 33,
+          "y": 3
+         },
+         {
+          "fg": "#f38ba8",
+          "text": "\u2501",
+          "x": 34,
+          "y": 3
+         },
+         {
+          "fg": "#f38ba8",
+          "text": "\u2501",
+          "x": 35,
+          "y": 3
+         },
+         {
+          "fg": "#f38ba8",
+          "text": "\u2501",
+          "x": 36,
+          "y": 3
+         },
+         {
+          "fg": "#f38ba8",
+          "text": "\u2501",
+          "x": 37,
+          "y": 3
+         },
+         {
+          "fg": "#f38ba8",
+          "text": "\u2501",
+          "x": 38,
+          "y": 3
+         },
+         {
+          "fg": "#f38ba8",
+          "text": "\u2513",
+          "x": 39,
+          "y": 3
+         },
+         {
+          "fg": "#f38ba8",
+          "text": "\u2503",
+          "x": 13,
+          "y": 4
+         },
+         {
+          "fg": "#f38ba8",
+          "text": "\u2503",
+          "x": 39,
+          "y": 4
+         },
+         {
+          "text": "\u255f",
+          "x": 5,
+          "y": 5
+         },
+         {
+          "text": "\u2500",
+          "x": 6,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "A",
+          "x": 7,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "T",
+          "x": 8,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "C",
+          "x": 9,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "G",
+          "x": 10,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "A",
+          "x": 11,
+          "y": 5
+         },
+         {
+          "fg": "#f38ba8",
+          "text": "\u2501",
+          "x": 12,
+          "y": 5
+         },
+         {
+          "fg": "#f38ba8",
+          "text": "\u2543",
+          "x": 13,
+          "y": 5
+         },
+         {
+          "text": "\u2500",
+          "x": 14,
+          "y": 5
+         },
+         {
+          "text": "\u2500",
+          "x": 15,
+          "y": 5
+         },
+         {
+          "text": "\u2500",
+          "x": 16,
+          "y": 5
+         },
+         {
+          "text": "\u2500",
+          "x": 17,
+          "y": 5
+         },
+         {
+          "text": "\u2500",
+          "x": 18,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "A",
+          "x": 19,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "A",
+          "x": 20,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "A",
+          "x": 21,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "A",
+          "x": 22,
+          "y": 5
+         },
+         {
+          "text": "\u2500",
+          "x": 23,
+          "y": 5
+         },
+         {
+          "text": "\u2500",
+          "x": 24,
+          "y": 5
+         },
+         {
+          "text": "\u2500",
+          "x": 25,
+          "y": 5
+         },
+         {
+          "text": "\u2500",
+          "x": 26,
+          "y": 5
+         },
+         {
+          "text": "\u2500",
+          "x": 27,
+          "y": 5
+         },
+         {
+          "text": "\u2500",
+          "x": 28,
+          "y": 5
+         },
+         {
+          "text": "\u252c",
+          "x": 29,
+          "y": 5
+         },
+         {
+          "text": "\u2500",
+          "x": 30,
+          "y": 5
+         },
+         {
+          "text": "\u2500",
+          "x": 31,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "T",
+          "x": 32,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "A",
+          "x": 33,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "A",
+          "x": 34,
+          "y": 5
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "T",
+          "x": 35,
+          "y": 5
+         },
+         {
+          "text": "\u2500",
+          "x": 36,
+          "y": 5
+         },
+         {
+          "text": "\u2500",
+          "x": 37,
+          "y": 5
+         },
+         {
+          "text": "\u2500",
+          "x": 38,
+          "y": 5
+         },
+         {
+          "fg": "#f38ba8",
+          "text": "\u2544",
+          "x": 39,
+          "y": 5
+         },
+         {
+          "fg": "#f38ba8",
+          "text": "\u2501",
+          "x": 40,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "G",
+          "x": 41,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "G",
+          "x": 42,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "A",
+          "x": 43,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "A",
+          "x": 44,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "C",
+          "x": 45,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": ".",
+          "x": 46,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": ".",
+          "x": 47,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": ".",
+          "x": 48,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "A",
+          "x": 49,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "G",
+          "x": 50,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "A",
+          "x": 51,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "G",
+          "x": 52,
+          "y": 5
+         },
+         {
+          "bg": "#f38ba8",
+          "fg": "#1e1e2e",
+          "text": "A",
+          "x": 53,
+          "y": 5
+         },
+         {
+          "text": "\u2500",
+          "x": 54,
+          "y": 5
+         },
+         {
+          "text": "\u2562",
+          "x": 55,
+          "y": 5
+         },
+         {
+          "text": "\u2502",
+          "x": 13,
+          "y": 6
+         },
+         {
+          "text": "\u2502",
+          "x": 29,
+          "y": 6
+         },
+         {
+          "text": "\u2502",
+          "x": 39,
+          "y": 6
+         },
+         {
+          "text": "\u2570",
+          "x": 13,
+          "y": 7
+         },
+         {
+          "text": "\u2500",
+          "x": 14,
+          "y": 7
+         },
+         {
+          "text": "\u2500",
+          "x": 15,
+          "y": 7
+         },
+         {
+          "text": "\u2500",
+          "x": 16,
+          "y": 7
+         },
+         {
+          "text": "\u2500",
+          "x": 17,
+          "y": 7
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "A",
+          "x": 18,
+          "y": 7
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "T",
+          "x": 19,
+          "y": 7
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "G",
+          "x": 20,
+          "y": 7
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "A",
+          "x": 21,
+          "y": 7
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "T",
+          "x": 22,
+          "y": 7
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "A",
+          "x": 23,
+          "y": 7
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "A",
+          "x": 24,
+          "y": 7
+         },
+         {
+          "text": "\u2500",
+          "x": 25,
+          "y": 7
+         },
+         {
+          "text": "\u2500",
+          "x": 26,
+          "y": 7
+         },
+         {
+          "text": "\u2500",
+          "x": 27,
+          "y": 7
+         },
+         {
+          "text": "\u2500",
+          "x": 28,
+          "y": 7
+         },
+         {
+          "text": "\u2534",
+          "x": 29,
+          "y": 7
+         },
+         {
+          "text": "\u2500",
+          "x": 30,
+          "y": 7
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "A",
+          "x": 31,
+          "y": 7
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "T",
+          "x": 32,
+          "y": 7
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "G",
+          "x": 33,
+          "y": 7
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "T",
+          "x": 34,
+          "y": 7
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "T",
+          "x": 35,
+          "y": 7
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "A",
+          "x": 36,
+          "y": 7
+         },
+         {
+          "bg": "#cdd6f4",
+          "fg": "#1e1e2e",
+          "text": "A",
+          "x": 37,
+          "y": 7
+         },
+         {
+          "text": "\u2500",
+          "x": 38,
+          "y": 7
+         },
+         {
+          "text": "\u256f",
+          "x": 39,
+          "y": 7
+         }
+        ],
+        "cols": 60,
+        "neutral_bg": "#1e1e2e",
+        "neutral_fg": "#cdd6f4",
+        "rows": 12
+       },
+       "layout": "IPY_MODEL_efeba939e0ff4dbdaea76ead80317426",
+       "rows": 12,
+       "tabbable": null,
+       "tooltip": null
+      }
+     }
+    },
+    "version_major": 2,
+    "version_minor": 0
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gen-python/src/python_api/repository/exports.rs
+++ b/gen-python/src/python_api/repository/exports.rs
@@ -11,12 +11,12 @@ use super::PyRepository;
 
 #[pymethods]
 impl PyRepository {
-    #[pyo3(signature = (filename, name=None, sample=None))]
+    #[pyo3(signature = (filename, sample=None, collection=None))]
     fn export_fasta(
         &self,
         filename: String,
-        name: Option<String>,
         sample: Option<String>,
+        collection: Option<String>,
     ) -> PyResult<()> {
         let conn = self.context.graph().conn();
         let op_conn = self.context.operations().conn();
@@ -24,18 +24,23 @@ impl PyRepository {
             track_database(conn, op_conn)
                 .map_err(|e| PyRuntimeError::new_err(format!("Error tracking database: {e}")))?;
         }
-        let name = name.unwrap_or_else(|| self.get_default_collection());
-        export_fasta(conn, &name, sample.as_deref(), &PathBuf::from(&filename))
-            .map_err(|e| PyRuntimeError::new_err(format!("Failed to export '{}': {e}", filename)))
+        let collection = collection.unwrap_or_else(|| self.get_default_collection());
+        export_fasta(
+            conn,
+            &collection,
+            sample.as_deref(),
+            &PathBuf::from(&filename),
+        )
+        .map_err(|e| PyRuntimeError::new_err(format!("Failed to export '{}': {e}", filename)))
     }
 
-    #[pyo3(signature = (filename, name=None, sample=None, node_max=None))]
+    #[pyo3(signature = (filename, sample=None, node_max=None, collection=None))]
     fn export_gfa(
         &self,
         filename: String,
-        name: Option<String>,
         sample: Option<String>,
         node_max: Option<i64>,
+        collection: Option<String>,
     ) -> PyResult<()> {
         let conn = self.context.graph().conn();
         let op_conn = self.context.operations().conn();
@@ -43,18 +48,24 @@ impl PyRepository {
             track_database(conn, op_conn)
                 .map_err(|e| PyRuntimeError::new_err(format!("Error tracking database: {e}")))?;
         }
-        let name = name.unwrap_or_else(|| self.get_default_collection());
+        let collection = collection.unwrap_or_else(|| self.get_default_collection());
         let sample = sample.unwrap_or_else(|| Sample::DEFAULT_NAME.to_string());
-        export_gfa(conn, &name, &PathBuf::from(&filename), &sample, node_max)
-            .map_err(|e| PyRuntimeError::new_err(format!("Failed to export '{}': {e}", filename)))
+        export_gfa(
+            conn,
+            &collection,
+            &PathBuf::from(&filename),
+            &sample,
+            node_max,
+        )
+        .map_err(|e| PyRuntimeError::new_err(format!("Failed to export '{}': {e}", filename)))
     }
 
-    #[pyo3(signature = (filename, name=None, sample=None))]
+    #[pyo3(signature = (filename, sample=None, collection=None))]
     fn export_genbank(
         &self,
         filename: String,
-        name: Option<String>,
         sample: Option<String>,
+        collection: Option<String>,
     ) -> PyResult<()> {
         let conn = self.context.graph().conn();
         let op_conn = self.context.operations().conn();
@@ -62,12 +73,12 @@ impl PyRepository {
             track_database(conn, op_conn)
                 .map_err(|e| PyRuntimeError::new_err(format!("Error tracking database: {e}")))?;
         }
-        let name = name.unwrap_or_else(|| self.get_default_collection());
+        let collection = collection.unwrap_or_else(|| self.get_default_collection());
         let sample = sample.unwrap_or_else(|| Sample::DEFAULT_NAME.to_string());
         let writer = fs::File::create(&filename).map_err(|e| {
             PyRuntimeError::new_err(format!("Failed to create '{}': {e}", filename))
         })?;
-        export_genbank(conn, &name, &sample, writer)
+        export_genbank(conn, &collection, &sample, writer)
             .map_err(|e| PyRuntimeError::new_err(format!("Failed to export '{}': {e}", filename)))
     }
 }

--- a/gen-python/src/python_api/repository/graph_ops.rs
+++ b/gen-python/src/python_api/repository/graph_ops.rs
@@ -10,17 +10,17 @@ use crate::python_api::block_group::PyBlockGroup;
 
 #[pymethods]
 impl PyRepository {
-    #[pyo3(signature = (sample, new_sample, region, name=None, backbone=None, breakpoints=None, chunk_size=None))]
+    #[pyo3(signature = (sample, new_sample, region, backbone=None, breakpoints=None, chunk_size=None, collection=None))]
     #[expect(clippy::too_many_arguments, reason = "mirrors underlying API")]
     fn derive_chunks(
         &self,
         sample: String,
         new_sample: String,
         region: String,
-        name: Option<String>,
         backbone: Option<String>,
         breakpoints: Option<Vec<i64>>,
         chunk_size: Option<i64>,
+        collection: Option<String>,
     ) -> PyResult<()> {
         if self.in_transaction {
             return Err(PyRuntimeError::new_err(
@@ -29,7 +29,7 @@ impl PyRepository {
         }
         derive_chunks_operation(
             &self.context,
-            name,
+            collection,
             sample,
             new_sample,
             region,
@@ -40,40 +40,54 @@ impl PyRepository {
         .map_err(|e| PyRuntimeError::new_err(format!("Error deriving chunks: {e}")))
     }
 
-    #[pyo3(signature = (sample, new_sample, region, name=None, backbone=None))]
+    #[pyo3(signature = (sample, new_sample, region, backbone=None, collection=None))]
     fn derive_subgraph(
         &self,
         sample: String,
         new_sample: String,
         region: String,
-        name: Option<String>,
         backbone: Option<String>,
+        collection: Option<String>,
     ) -> PyResult<()> {
         if self.in_transaction {
             return Err(PyRuntimeError::new_err(
                 "derive_subgraph cannot be called inside a transaction block",
             ));
         }
-        derive_subgraph_operation(&self.context, name, sample, new_sample, region, backbone)
-            .map_err(|e| PyRuntimeError::new_err(format!("Error deriving subgraph: {e}")))
+        derive_subgraph_operation(
+            &self.context,
+            collection,
+            sample,
+            new_sample,
+            region,
+            backbone,
+        )
+        .map_err(|e| PyRuntimeError::new_err(format!("Error deriving subgraph: {e}")))
     }
 
-    #[pyo3(signature = (sample, new_sample, regions, new_region, name=None))]
+    #[pyo3(signature = (sample, new_sample, regions, new_region, collection=None))]
     fn make_stitch(
         &self,
         sample: String,
         new_sample: String,
         regions: String,
         new_region: String,
-        name: Option<String>,
+        collection: Option<String>,
     ) -> PyResult<()> {
         if self.in_transaction {
             return Err(PyRuntimeError::new_err(
                 "make_stitch cannot be called inside a transaction block",
             ));
         }
-        make_stitch_operation(&self.context, name, sample, new_sample, regions, new_region)
-            .map_err(|e| PyRuntimeError::new_err(format!("Error making stitch: {e}")))
+        make_stitch_operation(
+            &self.context,
+            collection,
+            sample,
+            new_sample,
+            regions,
+            new_region,
+        )
+        .map_err(|e| PyRuntimeError::new_err(format!("Error making stitch: {e}")))
     }
 
     /// Stitch multiple block groups into a single new block group.

--- a/gen-python/src/python_api/repository/imports.rs
+++ b/gen-python/src/python_api/repository/imports.rs
@@ -18,18 +18,18 @@ use crate::python_api::sequence_part::PySequencePart;
 
 #[pymethods]
 impl PyRepository {
-    #[pyo3(signature = (filename, name=None, sample=None, shallow=false))]
+    #[pyo3(signature = (filename, sample=None, shallow=false, collection=None))]
     pub fn import_fasta(
         &self,
         filename: String,
-        name: Option<String>,
         sample: Option<String>,
         shallow: bool,
+        collection: Option<String>,
     ) -> PyResult<String> {
-        let name = name.unwrap_or_else(|| self.get_default_collection());
+        let collection = collection.unwrap_or_else(|| self.get_default_collection());
         let sample = sample.unwrap_or_else(|| Sample::DEFAULT_NAME.to_string());
         run_write(&self.context, !self.in_transaction, |ctx| {
-            import_fasta(ctx, &filename, &name, &sample, shallow)
+            import_fasta(ctx, &filename, &collection, &sample, shallow)
                 .map(|_| format!("'{}' imported.", filename))
                 .map_err(|e| match e {
                     FastaError::OperationError(OperationError::NoChanges) => {
@@ -40,17 +40,17 @@ impl PyRepository {
         })
     }
 
-    #[pyo3(signature = (filename, name=None, sample=None))]
+    #[pyo3(signature = (filename, sample=None, collection=None))]
     fn import_gfa(
         &self,
         filename: String,
-        name: Option<String>,
         sample: Option<String>,
+        collection: Option<String>,
     ) -> PyResult<String> {
-        let name = name.unwrap_or_else(|| self.get_default_collection());
+        let collection = collection.unwrap_or_else(|| self.get_default_collection());
         let sample = sample.unwrap_or_else(|| Sample::DEFAULT_NAME.to_string());
         run_write(&self.context, !self.in_transaction, |ctx| {
-            import_gfa(ctx, &PathBuf::from(&filename), &name, &sample)
+            import_gfa(ctx, &PathBuf::from(&filename), &collection, &sample)
                 .map(|_| format!("'{}' imported.", filename))
                 .map_err(|e| match e {
                     GFAImportError::OperationError(OperationError::NoChanges) => {
@@ -61,15 +61,15 @@ impl PyRepository {
         })
     }
 
-    #[pyo3(signature = (filename, name=None, sample=None))]
+    #[pyo3(signature = (filename, sample=None, collection=None))]
     fn import_genbank(
         &self,
         filename: String,
-        name: Option<String>,
         sample: Option<String>,
+        collection: Option<String>,
     ) -> PyResult<String> {
         use std::fs::File;
-        let name = name.unwrap_or_else(|| self.get_default_collection());
+        let collection = collection.unwrap_or_else(|| self.get_default_collection());
         let sample = sample.unwrap_or_else(|| Sample::DEFAULT_NAME.to_string());
         run_write(&self.context, !self.in_transaction, |ctx| {
             let mut reader: Box<dyn std::io::Read> = if filename.ends_with(".gz") {
@@ -85,7 +85,7 @@ impl PyRepository {
             import_genbank(
                 ctx,
                 &mut reader,
-                name.as_ref(),
+                collection.as_ref(),
                 &sample,
                 gen_models::operations::OperationInfo {
                     files: vec![{
@@ -102,15 +102,15 @@ impl PyRepository {
         })
     }
 
-    #[pyo3(signature = (library_name, parts_list, name=None, sample=None))]
+    #[pyo3(signature = (library_name, parts_list, sample=None, collection=None))]
     fn import_library(
         &self,
         library_name: String,
         parts_list: Vec<Vec<PySequencePart>>,
-        name: Option<String>,
         sample: Option<String>,
+        collection: Option<String>,
     ) -> PyResult<String> {
-        let name = name.unwrap_or_else(|| self.get_default_collection());
+        let collection = collection.unwrap_or_else(|| self.get_default_collection());
         let sample = sample.unwrap_or_else(|| Sample::DEFAULT_NAME.to_string());
         let rust_parts_list: Vec<Vec<SequencePart>> = parts_list
             .iter()
@@ -128,7 +128,7 @@ impl PyRepository {
         run_write(&self.context, !self.in_transaction, |ctx| {
             import_library(
                 ctx,
-                &name,
+                &collection,
                 &sample,
                 &library_name,
                 rust_parts_list.clone(),
@@ -148,23 +148,23 @@ impl PyRepository {
         })
     }
 
-    #[pyo3(signature = (library_name, parts, library, name=None, sample=None))]
+    #[pyo3(signature = (library_name, parts, library, sample=None, collection=None))]
     fn import_library_files(
         &self,
         library_name: String,
         parts: String,
         library: String,
-        name: Option<String>,
         sample: Option<String>,
+        collection: Option<String>,
     ) -> PyResult<String> {
         let parts_list = parse_library(&parts, &library)
             .map_err(|e| PyRuntimeError::new_err(format!("Problem parsing library files: {e}")))?;
-        let name = name.unwrap_or_else(|| self.get_default_collection());
+        let collection = collection.unwrap_or_else(|| self.get_default_collection());
         let sample = sample.unwrap_or_else(|| Sample::DEFAULT_NAME.to_string());
         run_write(&self.context, !self.in_transaction, |ctx| {
             import_library(
                 ctx,
-                &name,
+                &collection,
                 &sample,
                 &library_name,
                 parts_list.clone(),

--- a/gen-python/src/python_api/repository/mod.rs
+++ b/gen-python/src/python_api/repository/mod.rs
@@ -340,8 +340,8 @@ mod python_tests {
                 .import_fasta(
                     fasta.to_str().unwrap().to_string(),
                     Some("test".to_string()),
-                    None,
                     false,
+                    None,
                 )
                 .unwrap();
 
@@ -362,12 +362,12 @@ mod python_tests {
 
             py_repo
                 .borrow(py)
-                .import_fasta(path.clone(), Some("test".to_string()), None, false)
+                .import_fasta(path.clone(), Some("test".to_string()), false, None)
                 .unwrap();
 
             let err = py_repo
                 .borrow(py)
-                .import_fasta(path, Some("test".to_string()), None, false)
+                .import_fasta(path, Some("test".to_string()), false, None)
                 .unwrap_err()
                 .to_string();
             assert!(
@@ -394,16 +394,16 @@ mod python_tests {
                     .import_fasta(
                         fasta1.to_str().unwrap().to_string(),
                         Some("test".to_string()),
-                        None,
                         false,
+                        None,
                     )
                     .unwrap();
                 borrow
                     .import_fasta(
                         fasta2.to_str().unwrap().to_string(),
                         Some("test".to_string()),
-                        None,
                         false,
+                        None,
                     )
                     .unwrap();
             }
@@ -432,8 +432,8 @@ mod python_tests {
                 .import_fasta(
                     fasta.to_str().unwrap().to_string(),
                     Some("test".to_string()),
-                    None,
                     false,
+                    None,
                 )
                 .unwrap();
 
@@ -458,8 +458,8 @@ mod python_tests {
                 .import_fasta(
                     fasta.to_str().unwrap().to_string(),
                     Some("test".to_string()),
-                    None,
                     false,
+                    None,
                 )
                 .unwrap();
 
@@ -481,8 +481,8 @@ mod python_tests {
                 .import_fasta(
                     fasta.to_str().unwrap().to_string(),
                     Some("test".to_string()),
-                    None,
                     false,
+                    None,
                 )
                 .unwrap();
 
@@ -518,8 +518,8 @@ mod python_tests {
                 .import_fasta(
                     fasta.to_str().unwrap().to_string(),
                     Some("test".to_string()),
-                    None,
                     false,
+                    None,
                 )
                 .unwrap();
 
@@ -542,8 +542,8 @@ mod python_tests {
                 .import_fasta(
                     fasta.to_str().unwrap().to_string(),
                     Some("test".to_string()),
-                    None,
                     false,
+                    None,
                 )
                 .unwrap();
 
@@ -581,8 +581,8 @@ mod python_tests {
                 .import_fasta(
                     fasta.to_str().unwrap().to_string(),
                     Some("test".to_string()),
-                    None,
                     false,
+                    None,
                 )
                 .unwrap();
 
@@ -627,8 +627,8 @@ mod python_tests {
                 .import_fasta(
                     fasta.to_str().unwrap().to_string(),
                     Some("test".to_string()),
-                    None,
                     false,
+                    None,
                 )
                 .unwrap();
 

--- a/gen-python/src/python_api/repository/updates.rs
+++ b/gen-python/src/python_api/repository/updates.rs
@@ -19,7 +19,7 @@ use crate::python_api::sequence_part::PySequencePart;
 
 #[pymethods]
 impl PyRepository {
-    #[pyo3(signature = (filename, sample, new_sample, region_name, name=None))]
+    #[pyo3(signature = (filename, sample, new_sample, region_name, collection=None))]
     #[expect(clippy::too_many_arguments, reason = "mirrors underlying API")]
     fn update_with_fasta(
         &self,
@@ -27,13 +27,13 @@ impl PyRepository {
         sample: String,
         new_sample: String,
         region_name: String,
-        name: Option<String>,
+        collection: Option<String>,
     ) -> PyResult<String> {
-        let name = name.unwrap_or_else(|| self.get_default_collection());
+        let collection = collection.unwrap_or_else(|| self.get_default_collection());
         run_write(&self.context, !self.in_transaction, |ctx| {
             update_with_fasta(
                 ctx,
-                &name,
+                &collection,
                 &sample,
                 &new_sample,
                 &region_name,
@@ -50,17 +50,17 @@ impl PyRepository {
         })
     }
 
-    #[pyo3(signature = (filename, sample, new_sample, name=None))]
+    #[pyo3(signature = (filename, sample, new_sample, collection=None))]
     fn update_with_gfa(
         &self,
         filename: String,
         sample: String,
         new_sample: String,
-        name: Option<String>,
+        collection: Option<String>,
     ) -> PyResult<String> {
-        let name = name.unwrap_or_else(|| self.get_default_collection());
+        let collection = collection.unwrap_or_else(|| self.get_default_collection());
         run_write(&self.context, !self.in_transaction, |ctx| {
-            update_with_gfa(ctx, &name, &sample, &new_sample, &filename)
+            update_with_gfa(ctx, &collection, &sample, &new_sample, &filename)
                 .map(|_| format!("Updated from '{}'.", filename))
                 .map_err(|e| {
                     PyRuntimeError::new_err(format!("Failed to update from '{}': {e}", filename))
@@ -68,22 +68,22 @@ impl PyRepository {
         })
     }
 
-    #[pyo3(signature = (filename, csv, sample, name=None, parent_sample=None))]
+    #[pyo3(signature = (filename, csv, sample, parent_sample=None, collection=None))]
     fn update_with_gaf(
         &self,
         filename: String,
         csv: String,
         sample: String,
-        name: Option<String>,
         parent_sample: Option<String>,
+        collection: Option<String>,
     ) -> PyResult<String> {
-        let name = name.unwrap_or_else(|| self.get_default_collection());
+        let collection = collection.unwrap_or_else(|| self.get_default_collection());
         run_write(&self.context, !self.in_transaction, |ctx| {
             update_with_gaf(
                 ctx,
                 &filename,
                 &csv,
-                &name,
+                &collection,
                 &sample,
                 parent_sample.as_deref(),
             )
@@ -94,22 +94,22 @@ impl PyRepository {
         })
     }
 
-    #[pyo3(signature = (filename, name=None, genotype=None, sample=None, parent_samples=None, in_place=false))]
+    #[pyo3(signature = (filename, genotype=None, sample=None, parent_samples=None, in_place=false, collection=None))]
     fn update_with_vcf(
         &self,
         filename: String,
-        name: Option<String>,
         genotype: Option<String>,
         sample: Option<String>,
         parent_samples: Option<Vec<String>>,
         in_place: bool,
+        collection: Option<String>,
     ) -> PyResult<String> {
-        let name = name.unwrap_or_else(|| self.get_default_collection());
+        let collection = collection.unwrap_or_else(|| self.get_default_collection());
         run_write(&self.context, !self.in_transaction, |ctx| {
             update_with_vcf(
                 ctx,
                 &filename,
-                &name,
+                &collection,
                 genotype.clone().unwrap_or_default(),
                 sample.as_deref(),
                 parent_samples.unwrap_or_default(),
@@ -125,16 +125,16 @@ impl PyRepository {
         })
     }
 
-    #[pyo3(signature = (filename, sample, name=None, create_missing=false))]
+    #[pyo3(signature = (filename, sample, create_missing=false, collection=None))]
     fn update_with_genbank(
         &self,
         filename: String,
         sample: String,
-        name: Option<String>,
         create_missing: bool,
+        collection: Option<String>,
     ) -> PyResult<String> {
         use std::fs::File;
-        let name = name.unwrap_or_else(|| self.get_default_collection());
+        let collection = collection.unwrap_or_else(|| self.get_default_collection());
         run_write(&self.context, !self.in_transaction, |ctx| {
             let file = File::open(&filename).map_err(|e| {
                 PyRuntimeError::new_err(format!("Failed to open '{}': {e}", filename))
@@ -142,7 +142,7 @@ impl PyRepository {
             update_with_genbank(
                 ctx,
                 &file,
-                name.as_ref(),
+                collection.as_ref(),
                 &sample,
                 create_missing,
                 &gen_models::operations::OperationInfo {
@@ -161,7 +161,7 @@ impl PyRepository {
         })
     }
 
-    #[pyo3(signature = (sequence, sample, new_sample, region_name, name=None, no_reference_path_update=false))]
+    #[pyo3(signature = (sequence, sample, new_sample, region_name, no_reference_path_update=false, collection=None))]
     #[expect(clippy::too_many_arguments, reason = "mirrors underlying API")]
     fn update_with_sequence(
         &self,
@@ -169,14 +169,14 @@ impl PyRepository {
         sample: String,
         new_sample: String,
         region_name: String,
-        name: Option<String>,
         no_reference_path_update: bool,
+        collection: Option<String>,
     ) -> PyResult<String> {
-        let name = name.unwrap_or_else(|| self.get_default_collection());
+        let collection = collection.unwrap_or_else(|| self.get_default_collection());
         run_write(&self.context, !self.in_transaction, |ctx| {
             update_with_sequence(
                 ctx,
-                &name,
+                &collection,
                 &sample,
                 &new_sample,
                 &region_name,
@@ -188,17 +188,17 @@ impl PyRepository {
         })
     }
 
-    #[pyo3(signature = (name, sample, new_sample_name, path_name, parts_list))]
+    #[pyo3(signature = (sample, new_sample_name, path_name, parts_list, collection=None))]
     #[expect(clippy::too_many_arguments, reason = "mirrors underlying API")]
     fn update_with_library(
         &self,
-        name: Option<String>,
         sample: Option<String>,
         new_sample_name: String,
         path_name: String,
         parts_list: Vec<Vec<PySequencePart>>,
+        collection: Option<String>,
     ) -> PyResult<String> {
-        let name = name.unwrap_or_else(|| self.get_default_collection());
+        let collection = collection.unwrap_or_else(|| self.get_default_collection());
         let sample = sample.unwrap_or_else(|| Sample::DEFAULT_NAME.to_string());
         let rust_parts_list: Vec<Vec<SequencePart>> = parts_list
             .iter()
@@ -216,7 +216,7 @@ impl PyRepository {
         run_write(&self.context, !self.in_transaction, |ctx| {
             update_with_library(
                 ctx,
-                &name,
+                &collection,
                 &sample,
                 &new_sample_name,
                 &path_name,
@@ -229,24 +229,24 @@ impl PyRepository {
         })
     }
 
-    #[pyo3(signature = (name, sample, new_sample, path_name, library, parts))]
+    #[pyo3(signature = (sample, new_sample, path_name, library, parts, collection=None))]
     #[expect(clippy::too_many_arguments, reason = "mirrors underlying API")]
     fn update_with_library_files(
         &self,
-        name: Option<String>,
         sample: String,
         new_sample: String,
         path_name: String,
         library: String,
         parts: String,
+        collection: Option<String>,
     ) -> PyResult<String> {
         let parts_list = parse_library(&parts, &library)
             .map_err(|_| PyRuntimeError::new_err("Couldn't parse library files."))?;
-        let name = name.unwrap_or_else(|| self.get_default_collection());
+        let collection = collection.unwrap_or_else(|| self.get_default_collection());
         run_write(&self.context, !self.in_transaction, |ctx| {
             update_with_library(
                 ctx,
-                &name,
+                &collection,
                 &sample,
                 &new_sample,
                 &path_name,

--- a/src/imports/fasta.rs
+++ b/src/imports/fasta.rs
@@ -33,7 +33,7 @@ use crate::{
 pub fn import_fasta(
     context: &DbContext,
     fasta: &String,
-    name: &str,
+    collection_name: &str,
     sample: &str,
     shallow: bool,
 ) -> Result<Operation, FastaError> {
@@ -53,7 +53,7 @@ pub fn import_fasta(
     };
     let mut reader = fasta::io::reader::Builder.build_from_reader(reader_stream)?;
 
-    let collection = match Collection::create(conn, name) {
+    let collection = match Collection::create(conn, collection_name) {
         Ok(collection) => collection,
         Err(CollectionError::Duplicate(collection)) => collection,
         Err(e) => return Err(FastaError::CollectionError(e)),


### PR DESCRIPTION
## Summary

- Renames `name` → `collection` across all PyO3 repository methods (imports, exports, updates, graph_ops) and moves it to the last parameter position so callers can ignore it in the common case
- Adds `repository_api.ipynb` — a fully-executed example notebook covering imports, exports, updates, and graph operations, with a multi-omics section demonstrating collection-based organisation (genomics / transcriptomics / proteomics in one repo)
- Notebook uses `show_path()` on the edited sample after each update operation to highlight the edited path