### PR TITLE
feat(gen-models): add locus infrastructure (GraphLocus, BlockSlice, annotation helpers)

### DIFF
--- a/gen-models/src/lib.rs
+++ b/gen-models/src/lib.rs
@@ -15,6 +15,7 @@ pub mod files;
 pub mod generated;
 pub use generated::gen_models_capnp;
 pub mod lineage;
+pub mod locus;
 pub mod manifest;
 pub mod metadata;
 pub mod migrations;

--- a/gen-models/src/locus.rs
+++ b/gen-models/src/locus.rs
@@ -1,0 +1,99 @@
+//! Nameless addresses in graph space.
+//!
+//! Two coordinate systems for the same underlying position:
+//!
+//! - **Block space** (`GraphLocus`): a sequence of `BlockSlice`s, each one a
+//!   `GraphNode` with local start/end byte offsets.  This is what sequence
+//!   search returns — natural when you're navigating the rendered graph or
+//!   computing visual positions.
+
+use gen_core::{HashId, Strand};
+use gen_graph::GraphNode;
+use serde::{Deserialize, Serialize};
+
+use crate::{db::GraphConnection, node::Node};
+
+// ---------------------------------------------------------------------------
+// Block space
+// ---------------------------------------------------------------------------
+
+/// A slice of a single graph node: the node itself plus local start/end byte
+/// offsets within that node's sequence.  Middle blocks in a multi-node locus
+/// span the full node (`start = 0`, `end = node.length()`).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct BlockSlice {
+    pub node: GraphNode,
+    /// Local start offset within the node's sequence slice (`0..node.length()`).
+    pub start: usize,
+    /// Local end offset, exclusive (`start..=node.length()`).
+    pub end: usize,
+}
+
+impl BlockSlice {
+    pub fn full(node: GraphNode) -> Self {
+        Self {
+            node,
+            start: 0,
+            end: node.length() as usize,
+        }
+    }
+}
+
+/// A walk through graph space expressed as an ordered list of node slices.
+///
+/// Returned by sequence search.  Natural for visual navigation and rendering.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct GraphLocus {
+    pub slices: Vec<BlockSlice>,
+    pub strand: Strand,
+}
+
+impl GraphLocus {
+    /// Concatenate the sequence bytes covered by this locus.
+    pub fn sequence(&self, conn: &GraphConnection) -> Vec<u8> {
+        let node_ids: Vec<HashId> = self.slices.iter().map(|s| s.node.node_id).collect();
+        let sequences = Node::get_sequences_by_node_ids(conn, &node_ids);
+
+        let mut out = Vec::new();
+        for s in &self.slices {
+            let full = sequences[&s.node.node_id]
+                .get_sequence(None, None)
+                .expect("sequence data corrupt")
+                .into_bytes();
+            let block_start = s.node.sequence_start as usize;
+            let text = &full[block_start..block_start + s.node.length() as usize];
+            out.extend_from_slice(&text[s.start..s.end]);
+        }
+
+        if self.strand == Strand::Reverse {
+            reverse_complement(&out)
+        } else {
+            out
+        }
+    }
+}
+
+fn reverse_complement(seq: &[u8]) -> Vec<u8> {
+    seq.iter()
+        .rev()
+        .map(|&base| match base.to_ascii_uppercase() {
+            b'A' => b'T',
+            b'T' => b'A',
+            b'C' => b'G',
+            b'G' => b'C',
+            b'U' => b'A',
+            b'N' => b'N',
+            b'R' => b'Y',
+            b'Y' => b'R',
+            b'S' => b'S',
+            b'W' => b'W',
+            b'K' => b'M',
+            b'M' => b'K',
+            b'B' => b'V',
+            b'V' => b'B',
+            b'D' => b'H',
+            b'H' => b'D',
+            _ => base,
+        })
+        .collect()
+}

--- a/gen-python/examples/annotations.ipynb
+++ b/gen-python/examples/annotations.ipynb
@@ -1,0 +1,331 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "intro",
+   "metadata": {},
+   "source": [
+    "# Annotation listing and navigation\n",
+    "\n",
+    "This notebook imports pUC19 from a GenBank file, loads its feature annotations,\n",
+    "and navigates to the MCS (multiple cloning site) using `widget.go_to()` and\n",
+    "`widget.show()`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "imports",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import tempfile\n",
+    "import gen"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "import-gb",
+   "metadata": {},
+   "source": [
+    "## Import pUC19\n",
+    "\n",
+    "Create a fresh in-memory repository and import the GenBank fixture."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "import-genbank",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Block group: sequence-222046-\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Adjust this path if running from outside the project root.\n",
+    "FIXTURE = os.path.abspath(\"../../fixtures/puc19.gb\")\n",
+    "\n",
+    "tmp = tempfile.mkdtemp()\n",
+    "repo = gen.Repository(os.path.join(tmp, \".gen\"))\n",
+    "repo.import_genbank(FIXTURE)\n",
+    "\n",
+    "bg = repo.get_block_groups()[0]\n",
+    "print(\"Block group:\", bg.name)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "plot-section",
+   "metadata": {},
+   "source": [
+    "## Plot the graph\n",
+    "\n",
+    "Render the sequence graph in a widget, then load the GenBank feature annotations\n",
+    "as a track panel."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "plot-widget",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Annotation group: GenBank default/reference/sequence-222046-\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5a155b92a40841fea24817a83536e55b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "<gen.jupyter_widget.GenGraphWidget object at 0x10ada4c30>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "widget = bg.plot(rows=24)\n",
+    "\n",
+    "# The annotation group name is generated from the collection, sample, and locus\n",
+    "# name embedded in the GenBank file.\n",
+    "annotation_group = repo.query(\"SELECT name FROM annotation_groups\")[0][0]\n",
+    "print(\"Annotation group:\", annotation_group)\n",
+    "widget.add_annotation_track_group(annotation_group)\n",
+    "\n",
+    "widget"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "list-section",
+   "metadata": {},
+   "source": [
+    "## List all annotations\n",
+    "\n",
+    "`widget.list_annotations()` returns `AnnotationRecord` objects spanning all\n",
+    "sources (track panels and inline highlights).  Each record exposes `.name`,\n",
+    "`.track`, `.type`, and a full `.locus`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "list-annotations",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "21 annotations loaded\n",
+      "  'source'                        track  GraphLocus(348d9388[0..2686]+0 → 348d9388[0..2686]+2686, 1 blocks, strand=+)\n",
+      "  'pBR322ori-F'                   track  GraphLocus(348d9388[0..2686]+117 → 348d9388[0..2686]+137, 1 blocks, strand=+)\n",
+      "  'L4440'                         track  GraphLocus(348d9388[0..2686]+370 → 348d9388[0..2686]+388, 1 blocks, strand=+)\n",
+      "  'CAP binding site'              track  GraphLocus(348d9388[0..2686]+504 → 348d9388[0..2686]+526, 1 blocks, strand=+)\n",
+      "  'lac promoter'                  track  GraphLocus(348d9388[0..2686]+540 → 348d9388[0..2686]+571, 3 blocks, strand=+)\n",
+      "  'lac operator'                  track  GraphLocus(348d9388[0..2686]+578 → 348d9388[0..2686]+595, 1 blocks, strand=+)\n",
+      "  'M13/pUC Reverse'               track  GraphLocus(348d9388[0..2686]+583 → 348d9388[0..2686]+606, 1 blocks, strand=+)\n",
+      "  'M13 rev'                       track  GraphLocus(348d9388[0..2686]+602 → 348d9388[0..2686]+619, 1 blocks, strand=+)\n",
+      "  'M13 Reverse'                   track  GraphLocus(348d9388[0..2686]+602 → 348d9388[0..2686]+619, 1 blocks, strand=+)\n",
+      "  'lacZ-alpha'                    track  GraphLocus(348d9388[0..2686]+614 → 348d9388[0..2686]+938, 1 blocks, strand=+)\n",
+      "  'MCS'                           track  GraphLocus(348d9388[0..2686]+631 → 348d9388[0..2686]+688, 1 blocks, strand=+)\n",
+      "  'M13 Forward'                   track  GraphLocus(348d9388[0..2686]+688 → 348d9388[0..2686]+706, 1 blocks, strand=-)\n",
+      "  'M13 fwd'                       track  GraphLocus(348d9388[0..2686]+688 → 348d9388[0..2686]+705, 1 blocks, strand=-)\n",
+      "  'M13/pUC Forward'               track  GraphLocus(348d9388[0..2686]+697 → 348d9388[0..2686]+720, 1 blocks, strand=-)\n",
+      "  'pRS-marker'                    track  GraphLocus(348d9388[0..2686]+913 → 348d9388[0..2686]+933, 1 blocks, strand=-)\n",
+      "  \"pGEX 3'\"                       track  GraphLocus(348d9388[0..2686]+1032 → 348d9388[0..2686]+1055, 1 blocks, strand=+)\n",
+      "  'pBRforEco'                     track  GraphLocus(348d9388[0..2686]+1092 → 348d9388[0..2686]+1111, 1 blocks, strand=-)\n",
+      "  'AmpR promoter'                 track  GraphLocus(348d9388[0..2686]+1178 → 348d9388[0..2686]+1283, 1 blocks, strand=+)\n",
+      "  'AmpR'                          track  GraphLocus(348d9388[0..2686]+1283 → 348d9388[0..2686]+2144, 2 blocks, strand=+)\n",
+      "  'Amp-R'                         track  GraphLocus(348d9388[0..2686]+1501 → 348d9388[0..2686]+1521, 1 blocks, strand=-)\n",
+      "  'ori'                           track  GraphLocus(348d9388[0..2686]+2314 → 348d9388[0..2686]+217, 2 blocks, strand=+)\n"
+     ]
+    }
+   ],
+   "source": [
+    "anns = widget.list_annotations()\n",
+    "print(f\"{len(anns)} annotations loaded\")\n",
+    "for a in anns:\n",
+    "    print(f\"  {a.name!r:30s}  {a.type}  {a.locus}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "navigate-section",
+   "metadata": {},
+   "source": [
+    "## Navigate to the MCS\n",
+    "\n",
+    "Filter for the MCS feature and navigate to it two ways:\n",
+    "\n",
+    "* `widget.go_to(record)` — left-pins the annotation start at column 12, no highlight\n",
+    "* `widget.show(record)` — centres the camera and adds a highlight"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "find-mcs",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "MCS locus: GraphLocus(348d9388[0..2686]+631 → 348d9388[0..2686]+688, 1 blocks, strand=+)\n",
+      "MCS start: GraphPos(348d9388[0..2686] +631)\n"
+     ]
+    }
+   ],
+   "source": [
+    "mcs = next(a for a in anns if a.name == \"MCS\")\n",
+    "print(\"MCS locus:\", mcs.locus)\n",
+    "print(\"MCS start:\", mcs.locus.start())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "goto-mcs",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5a155b92a40841fea24817a83536e55b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "<gen.jupyter_widget.GenGraphWidget object at 0x10ada4c30>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Left-pin the MCS start at column 12 from the left edge.\n",
+    "widget.go_to(mcs)\n",
+    "widget"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "show-mcs",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "01f4356010d74479b3186d959e852b67",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "<gen.jupyter_widget.GenGraphWidget object at 0x10acbbb10>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Centre on the MCS and add a highlight.\n",
+    "widget.show(mcs)\n",
+    "widget"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "filter-section",
+   "metadata": {},
+   "source": [
+    "## Filter and batch-navigate\n",
+    "\n",
+    "You can filter the list and pass any record directly to `go_to` or `show`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "id": "filter-anns",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Promoters: ['lac promoter', 'AmpR promoter']\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'[\"\",\"\",\"\",\"\"]'"
+      ]
+     },
+     "execution_count": 39,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "promoters = [a for a in anns if \"promoter\" in a.name.lower()]\n",
+    "print(\"Promoters:\", [a.name for a in promoters])\n",
+    "\n",
+    "if promoters:\n",
+    "    widget.show(promoters[0])\n",
+    "    widget\n",
+    "\n",
+    "widget._controller.get_inline_annotation_names()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fc0759df-d793-4b81-a430-3721091a22bd",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gen-python/src/python_api/graph_search.rs
+++ b/gen-python/src/python_api/graph_search.rs
@@ -1,9 +1,10 @@
 use r#gen::{
-    graphs::graph_search::{GraphLocus, GraphPos},
+    graphs::graph_search::GraphPos,
     views::annotation_track::{AnnotationSegment, AnnotationSpan, graphlocus_to_annotation_span},
 };
 use gen_core::{HashId, Strand};
 use gen_graph::GraphNode;
+use gen_models::locus::GraphLocus;
 use pyo3::prelude::*;
 
 use super::block::PyBlock;
@@ -71,7 +72,7 @@ impl PyGraphLocus {
 
     /// Return the raw node sequence for highlight operations.
     pub fn locus_nodes(&self) -> Vec<GraphNode> {
-        self.inner.blocks.clone()
+        self.inner.slices.iter().map(|s| s.node).collect()
     }
 }
 
@@ -79,12 +80,14 @@ impl PyGraphLocus {
 impl PyGraphLocus {
     /// Position of the first matched byte (start of the locus).
     fn start(&self) -> PyGraphPos {
-        PyGraphPos::new(self.inner.blocks[0], self.inner.start_offset)
+        let s = &self.inner.slices[0];
+        PyGraphPos::new(s.node, s.start)
     }
 
     /// Position one past the last matched byte (exclusive end of the locus).
     fn end(&self) -> PyGraphPos {
-        PyGraphPos::new(*self.inner.blocks.last().unwrap(), self.inner.end_offset)
+        let s = self.inner.slices.last().unwrap();
+        PyGraphPos::new(s.node, s.end)
     }
 
     /// Ordered sequence of blocks that span this locus.
@@ -96,9 +99,9 @@ impl PyGraphLocus {
     #[getter]
     fn blocks(&self) -> Vec<PyBlock> {
         self.inner
-            .blocks
+            .slices
             .iter()
-            .map(|n| PyBlock::new(n.node_id, n.sequence_start, n.sequence_end))
+            .map(|s| PyBlock::new(s.node.node_id, s.node.sequence_start, s.node.sequence_end))
             .collect()
     }
 
@@ -113,10 +116,10 @@ impl PyGraphLocus {
     }
 
     fn __repr__(&self) -> String {
-        let sn = self.inner.blocks[0];
-        let en = *self.inner.blocks.last().unwrap();
-        let sh = format!("{}", sn.node_id);
-        let eh = format!("{}", en.node_id);
+        let first = &self.inner.slices[0];
+        let last = self.inner.slices.last().unwrap();
+        let sh = format!("{}", first.node.node_id);
+        let eh = format!("{}", last.node.node_id);
         let strand = match self.inner.strand {
             Strand::Forward => "+",
             Strand::Reverse => "-",
@@ -125,14 +128,14 @@ impl PyGraphLocus {
         format!(
             "GraphLocus({}[{}..{}]+{} → {}[{}..{}]+{}, {} blocks, strand={})",
             &sh[..8],
-            sn.sequence_start,
-            sn.sequence_end,
-            self.inner.start_offset,
+            first.node.sequence_start,
+            first.node.sequence_end,
+            first.start,
             &eh[..8],
-            en.sequence_start,
-            en.sequence_end,
-            self.inner.end_offset,
-            self.inner.blocks.len(),
+            last.node.sequence_start,
+            last.node.sequence_end,
+            last.end,
+            self.inner.slices.len(),
             strand,
         )
     }

--- a/gen-python/src/python_api/jupyter_widget.rs
+++ b/gen-python/src/python_api/jupyter_widget.rs
@@ -7,7 +7,6 @@ use std::{
 
 use r#gen::{
     get_connection,
-    graphs::graph_search::GraphLocus,
     views::{
         annotation_groups::load_annotation_group_entries,
         annotation_track::{AnnotationSpan, AnnotationTrack},
@@ -21,7 +20,9 @@ use r#gen::{
 };
 use gen_core::{HashId, PATH_END_NODE_ID, PATH_START_NODE_ID, is_end_node, is_start_node};
 use gen_graph::{GenGraph, GraphNode, project_path};
-use gen_models::{annotations::AnnotationError, block_group::BlockGroup, db::GraphConnection};
+use gen_models::{
+    annotations::AnnotationError, block_group::BlockGroup, db::GraphConnection, locus::GraphLocus,
+};
 use gen_tui::{
     LineStyle, graph_controller::GraphController, graph_widget::GraphWidget, layout::VisualDetail,
     plotter::PathStyle, theme::current_theme,

--- a/src/graphs/graph_search.rs
+++ b/src/graphs/graph_search.rs
@@ -5,7 +5,11 @@ use std::{
 
 use gen_core::{HashId, PATH_END_NODE_ID, PATH_START_NODE_ID, Strand};
 use gen_graph::{GenGraph, GraphNode};
-use gen_models::{db::GraphConnection, node::Node};
+use gen_models::{
+    db::GraphConnection,
+    locus::{BlockSlice, GraphLocus},
+    node::Node,
+};
 use petgraph::Direction;
 use serde::{Deserialize, Serialize};
 
@@ -19,58 +23,6 @@ pub struct GraphPos {
     pub block: GraphNode,
     /// Local offset within `block`'s sequence slice: `0..=block.length()`.
     pub offset: usize,
-}
-
-/// A linear walk through graph space that covers a complete match.
-///
-/// `blocks[0]` is the first node containing matched bytes;
-/// `blocks.last()` is the last. `start_offset` and `end_offset` anchor the
-/// match within those boundary nodes.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct GraphLocus {
-    /// Local offset of the first matched byte inside `blocks[0]`.
-    pub start_offset: usize,
-    /// Local offset past the last consumed byte in `blocks.last()`.
-    pub end_offset: usize,
-    /// Ordered sequence of nodes that spell the match. Length is at least 1.
-    pub blocks: Vec<GraphNode>,
-    /// Strand of the matched sequence.
-    pub strand: Strand,
-}
-
-/// Return the sequence bytes spanned by `locus`.
-///
-/// Fetches node sequences from the database, concatenates the relevant slices
-/// across all blocks, and reverse-complements the result for `Strand::Reverse`
-/// loci.
-pub fn locus_sequence(conn: &GraphConnection, locus: &GraphLocus) -> Vec<u8> {
-    let node_ids: Vec<HashId> = locus.blocks.iter().map(|n| n.node_id).collect();
-    let sequences = Node::get_sequences_by_node_ids(conn, &node_ids);
-
-    let n = locus.blocks.len();
-    let mut out = Vec::new();
-    for (i, block) in locus.blocks.iter().enumerate() {
-        let full = sequences[&block.node_id]
-            .get_sequence(None, None)
-            .expect("sequence data corrupt")
-            .into_bytes();
-        let block_start = usize::try_from(block.sequence_start).expect("negative sequence_start");
-        let block_end = usize::try_from(block.sequence_end).expect("negative sequence_end");
-        let text = &full[block_start..block_end];
-        let start = if i == 0 { locus.start_offset } else { 0 };
-        let end = if i == n - 1 {
-            locus.end_offset
-        } else {
-            text.len()
-        };
-        out.extend_from_slice(&text[start..end]);
-    }
-
-    if locus.strand == Strand::Reverse {
-        reverse_complement(&out)
-    } else {
-        out
-    }
 }
 
 /// Biological interpretation of the sequences being searched.
@@ -484,10 +436,23 @@ impl GenGraphMatcher {
 
         while let Some(ts) = stack.pop() {
             if ts.state.q_idx == query.len() {
+                let n = ts.path.len();
+                let slices = ts
+                    .path
+                    .into_iter()
+                    .enumerate()
+                    .map(|(i, node)| BlockSlice {
+                        node,
+                        start: if i == 0 { ts.start_offset } else { 0 },
+                        end: if i == n - 1 {
+                            ts.state.offset
+                        } else {
+                            node.length() as usize
+                        },
+                    })
+                    .collect();
                 out.push(GraphLocus {
-                    start_offset: ts.start_offset,
-                    end_offset: ts.state.offset,
-                    blocks: ts.path,
+                    slices,
                     strand: Strand::Unknown,
                 });
                 continue;
@@ -989,11 +954,9 @@ mod tests {
         let hits = matcher.find_all(b"AAAAAAAAAA");
         assert_eq!(hits.len(), 2);
 
-        assert!(
-            hits.iter().any(|hit| {
-                hit.start_offset == 0 && hit.end_offset == 10 && hit.blocks.len() == 1
-            })
-        );
+        assert!(hits.iter().any(|hit| {
+            hit.slices.len() == 1 && hit.slices[0].start == 0 && hit.slices[0].end == 10
+        }));
     }
 
     #[test]
@@ -1003,11 +966,9 @@ mod tests {
         let hits = matcher.find_all(b"AAAAATTTTT");
         assert_eq!(hits.len(), 2);
 
-        assert!(
-            hits.iter().any(|hit| {
-                hit.blocks.len() == 2 && hit.start_offset == 5 && hit.end_offset == 5
-            })
-        );
+        assert!(hits.iter().any(|hit| {
+            hit.slices.len() == 2 && hit.slices[0].start == 5 && hit.slices[1].end == 5
+        }));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ use r#gen::{
     },
     diffs::gfa::gfa_sample_diff,
     get_connection, get_operation_connection,
-    graphs::graph_search::{GenGraphMatcher, GraphLocus, SeedIndex},
+    graphs::graph_search::{GenGraphMatcher, SeedIndex},
     operation_management,
     operation_management::{parse_patch_operations, pull, push},
     patch,
@@ -707,15 +707,15 @@ fn call_cli() -> Result<(), Box<dyn std::error::Error>> {
                     .unwrap_or_else(|| Ok(matcher.find_all(query_bytes)))?;
                 for m in matches {
                     let block_strings: Vec<String> = m
-                        .blocks
+                        .slices
                         .iter()
-                        .map(|node| {
-                            let hash = format!("{}", node.node_id);
+                        .map(|s| {
+                            let hash = format!("{}", s.node.node_id);
                             format!(
                                 "{}:{}-{}",
                                 &hash[..12],
-                                node.sequence_start,
-                                node.sequence_end
+                                s.node.sequence_start,
+                                s.node.sequence_end
                             )
                         })
                         .collect();
@@ -724,7 +724,7 @@ fn call_cli() -> Result<(), Box<dyn std::error::Error>> {
                         bg.sample_name,
                         bg.name,
                         block_strings.join(", "),
-                        m.start_offset
+                        m.slices.first().map(|s| s.start).unwrap_or(0)
                     );
                 }
             }

--- a/src/views/annotation_track.rs
+++ b/src/views/annotation_track.rs
@@ -5,18 +5,17 @@ use std::{
 
 use gen_core::{HashId, Strand, is_end_node, is_start_node};
 use gen_graph::GenGraph;
+use gen_models::locus::{BlockSlice, GraphLocus};
 use gen_tui::{
     GraphController, ViewportState, VisualDetail, WorldRect, plotter::NodeSizer,
     theme::current_theme,
 };
-use petgraph::visit::NodeIndexable;
+use petgraph::visit::{IntoNodeIdentifiers, NodeIndexable};
 use ratatui::{
     buffer::Buffer,
     layout::Rect,
     style::{Color, Style},
 };
-
-use crate::graphs::graph_search::GraphLocus;
 
 #[derive(Clone, Debug)]
 pub struct AnnotationSegment {
@@ -43,28 +42,14 @@ pub struct AnnotationTrack {
 }
 
 pub fn graphlocus_to_annotation_span(locus: &GraphLocus, name: &str) -> AnnotationSpan {
-    let n = locus.blocks.len();
     let segments = locus
-        .blocks
+        .slices
         .iter()
-        .enumerate()
-        .map(|(i, node)| {
-            let start = if i == 0 {
-                node.sequence_start + locus.start_offset as i64
-            } else {
-                node.sequence_start
-            };
-            let end = if i == n - 1 {
-                node.sequence_start + locus.end_offset as i64
-            } else {
-                node.sequence_end
-            };
-            AnnotationSegment {
-                node_id: node.node_id,
-                start,
-                end,
-                strand: locus.strand,
-            }
+        .map(|s| AnnotationSegment {
+            node_id: s.node.node_id,
+            start: s.node.sequence_start + s.start as i64,
+            end: s.node.sequence_start + s.end as i64,
+            strand: locus.strand,
         })
         .collect();
     AnnotationSpan {
@@ -72,6 +57,31 @@ pub fn graphlocus_to_annotation_span(locus: &GraphLocus, name: &str) -> Annotati
         name: name.to_string(),
         segments,
     }
+}
+
+pub fn graph_locus_from_annotation_span(
+    span: &AnnotationSpan,
+    graph: &GenGraph,
+) -> Option<GraphLocus> {
+    if span.segments.is_empty() {
+        return None;
+    }
+    let strand = span.segments.first()?.strand;
+    let node_map: HashMap<_, _> = graph.node_identifiers().map(|n| (n.node_id, n)).collect();
+    let slices: Option<Vec<BlockSlice>> = span
+        .segments
+        .iter()
+        .map(|seg| {
+            let node = *node_map.get(&seg.node_id)?;
+            let start = (seg.start - node.sequence_start).max(0) as usize;
+            let end = (seg.end - node.sequence_start).max(0) as usize;
+            Some(BlockSlice { node, start, end })
+        })
+        .collect();
+    Some(GraphLocus {
+        slices: slices?,
+        strand,
+    })
 }
 
 impl AnnotationTrack {

--- a/src/views/gen_graph_widget.rs
+++ b/src/views/gen_graph_widget.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use gen_core::{is_end_node, is_start_node};
 use gen_graph::{GenGraph, GraphNode};
-use gen_models::{db::GraphConnection, node::Node, sequence::SequenceError};
+use gen_models::{db::GraphConnection, locus::GraphLocus, node::Node, sequence::SequenceError};
 use gen_tui::{
     geometry::{WorldPos, WorldRect},
     graph_controller::{GraphController, WorldBuffer},
@@ -13,8 +13,6 @@ use gen_tui::{
 };
 use petgraph::{graph::NodeIndex, visit::NodeIndexable};
 use ratatui::style::Style;
-
-use crate::graphs::graph_search::GraphLocus;
 
 /// Labels for special start/end nodes
 pub mod label {
@@ -291,31 +289,26 @@ pub fn locus_label_bounds(
         Some(WorldPos::new(rect.min.x + col, center.y))
     };
 
-    let last = locus.blocks.len() - 1;
+    let last = locus.slices.len() - 1;
 
-    let left_pos = locus.blocks.iter().enumerate().find_map(|(i, &block)| {
-        let col_raw = if i == 0 { locus.start_offset as i64 } else { 0 };
-        block_world_pos(block, col_raw)
+    let left_pos = locus.slices.iter().enumerate().find_map(|(i, s)| {
+        let col_raw = if i == 0 { s.start as i64 } else { 0 };
+        block_world_pos(s.node, col_raw)
     })?;
 
-    let right_pos = locus
-        .blocks
-        .iter()
-        .enumerate()
-        .rev()
-        .find_map(|(i, &block)| {
-            let col_raw = if i == last {
-                locus.end_offset.saturating_sub(1) as i64
-            } else {
-                block.length() - 1
-            };
-            block_world_pos(block, col_raw)
-        })?;
+    let right_pos = locus.slices.iter().enumerate().rev().find_map(|(i, s)| {
+        let col_raw = if i == last {
+            s.end.saturating_sub(1) as i64
+        } else {
+            s.node.length() - 1
+        };
+        block_world_pos(s.node, col_raw)
+    })?;
 
     let mut y_min = i64::MAX;
     let mut y_max = i64::MIN;
-    for &block in &locus.blocks {
-        let Some(&(center, _)) = pos_map.get(&block) else {
+    for s in &locus.slices {
+        let Some(&(center, _)) = pos_map.get(&s.node) else {
             continue;
         };
         y_min = y_min.min(center.y);
@@ -375,24 +368,19 @@ pub fn highlight_match_range<S: NodeSizer<GenGraph>>(
 ) {
     let detail_level = controller.get_detail_level();
 
-    let path_len = m.blocks.len();
-    for (i, &node) in m.blocks.iter().enumerate() {
-        let block_seq_len = node.length();
-        let col_start_raw = if i == 0 { m.start_offset as i64 } else { 0 };
-        let col_end_raw = if i == path_len - 1 {
-            m.end_offset.saturating_sub(1) as i64
-        } else {
-            block_seq_len - 1
-        };
+    for s in &m.slices {
+        let block_seq_len = s.node.length();
+        let col_start_raw = s.start as i64;
+        let col_end_raw = s.end.saturating_sub(1) as i64;
         let (col_start, col_end) = (
             clamp_col(col_start_raw, block_seq_len, detail_level),
             clamp_col(col_end_raw, block_seq_len, detail_level),
         );
-        controller.set_cell_highlight(node, (col_start, 0), (col_end, 0), style);
+        controller.set_cell_highlight(s.node, (col_start, 0), (col_end, 0), style);
     }
 
-    for (&src, &dst) in m.blocks.iter().zip(m.blocks.iter().skip(1)) {
-        controller.set_edge_highlight((src, dst), style);
+    for (s, t) in m.slices.iter().zip(m.slices.iter().skip(1)) {
+        controller.set_edge_highlight((s.node, t.node), style);
     }
 }
 


### PR DESCRIPTION
## Summary
- Adds `gen-models::locus` module: `GraphLocus`, `BlockSlice`, and annotation span conversion helpers
- Migrates `graph_search::GraphLocus` to use `gen_models::locus::GraphLocus`

## Test plan
- [ ] `cargo test -p gen-models`
- [ ] `cargo test -p gen` (graph_search integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)