### PR TITLE
Add file path to operation files

### DIFF
--- a/gen-capnp-schemas/gen-models.capnp
+++ b/gen-capnp-schemas/gen-models.capnp
@@ -230,6 +230,7 @@ struct ManifestOperation {
 struct ManifestOperationFileAddition {
   fileAddition @0 :FileAddition;
   filename @1 :Text;
+  filePath @2 :Text;
 }
 
 struct ManifestAnnotationFileAddition {

--- a/gen-models/migrations/operations/05-operation-files-file-path/down.sql
+++ b/gen-models/migrations/operations/05-operation-files-file-path/down.sql
@@ -1,0 +1,16 @@
+UPDATE file_additions
+SET asset_uri = COALESCE(
+  (
+    SELECT 'file://' || of.file_path
+    FROM operation_files of
+    WHERE of.file_addition_id = file_additions.id
+      AND of.file_path NOT LIKE '%://%'
+    ORDER BY of.id
+    LIMIT 1
+  ),
+  asset_uri
+)
+WHERE asset_uri LIKE 'file://.gen/assets/%';
+
+ALTER TABLE operation_files
+DROP COLUMN file_path;

--- a/gen-models/migrations/operations/05-operation-files-file-path/up.sql
+++ b/gen-models/migrations/operations/05-operation-files-file-path/up.sql
@@ -1,0 +1,29 @@
+ALTER TABLE operation_files
+ADD COLUMN file_path TEXT NOT NULL DEFAULT '';
+
+UPDATE operation_files
+SET file_path = (
+  SELECT CASE
+    WHEN fa.asset_uri LIKE 'file://%' THEN substr(fa.asset_uri, 8)
+    ELSE fa.asset_uri
+  END
+  FROM file_additions fa
+  WHERE fa.id = operation_files.file_addition_id
+);
+
+UPDATE file_additions
+SET asset_uri = 'file://.gen/assets/' || lower(hex(checksum)) || '.' ||
+  CASE file_type
+    WHEN 'gb' THEN 'gb'
+    WHEN 'fasta' THEN 'fa'
+    WHEN 'gfa' THEN 'gfa'
+    WHEN 'gaf' THEN 'gaf'
+    WHEN 'vcf' THEN 'vcf'
+    WHEN 'changeset' THEN 'cs'
+    WHEN 'csv' THEN 'csv'
+    WHEN 'gff3' THEN 'gff3'
+    WHEN 'bed' THEN 'bed'
+    WHEN 'tabix' THEN 'tbi'
+    ELSE 'none'
+  END
+WHERE asset_uri LIKE 'file://%';

--- a/gen-models/src/assets.rs
+++ b/gen-models/src/assets.rs
@@ -492,6 +492,42 @@ impl LocalAssetUri {
         Self::stored_relative_path(workspace, &source_path, checksum, file_type)
     }
 
+    pub fn is_asset_relative_path(
+        workspace: &Workspace,
+        relative_path: &str,
+    ) -> Result<bool, FileAdditionError> {
+        let repo_root = workspace.repo_root()?;
+        let asset_dir = workspace.asset_dir()?;
+        let asset_relative_dir =
+            asset_dir
+                .strip_prefix(&repo_root)
+                .map_err(|_| FileAdditionError::PathOutsideRepo {
+                    path: asset_dir.clone(),
+                    repo_root: repo_root.clone(),
+                })?;
+
+        let candidate = if relative_path.is_empty() {
+            PathBuf::new()
+        } else {
+            Self::sanitize_relative_path(Path::new(relative_path))?
+        };
+
+        Ok(candidate.starts_with(asset_relative_dir))
+    }
+
+    pub fn repo_relative_destination_path(
+        workspace: &Workspace,
+        relative_path: &str,
+    ) -> Result<PathBuf, FileAdditionError> {
+        let sanitized = if relative_path.is_empty() {
+            PathBuf::new()
+        } else {
+            Self::sanitize_relative_path(Path::new(relative_path))?
+        };
+
+        Ok(workspace.repo_root()?.join(sanitized))
+    }
+
     fn file_path(&self) -> &str {
         self.asset_uri
             .strip_prefix(Self::SCHEME)

--- a/gen-models/src/assets.rs
+++ b/gen-models/src/assets.rs
@@ -492,6 +492,7 @@ impl LocalAssetUri {
         Self::stored_relative_path(workspace, &source_path, checksum, file_type)
     }
 
+    /// Checks whether a relative path is in the .gen/assets directory of a workspace.
     pub fn is_asset_relative_path(
         workspace: &Workspace,
         relative_path: &str,
@@ -515,6 +516,8 @@ impl LocalAssetUri {
         Ok(candidate.starts_with(asset_relative_dir))
     }
 
+    /// Given a workspace and a relative path, try to safely give a destination path to copy
+    /// the asset into
     pub fn repo_relative_destination_path(
         workspace: &Workspace,
         relative_path: &str,
@@ -566,16 +569,17 @@ impl LocalAssetUri {
 
     fn resolve_input_source_path(
         workspace: &Workspace,
-        path_or_uri: &str,
+        file_path_or_uri: &str,
     ) -> Result<PathBuf, FileAdditionError> {
-        if !Self::is_local_path_or_file_uri(path_or_uri) {
+        if !Self::is_local_path_or_file_uri(file_path_or_uri) {
             return Err(FileAdditionError::FileReadError(io::Error::new(
                 io::ErrorKind::InvalidInput,
-                format!("unsupported non-local uri: {path_or_uri}"),
+                format!("unsupported non-local uri: {file_path_or_uri}"),
             )));
         }
 
-        let file_path = Self::path_from_uri(path_or_uri).unwrap_or_else(|| path_or_uri.to_string());
+        let file_path =
+            Self::path_from_uri(file_path_or_uri).unwrap_or_else(|| file_path_or_uri.to_string());
         if file_path.is_empty() {
             return Ok(PathBuf::new());
         }

--- a/gen-models/src/assets.rs
+++ b/gen-models/src/assets.rs
@@ -393,12 +393,7 @@ impl AssetUri for LocalAssetUri {
         checksum: &HashId,
         file_type: FileTypes,
     ) -> Result<String, FileAdditionError> {
-        let relative_file_path = Self::stored_relative_path(
-            workspace,
-            &self.resolved_source_file_path(workspace)?,
-            checksum,
-            file_type,
-        )?;
+        let relative_file_path = Self::asset_relative_path(workspace, checksum, file_type)?;
         Ok(Self::asset_uri(&relative_file_path))
     }
 
@@ -460,6 +455,14 @@ impl LocalAssetUri {
         asset_uri.starts_with(Self::SCHEME)
     }
 
+    pub fn has_uri_scheme(path_or_uri: &str) -> bool {
+        path_or_uri.contains("://")
+    }
+
+    pub fn is_local_path_or_file_uri(path_or_uri: &str) -> bool {
+        Self::is_file_uri(path_or_uri) || !Self::has_uri_scheme(path_or_uri)
+    }
+
     pub fn asset_uri(path: &str) -> String {
         let path = path.strip_prefix('/').unwrap_or(path);
         if Self::is_file_uri(path) {
@@ -473,6 +476,20 @@ impl LocalAssetUri {
         asset_uri
             .strip_prefix(Self::SCHEME)
             .map(ToString::to_string)
+    }
+
+    pub fn operation_file_path(
+        workspace: &Workspace,
+        path_or_uri: &str,
+        checksum: &HashId,
+        file_type: FileTypes,
+    ) -> Result<String, FileAdditionError> {
+        let source_path = if Self::is_file_uri(path_or_uri) {
+            Self::resolve_source_path(workspace, path_or_uri)?
+        } else {
+            Self::resolve_input_source_path(workspace, path_or_uri)?
+        };
+        Self::stored_relative_path(workspace, &source_path, checksum, file_type)
     }
 
     fn file_path(&self) -> &str {
@@ -515,6 +532,13 @@ impl LocalAssetUri {
         workspace: &Workspace,
         path_or_uri: &str,
     ) -> Result<PathBuf, FileAdditionError> {
+        if !Self::is_local_path_or_file_uri(path_or_uri) {
+            return Err(FileAdditionError::FileReadError(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("unsupported non-local uri: {path_or_uri}"),
+            )));
+        }
+
         let file_path = Self::path_from_uri(path_or_uri).unwrap_or_else(|| path_or_uri.to_string());
         if file_path.is_empty() {
             return Ok(PathBuf::new());

--- a/gen-models/src/assets.rs
+++ b/gen-models/src/assets.rs
@@ -1130,6 +1130,21 @@ mod tests {
         assert!(matches!(err, FileAdditionError::PathOutsideRepo { .. }));
     }
 
+    #[test]
+    fn test_new_for_workspace_rejects_non_local_uri() {
+        let context = setup_gen();
+        let workspace = context.workspace();
+
+        let err = LocalAssetUri::new_for_workspace(workspace, "https://example.com/reference.fa")
+            .err()
+            .expect("expected non-local uri to be rejected");
+        assert!(matches!(err, FileAdditionError::FileReadError(_)));
+        assert!(
+            err.to_string()
+                .contains("unsupported non-local uri: https://example.com/reference.fa")
+        );
+    }
+
     #[cfg(unix)]
     #[test]
     fn test_resolve_source_path_rejects_symlink_escape() {

--- a/gen-models/src/manifest.rs
+++ b/gen-models/src/manifest.rs
@@ -17,6 +17,7 @@ use crate::{
 pub struct ManifestOperationFileAddition {
     pub file_addition: FileAddition,
     pub filename: String,
+    pub file_path: String,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -36,12 +37,14 @@ impl<'a> Capnp<'a> for ManifestOperationFileAddition {
         let mut file_addition_builder = builder.reborrow().init_file_addition();
         self.file_addition.write_capnp(&mut file_addition_builder);
         builder.set_filename(&self.filename);
+        builder.set_file_path(&self.file_path);
     }
 
     fn read_capnp(reader: Self::Reader) -> Self {
         Self {
             file_addition: FileAddition::read_capnp(reader.get_file_addition().unwrap()),
             filename: reader.get_filename().unwrap().to_string().unwrap(),
+            file_path: reader.get_file_path().unwrap().to_string().unwrap(),
         }
     }
 }
@@ -62,6 +65,7 @@ impl ManifestOperationFileAddition {
                         checksum: file.checksum,
                     },
                     filename: file.filename,
+                    file_path: file.file_path,
                 })
                 .collect(),
         )
@@ -496,6 +500,7 @@ mod tests {
                     checksum: HashId([2u8; 32]),
                 },
                 filename: "file.fa".to_string(),
+                file_path: "fixtures/file.fa".to_string(),
             }],
             annotation_file_additions: vec![ManifestAnnotationFileAddition {
                 file_addition: FileAddition {

--- a/gen-models/src/operations.rs
+++ b/gen-models/src/operations.rs
@@ -161,10 +161,16 @@ impl Operation {
         operation_hash: &HashId,
         file_addition_id: &HashId,
         filename: &str,
+        file_path: &str,
     ) -> SQLResult<()> {
-        let query = "INSERT INTO operation_files (operation_hash, file_addition_id, filename) VALUES (?1, ?2, ?3)";
+        let query = "INSERT INTO operation_files (operation_hash, file_addition_id, filename, file_path) VALUES (?1, ?2, ?3, ?4)";
         let mut stmt = conn.prepare(query).unwrap();
-        stmt.execute(params![operation_hash, file_addition_id, filename])?;
+        stmt.execute(params![
+            operation_hash,
+            file_addition_id,
+            filename,
+            file_path
+        ])?;
         Ok(())
     }
 
@@ -382,15 +388,19 @@ pub struct OperationFileInfo {
 }
 
 impl OperationFileInfo {
-    fn from_parts(file_addition: FileAddition, filename: String) -> Self {
+    fn from_parts(file_addition: FileAddition, filename: String, file_path: String) -> Self {
         Self {
             id: file_addition.id,
-            file_path: filename.clone(),
+            file_path,
             filename,
             asset_uri: file_addition.asset_uri,
             file_type: file_addition.file_type,
             checksum: file_addition.checksum,
         }
+    }
+
+    pub fn hashed_filename(&self) -> String {
+        LocalAssetUri::asset_filename(&self.checksum, self.file_type)
     }
 }
 
@@ -425,12 +435,13 @@ impl OperationFile {
         conn: &OperationsConnection,
         operation_hash: &HashId,
     ) -> Result<Vec<OperationFileInfo>, FileAdditionError> {
-        let query = "select fa.*, of.filename from file_additions fa join operation_files of on (fa.id = of.file_addition_id) where of.operation_hash = ?1";
+        let query = "select fa.*, of.filename, of.file_path from file_additions fa join operation_files of on (fa.id = of.file_addition_id) where of.operation_hash = ?1";
         let mut stmt = conn.prepare(query)?;
         stmt.query_map(params![operation_hash], |row| {
             Ok(OperationFileInfo::from_parts(
                 FileAddition::process_row(row),
                 row.get(4)?,
+                row.get(5)?,
             ))
         })?
         .collect::<Result<Vec<_>, _>>()
@@ -441,7 +452,7 @@ impl OperationFile {
         conn: &OperationsConnection,
         operations: &[HashId],
     ) -> Result<HashMap<HashId, Vec<OperationFileInfo>>, FileAdditionError> {
-        let query = "select fa.*, of.filename, of.operation_hash from file_additions fa join operation_files of on (fa.id = of.file_addition_id) where of.operation_hash in rarray(?1)";
+        let query = "select fa.*, of.filename, of.file_path, of.operation_hash from file_additions fa join operation_files of on (fa.id = of.file_addition_id) where of.operation_hash in rarray(?1)";
         let mut stmt = conn.prepare(query)?;
         let rows = stmt.query_map(
             params![Rc::new(
@@ -452,8 +463,12 @@ impl OperationFile {
             )],
             |row| {
                 Ok((
-                    OperationFileInfo::from_parts(FileAddition::process_row(row), row.get(4)?),
-                    row.get::<_, HashId>(5)?,
+                    OperationFileInfo::from_parts(
+                        FileAddition::process_row(row),
+                        row.get(4)?,
+                        row.get(5)?,
+                    ),
+                    row.get::<_, HashId>(6)?,
                 ))
             },
         )?;
@@ -488,22 +503,37 @@ pub fn add_files_operation(
             let file_type = FileTypes::infer_from_path(path);
             let file_addition =
                 FileAddition::get_or_create(workspace, operation_conn, path, file_type, None)?;
-            Ok::<(FileAddition, String), FileAdditionError>((
+            let operation_file_path = if LocalAssetUri::is_local_path_or_file_uri(path) {
+                LocalAssetUri::operation_file_path(
+                    workspace,
+                    path,
+                    &file_addition.checksum,
+                    file_type,
+                )?
+            } else {
+                path.clone()
+            };
+            Ok::<(FileAddition, String, String), FileAdditionError>((
                 file_addition,
                 OperationFile::new(path.clone()).filename,
+                operation_file_path,
             ))
         })
         .collect::<Result<Vec<_>, _>>()?;
 
     let unique_file_additions = file_additions
         .into_iter()
-        .unique_by(|(file_addition, filename)| (file_addition.id, filename.clone()))
+        .unique_by(|(file_addition, filename, file_path)| {
+            (file_addition.id, filename.clone(), file_path.clone())
+        })
         .collect::<Vec<_>>();
 
     let operation_hash = HashId(calculate_hash(
         &unique_file_additions
             .iter()
-            .map(|(file_addition, filename)| format!("{}:{filename}", file_addition.id))
+            .map(|(file_addition, filename, file_path)| {
+                format!("{}:{filename}:{file_path}", file_addition.id)
+            })
             .sorted()
             .join(":"),
     ));
@@ -520,8 +550,14 @@ pub fn add_files_operation(
         Err(err) => return Err(err.into()),
     };
 
-    for (file_addition, filename) in &unique_file_additions {
-        Operation::add_file(operation_conn, &operation.hash, &file_addition.id, filename)?;
+    for (file_addition, filename, file_path) in &unique_file_additions {
+        Operation::add_file(
+            operation_conn,
+            &operation.hash,
+            &file_addition.id,
+            filename,
+            file_path,
+        )?;
     }
 
     Operation::add_database(operation_conn, &operation.hash, &db_uuid)?;
@@ -548,7 +584,7 @@ pub fn add_files_operation(
 
     for file_addition in unique_file_additions
         .into_iter()
-        .map(|(file_addition, _filename)| file_addition)
+        .map(|(file_addition, _filename, _file_path)| file_addition)
         .unique_by(|file_addition| file_addition.id)
     {
         file_addition.store_file(workspace)?;
@@ -2674,12 +2710,6 @@ mod tests {
         let file1_path = repo_root.join("test_file.txt");
         fs::write(&file1_path, b"Test file content").unwrap();
         let file1_path_str = file1_path.to_string_lossy().to_string();
-        let relative1 = file1_path
-            .strip_prefix(&repo_root)
-            .unwrap()
-            .to_string_lossy()
-            .to_string();
-
         let fa1 = FileAddition::get_or_create(
             context.workspace(),
             op_conn,
@@ -2689,13 +2719,20 @@ mod tests {
         )
         .expect("Failed to create FileAddition");
 
-        assert_eq!(fa1.asset_uri, LocalAssetUri::asset_uri(&relative1));
-        assert_eq!(fa1.file_path(), relative1);
-
         let checksum = calculate_file_checksum(&file1_path_str).unwrap();
+        let expected_asset_path = format!(
+            ".gen/assets/{checksum}.{}",
+            FileTypes::suffix(FileTypes::Fasta)
+        );
+        assert_eq!(
+            fa1.asset_uri,
+            LocalAssetUri::asset_uri(&expected_asset_path)
+        );
+        assert_eq!(fa1.file_path(), expected_asset_path);
+
         let relative1_id = LocalAssetUri::generate_file_addition_id(
             &checksum,
-            &LocalAssetUri::asset_uri(&relative1),
+            &LocalAssetUri::asset_uri(&expected_asset_path),
         );
 
         assert_eq!(fa1.id, relative1_id);
@@ -2734,7 +2771,7 @@ mod tests {
         )
         .expect("Failed to create different FileAddition");
 
-        assert_ne!(fa1.id, fa3.id);
+        assert_eq!(fa1.id, fa3.id);
 
         fs::write(&file1_path, b"new content").unwrap();
         let fa1_new = FileAddition::get_or_create(
@@ -2854,17 +2891,17 @@ mod tests {
         .unwrap();
 
         let operation_1_files =
-            FileAddition::get_files_for_operation(operation_conn, &operation_1.hash);
+            OperationFile::get_files_for_operation(operation_conn, &operation_1.hash).unwrap();
         let operation_2_files =
-            FileAddition::get_files_for_operation(operation_conn, &operation_2.hash);
+            OperationFile::get_files_for_operation(operation_conn, &operation_2.hash).unwrap();
 
         let shared_file_1 = operation_1_files
             .iter()
-            .find(|file| file.file_path() == "shared.txt")
+            .find(|file| file.file_path == "shared.txt")
             .unwrap();
         let shared_file_2 = operation_2_files
             .iter()
-            .find(|file| file.file_path() == "shared.txt")
+            .find(|file| file.file_path == "shared.txt")
             .unwrap();
 
         assert_eq!(shared_file_1.id, shared_file_2.id);
@@ -2881,7 +2918,7 @@ mod tests {
             asset_names.contains(
                 &operation_2_files
                     .iter()
-                    .find(|file| file.file_path() == "unique.txt")
+                    .find(|file| file.file_path == "unique.txt")
                     .unwrap()
                     .clone()
                     .hashed_filename()
@@ -2973,11 +3010,12 @@ mod tests {
             .ok_or_else(|| "missing second operation files".to_string())?;
 
         assert_eq!(alpha[0].filename, "alpha.fa");
-        assert_eq!(alpha[0].file_path, "alpha.fa");
+        assert!(alpha[0].file_path.ends_with(".fa"));
         assert_eq!(beta[0].filename, "beta.fa");
-        assert_eq!(beta[0].file_path, "beta.fa");
+        assert!(beta[0].file_path.ends_with(".fa"));
         assert!(alpha[0].asset_uri.ends_with(".fa"));
         assert!(beta[0].asset_uri.ends_with(".fa"));
+        assert_eq!(alpha[0].file_path, beta[0].file_path);
         assert_eq!(alpha[0].id, beta[0].id);
         assert_eq!(alpha[0].checksum, beta[0].checksum);
         Ok(())

--- a/gen-models/src/session_operations.rs
+++ b/gen-models/src/session_operations.rs
@@ -76,8 +76,14 @@ pub fn end_operation(
                     Ok(fa) => fa,
                     Err(err) => return Err(OperationError::SQLError(format!("{err}"))),
                 };
-                Operation::add_file(operation_conn, &operation.hash, &fa.id, &op_file.filename)
-                    .map_err(|err| OperationError::SQLError(format!("{err}")))?;
+                Operation::add_file(
+                    operation_conn,
+                    &operation.hash,
+                    &fa.id,
+                    &op_file.filename,
+                    &op_file.file_path,
+                )
+                .map_err(|err| OperationError::SQLError(format!("{err}")))?;
                 if fa.file_type != FileTypes::Changeset && fa.file_type != FileTypes::None {
                     match fa.store_file(context.workspace()) {
                         Ok(()) => {}

--- a/src/operation_management.rs
+++ b/src/operation_management.rs
@@ -14,6 +14,7 @@ use gen_core::{
 };
 use gen_models::{
     annotations::{AnnotationFile, AnnotationFileError},
+    assets::LocalAssetUri,
     changesets::{apply_changeset, revert_changeset},
     db::{DbContext, OperationsConnection},
     errors::{BranchError, ChangesetError, FileAdditionError, OperationError, RemoteError},
@@ -30,6 +31,7 @@ use gen_models::{
     session_operations::{end_operation, start_operation},
     traits::*,
 };
+use log::info;
 use petgraph::Direction;
 use reqwest::blocking::{Client, multipart};
 use rusqlite::{self, Error as SQLError};
@@ -512,7 +514,6 @@ fn connect_file_remote(
 
     Ok((Workspace::new(remote_path), remote_op_conn))
 }
-
 fn apply_operations_to_remote(
     local_context: &DbContext,
     remote_op_conn: &OperationsConnection,
@@ -567,6 +568,40 @@ fn apply_operations_to_remote(
                         dst_path.to_string_lossy().to_string(),
                     )
                 })?;
+
+                // This is materializing the file in the directory. If file_addition file_path
+                // will always be the asset_dir path, while file_addition.file_path can be like
+                // fastas/hg19.fa. So if we are not in the asset_dir, we copy it out
+                if file_addition.file_path != file_addition.file_addition.file_path()
+                    && LocalAssetUri::is_asset_relative_path(
+                        remote_workspace,
+                        file_addition.file_addition.file_path(),
+                    )?
+                {
+                    let user_dst_path = LocalAssetUri::repo_relative_destination_path(
+                        remote_workspace,
+                        &file_addition.file_path,
+                    )
+                    .map_err(|err| RemoteOperationError::IOError(std::io::Error::other(err)))?;
+                    if user_dst_path.exists() {
+                        info!(
+                            "Skipping copy for existing file {}",
+                            user_dst_path.to_string_lossy()
+                        );
+                    } else {
+                        if let Some(parent) = user_dst_path.parent() {
+                            fs::create_dir_all(parent)?;
+                        }
+
+                        fs::copy(&dst_path, &user_dst_path).map_err(|_| {
+                            RemoteOperationError::FileTransferError(
+                                file_addition.file_path.clone(),
+                                dst_path.to_string_lossy().to_string(),
+                                user_dst_path.to_string_lossy().to_string(),
+                            )
+                        })?;
+                    }
+                }
             }
         }
 
@@ -1223,6 +1258,36 @@ fn copy_operation_from_remote_fs(
                     dst_path.to_string_lossy().to_string(),
                 )
             })?;
+
+            if file_addition.file_path != file_addition.file_addition.file_path()
+                && LocalAssetUri::is_asset_relative_path(
+                    local_workspace,
+                    file_addition.file_addition.file_path(),
+                )?
+            {
+                let user_dst_path = LocalAssetUri::repo_relative_destination_path(
+                    local_workspace,
+                    &file_addition.file_path,
+                )
+                .map_err(|err| RemoteOperationError::IOError(std::io::Error::other(err)))?;
+                if user_dst_path.exists() {
+                    info!(
+                        "Skipping copy for existing file {}",
+                        user_dst_path.to_string_lossy()
+                    );
+                } else {
+                    if let Some(parent) = user_dst_path.parent() {
+                        fs::create_dir_all(parent)?;
+                    }
+                    fs::copy(&dst_path, &user_dst_path).map_err(|_| {
+                        RemoteOperationError::FileTransferError(
+                            file_addition.file_path.clone(),
+                            dst_path.to_string_lossy().to_string(),
+                            user_dst_path.to_string_lossy().to_string(),
+                        )
+                    })?;
+                }
+            }
         }
     }
     for annotation_file in &manifest_operation.annotation_file_additions {
@@ -2337,6 +2402,7 @@ mod tests {
     mod apply_operations_to_remote {
         use gen_models::{
             collection::Collection,
+            manifest::ManifestOperationFileAddition,
             operations::{OperationFile, OperationInfo},
             session_operations::{end_operation, start_operation},
         };
@@ -2426,6 +2492,55 @@ mod tests {
                 assert!(remote_operation.is_some());
                 assert_eq!(remote_operation.unwrap().hash, operation.hash);
             }
+        }
+
+        #[test]
+        fn test_apply_operations_to_remote_rejects_absolute_file_path() {
+            let local_context = setup_gen();
+            let local_conn = local_context.graph().conn();
+            let local_op_conn = local_context.operations().conn();
+            track_database(local_conn, local_op_conn).unwrap();
+            let local_root = local_context.repo_root().unwrap();
+
+            Collection::create(local_conn, "test_collection").unwrap();
+            let mut session = start_operation(local_conn);
+            Collection::create(local_conn, "test_collection_0").unwrap();
+
+            let file_path = "test_file_0.fa".to_string();
+            fs::write(local_root.join(&file_path), "test file content").unwrap();
+            end_operation(
+                &local_context,
+                &mut session,
+                &OperationInfo {
+                    files: vec![OperationFile::new(file_path).set_file_type(FileTypes::Fasta)],
+                    description: "Test operation 0".to_string(),
+                },
+                "Test operation 0",
+                None,
+            )
+            .unwrap();
+
+            let local_main = Branch::get_by_name(local_op_conn, "main").unwrap();
+            let remote_context = setup_gen();
+            let remote_op_conn = remote_context.operations().conn();
+            let remote_workspace = remote_context.workspace();
+
+            let mut local_manifest = ManifestGenerator::new(local_op_conn)
+                .generate_manifest("main", local_main.current_operation_hash.as_ref())
+                .unwrap();
+            local_manifest.operations[0].file_additions[0] = ManifestOperationFileAddition {
+                file_path: "/etc/passwd".to_string(),
+                ..local_manifest.operations[0].file_additions[0].clone()
+            };
+
+            let result = apply_operations_to_remote(
+                &local_context,
+                remote_op_conn,
+                &local_manifest.operations,
+                remote_workspace,
+            );
+
+            assert!(matches!(result, Err(RemoteOperationError::IOError(_))));
         }
     }
 
@@ -2636,6 +2751,51 @@ mod tests {
 
             let result = push_to_file_remote(&context, &remote_url, "main");
             assert!(matches!(result, Err(RemoteOperationError::NoOperations)));
+        }
+
+        #[test]
+        fn test_copy_operation_from_remote_fs_rejects_absolute_file_path() {
+            let local_context = setup_gen();
+            let local_workspace = local_context.workspace();
+            let conn = local_context.graph().conn();
+            let op_conn = local_context.operations().conn();
+            track_database(conn, op_conn).unwrap();
+
+            let remote_context = setup_gen_on_disk();
+            let remote_conn = remote_context.graph().conn();
+            let remote_op_conn = remote_context.operations().conn();
+            track_database(remote_conn, remote_op_conn).unwrap();
+
+            let remote_operation = create_operation(
+                &remote_context,
+                "remote_file.fa",
+                FileTypes::Fasta,
+                "remote operation",
+                HashId::random_str(),
+            );
+
+            let branch = Branch::get_by_name(remote_op_conn, "main").unwrap();
+            let mut remote_manifest = ManifestGenerator::new(remote_op_conn)
+                .generate_manifest("main", branch.current_operation_hash.as_ref())
+                .unwrap();
+            let manifest_operation = remote_manifest
+                .operations
+                .iter_mut()
+                .find(|op| op.operation.hash == remote_operation.hash)
+                .unwrap();
+            manifest_operation.file_additions[0] =
+                gen_models::manifest::ManifestOperationFileAddition {
+                    file_path: "/etc/passwd".to_string(),
+                    ..manifest_operation.file_additions[0].clone()
+                };
+
+            let result = copy_operation_from_remote_fs(
+                manifest_operation,
+                local_workspace,
+                remote_context.workspace(),
+            );
+
+            assert!(matches!(result, Err(RemoteOperationError::IOError(_))));
         }
     }
 }

--- a/src/operation_management.rs
+++ b/src/operation_management.rs
@@ -650,6 +650,7 @@ fn apply_operations_to_remote(
                         &operation.hash,
                         &remote_file_addition.id,
                         &file_addition.filename,
+                        &file_addition.file_path,
                     )?;
                 }
                 for annotation_file in &manifest_op.annotation_file_additions {
@@ -1107,6 +1108,7 @@ fn ingest_manifest_operation(
                     &operation.hash,
                     &local_file_addition.id,
                     &file_addition.filename,
+                    &file_addition.file_path,
                 )?;
             }
             for annotation_file in &manifest_operation.annotation_file_additions {


### PR DESCRIPTION
Stores the filepath in operation files and always makes fileaddition asset_uri go under .gen/assets if it's a file uri. Previously, asset_uri could be like fasta/hg19.fa, which would not be stable across operations. 