### PR TITLE
feat(jupyter-widget): per-cell cloning, freeze, and snapshots

### DIFF
--- a/gen-python/examples/annotations.ipynb
+++ b/gen-python/examples/annotations.ipynb
@@ -146,46 +146,25 @@
     "\n",
     "Filter for the MCS feature and navigate to it two ways:\n",
     "\n",
-    "* `widget.go_to(ann)` \u2014 left-pins the annotation start at column 12, no highlight\n",
-    "* `widget.show(ann)` \u2014 left-pins the annotation start and adds a highlight"
+    "* `widget.go_to(ann)` — left-pins the annotation start at column 12, no highlight\n",
+    "* `widget.show(ann)` — left-pins the annotation start and adds a highlight"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "find-mcs",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "MCS locus: 348d9388:0-2686(+)\n",
-      "MCS start: 348d9388:0-2686+631\n"
-     ]
-    }
-   ],
-   "source": [
-    "mcs = next(a for a in anns if a.name == \"MCS\")\n",
-    "print(\"MCS locus:\", mcs.locus)\n",
-    "print(\"MCS start:\", mcs.locus.start())"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
    "id": "goto-mcs",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "76c94f590f4a43869d4052efd3f1bf28",
+       "model_id": "239be2be7b384de1ba41377eb810a7ea",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "<gen.jupyter_widget.GenGraphWidget object at 0x10ae46030>"
+       "<gen.jupyter_widget.GenGraphWidget object at 0x10caf2850>"
       ]
      },
      "metadata": {},
@@ -194,36 +173,26 @@
    ],
    "source": [
     "# Left-pin the MCS start at column 12 from the left edge.\n",
+    "mcs = next(a for a in anns if a.name == \"MCS\")\n",
     "fig.go_to(mcs)\n",
     "fig\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "id": "709252ad-a8d7-4947-89cb-a8d804af1557",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Freeze the cell so we can compare\n",
-    "fig = bg.plot(rows=24)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 5,
    "id": "show-mcs",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7e2c39d879d84b2da0afc4a9b3f3a57f",
+       "model_id": "3d64ee104c4742d9b0f9a765caa4d450",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "<gen.jupyter_widget.GenGraphWidget object at 0x10af0c250>"
+       "<gen.jupyter_widget.GenGraphWidget object at 0x10caf3390>"
       ]
      },
      "metadata": {},
@@ -231,8 +200,10 @@
     }
    ],
    "source": [
-    "# Also add a highlight.\n",
-    "fig.show(mcs)\n",
+    "# Or go somewhere and immediately add a highlight.\n",
+    "pbla = next(a for a in anns if a.name == \"AmpR promoter\")\n",
+    "\n",
+    "fig.show(pbla)\n",
     "fig"
    ]
   },
@@ -248,7 +219,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 6,
    "id": "1e9bd125",
    "metadata": {},
    "outputs": [
@@ -258,6 +229,20 @@
      "text": [
       "5 match(es) found\n"
      ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "de2697a3f5ce42ecb6a01274050b7041",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "<gen.jupyter_widget.GenGraphWidget object at 0x10cae75c0>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -272,12 +257,15 @@
     "print(f\"{len(matches)} match(es) found\")\n",
     "\n",
     "for i, locus in enumerate(matches):\n",
-    "    fig.add_annotation(gen.Annotation(locus, f\"Dcm ({i + 1} of {len(matches)})\"), )"
+    "    fig.add_annotation(gen.Annotation(locus, f\"Dcm ({i + 1} of {len(matches)})\"), )\n",
+    "\n",
+    "fig.go_to(matches[0])\n",
+    "fig"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 7,
    "id": "88cd6304",
    "metadata": {},
    "outputs": [
@@ -292,12 +280,12 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "522f9943dde34dcbba3e521d4ad6e8ef",
+       "model_id": "128e32a8cb914ba2be5e778c6e50738c",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "<gen.jupyter_widget.GenGraphWidget object at 0x10a652450>"
+       "<gen.jupyter_widget.GenGraphWidget object at 0x10cb6deb0>"
       ]
      },
      "metadata": {},
@@ -313,47 +301,9 @@
     "print(f\"{len(hits)} Dcm hit(s)\")\n",
     "\n",
     "\n",
-    "#fig.go_to(hits[0])\n",
+    "fig.go_to(hits[0])\n",
     "fig"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "id": "fc0759df-d793-4b81-a430-3721091a22bd",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[GraphLocus([348d9388[0:2686][112:117]], strand='+'),\n",
-       " GraphLocus([348d9388[0:2686][125:130]], strand='+'),\n",
-       " GraphLocus([348d9388[0:2686][246:251]], strand='+'),\n",
-       " GraphLocus([348d9388[0:2686][534:539]], strand='+'),\n",
-       " GraphLocus([348d9388[0:2686][725:730]], strand='+'),\n",
-       " GraphLocus([348d9388[0:2686][112:117]], strand='-'),\n",
-       " GraphLocus([348d9388[0:2686][125:130]], strand='-'),\n",
-       " GraphLocus([348d9388[0:2686][246:251]], strand='-'),\n",
-       " GraphLocus([348d9388[0:2686][534:539]], strand='-'),\n",
-       " GraphLocus([348d9388[0:2686][725:730]], strand='-')]"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "results"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "74e314b4-eb7d-46a6-a7b8-686454089264",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -817,7 +767,7 @@
          },
          {
           "fg": "#313244",
-          "text": "\u2500",
+          "text": "─",
           "x": 0,
           "y": 16
          },
@@ -1075,109 +1025,109 @@
          },
          {
           "fg": "#313244",
-          "text": "\u2500",
+          "text": "─",
           "x": 43,
           "y": 16
          },
          {
           "fg": "#313244",
-          "text": "\u2500",
+          "text": "─",
           "x": 44,
           "y": 16
          },
          {
           "fg": "#313244",
-          "text": "\u2500",
+          "text": "─",
           "x": 45,
           "y": 16
          },
          {
           "fg": "#313244",
-          "text": "\u2500",
+          "text": "─",
           "x": 46,
           "y": 16
          },
          {
           "fg": "#313244",
-          "text": "\u2500",
+          "text": "─",
           "x": 47,
           "y": 16
          },
          {
           "fg": "#313244",
-          "text": "\u2500",
+          "text": "─",
           "x": 48,
           "y": 16
          },
          {
           "fg": "#313244",
-          "text": "\u2500",
+          "text": "─",
           "x": 49,
           "y": 16
          },
          {
           "fg": "#313244",
-          "text": "\u2500",
+          "text": "─",
           "x": 50,
           "y": 16
          },
          {
           "fg": "#313244",
-          "text": "\u2500",
+          "text": "─",
           "x": 51,
           "y": 16
          },
          {
           "fg": "#313244",
-          "text": "\u2500",
+          "text": "─",
           "x": 52,
           "y": 16
          },
          {
           "fg": "#313244",
-          "text": "\u2500",
+          "text": "─",
           "x": 53,
           "y": 16
          },
          {
           "fg": "#313244",
-          "text": "\u2500",
+          "text": "─",
           "x": 54,
           "y": 16
          },
          {
           "fg": "#313244",
-          "text": "\u2500",
+          "text": "─",
           "x": 55,
           "y": 16
          },
          {
           "fg": "#313244",
-          "text": "\u2500",
+          "text": "─",
           "x": 56,
           "y": 16
          },
          {
           "fg": "#313244",
-          "text": "\u2500",
+          "text": "─",
           "x": 57,
           "y": 16
          },
          {
           "fg": "#313244",
-          "text": "\u2500",
+          "text": "─",
           "x": 58,
           "y": 16
          },
          {
           "fg": "#313244",
-          "text": "\u2500",
+          "text": "─",
           "x": 59,
           "y": 16
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 0,
           "y": 17
          },
@@ -1226,319 +1176,319 @@
          {
           "bg": "#a6e3a1",
           "fg": "#1e1e2e",
-          "text": "\u203a",
+          "text": "›",
           "x": 7,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 8,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 9,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 10,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 11,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 12,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 13,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 14,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 15,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 16,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 17,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 18,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 19,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 20,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 21,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 22,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 23,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 24,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 25,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 26,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 27,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 28,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 29,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 30,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 31,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 32,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 33,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 34,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 35,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 36,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 37,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 38,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 39,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 40,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 41,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 42,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 43,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 44,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 45,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 46,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 47,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 48,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 49,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 50,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 51,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 52,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 53,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 54,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 55,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 56,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 57,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 58,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 59,
           "y": 17
          },
@@ -1568,7 +1518,7 @@
          },
          {
           "fg": "#94e2d5",
-          "text": "\u203a",
+          "text": "›",
           "x": 4,
           "y": 18
          },
@@ -1904,7 +1854,7 @@
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 0,
           "y": 19
          },
@@ -1981,308 +1931,308 @@
          {
           "bg": "#a6e3a1",
           "fg": "#1e1e2e",
-          "text": "\u203a",
+          "text": "›",
           "x": 11,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 12,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 13,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 14,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 15,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 16,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 17,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 18,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 19,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 20,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 21,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 22,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 23,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 24,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 25,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 26,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 27,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 28,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 29,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 30,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 31,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 32,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 33,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 34,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 35,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 36,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 37,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 38,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 39,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 40,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 41,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 42,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 43,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 44,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 45,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 46,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 47,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 48,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 49,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 50,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 51,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 52,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 53,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 54,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 55,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 56,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 57,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 58,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 59,
           "y": 19
          },
          {
           "fg": "#94e2d5",
-          "text": "\u2588",
+          "text": "█",
           "x": 58,
           "y": 20
          },
          {
           "bg": "#94e2d5",
           "fg": "#1e1e2e",
-          "text": "\u2039",
+          "text": "‹",
           "x": 59,
           "y": 20
          },
@@ -2310,338 +2260,338 @@
          {
           "bg": "#a6e3a1",
           "fg": "#1e1e2e",
-          "text": "\u203a",
+          "text": "›",
           "x": 4,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 5,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 6,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 7,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 8,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 9,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 10,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 11,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 12,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 13,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 14,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 15,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 16,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 17,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 18,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 19,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 20,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 21,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 22,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 23,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 24,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 25,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 26,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 27,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 28,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 29,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 30,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 31,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 32,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 33,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 34,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 35,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 36,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 37,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 38,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 39,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 40,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 41,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 42,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 43,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 44,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 45,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 46,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 47,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 48,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 49,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 50,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 51,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 52,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 53,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 54,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 55,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 56,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 57,
           "y": 21
          },
          {
           "fg": "#94e2d5",
-          "text": "\u2588",
+          "text": "█",
           "x": 58,
           "y": 22
          },
          {
           "bg": "#94e2d5",
           "fg": "#1e1e2e",
-          "text": "\u2039",
+          "text": "‹",
           "x": 59,
           "y": 22
          }
@@ -3168,7 +3118,7 @@
          },
          {
           "fg": "#313244",
-          "text": "\u2500",
+          "text": "─",
           "x": 0,
           "y": 16
          },
@@ -3426,109 +3376,109 @@
          },
          {
           "fg": "#313244",
-          "text": "\u2500",
+          "text": "─",
           "x": 43,
           "y": 16
          },
          {
           "fg": "#313244",
-          "text": "\u2500",
+          "text": "─",
           "x": 44,
           "y": 16
          },
          {
           "fg": "#313244",
-          "text": "\u2500",
+          "text": "─",
           "x": 45,
           "y": 16
          },
          {
           "fg": "#313244",
-          "text": "\u2500",
+          "text": "─",
           "x": 46,
           "y": 16
          },
          {
           "fg": "#313244",
-          "text": "\u2500",
+          "text": "─",
           "x": 47,
           "y": 16
          },
          {
           "fg": "#313244",
-          "text": "\u2500",
+          "text": "─",
           "x": 48,
           "y": 16
          },
          {
           "fg": "#313244",
-          "text": "\u2500",
+          "text": "─",
           "x": 49,
           "y": 16
          },
          {
           "fg": "#313244",
-          "text": "\u2500",
+          "text": "─",
           "x": 50,
           "y": 16
          },
          {
           "fg": "#313244",
-          "text": "\u2500",
+          "text": "─",
           "x": 51,
           "y": 16
          },
          {
           "fg": "#313244",
-          "text": "\u2500",
+          "text": "─",
           "x": 52,
           "y": 16
          },
          {
           "fg": "#313244",
-          "text": "\u2500",
+          "text": "─",
           "x": 53,
           "y": 16
          },
          {
           "fg": "#313244",
-          "text": "\u2500",
+          "text": "─",
           "x": 54,
           "y": 16
          },
          {
           "fg": "#313244",
-          "text": "\u2500",
+          "text": "─",
           "x": 55,
           "y": 16
          },
          {
           "fg": "#313244",
-          "text": "\u2500",
+          "text": "─",
           "x": 56,
           "y": 16
          },
          {
           "fg": "#313244",
-          "text": "\u2500",
+          "text": "─",
           "x": 57,
           "y": 16
          },
          {
           "fg": "#313244",
-          "text": "\u2500",
+          "text": "─",
           "x": 58,
           "y": 16
          },
          {
           "fg": "#313244",
-          "text": "\u2500",
+          "text": "─",
           "x": 59,
           "y": 16
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 0,
           "y": 17
          },
@@ -3577,319 +3527,319 @@
          {
           "bg": "#a6e3a1",
           "fg": "#1e1e2e",
-          "text": "\u203a",
+          "text": "›",
           "x": 7,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 8,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 9,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 10,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 11,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 12,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 13,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 14,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 15,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 16,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 17,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 18,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 19,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 20,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 21,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 22,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 23,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 24,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 25,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 26,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 27,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 28,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 29,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 30,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 31,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 32,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 33,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 34,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 35,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 36,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 37,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 38,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 39,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 40,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 41,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 42,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 43,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 44,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 45,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 46,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 47,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 48,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 49,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 50,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 51,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 52,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 53,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 54,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 55,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 56,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 57,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 58,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 59,
           "y": 17
          },
@@ -3919,7 +3869,7 @@
          },
          {
           "fg": "#94e2d5",
-          "text": "\u203a",
+          "text": "›",
           "x": 4,
           "y": 18
          },
@@ -4255,7 +4205,7 @@
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 0,
           "y": 19
          },
@@ -4332,308 +4282,308 @@
          {
           "bg": "#a6e3a1",
           "fg": "#1e1e2e",
-          "text": "\u203a",
+          "text": "›",
           "x": 11,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 12,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 13,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 14,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 15,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 16,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 17,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 18,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 19,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 20,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 21,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 22,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 23,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 24,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 25,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 26,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 27,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 28,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 29,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 30,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 31,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 32,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 33,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 34,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 35,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 36,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 37,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 38,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 39,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 40,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 41,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 42,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 43,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 44,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 45,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 46,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 47,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 48,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 49,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 50,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 51,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 52,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 53,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 54,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 55,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 56,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 57,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 58,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 59,
           "y": 19
          },
          {
           "fg": "#94e2d5",
-          "text": "\u2588",
+          "text": "█",
           "x": 58,
           "y": 20
          },
          {
           "bg": "#94e2d5",
           "fg": "#1e1e2e",
-          "text": "\u2039",
+          "text": "‹",
           "x": 59,
           "y": 20
          },
@@ -4661,338 +4611,338 @@
          {
           "bg": "#a6e3a1",
           "fg": "#1e1e2e",
-          "text": "\u203a",
+          "text": "›",
           "x": 4,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 5,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 6,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 7,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 8,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 9,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 10,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 11,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 12,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 13,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 14,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 15,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 16,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 17,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 18,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 19,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 20,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 21,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 22,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 23,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 24,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 25,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 26,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 27,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 28,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 29,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 30,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 31,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 32,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 33,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 34,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 35,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 36,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 37,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 38,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 39,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 40,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 41,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 42,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 43,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 44,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 45,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 46,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 47,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 48,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 49,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 50,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 51,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 52,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 53,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 54,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 55,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 56,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 57,
           "y": 21
          },
          {
           "fg": "#94e2d5",
-          "text": "\u2588",
+          "text": "█",
           "x": 58,
           "y": 22
          },
          {
           "bg": "#94e2d5",
           "fg": "#1e1e2e",
-          "text": "\u2039",
+          "text": "‹",
           "x": 59,
           "y": 22
          }
@@ -5205,12 +5155,12 @@
           "y": 10
          },
          {
-          "text": "\u255f",
+          "text": "╟",
           "x": 5,
           "y": 11
          },
          {
-          "text": "\u2500",
+          "text": "─",
           "x": 6,
           "y": 11
          },
@@ -5306,12 +5256,12 @@
           "y": 11
          },
          {
-          "text": "\u2500",
+          "text": "─",
           "x": 20,
           "y": 11
          },
          {
-          "text": "\u2562",
+          "text": "╢",
           "x": 21,
           "y": 11
          },
@@ -5605,7 +5555,7 @@
          },
          {
           "fg": "#313244",
-          "text": "\u2500",
+          "text": "─",
           "x": 0,
           "y": 22
          },
@@ -6002,79 +5952,79 @@
          {
           "bg": "#a6e3a1",
           "fg": "#1e1e2e",
-          "text": "\u203a",
+          "text": "›",
           "x": 7,
           "y": 23
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 8,
           "y": 23
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 9,
           "y": 23
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 10,
           "y": 23
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 11,
           "y": 23
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 12,
           "y": 23
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 13,
           "y": 23
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 14,
           "y": 23
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 15,
           "y": 23
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 16,
           "y": 23
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 17,
           "y": 23
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 18,
           "y": 23
          },
          {
           "fg": "#a6e3a1",
-          "text": "\u2588",
+          "text": "█",
           "x": 19,
           "y": 23
          }

--- a/gen-python/examples/annotations.ipynb
+++ b/gen-python/examples/annotations.ipynb
@@ -16,14 +16,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "id": "imports",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-27T21:12:12.606547Z",
-     "iopub.status.busy": "2026-05-27T21:12:12.606212Z",
-     "iopub.status.idle": "2026-05-27T21:12:12.658186Z",
-     "shell.execute_reply": "2026-05-27T21:12:12.657789Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
@@ -45,14 +38,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "id": "import-genbank",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-27T21:12:12.659610Z",
-     "iopub.status.busy": "2026-05-27T21:12:12.659528Z",
-     "iopub.status.idle": "2026-05-27T21:12:12.682597Z",
-     "shell.execute_reply": "2026-05-27T21:12:12.682172Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -113,14 +99,7 @@
    "cell_type": "code",
    "execution_count": 3,
    "id": "list-annotations",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-27T21:12:12.683834Z",
-     "iopub.status.busy": "2026-05-27T21:12:12.683754Z",
-     "iopub.status.idle": "2026-05-27T21:12:12.685817Z",
-     "shell.execute_reply": "2026-05-27T21:12:12.685427Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -167,22 +146,15 @@
     "\n",
     "Filter for the MCS feature and navigate to it two ways:\n",
     "\n",
-    "* `widget.go_to(ann)` — left-pins the annotation start at column 12, no highlight\n",
-    "* `widget.show(ann)` — left-pins the annotation start and adds a highlight"
+    "* `widget.go_to(ann)` \u2014 left-pins the annotation start at column 12, no highlight\n",
+    "* `widget.show(ann)` \u2014 left-pins the annotation start and adds a highlight"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
    "id": "find-mcs",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-27T21:12:12.686757Z",
-     "iopub.status.busy": "2026-05-27T21:12:12.686684Z",
-     "iopub.status.idle": "2026-05-27T21:12:12.688549Z",
-     "shell.execute_reply": "2026-05-27T21:12:12.688176Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -201,26 +173,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 11,
    "id": "goto-mcs",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-27T21:12:12.689439Z",
-     "iopub.status.busy": "2026-05-27T21:12:12.689375Z",
-     "iopub.status.idle": "2026-05-27T21:12:12.692822Z",
-     "shell.execute_reply": "2026-05-27T21:12:12.692455Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "07a4f66e117e4f5f910e2b3c8730c081",
+       "model_id": "76c94f590f4a43869d4052efd3f1bf28",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "<gen.jupyter_widget.GenGraphWidget object at 0x10825da90>"
+       "<gen.jupyter_widget.GenGraphWidget object at 0x10ae46030>"
       ]
      },
      "metadata": {},
@@ -235,45 +200,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 12,
    "id": "709252ad-a8d7-4947-89cb-a8d804af1557",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-27T21:12:12.693693Z",
-     "iopub.status.busy": "2026-05-27T21:12:12.693634Z",
-     "iopub.status.idle": "2026-05-27T21:12:12.697190Z",
-     "shell.execute_reply": "2026-05-27T21:12:12.696892Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Freeze the cell so we can compare\n",
-    "fig.freeze()\n",
     "fig = bg.plot(rows=24)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 13,
    "id": "show-mcs",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-27T21:12:12.698172Z",
-     "iopub.status.busy": "2026-05-27T21:12:12.698093Z",
-     "iopub.status.idle": "2026-05-27T21:12:12.701357Z",
-     "shell.execute_reply": "2026-05-27T21:12:12.701021Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "5c716ecae5804957a55102730acfedc7",
+       "model_id": "7e2c39d879d84b2da0afc4a9b3f3a57f",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "<gen.jupyter_widget.GenGraphWidget object at 0x108257250>"
+       "<gen.jupyter_widget.GenGraphWidget object at 0x10af0c250>"
       ]
      },
      "metadata": {},
@@ -300,14 +250,7 @@
    "cell_type": "code",
    "execution_count": 8,
    "id": "1e9bd125",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-27T21:12:12.702279Z",
-     "iopub.status.busy": "2026-05-27T21:12:12.702220Z",
-     "iopub.status.idle": "2026-05-27T21:12:12.708980Z",
-     "shell.execute_reply": "2026-05-27T21:12:12.708535Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -318,7 +261,6 @@
     }
    ],
    "source": [
-    "fig.freeze()\n",
     "fig = bg.plot(rows=24)\n",
     "\n",
     "# Search for Dcm methylation sites and add matches to the widget.\n",
@@ -337,14 +279,7 @@
    "cell_type": "code",
    "execution_count": 9,
    "id": "88cd6304",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-27T21:12:12.711307Z",
-     "iopub.status.busy": "2026-05-27T21:12:12.711237Z",
-     "iopub.status.idle": "2026-05-27T21:12:12.713210Z",
-     "shell.execute_reply": "2026-05-27T21:12:12.712942Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -357,12 +292,12 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c65eb193e68640fbbed40a0698549e77",
+       "model_id": "522f9943dde34dcbba3e521d4ad6e8ef",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "<gen.jupyter_widget.GenGraphWidget object at 0x108257750>"
+       "<gen.jupyter_widget.GenGraphWidget object at 0x10a652450>"
       ]
      },
      "metadata": {},
@@ -386,14 +321,7 @@
    "cell_type": "code",
    "execution_count": 10,
    "id": "fc0759df-d793-4b81-a430-3721091a22bd",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-27T21:12:12.714133Z",
-     "iopub.status.busy": "2026-05-27T21:12:12.714074Z",
-     "iopub.status.idle": "2026-05-27T21:12:12.716612Z",
-     "shell.execute_reply": "2026-05-27T21:12:12.716283Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -889,7 +817,7 @@
          },
          {
           "fg": "#313244",
-          "text": "─",
+          "text": "\u2500",
           "x": 0,
           "y": 16
          },
@@ -1147,109 +1075,109 @@
          },
          {
           "fg": "#313244",
-          "text": "─",
+          "text": "\u2500",
           "x": 43,
           "y": 16
          },
          {
           "fg": "#313244",
-          "text": "─",
+          "text": "\u2500",
           "x": 44,
           "y": 16
          },
          {
           "fg": "#313244",
-          "text": "─",
+          "text": "\u2500",
           "x": 45,
           "y": 16
          },
          {
           "fg": "#313244",
-          "text": "─",
+          "text": "\u2500",
           "x": 46,
           "y": 16
          },
          {
           "fg": "#313244",
-          "text": "─",
+          "text": "\u2500",
           "x": 47,
           "y": 16
          },
          {
           "fg": "#313244",
-          "text": "─",
+          "text": "\u2500",
           "x": 48,
           "y": 16
          },
          {
           "fg": "#313244",
-          "text": "─",
+          "text": "\u2500",
           "x": 49,
           "y": 16
          },
          {
           "fg": "#313244",
-          "text": "─",
+          "text": "\u2500",
           "x": 50,
           "y": 16
          },
          {
           "fg": "#313244",
-          "text": "─",
+          "text": "\u2500",
           "x": 51,
           "y": 16
          },
          {
           "fg": "#313244",
-          "text": "─",
+          "text": "\u2500",
           "x": 52,
           "y": 16
          },
          {
           "fg": "#313244",
-          "text": "─",
+          "text": "\u2500",
           "x": 53,
           "y": 16
          },
          {
           "fg": "#313244",
-          "text": "─",
+          "text": "\u2500",
           "x": 54,
           "y": 16
          },
          {
           "fg": "#313244",
-          "text": "─",
+          "text": "\u2500",
           "x": 55,
           "y": 16
          },
          {
           "fg": "#313244",
-          "text": "─",
+          "text": "\u2500",
           "x": 56,
           "y": 16
          },
          {
           "fg": "#313244",
-          "text": "─",
+          "text": "\u2500",
           "x": 57,
           "y": 16
          },
          {
           "fg": "#313244",
-          "text": "─",
+          "text": "\u2500",
           "x": 58,
           "y": 16
          },
          {
           "fg": "#313244",
-          "text": "─",
+          "text": "\u2500",
           "x": 59,
           "y": 16
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 0,
           "y": 17
          },
@@ -1298,319 +1226,319 @@
          {
           "bg": "#a6e3a1",
           "fg": "#1e1e2e",
-          "text": "›",
+          "text": "\u203a",
           "x": 7,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 8,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 9,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 10,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 11,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 12,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 13,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 14,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 15,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 16,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 17,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 18,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 19,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 20,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 21,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 22,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 23,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 24,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 25,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 26,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 27,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 28,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 29,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 30,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 31,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 32,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 33,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 34,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 35,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 36,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 37,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 38,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 39,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 40,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 41,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 42,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 43,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 44,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 45,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 46,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 47,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 48,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 49,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 50,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 51,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 52,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 53,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 54,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 55,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 56,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 57,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 58,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 59,
           "y": 17
          },
@@ -1640,7 +1568,7 @@
          },
          {
           "fg": "#94e2d5",
-          "text": "›",
+          "text": "\u203a",
           "x": 4,
           "y": 18
          },
@@ -1976,7 +1904,7 @@
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 0,
           "y": 19
          },
@@ -2053,308 +1981,308 @@
          {
           "bg": "#a6e3a1",
           "fg": "#1e1e2e",
-          "text": "›",
+          "text": "\u203a",
           "x": 11,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 12,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 13,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 14,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 15,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 16,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 17,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 18,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 19,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 20,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 21,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 22,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 23,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 24,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 25,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 26,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 27,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 28,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 29,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 30,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 31,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 32,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 33,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 34,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 35,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 36,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 37,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 38,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 39,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 40,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 41,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 42,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 43,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 44,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 45,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 46,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 47,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 48,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 49,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 50,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 51,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 52,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 53,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 54,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 55,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 56,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 57,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 58,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 59,
           "y": 19
          },
          {
           "fg": "#94e2d5",
-          "text": "█",
+          "text": "\u2588",
           "x": 58,
           "y": 20
          },
          {
           "bg": "#94e2d5",
           "fg": "#1e1e2e",
-          "text": "‹",
+          "text": "\u2039",
           "x": 59,
           "y": 20
          },
@@ -2382,338 +2310,338 @@
          {
           "bg": "#a6e3a1",
           "fg": "#1e1e2e",
-          "text": "›",
+          "text": "\u203a",
           "x": 4,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 5,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 6,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 7,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 8,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 9,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 10,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 11,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 12,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 13,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 14,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 15,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 16,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 17,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 18,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 19,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 20,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 21,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 22,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 23,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 24,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 25,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 26,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 27,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 28,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 29,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 30,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 31,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 32,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 33,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 34,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 35,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 36,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 37,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 38,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 39,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 40,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 41,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 42,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 43,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 44,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 45,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 46,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 47,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 48,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 49,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 50,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 51,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 52,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 53,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 54,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 55,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 56,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 57,
           "y": 21
          },
          {
           "fg": "#94e2d5",
-          "text": "█",
+          "text": "\u2588",
           "x": 58,
           "y": 22
          },
          {
           "bg": "#94e2d5",
           "fg": "#1e1e2e",
-          "text": "‹",
+          "text": "\u2039",
           "x": 59,
           "y": 22
          }
@@ -3240,7 +3168,7 @@
          },
          {
           "fg": "#313244",
-          "text": "─",
+          "text": "\u2500",
           "x": 0,
           "y": 16
          },
@@ -3498,109 +3426,109 @@
          },
          {
           "fg": "#313244",
-          "text": "─",
+          "text": "\u2500",
           "x": 43,
           "y": 16
          },
          {
           "fg": "#313244",
-          "text": "─",
+          "text": "\u2500",
           "x": 44,
           "y": 16
          },
          {
           "fg": "#313244",
-          "text": "─",
+          "text": "\u2500",
           "x": 45,
           "y": 16
          },
          {
           "fg": "#313244",
-          "text": "─",
+          "text": "\u2500",
           "x": 46,
           "y": 16
          },
          {
           "fg": "#313244",
-          "text": "─",
+          "text": "\u2500",
           "x": 47,
           "y": 16
          },
          {
           "fg": "#313244",
-          "text": "─",
+          "text": "\u2500",
           "x": 48,
           "y": 16
          },
          {
           "fg": "#313244",
-          "text": "─",
+          "text": "\u2500",
           "x": 49,
           "y": 16
          },
          {
           "fg": "#313244",
-          "text": "─",
+          "text": "\u2500",
           "x": 50,
           "y": 16
          },
          {
           "fg": "#313244",
-          "text": "─",
+          "text": "\u2500",
           "x": 51,
           "y": 16
          },
          {
           "fg": "#313244",
-          "text": "─",
+          "text": "\u2500",
           "x": 52,
           "y": 16
          },
          {
           "fg": "#313244",
-          "text": "─",
+          "text": "\u2500",
           "x": 53,
           "y": 16
          },
          {
           "fg": "#313244",
-          "text": "─",
+          "text": "\u2500",
           "x": 54,
           "y": 16
          },
          {
           "fg": "#313244",
-          "text": "─",
+          "text": "\u2500",
           "x": 55,
           "y": 16
          },
          {
           "fg": "#313244",
-          "text": "─",
+          "text": "\u2500",
           "x": 56,
           "y": 16
          },
          {
           "fg": "#313244",
-          "text": "─",
+          "text": "\u2500",
           "x": 57,
           "y": 16
          },
          {
           "fg": "#313244",
-          "text": "─",
+          "text": "\u2500",
           "x": 58,
           "y": 16
          },
          {
           "fg": "#313244",
-          "text": "─",
+          "text": "\u2500",
           "x": 59,
           "y": 16
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 0,
           "y": 17
          },
@@ -3649,319 +3577,319 @@
          {
           "bg": "#a6e3a1",
           "fg": "#1e1e2e",
-          "text": "›",
+          "text": "\u203a",
           "x": 7,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 8,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 9,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 10,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 11,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 12,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 13,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 14,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 15,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 16,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 17,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 18,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 19,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 20,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 21,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 22,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 23,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 24,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 25,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 26,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 27,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 28,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 29,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 30,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 31,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 32,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 33,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 34,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 35,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 36,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 37,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 38,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 39,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 40,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 41,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 42,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 43,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 44,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 45,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 46,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 47,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 48,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 49,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 50,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 51,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 52,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 53,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 54,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 55,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 56,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 57,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 58,
           "y": 17
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 59,
           "y": 17
          },
@@ -3991,7 +3919,7 @@
          },
          {
           "fg": "#94e2d5",
-          "text": "›",
+          "text": "\u203a",
           "x": 4,
           "y": 18
          },
@@ -4327,7 +4255,7 @@
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 0,
           "y": 19
          },
@@ -4404,308 +4332,308 @@
          {
           "bg": "#a6e3a1",
           "fg": "#1e1e2e",
-          "text": "›",
+          "text": "\u203a",
           "x": 11,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 12,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 13,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 14,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 15,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 16,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 17,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 18,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 19,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 20,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 21,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 22,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 23,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 24,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 25,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 26,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 27,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 28,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 29,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 30,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 31,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 32,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 33,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 34,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 35,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 36,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 37,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 38,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 39,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 40,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 41,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 42,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 43,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 44,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 45,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 46,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 47,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 48,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 49,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 50,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 51,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 52,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 53,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 54,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 55,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 56,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 57,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 58,
           "y": 19
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 59,
           "y": 19
          },
          {
           "fg": "#94e2d5",
-          "text": "█",
+          "text": "\u2588",
           "x": 58,
           "y": 20
          },
          {
           "bg": "#94e2d5",
           "fg": "#1e1e2e",
-          "text": "‹",
+          "text": "\u2039",
           "x": 59,
           "y": 20
          },
@@ -4733,338 +4661,338 @@
          {
           "bg": "#a6e3a1",
           "fg": "#1e1e2e",
-          "text": "›",
+          "text": "\u203a",
           "x": 4,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 5,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 6,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 7,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 8,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 9,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 10,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 11,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 12,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 13,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 14,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 15,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 16,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 17,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 18,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 19,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 20,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 21,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 22,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 23,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 24,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 25,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 26,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 27,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 28,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 29,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 30,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 31,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 32,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 33,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 34,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 35,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 36,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 37,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 38,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 39,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 40,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 41,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 42,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 43,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 44,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 45,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 46,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 47,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 48,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 49,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 50,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 51,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 52,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 53,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 54,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 55,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 56,
           "y": 21
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 57,
           "y": 21
          },
          {
           "fg": "#94e2d5",
-          "text": "█",
+          "text": "\u2588",
           "x": 58,
           "y": 22
          },
          {
           "bg": "#94e2d5",
           "fg": "#1e1e2e",
-          "text": "‹",
+          "text": "\u2039",
           "x": 59,
           "y": 22
          }
@@ -5277,12 +5205,12 @@
           "y": 10
          },
          {
-          "text": "╟",
+          "text": "\u255f",
           "x": 5,
           "y": 11
          },
          {
-          "text": "─",
+          "text": "\u2500",
           "x": 6,
           "y": 11
          },
@@ -5378,12 +5306,12 @@
           "y": 11
          },
          {
-          "text": "─",
+          "text": "\u2500",
           "x": 20,
           "y": 11
          },
          {
-          "text": "╢",
+          "text": "\u2562",
           "x": 21,
           "y": 11
          },
@@ -5677,7 +5605,7 @@
          },
          {
           "fg": "#313244",
-          "text": "─",
+          "text": "\u2500",
           "x": 0,
           "y": 22
          },
@@ -6074,79 +6002,79 @@
          {
           "bg": "#a6e3a1",
           "fg": "#1e1e2e",
-          "text": "›",
+          "text": "\u203a",
           "x": 7,
           "y": 23
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 8,
           "y": 23
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 9,
           "y": 23
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 10,
           "y": 23
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 11,
           "y": 23
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 12,
           "y": 23
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 13,
           "y": 23
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 14,
           "y": 23
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 15,
           "y": 23
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 16,
           "y": 23
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 17,
           "y": 23
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 18,
           "y": 23
          },
          {
           "fg": "#a6e3a1",
-          "text": "█",
+          "text": "\u2588",
           "x": 19,
           "y": 23
          }

--- a/gen-python/examples/demo_notebook.ipynb
+++ b/gen-python/examples/demo_notebook.ipynb
@@ -145,46 +145,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "AttributeError",
-     "evalue": "'builtins.Repository' object has no attribute 'block_group_to_networkx'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mAttributeError\u001b[39m                            Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[6]\u001b[39m\u001b[32m, line 5\u001b[39m\n\u001b[32m      2\u001b[39m \u001b[38;5;28;01mimport\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01mnetworkx\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mas\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01mnx\u001b[39;00m\n\u001b[32m      3\u001b[39m \u001b[38;5;28;01mimport\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01mmatplotlib\u001b[39;00m\u001b[34;01m.\u001b[39;00m\u001b[34;01mpyplot\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mas\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01mplt\u001b[39;00m\n\u001b[32m----> \u001b[39m\u001b[32m5\u001b[39m nx_repr = \u001b[43mrepo\u001b[49m\u001b[43m.\u001b[49m\u001b[43mblock_group_to_networkx\u001b[49m(bg)\n\u001b[32m      6\u001b[39m \u001b[38;5;28mprint\u001b[39m(\n\u001b[32m      7\u001b[39m     \u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mConverted to NetworkX graph with \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mnx_repr.number_of_nodes()\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m nodes and \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mnx_repr.number_of_edges()\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m edges\u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m      8\u001b[39m )\n\u001b[32m     10\u001b[39m \u001b[38;5;66;03m# Analyze the graph\u001b[39;00m\n",
-      "\u001b[31mAttributeError\u001b[39m: 'builtins.Repository' object has no attribute 'block_group_to_networkx'"
-     ]
-    }
-   ],
-   "source": [
-    "try:\n",
-    "    import networkx as nx\n",
-    "    import matplotlib.pyplot as plt\n",
-    "\n",
-    "    nx_repr = repo.block_group_to_networkx(bg)\n",
-    "    print(\n",
-    "        f\"Converted to NetworkX graph with {nx_repr.number_of_nodes()} nodes and {nx_repr.number_of_edges()} edges\"\n",
-    "    )\n",
-    "\n",
-    "    # Analyze the graph\n",
-    "    if nx_repr.number_of_nodes() > 0:\n",
-    "        # Get node degrees\n",
-    "        degrees = [nx_repr.degree(n) for n in nx_repr.nodes()]\n",
-    "        avg_degree = sum(degrees) / len(degrees) if degrees else 0\n",
-    "        print(f\"Average node degree: {avg_degree:.2f}\")\n",
-    "\n",
-    "    # Draw the graph\n",
-    "    plt.figure()\n",
-    "    nx.draw(nx_repr, with_labels=True)\n",
-    "    plt.show()\n",
-    "\n",
-    "except ImportError:\n",
-    "    print(\"NetworkX not installed. Install with: pip install networkx\")"
-   ]
+   "outputs": [],
+   "source": "try:\n    import networkx as nx\n    import matplotlib.pyplot as plt\n\n    nx_repr = bg.to_networkx()\n    print(\n        f\"Converted to NetworkX graph with {nx_repr.number_of_nodes()} nodes and {nx_repr.number_of_edges()} edges\"\n    )\n\n    # Analyze the graph\n    if nx_repr.number_of_nodes() > 0:\n        # Get node degrees\n        degrees = [nx_repr.degree(n) for n in nx_repr.nodes()]\n        avg_degree = sum(degrees) / len(degrees) if degrees else 0\n        print(f\"Average node degree: {avg_degree:.2f}\")\n\n    # Draw the graph\n    plt.figure()\n    nx.draw(nx_repr, with_labels=True)\n    plt.show()\n\nexcept ImportError:\n    print(\"NetworkX not installed. Install with: pip install networkx\")"
   },
   {
    "cell_type": "markdown",
@@ -199,18 +163,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "try:\n",
-    "    import rustworkx as rx\n",
-    "    import rustworkx.visualization as rxv\n",
-    "\n",
-    "    rx_repr = repo.block_group_to_rustworkx(bg)\n",
-    "\n",
-    "    display(rxv.graphviz_draw(rx_repr))\n",
-    "\n",
-    "except ImportError:\n",
-    "    print(\"RustworkX not installed. Install with: pip install rustworkx\")"
-   ]
+   "source": "try:\n    import rustworkx as rx\n    import rustworkx.visualization as rxv\n\n    rx_repr = bg.to_rustworkx()\n\n    display(rxv.graphviz_draw(rx_repr))\n\nexcept ImportError:\n    print(\"RustworkX not installed. Install with: pip install rustworkx\")"
   },
   {
    "cell_type": "markdown",
@@ -224,17 +177,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "dict_repr = repo.block_group_to_dict(bg)\n",
-    "print(\n",
-    "    \"Edges are keyed by pairs of node tuples (node_id, start, end):\"\n",
-    ")\n",
-    "display(dict_repr[\"edges\"])\n",
-    "\n",
-    "\n",
-    "print(\"Node identifiers are also stored as node attributes:\")\n",
-    "display(dict_repr[\"nodes\"])"
-   ]
+   "source": "dict_repr = bg.to_dict()\nprint(\n    \"Edges are keyed by pairs of node tuples (node_id, start, end):\"\n)\ndisplay(dict_repr[\"edges\"])\n\n\nprint(\"Node identifiers are also stored as node attributes:\")\ndisplay(dict_repr[\"nodes\"])"
   },
   {
    "cell_type": "markdown",

--- a/gen-python/examples/demo_notebook.ipynb
+++ b/gen-python/examples/demo_notebook.ipynb
@@ -4,324 +4,124 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Gen Python API — Walkthrough\n",
+    "# Gen Python API Tutorial\n",
     "\n",
-    "This notebook demonstrates the core capabilities of the `gen` Python package:\n",
-    "initializing a repository, importing a reference sequence, applying variants\n",
-    "from a VCF, searching for sequence motifs, and visualizing the resulting graph."
+    "We start off by initializing a new repository:\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-27T21:12:08.143937Z",
-     "iopub.status.busy": "2026-05-27T21:12:08.143658Z",
-     "iopub.status.idle": "2026-05-27T21:12:08.448257Z",
-     "shell.execute_reply": "2026-05-27T21:12:08.447807Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "gen version: 0.1.31\n"
-     ]
-    }
-   ],
+   "metadata": {},
+   "outputs": [],
    "source": [
-    "import os\n",
-    "import tempfile\n",
-    "\n",
     "import gen\n",
     "\n",
-    "print(f\"gen version: {gen.__version__}\")"
+    "repo = gen.Repository()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Initialize a repository\n",
-    "\n",
-    "A `Repository` is the top-level object. Passing a path to a `.gen` directory\n",
-    "creates a new repository there; omitting the path searches the current working\n",
-    "directory for an existing one."
+    "This searches the current working directory for a `.gen` folder that holds the data and operations infrastructure. If no existing repository was found, a new .gen folder and database will be created.  You can also load a local repository that is outside of the present working directory by specifying the location of its .gen folder."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-27T21:12:08.468891Z",
-     "iopub.status.busy": "2026-05-27T21:12:08.468795Z",
-     "iopub.status.idle": "2026-05-27T21:12:08.476849Z",
-     "shell.execute_reply": "2026-05-27T21:12:08.476468Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Repository created at: /var/folders/f8/8zf8xczs0pxf9_vfnlmqlx9h0000gn/T/tmpabrgfnjs/gen/.gen\n"
+      "Imported: /Users/bvh/git/gen/fixtures/anderson_promoters.gfa\n"
      ]
     }
    ],
    "source": [
-    "tmpdir = tempfile.mkdtemp()\n",
-    "repo = gen.Repository(os.path.join(tmpdir, \"gen\"))\n",
-    "print(f\"Repository created at: {repo.gen_dir}\")"
+    "import tempfile\n",
+    "import pathlib\n",
+    "import gen\n",
+    "\n",
+    "tmp = tempfile.TemporaryDirectory()\n",
+    "repo = gen.Repository(tmp.name)\n",
+    "\n",
+    "gfa_path = pathlib.Path(\"../../fixtures/anderson_promoters.gfa\").resolve()\n",
+    "repo.import_gfa(str(gfa_path))\n",
+    "print(\"Imported:\", gfa_path)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Import a reference sequence\n",
-    "\n",
-    "`import_reference_fasta` loads a FASTA file and registers each contig under a\n",
-    "named reference. The reference name (e.g. `\"hg38\"`) is how you refer to it\n",
-    "when applying variants or querying the repository."
+    "The repository can be queried through methods like get_block_groups() (recommended), or direct database access."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-27T21:12:08.477890Z",
-     "iopub.status.busy": "2026-05-27T21:12:08.477815Z",
-     "iopub.status.idle": "2026-05-27T21:12:08.490188Z",
-     "shell.execute_reply": "2026-05-27T21:12:08.489790Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "'/var/folders/f8/8zf8xczs0pxf9_vfnlmqlx9h0000gn/T/tmpabrgfnjs/reference.fa' imported.\n"
+      "Number of block groups: 1\n"
      ]
     }
    ],
    "source": [
-    "fasta_path = os.path.join(tmpdir, \"reference.fa\")\n",
-    "with open(fasta_path, \"w\") as f:\n",
-    "    f.write(\">m123\\nATCGATCGATCGATCGATCGGGAACACACAGAGA\\n\")\n",
-    "\n",
-    "result = repo.import_reference_fasta(fasta_path, \"reference\")\n",
-    "print(result)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Explore block groups\n",
-    "\n",
-    "Each contig in the imported FASTA becomes a *block group* — the internal\n",
-    "representation of a sequence graph."
+    "bgs = repo.get_block_groups()\n",
+    "print(f\"Number of block groups: {len(bgs)}\")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-27T21:12:08.491188Z",
-     "iopub.status.busy": "2026-05-27T21:12:08.491113Z",
-     "iopub.status.idle": "2026-05-27T21:12:08.493125Z",
-     "shell.execute_reply": "2026-05-27T21:12:08.492801Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1 block group(s) after import:\n",
-      "  name='m123'  collection='default'  sample='reference'\n"
+      "Number of block groups: 1\n"
      ]
     }
    ],
    "source": [
-    "bgs = repo.get_block_groups()\n",
-    "print(f\"{len(bgs)} block group(s) after import:\")\n",
-    "for bg in bgs:\n",
-    "    print(f\"  name={bg.name!r}  collection={bg.collection_name!r}  sample={bg.sample_name!r}\")"
+    "result = repo.query(\"SELECT COUNT(*) FROM block_groups\") \n",
+    "print(f\"Number of block groups: {result[0][0]}\")"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Apply variants from a VCF\n",
+    "## Working with Graphs\n",
     "\n",
-    "`update_with_vcf` reads a VCF file and creates a new sample whose graph\n",
-    "incorporates the specified variants. The `sample` argument selects which\n",
-    "sample column to read from the VCF."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-27T21:12:08.494106Z",
-     "iopub.status.busy": "2026-05-27T21:12:08.494037Z",
-     "iopub.status.idle": "2026-05-27T21:12:08.505427Z",
-     "shell.execute_reply": "2026-05-27T21:12:08.505120Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Updated from '/var/folders/f8/8zf8xczs0pxf9_vfnlmqlx9h0000gn/T/tmpabrgfnjs/variants.vcf'.\n"
-     ]
-    }
-   ],
-   "source": [
-    "vcf_path = os.path.join(tmpdir, \"variants.vcf\")\n",
-    "with open(vcf_path, \"w\") as f:\n",
-    "    f.write(\n",
-    "        \"##fileformat=VCFv4.1\\n\"\n",
-    "        \"##contig=<ID=m123,length=34>\\n\"\n",
-    "        \"##FORMAT=<ID=GT,Number=1,Type=String,Description=\\\"Genotype\\\">\\n\"\n",
-    "        \"#CHROM\\tPOS\\tID\\tREF\\tALT\\tQUAL\\tFILTER\\tINFO\\tFORMAT\\tsample1\\n\"\n",
-    "        \"m123\\t3\\t.\\tCG\\tC\\t.\\t.\\t.\\tGT\\t1/1\\n\"\n",
-    "        \"m123\\t10\\t.\\tT\\tTAGA\\t.\\t.\\t.\\tGT\\t1/1\\n\"\n",
-    "    )\n",
+    "Gen organizes genomic data in sequence graphs. Let's explore how to access and work with graphs. Internally, these are called block_groups. (Method names will be updated to refer to 'sequence graphs' in a future release)\n",
     "\n",
-    "result = repo.update_with_vcf(vcf_path, sample=\"sample1\", reference=\"reference\")\n",
-    "print(result)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-27T21:12:08.506497Z",
-     "iopub.status.busy": "2026-05-27T21:12:08.506427Z",
-     "iopub.status.idle": "2026-05-27T21:12:08.508177Z",
-     "shell.execute_reply": "2026-05-27T21:12:08.507848Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2 block group(s) after VCF update:\n",
-      "  name='m123'  collection='default'  sample='reference'\n",
-      "  name='m123'  collection='default'  sample='sample1'\n"
-     ]
-    }
-   ],
-   "source": [
-    "bgs = repo.get_block_groups()\n",
-    "print(f\"{len(bgs)} block group(s) after VCF update:\")\n",
-    "for bg in bgs:\n",
-    "    print(f\"  name={bg.name!r}  collection={bg.collection_name!r}  sample={bg.sample_name!r}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Search for a sequence motif\n",
+    "### Interactive graph widget\n",
     "\n",
-    "`repo.search(query)` finds all occurrences of a sequence across every block\n",
-    "group. Results are `(BlockGroup, [GraphLocus])` pairs; each `GraphLocus`\n",
-    "describes where in the graph the match lives."
+    "`display(block_group)` renders a navigable terminal-style graph viewer directly in the notebook, use the mouse to navigate.\n",
+    "You can also control the widget programatically for more control."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-27T21:12:08.509112Z",
-     "iopub.status.busy": "2026-05-27T21:12:08.509039Z",
-     "iopub.status.idle": "2026-05-27T21:12:08.511607Z",
-     "shell.execute_reply": "2026-05-27T21:12:08.511264Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Searching for 'ATCGATCG':\n",
-      "  'm123' (sample='reference'): 7 match(es)\n",
-      "    strand=+  blocks=1\n",
-      "    strand=+  blocks=1\n",
-      "    strand=+  blocks=1\n",
-      "    strand=+  blocks=1\n",
-      "    strand=-  blocks=1\n",
-      "    strand=-  blocks=1\n",
-      "    strand=-  blocks=1\n",
-      "  'm123' (sample='sample1'): 7 match(es)\n",
-      "    strand=+  blocks=3\n",
-      "    strand=+  blocks=2\n",
-      "    strand=+  blocks=2\n",
-      "    strand=+  blocks=1\n",
-      "    strand=-  blocks=3\n",
-      "    strand=-  blocks=2\n",
-      "    strand=-  blocks=1\n"
-     ]
-    }
-   ],
-   "source": [
-    "query = \"ATCGATCG\"\n",
-    "results = repo.search(query)\n",
-    "\n",
-    "print(f\"Searching for {query!r}:\")\n",
-    "for bg, loci in results:\n",
-    "    if loci:\n",
-    "        print(f\"  {bg.name!r} (sample={bg.sample_name!r}): {len(loci)} match(es)\")\n",
-    "        for locus in loci:\n",
-    "            print(f\"    strand={locus.strand}  blocks={len(locus.slices)}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## Visualize the graph\n",
-    "\n",
-    "`bg.plot()` returns an interactive `GenGraphWidget`. This requires the Jupyter\n",
-    "extra (`pip install gen[jupyter]`). In a notebook environment it renders an\n",
-    "interactive terminal-style graph viewer you can navigate with the mouse."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-27T21:12:08.512531Z",
-     "iopub.status.busy": "2026-05-27T21:12:08.512467Z",
-     "iopub.status.idle": "2026-05-27T21:12:08.516701Z",
-     "shell.execute_reply": "2026-05-27T21:12:08.516337Z"
-    }
-   },
    "outputs": [
     {
      "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ce4c931a89bd42b093edcdf9c14e0871",
-       "version_major": 2,
-       "version_minor": 0
-      },
+      "text/html": [
+       "<img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAABSgAAAGMCAYAAADZU0xjAAAgAElEQVR4Xu3dd7xcVbk/4JUgaBABpQloBERAQLgXuxdFihQhAqEZqQFBSgAxFCMX5KIBQWMQgokhEuktgBBBaqRJlSAIUgRBqvoTCAgkFMnvs/c5Z2eYzOSUzD5rzc7z/OPeM8mws+Zd71rzdcqAwYPXmR0AAAAAACIYIKAEAAAAAGIRUAIAAAAA0QgoAQAAAIBoBJQAAAAAQDQCSgAAAAAgGgElAAAAABCNgBIAAAAAiEZACQAAAABEI6AEAAAAAKIRUAIAAAAA0QgoAQAAAIBoBJQAAAAAQDQCSgAAAAAgGgElAAAAABCNgBIAAAAAiEZACQAAAABEI6AEAAAAAKIRUAIAAAAA0QgoAQAAAIBoBJQAAAAAQDQCSgAAAAAgGgElAAAAABCNgBIAAAAAiEZACQAAAABEI6AEAAAAAKIRUAIAAAAA0QgoAQAAAIBoBJQAAAAAQDQCSgAAAAAgGgElAAAAABCNgBIAAAAAiEZACQAAAABEI6AEAAAAAKIRUAIAAAAA0QgoAQAAAIBoBJQAAAAAQDQCSgAAAAAgGgElAAAAABCNgBIAAAAAiEZACQAAAABEI6AEAAAAAKIRUAIAAAAA0QgoAQAAAIBoBJQAAAAAQDQCSgAAAAAgGgElAAAAABCNgBIAAAAAiEZACQAAAABEI6AEAAAAAKIRUAIAAAAA0QgoAQAAAIBoBJQAAAAAQDQCSgAAAAAgGgElAAAAABCNgBIAAAAAiEZACQAAAABEI6AEAAAAAKIRUAIAAAAA0QgoAQAAAIBoBJQAAAAAQDQCSgAAAAAgGgElAAAAABCNgBIAAAAAiEZACQAAAABEI6AEAAAAAKIRUAIAAAAA0QgoAQAAAIBoBJQAAAAAQDQCSgAAAAAgGgElAAAAABCNgBIAAAAAiEZACQAAAABEI6AEAAAAAKIRUAIAAAAA0QgoAQAAAIBoBJQAAAAAQDQCSgAAAAAgGgElAAAAABCNgBIAAAAAiEZACQAAAABEI6AEAAAAAKIRUAIAAAAA0QgoAQAAAIBoBJQAAAAAQDQCSgAAAAAgGgElAAAAABCNgBIAAAAAiEZACQAAAABEI6AEAAAAAKIRUAIAAAAA0QgoAQAAAIBoBJQAAAAAQDQCSgAAAAAgGgElAAAAABCNgBIAAAAAiEZACQAAAABEI6AEAAAAAKIRUAIAAAAA0QgoAQAAAIBoBJQAAAAAQDQCSgAAAAAgGgElAAAAABCNgBIAAAAAiEZACQAAAABEI6AEAAAAAKIRUAIAAAAA0QgoAQAAAIBoBJQAAAAAQDQCSgAAAAAgGgElAAAAABCNgBIAAAAAiEZACQAAAABEI6AEAAAAAKIRUAIAAAAA0QgoAQAAAIBoBJQAAAAAQDQCSgAAAAAgGgElAAAAABCNgBIAAAAAiEZACQAAAABEI6AEAAAAAKIRUAIAAAAA0QgoAQAAAIBoBJQAAAAAQDQCSgAAAAAgGgElAAAAABCNgBIAAAAAiEZACQAAAABEI6AEAAAAAKIRUAIAAAAA0QgoAQAAAIBoBJTQwKVX3Voct9K2m3+hOIayqF/amfotl/EFqBZ9HfqP+VYuASU0oPHQztQv7Uz9lsv4AlSLvg79x3wrl4ASGtB4aGfql3amfstlfAGqRV+H/mO+lUtACQ1oPLQz9Us7U7/lMr4A1aKvQ/8x38oloIQGNB7amfqlnanfchlfgGrR16H/mG/lElBCA7WN59abp4Vp115ZnPfWdjvtGj6+1rr5sR/JoT+oX9qZ+i1XTzbWN99wbbhx2tXF+TbbfyOsvc56xXkj1jeAOKyb0H/so8oloIQGahvPRef9Kpx7xsTivLdGjjo2rL/BJvmxF3D0B/VLO1O/5erJxnrUyH3DQw/cV5xvstmQcMAho4rzRqxvAHFYN6H/2EeVS0AJDdQ2nisvnxIuPHdycd7ljddfDzNnvlacL7Hk+4vjWiMO+V741Gf/Jz/2Ao7+oH5pZ+q3XN1trGe8+EIYPmyr4jwzaNCi4awpV4eFFlqouK2e9Q0gDusm9B/7qHIJKKGB7hpPZsaLz4fhw4YU5z35O17A0R96Uovql1Sp33J1N743XH9V+NmPjy3Ouxw/ZkJYY611ivN61jeAOLrr6xn7PmiN7uabfdT8EVBCA901noyFnlSpX9qZ+i1Xd+N74g+/F2675Yb8eLe99g9n/vLn+fHQnXYNuw7fLz9uREAJEEd3fT3jdQu0RnfzzT5q/ggooYHuGk/GQk+q1C/tTP2Wa17j+/rrs8LXt94oP15q6WXDyRPPCTsP/Up+vtzyK4QJk6fkx40IKAHimFdf7+J1C7TGvOabfdT8E1BCA/NqPF0s9KRK/dLO1G+55jW+0++6LfzgqJH58Ve/tn3Ye//vhKMOHxHuv296ftu4SeeHFT80OD+uJ6AEiGNefb2L1y3QGvOab/ZR809ACQ3Mq/F0sdCTKvVLO1O/5ZrX+P5i3E/CVb+5JD/+3jEnhk9/bv3w6ynnhjMmjctvG77PgeFrQ4flx/UElABxzKuvd/G6BVpjXvPNPmr+CShJ1uKLLxk+/8UNw2prrBkWWuhd/XqdG2y0Wbf/vb4s9DdOu7o47g+vvfZquOv2W8K90+8Mb7/9dn/8J+mkfuef+o1H/VZXs/UtWyP2/MaQ8NKMF/Pzcy6+Jiz63sXCXx97JIw8YI/8tuxHcrIfy2nE+gYsyKyb88++j55Kcb7ZR7WGgJLkLLbY+8JPf35GWGbZDyZ3bbX6ElDGMnv27HDd1VPDz0/6UaxLWGCo39ZTv/1H/S64/vLwn8PhB38zH4A11143jP7J+Px49uy3w85DNw0zZ76Wn//q/CvCEku+Pz9Ogf4AxGTdbD19nWZSnm/2Ua0hoCQpyyy7XDhpwtlh0UXfm9R1NdJOAWWX2u/FoPXUb7nUb7nU74Lt/LN/GS44+5f5IGS/3r3tDrsUA3LKmNFh2rVX5McHH3Z0+PLGm3fekw79Aehv1s1y6evUSn2+2Ue1hoCSpIwdf2ZYaeVVk7qmZtoxoMxMOOXH4eorLu38V9BK6rd86rc86nfBdtA+O4ennnw8H4Qx4yaHVVZdvRiQW268Low5/uj8+PPrfzkc/r/Hdd6TFv0B6E/WzfLp63RJfb7ZR7WGgJJkLL/Ch8LPT7+wuJ7sY2WXXXxe/h2Kzz///4rb+8OEyVO6/c/0JaDcd/j2xXF/yMLeIdvuFNb6xH8X/7n666Y11G/rqd/+o37LNe6088K73rVwfvyne6eHU0+KF/A1Wt/+/twzYb/hO+THgwYtGs6++JowcODAznuzdeOFMHzYVsX5+ZdNC+9+93uK84z1DViQWDdbz76PZlKfb/ZRrSOgJBkjRx0b1t9gk+J6jjvm8DycjKEnYWN90NeTvxPrV06PGzM+fHytdYvrOGS/3cITjz9anDP/1G951G/51G+5Lrz8hrDwIovkx3fcelP40bHf7byn/zVaq3479eIw8dQxxfkKKw4ujrs8+8yTxfFRPxgT1vv054vzjPUNWJBYN8tj30e91OebfVTrCChJxkkTzgofWemj+fW88u+Xw647xPuOq0Yv4Oq1U0CZ/T+S2dviu/i4ROup3/Ko3/Kp33KlHlAe/d0Dw5/+eHdxvd3ZfKuh4VsjDi3OM7ECSv0BiMG6WR59nXqpzzf7qNYRUJKMMy68Miy++JL59fz10YfDyBHDo11b1QLKzCW//X0YMGBAfvzb31wSJo77SbTxrSL1Wy71Wy71W66UA8r6/0PwSxtuWhzXmjVrZrjztpvz4+xXvCefNzUMGDDnY+CxAsqM/gD0N+tmufR1aqU83+yjWktASTJqv9PqD3f8Poz+/mHRrq2KAeWFU28MCy/c8R1osT9iWEXqt1zqt1zqt1wpB5S1P4Cz9jrrhR+cOK7zqt/p7bffDrtst2mYOfO1/PzEn00KH1t9zc574waU+gPQ36yb5dLXqZXyfLOPai0BJclI+QVcI+30Ee9MSuNbRSmNbyUD9oS+w6+KUhpf9Vuu+vEde8Ix4abfXZMf77bX/mHbHXbpvGdup4wZHaZde0V+vNMue4Wv77JX5z2RA0r9AehnKfWd+r7eiNcttLOU55t9VGsJKElGyo2nEQs9tdRvuVIa3ypKaXy90CpX7fi++eabYcchGxTnY8ZNDqusunpxXq/2XQIfHrxyOHniOZ33CCiBBYt1s1wpjS/xpVQP9lHlElCSjFQbTzMCSmqp33KlNL5VlNL4CijLVTu+995zVzhm1MH58aBBi4azL74mDBw453sl67380oyw+05fLc7HT74ofHD5FfPjmN9BmVL9AguGlPqOdZOqS3W+2Ue1noCSZKTaeJqpf6HWk82BF3DVpX7LldL4VlFK49uTXqr/9l3t+J49eUK4+IIz8+Mvb7x5OPiwjndHzsthB+0VHn3kwfx4xHeODBtvumV+bH0DFiTWzXKlNL7El1I92EeVS0BJMlJtPK3kBVx1qd9ypTS+VZTS+PYkoOwL/beD8QWYf9bNcqU0vsSXUj3YR5VLQEkyNJ5ypTS+VZTS+Fo46S31Wy7jW66UxhdYMKTUd+z7qDrzrVwpja+AkmSkNDEs9PSW+i1XSuNbRSmNr/5bLuMLMP+sm+VKaXyJL6V6sI8ql4CSZGg85UppfKsopfG1cNJb6rdcxrdcKY0vsGBIqe/Y91F15lu5UhpfASXJSGliWOjpLfVbrpTGt4pSGl/9t1zGF2D+WTfLldL4El9K9WAfVS4BJcnQeMqV0vhWUUrja+Gkt9RvuYxvuVIaX2DBkFLfse+j6sy3cqU0vgJKkpHSxLDQ01vqt1wpjW8VpTS++m+5jC/A/LNuliul8SW+lOrBPqpcAsqK+eU5l4cPLLV0/q96/LG/hO8csHt+XDuRLrngrHDW5PHFeSpSajxVlNL4auz0lvotV0rjW0XGt1wpjW9Z6xswt203/0Jx3N9S6jtVlNL46usdzLfqSmm+CSgrRkBJMyk1nrIWegtndanfcqU0vlVkfMuV0viWtb4Bc7Pvqy59PT3mW3WlNN8ElBUjoKSZlBpPWS/gLJzVpX7LldL4VpHxLVdK41vW+gbMzb6vuvT19Jhv1ZXSfBNQVoyAkmZSajxlvYCzcFaX+i1XSuNbRca3XCmNb1nrGzA3+77q0tfTY75VV0rzTUBZMQJKmkmp8ZT1As7CWV3qt1wpjW8VGd9ypTS+vV3fXnnl32HQoEXDQgstVNzWCm+99WaYNWtWWGyx9xW3LYiMb4d2q4eePm/2fdXVzn29rPlW1uP2lPlWXSnNNwFlxQgoaSalxlP7Au7Wm6eFaddeWZz31nY77Ro+vta6+bGFs7pSrd9mbr7h2nDjtKuL8222/0ZYe531ivNG1G91pVS/VZTS+HYXUL788oxw3VW/CY/95aHwwJ/uCS/NeDG/fYUVB4dP/Ncnw9ZDvx6WX/HDnX+6d6bfdVuY/ofbw18e/nN45KEHittXWnnV8MUNNw0bbLxZWGqpZYrb67VyPe6JvvTJ7hjfOea3HppJ6XmzblZXO/X1TFnzbX4ft5V93XyrrpTmm4CyYgSUNJNS46l9AXfReb8K554xsTjvrZGjjg3rb7BJfmzhrK5U67eZUSP3DQ89cF9xvslmQ8IBh4wqzhtRv9WVUv1WUUrjO6+A8om/Php+ePSh4fl//bO4rZH9DjoibPrVrYvz7vznP/8JZ0+eEH495ZzitkayF7Rjx59ZnNdr5XrcE33pk/NifDu0qh6aSel5s25WV7v09bLmW6set5V93XyrrpTmm4CyYgSUNJNS46l9AXfl5VPChedOLs67vPH662HmzNeK8yWWfH9xXGvEId8Ln/rs/+THFs7qSrV+G5nx4gth+LCtivNM9lG1s6ZcPc+Pq6nf6kqpfqsopfFtFlDeefvN4fhjjijOM+uu95nw0Y+tHl584fnw8J/vD88+82R++3Y77RZ2Gb5v55+at1mzZoYfHTsq3Dv9zuK27N2Ya669blh8iSXCE48/Fh68/958Pe3uhWwr1+Pu9LVPNmN8O7SyHhpJ7XmzblZXO/T1suZbKx+3lX3dfKuulOabgLJiBJQ0k1LjafYCrtaMF58Pw4cNKc578ncsnNXVTvV7w/VXhZ/9+Ni5nozjx0wIa6y1TnFeT/1WV0r1W0UpjW+jtSp7sbnnsCHFi8FVVl09fH/02LD4Ekt2/okOd995azjlp6PzdxL2NKC8/JLzw+SJJxfnI75zZNh40y2L88yrr7wSppx/Rrjvj38IY8bN/UK1O31Zj7vT1z7ZiPGdo+x6SO15s25WV+p9PVPWfCvrcWv1pa+bb9WV0nwTUFaMgJJmUmo8PVkELZzUaqf6PfGH3wu33XJDft277bV/OPOXP8+Ph+60a9h1+H75cSM2ftWVUv1WUUrj22h9u+Kyi8Kk8WPz4w8PXjn86KSJYdFF39t57ztl36H492efCautsVZxWzOvvz4rfGv37YrvsTzo0KPChpts0Xnv3LIg7z3vGVSc91Rf1uPu9LVPNmJ8O/RHPaT2vFk3qyv1vl7WfCvrcev1pa+bb9WV0nwTUFaMgJJmUmo8PVkELZzUapf6zTaWX996o/yal1p62XDyxHPCzkO/kp8vt/wKYcLkKflxIzZ+1ZVS/VZRSuNbv7698cbrYZ/dhhYvNrOPy2282Ts/2txXv516cZh46pj8OPt43unnTg0DBw7svLd1+rIez8v89Ml6xneOsushxefNulldKff1TFnzrazHrdeXvm6+VVdK801AWTECSppJqfH0ZBG0cFKrXeo3+7XFHxw1Mr/mr35t+7D3/t8JRx0+Itx/3/T8tnGTzg8rfmhwflzPxq+6UqrfKkppfOvXt2zuZz2gyzmXXNv03ZO9Vdtbhu36zbDjznt23tNafVmP52V++mQ94ztH2fWQ4vNm3ayulPt6pqz5Vtbj1utLXzffqiul+SagrBgBJc2k1Hh6sghaOKnVLvX7i3E/CVf95pL8mr93zInh059bP/x6yrnhjEnj8tuG73Ng+NrQYflxPRu/6kqpfqsopfGtX99qv7Pvvz/52XD06I6PerfCN3fZpvhF8ON/+ouwxpqf6LyntfqyHs/L/PTJesZ3jrLrIcXnzbpZXSn39UxZ862sx63Xl75uvlVXSvNNQFkxPQkon3v26fDIQw8U56n40oabhgEDBuSXc8etN4UfHfvdVC6tEmobT/YrjPfec1e0f9cGG23W7X+7LwvnjdOuLo77m/otVzvU79tvvx32/MaQ4qOc51x8TVj0vYuFvz72SBh5wB75bdmPP2Q/AtGI+q2ulDZ+VZRyf8h+PfW8M0/Lh32jr2wZDhx5ZEuegv+89VbYfqsvFec/P/3CsPwKHyrOW6kv63Ez89sn6xnfDmXXQ6rPm3WzulLu62XNt7Iet5G+9HXzrbpSmm8CyorpSUDZDgSUrVfbeNpBXxbOVKjf1muH+v3Lw38Ohx/8zfx611x73TD6J+Pz49mz3w47D920+AXfX51/Rf69QqlSv60noCxXyv3h1LHHh+uunppfZ19+AKaZf/7jufyHFLp0BX1laOV63Oo+aXw7lF0P7fK8xWLdbL2U+3pZ862sx22klX29v5lvrZfSfBNQVoyAkmZSajw9YeGkVjvU7/ln/zJccPYv8+vNfpV22x126bz6EE4ZMzpMu/aK/Pjgw44OX95488570mPj13oCynKl3B+OPfKQcM/dd+TXucfeB4att3vnR5ezdwDefefcLwwP+PaoMHilVYrzetknYY749t7FeZkvLlu5Hre6TxrfDmXXQ7s8b7FYN1sv5b5e1nwr63EbaWVf72/mW+ulNN8ElBUjoKSZlBpPT1g4qdUO9XvQPjuHp558PL/eMeMmh1VWXb3z6kO45cbrwpjjj86PP7/+l8Ph/3tc5z3psfFrPQFluVLuD9m8z+Z/ptEPHpx04v81/Nhcd9899sxTfwsj9p4Tdl5w+e/CIou8uzhvpVaux63uk8a3Q9n10C7PWyzWzdZLua+XNd/KetxGWtnX+5v51nopzTcBZcX0JKC8/porwkXnTS7OUzHutPPCu961cH45Gk/r1TaeP907PZx6Uvcb/7JMmDylOG6mLwvnvsO3L477m/otV+r1+/fnngn7Dd8hv9ZBgxYNZ198TRg4cGDn1Wf1/EIYPmyr4vz8y6aFd7/7PcV5Rv1Wl4CyXCn3h7Mmjw+XXHBWfp1bbDU07DPi0M6r7pC9g7LrHZYPPXBf563dB5SzZs4Mw7bduDg/7axLw9LLLFect1Jf1uNGWtEn6xnfDmXWQ8rPm3WzulLu62XNt7Iet5G+9HXzrbpSmm8CyorpSUCZbZSzDV1qvIArV0rj25NFsC8Lp1+Xq67U6/e3Uy8OE08dUzwBK6w4uDju8uwzTxbHR/1gTFjv058vzjPqt7pSqt8qSml869eqq6+4NEw45cf58ee+sEE44ujjO++Z2wnHjgq333pjftxdQJn5xrabFN/Z+JNTTg8f/dganfe0Vl/W40Za0SfrGd85yqqHlJ8362Z1pdzXM2XNt7Iet15f+rr5Vl0pzTcBZcUIKGkmpcbTk0XQwkmt1Ov36O8eGP70x7uL6+3O5lsNDd+qeyeVjV91pVS/VZTS+Navb9n3S/7w6I65vtTSy+bviBkwYEDnve/U24DysIP2Co8+8mB+fMAho8Imm815sdlKfVmPG2lFn6xnfOcoqx5Sft6sm9WVcl/PlDXfynrcen3p6+ZbdaU03wSUFSOgpJmUGk9PFkELJ7VSrt9X/v1y2HWHOT/m8KUNNy2Oa82aNTPcedvN+XH267STz5saBgyY8/FGG7/qSql+qyil8a1f3154/l9hr52/VpwfN2Z8+Pha6xbntXobUJ7+i5+FqZdekB+vtsZa4YSTTuu8p7X6sh7Xa1WfrGd85yijHlJ/3qyb1ZVyX8+UMd8yZT1uvb70dfOtulKabwLKihFQ0kxKjacni6CFk1op12/tDzusvc564Qcnjuu86nd6++23wy7bbVp8dOfEn00KH1t9zc57bfyqLKX6raKUxrfR+jb+5BPCNVdelh9v9JUtw4Ejj+y85516G1D+8x/PhW/tvl1xPubUX4VVPrpacd4qfVmP67WqTzZifDuUUQ+pP28Ck+pKva+XMd8yZT1uvb70dfOtulKabwLKihFQ0kxKjacni6CFk1op1+/YE44JN/3umvw6d9tr/7DtDrt0XvXcThkzOky79or8eKdd9gpf32Wvznts/KospfqtopTGt9H69tyzT4f999yxON95933C9sP2KM679DagzJw69vhw3dVT8+PsHYdZ8PfhwSt33jtH9uN4v7/p+rDvgYcVt/VUX9bjeq3qk40Y3zlaXQ+pP28Ck+pKva9nWj3fupT1uLX60tfNt+pKab4JKCtGQEkzKTWeniyCFk5qpVq/b775ZthxyAbFdY4ZNzmssurqxXm92nejZJvNkyee03mPjV+VpVS/VZTS+DZb3yaNHxuuuOyi4vwzn/9iWO9TnwsfWXnVMPO1V8Mdt92c/+BLl54GlFk4N/KAPYp3HGa/jr3FkKH5uw7ft/gS4cm/PR7+ePcd+cemV1p51TB2/Jmdf7Pn+rIe12pln2xmQR7fWq2sh3Z43gQm1dUOfb2V861WWY9bqy993XyrrpTmm4CyYgSUNJNS4+nJImjhpFaq9XvvPXeFY0YdnF9jtoE8++JrwsCBzb8v7eWXZoTdd/pqcT5+8kXhg8uvmB/b+FVXSvVbRSmNb7P1bfbs2eHSC88OZ00eX9zWzJprrxsOO3J0WPL9Hyhum5e/P/dMOO77h4ennny8uK2R/nwhW6uVfbKZBXl867WqHtrhebNuVlc79PVMq+ZbvbIet4vXWdRKab4JKCtGQEkzKTWeZi/gatW/QOnJ37FRra5U6/fsyRPCxRd0bAy/vPHm4eDDOt71My+1v9A44jtHho033TI/Vr/VlVL9VlFK49vdWjX9rtvCeWdNKnpAreyjfNnHnzfcZIt5/jBMI9mPy5wx6dRw2y2/Cy/NeLG4vcsaa60ThmyzY/jCFzcqbuupvqzHtVrZJ7uzII5vI62oh3Z43qyb1dVOfb0V862Rsh4305e+br5VV0rzTUBZMQJKmkmp8fRkEewLC2d1qd9ypTS+VWR8y5XS+PZ0fXvrrTfD00/+LTz91BPhA0stEz40+CNh8cWXLO6fH9kL2ScefzS8+sq/88deZrkPhqWWWqa4f0FgfOdop3ro7fNm31dd7djXM2XNt7IetzfMt+pKab4JKCtGQEkzKTWenr6A6y0LZ3Wp33KlNL5VZHzLldL4lrW+AXOz76sufT095lt1pTTfBJQVI6CkmZQaT1kv4Cyc1aV+y5XS+FaR8S1XSuNb1voGzM2+r7r09fSYb9WV0nwTUFaMgJJmUmo8Zb2As3BWl/otV0rjW0XGt1wpjW9Z6xswN/u+6tLX02O+VVdK801AWTECSppJqfGU9QLOwlld6rdcKY1vFRnfcqU0vmWtb8Dc7PuqS19Pj/lWXSnNNwFlxQgoaSalxlPWCzgLZ3Wp33KlNL5VZHzLldL4lrW+AXOz76sufT095lt1pTTfBJQVI6CkmZQaT1kv4Cyc1aV+y5XS+FaR8S1XSuNb1voGzM2+r7r09fSYb9WV0nwTUJKMlCZGFRnfcqU0vmW9QLYxqS71Wy7jW66UxhdYMKTUd+z7qDrzrVwpja+AkmSkNDGqyPiWK6XxtVGlt9RvuYxvuVIaX2DBkFLfse+j6sy3cqU0vgJKkpHSxKgi41uulMbXRpXeUr/lMr7lSml8gQVDSn3Hvo+qM9/KldL4CihJRkoTo4qMb7lSGl8bVXpL/ZbL+JYrpfEFFgwp9R37PqrOfCtXSuMroCQZKU2MKjK+5UppfHu7UX3llX+HQYMWDQsttFBxWyO+g7K62rmzmGgAABABSURBVLl+33rrzTBr1qyw2GLvm+cTpH476A8A88+6Wa6Uxpf4UqqH3u6jeso+tYOAkmSk1HiqyPiWK6Xx7W7hfPnlGeG6q34THvvLQ+GBP90TXprxYn77CisODp/4r0+GrYd+PSy/4oc7//QcFs7qaqf6zUy/67Yw/Q+3h788/OfwyEMPFE/MSiuvGr644aZhg403C0sttUxxe0b9dtAfAOafdbNcKY0v8aVUD7X7qFtvnhamXXtlcd5b2+20a/j4Wuvmx/apHQSUJCOlxlNFxrdcKY3vvAKIJ/76aPjh0YeG5//1z+K2RvY76Iiw6Ve3Ls4zFs7qapf6/c9//hPOnjwh/HrKOfN8MrKgcuz4M4vzjPrtoD8AzD/rZrlSGl/iS6keavdRF533q3DuGROL894aOerYsP4Gm+TH9qkdBJQkI6XGU0XGt1wpjW+zAOLO228Oxx9zRHGeWXe9z4SPfmz18OILz4eH/3x/ePaZJ/Pbt9tpt7DL8H07/1QHC2d1tUP9zpo1M/zo2FHh3ul3Fk9E9q7fNddeNyy+xBLhiccfCw/ef2+YOfM1AeU86A8A88+6Wa6Uxpf4UqqH2n3UlZdPCReeO7k47/LG66/n+9EuSyz5/uK41ohDvhc+9dn/yY+9zuogoCQZKTWeKjK+5UppfBsFEFm4s+ewIcViucqqq4fvjx4bFl9iyc4/0eHuO28Np/x0dNhksyECygVI6vWbufyS88PkiScXz8qI7xwZNt50y+I88+orr4Qp558R7vvjH8KYce/cMNr4ddAfAOafdbNcKY0v8aVUD432UfVmvPh8GD5sSHHek79jn9pBQEkyzvv19eE97xmUX0/24vL73z0omWurgim/uSks9K535f+U7Psyfjz6f6vwz0pGSvXbaBG84rKLwqTxY/PjDw9eOfzopIlh0UXf23nvO2XfUfn3Z58Jq62xVnFbJubCqX7LlXr9vv76rPCt3bcrvi/1oEOPChtuskXn1c8tC+S71pMuMes39Y21/gDQO9bNctn3USv1+Vav3QLKlOabgJJkTDrnsuJHDZ568vFw0D47J3Nt7W7AgIHhkt/eUvwzLr7gzPx73GidlOq3PqB8443Xwz67DS3CnezjBBtvtlXnvT0XK+BRv+VLuX4zv516cZh46pj8OPuYzOnnTg0DBw7s1cDEqt9MygGl/gDQe9bN8tj3US/1+VavnQLK1OabgJJknHDSacU7tv7z1lthp202yv+X+bfRV7YMB448sjgfc/zR4ZYbryvOmX8p1W99QHn/fdPDUYePKM7PueTapu+enJdYAY/6LV/K9ZvJ6jer48ywXb8Zdtx5z14PSqz6zaQcUOoPAL1n3SyPfR/1Up9v9dopoExtvgkoScbu3xwRttn+G8X13PS7a8LYE44pzumb9y2+RDh10vn5/2Zmz54d9vj6luHll2Z0/glaIaX6rQ8ob7j+qvCzHx+bH//3Jz8bjh7d8VHv3ooR8Kjf/pFy/Wa+ucs2xS/PH//TX4Q11vxErwcmRv12STmg1B8Aes+6WQ77PhpJfb7Va5eAMsX5JqAkGQsvskg479Lrw0ILLVRcU/bLwo8+8mB47bVXi9vouWWX+2BYdbU1w8ILL1zc9vCD94fvHrJPcU5rpFS/G2y0WXFdmezX5c4787T8uP7/JeuNG6ddXRz3B/Xbf1Ku3+yd9Ntv9aViMH5++oVh+RU+VJz3VH/Xb60vbbhpGDBgQH4848UXwr333NV5T//THwDmn3Wz9ez7aCbl+dZIXwLK/t6npjrfBJQkpdGvstI62bsnDx0xPPz1sUeK22idVOv31LHHh+uunppf49Cddg27Dt+v84rbi/otV6r1+89/PJf/QE6Xcy6+Jiz63sWKc+aP/gDQN9bNctn3USvV+dZIXwLK2FKZbwJKknPE0ceHz31hg+Suq93Nnv12OPGH/xtu//0N7f5PSVqK9XvskYeEe+6+Ix+3PfY+MGy93bB3jGH2Dsu775x74Tzg26PC4JVWKc5jUr/9I8X6feShB8IR3967GIB22OS1E/0BoO+sm+Ww76ORFOdbI+0WUKY03wSUJGnYbnuHDTfZIiy9zLL5L0vRd2++8UZ45ukn81/AffCBe4vbKU9q9Vv7o0iNfmDkpBP/r+HHCvr6XX+tpH77X2r1+8xTfwsj9p4Tql9w+e/CIou8uzhn/ugPAPPHutk69n10J7X51ki7BJQpzjcBJclbdrnlw4CBHd/dRe+89uqr4d8vv1Sc0/9i1O+EyVPe8Q89a/L4cMkFZ+XHW2w1NOwz4tDOezpk76DseoflQw/c13nr3AHlvsO3L477g/qNL4X6nTVzZhi27cbFYJx21qVh6WWWK857qr/rN1X6A0B5rJt9Z99Hb6Uw3xrpS0DZ3/vUVOebgBKgYuoXwauvuDRMOOXH+XH29QnZxyOaOeHYUeH2W2/Mj+sDypi/gsyCo75+M9/YdpMwc+Zr+fFPTjk9fPRja3Te03Pqt0P9+OoPAO2tvq9nrJtQjkbzrV5fAkr71A4CSoCKqV8Es++X/OHRHe+aXGrpZfN3oHX9onA9ASWx1ddv5rCD9gqPPvJgfnzAIaPCJpvN2fT1lI1fh/rx1R8A2lt9X89YN6EcjeZbPQFl3wkoASqmfuF84fl/hb12/lpxftyY8eHja61bnNcSUBJbff1mTv/Fz8LUSy/Ij1dbY61wwkmndd7TcwLKDvXjqz8AtLf6vp6xbkI5Gs23egLKvhNQAlRMo4Vz/MknhGuuvCw/3ugrW4YDRx7Zec87CSiJrVH9/vMfz4Vv7b5dcT7m1F+FVT66WnHeEwLKDo3GV38AaF+N+rp1E8rRaL7VE1D2nYASoGIaLZzPPft02H/PHYvznXffJ2w/bI/ivIuAktga1W/m1LHHh+uunpofL7Hk+8MPThwXPjx45c575/jTvdPD72+6Pux74GHFbRkBZYdG46s/ALSvRn09Y92E1ms232oJKPtOQAlQMc0Wzknjx4YrLruoOP/M578Y1vvU58JHVl41zHzt1XDHbTfnP5jRxY/kEEOz+s1CtJEH7FH8WM6gQYuGLYYMDR9bfc3wvsWXCE/+7fHwx7vvCHfednNYaeVVw9jxZ3b+zQ4Cyg7Nxld/AGhPzfq6dRNar9l8qyWg7DsBJUDFNFs4Z8+eHS698Oxw1uTxxW3NrLn2uuGwI0eHJd//geI2AQ/9oVn9Zv7+3DPhuO8fHp568vHitkYElM01G1/9AaA9NevrGesmtNa85lsXAWXfCSgBKqa7hXP6XbeF886aVPwqcq3so7O77bV/2HCTLcKAAQOL2zMCSvpDd/U7a9bMcMakU8Ntt/wuvDTjxeL2LmustU4Yss2O4Qtf3Ki4LaN+O3Q3vvoDQHvprq9bN6F1uptvmZdfmhF23+mrxXlP/o59agcBJUDF9GQRzLz11pvh6Sf/Fp5+6onwgaWWCR8a/JGw+OJLFvfXs3DSH3pav5ksoHzi8UfDq6/8O6/hZZb7YFhqqWWK+2up3w49HV/9AaA99LSvZ6ybMH96M996wz61g4ASoGIsnLQz9Vsu4wtQLfo69B/zrVwCSoCKsXDSztRvuYwvQLXo69B/zLdyCSgBKsbCSTtTv+UyvgDVoq9D/zHfyiWgBKgYCyftTP2Wy/gCVIu+Dv3HfCuXgBKgYiyctDP1Wy7jC1At+jr0H/OtXAJKgIqxcNLO1G+5jC9Atejr0H/Mt3IJKAEAAACAaASUAAAAAEA0AkoAAAAAIBoBJQAAAAAQjYASAAAAAIhGQAkAAAAARCOgBAAAAACiEVACAAAAANEIKAEAAACAaASUAAAAAEA0AkoAAAAAIBoBJQAAAAAQjYASAAAAAIhGQAkAAAAARCOgBAAAAACiEVACAAAAANEIKAEAAACAaASUAAAAAEA0AkoAAAAAIBoBJQAAAAAQjYASAAAAAIhGQAkAAAAARCOgBAAAAACiEVACAAAAANEIKAEAAACAaASUAAAAAEA0AkoAAAAAIBoBJQAAAAAQjYASAAAAAIhGQAkAAAAARCOgBAAAAACiEVACAAAAANEIKAEAAACAaASUAAAAAEA0AkoAAAAAIBoBJQAAAAAQjYASAAAAAIhGQAkAAAAARCOgBAAAAACiEVACAAAAANEIKAEAAACAaASUAAAAAEA0AkoAAAAAIBoBJQAAAAAQjYASAAAAAIhGQAkAAAAARCOgBAAAAACiEVACAAAAANEIKAEAAACAaASUAAAAAEA0AkoAAAAAIBoBJQAAAAAQjYASAAAAAIhGQAkAAAAARCOgBAAAAACiEVACAAAAANEIKAEAAACAaASUAAAAAEA0AkoAAAAAIBoBJQAAAAAQjYASAAAAAIhGQAkAAAAARCOgBAAAAACiEVACAAAAANEIKAEAAACAaASUAAAAAEA0AkoAAAAAIBoBJQAAAAAQjYASAAAAAIhGQAkAAAAARCOgBAAAAACiEVACAAAAANEIKAEAAACAaASUAAAAAEA0AkoAAAAAIBoBJQAAAAAQjYASAAAAAIhGQAkAAAAARCOgBAAAAACiEVACAAAAANEIKAEAAACAaASUAAAAAEA0AkoAAAAAIBoBJQAAAAAQjYASAAAAAIhGQAkAAAAARCOgBAAAAACiEVACAAAAANEIKAEAAACAaASUAAAAAEA0AkoAAAAAIBoBJQAAAAAQjYASAAAAAIhGQAkAAAAARCOgBAAAAACiEVACAAAAANEIKAEAAACAaASUAAAAAEA0AkoAAAAAIBoBJQAAAAAQjYASAAAAAIhGQAkAAAAARCOgBAAAAACiEVACAAAAANEIKAEAAACAaASUAAAAAEA0AkoAAAAAIBoBJQAAAAAQjYASAAAAAIhGQAkAAAAARCOgBAAAAACiEVACAAAAANEIKAEAAACAaASUAAAAAEA0AkoAAAAAIBoBJQAAAAAQjYASAAAAAIhGQAkAAAAARCOgBAAAAACiEVACAAAAANEIKAEAAACAaASUAAAAAEA0AkoAAAAAIBoBJQAAAAAQjYASAAAAAIhGQAkAAAAARCOgBAAAAACiEVACAAAAANEIKAEAAACAaASUAAAAAEA0AkoAAAAAIBoBJQAAAAAQjYASAAAAAIhGQAkAAAAARCOgBAAAAACiEVACAAAAANEIKAEAAACAaASUAAAAAEA0AkoAAAAAIBoBJQAAAAAQjYASAAAAAIhGQAkAAAAARCOgBAAAAACiEVACAAAAANEIKAEAAACAaASUAAAAAEA0AkoAAAAAIBoBJQAAAAAQjYASAAAAAIhGQAkAAAAARCOgBAAAAACiEVACAAAAANEIKAEAAACAaASUAAAAAEA0AkoAAAAAIBoBJQAAAAAQjYASAAAAAIhGQAkAAAAARCOgBAAAAACiEVACAAAAANEIKAEAAACAaASUAAAAAEA0AkoAAAAAIBoBJQAAAAAQjYASAAAAAIjm/wPRAc/SVjfuawAAABBkZUJHMDA0QTkyRjMyODkwNUMxNZAALlUAAAAASUVORK5CYII=\" style=\"display:block;font-family:monospace;width:720px;height:204px\" />"
+      ],
       "text/plain": [
-       "<gen.jupyter_widget.GenGraphWidget object at 0x10c325160>"
+       "<IPython.core.display.HTML object>"
       ]
      },
      "metadata": {},
@@ -329,19 +129,122 @@
     }
    ],
    "source": [
-    "reference_bg = next(bg for bg in bgs if bg.sample_name == \"reference\")\n",
+    "bgs = repo.get_block_groups()\n",
+    "bg = bgs[0]\n",
     "\n",
-    "if gen.GenGraphWidget is not None:\n",
-    "    widget = reference_bg.plot(cols=120)\n",
-    "    display(widget)\n",
-    "else:\n",
-    "    print(\"Jupyter widget not available. Install with: pip install gen[jupyter]\")"
+    "bg"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Networkx\n",
+    "Arguably the most popular graph library for Python"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "AttributeError",
+     "evalue": "'builtins.Repository' object has no attribute 'block_group_to_networkx'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+      "\u001b[31mAttributeError\u001b[39m                            Traceback (most recent call last)",
+      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[6]\u001b[39m\u001b[32m, line 5\u001b[39m\n\u001b[32m      2\u001b[39m \u001b[38;5;28;01mimport\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01mnetworkx\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mas\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01mnx\u001b[39;00m\n\u001b[32m      3\u001b[39m \u001b[38;5;28;01mimport\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01mmatplotlib\u001b[39;00m\u001b[34;01m.\u001b[39;00m\u001b[34;01mpyplot\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mas\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01mplt\u001b[39;00m\n\u001b[32m----> \u001b[39m\u001b[32m5\u001b[39m nx_repr = \u001b[43mrepo\u001b[49m\u001b[43m.\u001b[49m\u001b[43mblock_group_to_networkx\u001b[49m(bg)\n\u001b[32m      6\u001b[39m \u001b[38;5;28mprint\u001b[39m(\n\u001b[32m      7\u001b[39m     \u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mConverted to NetworkX graph with \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mnx_repr.number_of_nodes()\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m nodes and \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mnx_repr.number_of_edges()\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m edges\u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m      8\u001b[39m )\n\u001b[32m     10\u001b[39m \u001b[38;5;66;03m# Analyze the graph\u001b[39;00m\n",
+      "\u001b[31mAttributeError\u001b[39m: 'builtins.Repository' object has no attribute 'block_group_to_networkx'"
+     ]
+    }
+   ],
+   "source": [
+    "try:\n",
+    "    import networkx as nx\n",
+    "    import matplotlib.pyplot as plt\n",
+    "\n",
+    "    nx_repr = repo.block_group_to_networkx(bg)\n",
+    "    print(\n",
+    "        f\"Converted to NetworkX graph with {nx_repr.number_of_nodes()} nodes and {nx_repr.number_of_edges()} edges\"\n",
+    "    )\n",
+    "\n",
+    "    # Analyze the graph\n",
+    "    if nx_repr.number_of_nodes() > 0:\n",
+    "        # Get node degrees\n",
+    "        degrees = [nx_repr.degree(n) for n in nx_repr.nodes()]\n",
+    "        avg_degree = sum(degrees) / len(degrees) if degrees else 0\n",
+    "        print(f\"Average node degree: {avg_degree:.2f}\")\n",
+    "\n",
+    "    # Draw the graph\n",
+    "    plt.figure()\n",
+    "    nx.draw(nx_repr, with_labels=True)\n",
+    "    plt.show()\n",
+    "\n",
+    "except ImportError:\n",
+    "    print(\"NetworkX not installed. Install with: pip install networkx\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## RustworkX\n",
+    "Similar to NetworkX but built on Rust under the hood."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import rustworkx as rx\n",
+    "    import rustworkx.visualization as rxv\n",
+    "\n",
+    "    rx_repr = repo.block_group_to_rustworkx(bg)\n",
+    "\n",
+    "    display(rxv.graphviz_draw(rx_repr))\n",
+    "\n",
+    "except ImportError:\n",
+    "    print(\"RustworkX not installed. Install with: pip install rustworkx\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Dictionary"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dict_repr = repo.block_group_to_dict(bg)\n",
+    "print(\n",
+    "    \"Edges are keyed by pairs of node tuples (node_id, start, end):\"\n",
+    ")\n",
+    "display(dict_repr[\"edges\"])\n",
+    "\n",
+    "\n",
+    "print(\"Node identifiers are also stored as node attributes:\")\n",
+    "display(dict_repr[\"nodes\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -356,208 +259,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.13.3"
-  },
-  "widgets": {
-   "application/vnd.jupyter.widget-state+json": {
-    "state": {
-     "852e84c500a24fc989e33eaaf4e4a497": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "2.0.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "2.0.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border_bottom": null,
-       "border_left": null,
-       "border_right": null,
-       "border_top": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "ce4c931a89bd42b093edcdf9c14e0871": {
-      "model_module": "anywidget",
-      "model_module_version": "~0.9.*",
-      "model_name": "AnyModel",
-      "state": {
-       "_anywidget_id": "gen.jupyter_widget.GenGraphWidget",
-       "_dom_classes": [],
-       "_esm": "// Generated from js/index.ts by `npm run build-jupyter` / `make jupyter`. Edit TypeScript sources, not this file.\n\n// js/grid.ts\nvar TEXT_SIZE = 14;\nvar CELL_SIZE = Math.round(TEXT_SIZE / 0.875);\nvar BOX_SCALE = 1.15;\nvar FONT_FAMILY = \"monospace\";\nvar BOX_FONT = `${CELL_SIZE}px ${FONT_FAMILY}`;\nvar TEXT_FONT = `${TEXT_SIZE}px ${FONT_FAMILY}`;\nfunction cellFont(size, cell) {\n  const style = cell.bold && cell.italic ? \"bold italic\" : cell.bold ? \"bold\" : cell.italic ? \"italic\" : \"\";\n  return style ? `${style} ${size}px ${FONT_FAMILY}` : `${size}px ${FONT_FAMILY}`;\n}\nfunction measure(ctx, font, text) {\n  ctx.font = font;\n  ctx.textAlign = \"left\";\n  ctx.textBaseline = \"alphabetic\";\n  return ctx.measureText(text);\n}\nfunction isBoxLike(ch) {\n  if (!ch || ch === \" \") return false;\n  const cp = ch.codePointAt(0);\n  return cp >= 9472 && cp <= 9599 || // box drawing\n  cp >= 9600 && cp <= 9631 || // block elements\n  cp >= 10240 && cp <= 10495;\n}\nfunction makeGridMetrics(ctx) {\n  const block = measure(ctx, BOX_FONT, \"\\u2588\");\n  const cellW = Math.ceil(block.actualBoundingBoxLeft + block.actualBoundingBoxRight);\n  const cellH = Math.ceil(block.actualBoundingBoxAscent + block.actualBoundingBoxDescent);\n  const boxDrawX = block.actualBoundingBoxLeft;\n  const boxDrawY = block.actualBoundingBoxAscent;\n  const textProbe = measure(ctx, TEXT_FONT, \"Mg\");\n  const textMono = measure(ctx, TEXT_FONT, \"M\");\n  const textAscent = textProbe.emHeightAscent ?? textProbe.fontBoundingBoxAscent ?? textProbe.actualBoundingBoxAscent;\n  const textDescent = textProbe.emHeightDescent ?? textProbe.fontBoundingBoxDescent ?? textProbe.actualBoundingBoxDescent;\n  const textX = Math.round((cellW - textMono.width) / 2);\n  const textBaseline = Math.round((cellH + textAscent - textDescent) / 2) + 1;\n  return { cellW, cellH, boxDrawX, boxDrawY, textX, textBaseline };\n}\n\n// js/glyphs.ts\nvar GLYPH_SPLIT = /* @__PURE__ */ new Map([\n  // Pure-heavy lines and half-lines: map to their light/rounded equivalents\n  [9473, [9472, void 0]],\n  [9475, [9474, void 0]],\n  [9477, [9476, void 0]],\n  [9479, [9478, void 0]],\n  [9481, [9480, void 0]],\n  [9483, [9482, void 0]],\n  [9592, [9588, void 0]],\n  [9593, [9589, void 0]],\n  [9594, [9590, void 0]],\n  [9595, [9591, void 0]],\n  // Pure-heavy corners\n  [9487, [9581, void 0]],\n  [9491, [9582, void 0]],\n  [9495, [9584, void 0]],\n  [9499, [9583, void 0]],\n  // Pure-heavy tees and cross\n  [9507, [9500, void 0]],\n  [9515, [9508, void 0]],\n  [9523, [9516, void 0]],\n  [9531, [9524, void 0]],\n  [9547, [9532, void 0]],\n  // Mixed-weight corners (one heavy arm, one light arm)\n  [9485, [9590, 9591]],\n  [9486, [9591, 9590]],\n  [9489, [9588, 9591]],\n  [9490, [9591, 9588]],\n  [9493, [9590, 9589]],\n  [9494, [9589, 9590]],\n  [9497, [9588, 9589]],\n  [9498, [9589, 9588]],\n  // Mixed-weight tees (heavy stem, mixed crossbar)\n  [9501, [9590, 9474]],\n  [9502, [9589, 9484]],\n  [9503, [9591, 9492]],\n  [9504, [9474, 9590]],\n  [9505, [9492, 9591]],\n  [9506, [9484, 9589]],\n  [9509, [9588, 9474]],\n  [9510, [9589, 9488]],\n  [9511, [9591, 9496]],\n  [9512, [9474, 9588]],\n  [9513, [9496, 9591]],\n  [9514, [9488, 9589]],\n  [9517, [9588, 9484]],\n  [9518, [9590, 9488]],\n  [9519, [9472, 9591]],\n  [9520, [9591, 9472]],\n  [9521, [9488, 9590]],\n  [9522, [9484, 9588]],\n  [9525, [9588, 9492]],\n  [9526, [9590, 9496]],\n  [9527, [9472, 9589]],\n  [9528, [9589, 9472]],\n  [9529, [9496, 9590]],\n  [9530, [9492, 9588]],\n  // Mixed-weight crosses\n  [9533, [9588, 9500]],\n  [9534, [9590, 9508]],\n  [9535, [9472, 9474]],\n  [9536, [9589, 9516]],\n  [9537, [9591, 9524]],\n  [9538, [9474, 9472]],\n  [9539, [9496, 9484]],\n  [9540, [9492, 9488]],\n  [9541, [9488, 9492]],\n  [9542, [9484, 9496]],\n  [9543, [9524, 9591]],\n  [9544, [9516, 9589]],\n  [9545, [9508, 9590]],\n  [9546, [9500, 9588]]\n]);\nvar NODE_GLYPH_CP = 9679;\n\n// js/renderer.ts\nfunction drawSplitGlyph(ctx, heavyCp, lightCp, px, py, cellW, cellH, boxDrawX, boxDrawY, fg, neutral_fg, boxFont) {\n  ctx.save();\n  ctx.beginPath();\n  ctx.rect(px, py, cellW, cellH);\n  ctx.clip();\n  if (lightCp !== void 0) {\n    ctx.fillStyle = neutral_fg;\n    ctx.font = boxFont;\n    ctx.save();\n    ctx.translate(px + cellW / 2, py + cellH / 2);\n    ctx.scale(BOX_SCALE, BOX_SCALE);\n    ctx.fillText(String.fromCodePoint(lightCp), boxDrawX - cellW / 2, boxDrawY - cellH / 2);\n    ctx.restore();\n  }\n  ctx.fillStyle = fg;\n  ctx.font = boxFont;\n  ctx.save();\n  ctx.translate(px + cellW / 2, py + cellH / 2);\n  ctx.scale(BOX_SCALE, BOX_SCALE);\n  ctx.fillText(String.fromCodePoint(heavyCp), boxDrawX - cellW / 2, boxDrawY - cellH / 2);\n  ctx.restore();\n  ctx.restore();\n}\nfunction paintFrame(ctx, canvas, grid, frame) {\n  const nodeCells = /* @__PURE__ */ new Set();\n  if (!frame?.cells) return nodeCells;\n  const { cellW, cellH, boxDrawX, boxDrawY, textX, textBaseline } = grid;\n  const { cols, rows, cells, neutral_fg = \"#cdd6f4\", neutral_bg = \"#1e1e2e\" } = frame;\n  canvas.width = cols * cellW;\n  canvas.height = rows * cellH;\n  ctx.fillStyle = neutral_bg;\n  ctx.fillRect(0, 0, canvas.width, canvas.height);\n  ctx.textAlign = \"left\";\n  ctx.textBaseline = \"alphabetic\";\n  for (const cell of cells) {\n    const { x: c, y: r, text } = cell;\n    const fg = cell.fg ?? neutral_fg;\n    const bg = cell.bg ?? neutral_bg;\n    const px = c * cellW;\n    const py = r * cellH;\n    if (!text || text === \" \") continue;\n    const cp = text.codePointAt(0);\n    if (!isBoxLike(text)) nodeCells.add(`${c},${r}`);\n    if (cp === NODE_GLYPH_CP) {\n      if (bg !== neutral_bg) {\n        ctx.fillStyle = bg;\n        ctx.fillRect(px, py, cellW, cellH);\n      }\n      ctx.fillStyle = fg;\n      ctx.beginPath();\n      ctx.arc(px + cellW / 2, py + cellH / 2, cellW / 2, 0, Math.PI * 2);\n      ctx.fill();\n      continue;\n    }\n    if (bg !== neutral_bg) {\n      ctx.fillStyle = bg;\n      ctx.fillRect(px, py, cellW, cellH);\n    }\n    const split = GLYPH_SPLIT.get(cp);\n    if (split !== void 0) {\n      const [heavyCp, lightCp] = split;\n      const boxFont = cellFont(CELL_SIZE, { bold: false, italic: !!cell.italic });\n      drawSplitGlyph(ctx, heavyCp, lightCp, px, py, cellW, cellH, boxDrawX, boxDrawY, fg, neutral_fg, boxFont);\n    } else if (isBoxLike(text)) {\n      ctx.fillStyle = fg;\n      ctx.font = cellFont(CELL_SIZE, cell);\n      ctx.save();\n      ctx.beginPath();\n      ctx.rect(px, py, cellW, cellH);\n      ctx.clip();\n      ctx.translate(px + cellW / 2, py + cellH / 2);\n      ctx.scale(BOX_SCALE, BOX_SCALE);\n      ctx.fillText(text, boxDrawX - cellW / 2, boxDrawY - cellH / 2);\n      ctx.restore();\n    } else {\n      ctx.fillStyle = fg;\n      ctx.font = cellFont(TEXT_SIZE, cell);\n      ctx.fillText(text, px + textX, py + textBaseline);\n    }\n    if (cell.underline) {\n      ctx.fillStyle = fg;\n      const underlineY = Math.min(py + cellH - 1, py + textBaseline + 1);\n      ctx.fillRect(px, underlineY, cellW, 1);\n    }\n  }\n  return nodeCells;\n}\n\n// js/interaction.ts\nvar DRAG_THRESHOLD = 4;\nfunction attachInteraction(canvas, model, grid, getNodeCells, isFrozen) {\n  const { cellW, cellH } = grid;\n  canvas.addEventListener(\"mousemove\", (e) => {\n    if (isFrozen()) return;\n    if (pointerDown) return;\n    const rect = canvas.getBoundingClientRect();\n    const col = Math.floor((e.clientX - rect.left) / cellW);\n    const row = Math.floor((e.clientY - rect.top) / cellH);\n    canvas.style.cursor = getNodeCells().has(`${col},${row}`) ? \"pointer\" : \"grab\";\n  });\n  let pointerDown = false;\n  let isDragging = false;\n  let dragStartX = 0;\n  let dragStartY = 0;\n  let lastDragX = 0;\n  let lastDragY = 0;\n  let dragRemX = 0;\n  let dragRemY = 0;\n  canvas.addEventListener(\"mousedown\", (e) => {\n    if (isFrozen() || e.button !== 0) return;\n    pointerDown = true;\n    isDragging = false;\n    dragStartX = lastDragX = e.clientX;\n    dragStartY = lastDragY = e.clientY;\n    dragRemX = 0;\n    dragRemY = 0;\n    e.preventDefault();\n  });\n  window.addEventListener(\"mousemove\", (e) => {\n    if (!pointerDown) return;\n    const totalDx = e.clientX - dragStartX;\n    const totalDy = e.clientY - dragStartY;\n    if (!isDragging && (Math.abs(totalDx) > DRAG_THRESHOLD || Math.abs(totalDy) > DRAG_THRESHOLD)) {\n      isDragging = true;\n      canvas.style.cursor = \"grabbing\";\n    }\n    if (isDragging) {\n      dragRemX += e.clientX - lastDragX;\n      dragRemY += e.clientY - lastDragY;\n      const termDx = Math.trunc(dragRemX / cellW);\n      const termDy = Math.trunc(dragRemY / cellH);\n      if (termDx !== 0 || termDy !== 0) {\n        model.send({ type: \"pan\", dx: termDx, dy: termDy });\n        dragRemX -= termDx * cellW;\n        dragRemY -= termDy * cellH;\n      }\n    }\n    lastDragX = e.clientX;\n    lastDragY = e.clientY;\n  });\n  window.addEventListener(\"mouseup\", (e) => {\n    if (!pointerDown || e.button !== 0) return;\n    if (!isDragging) {\n      const rect = canvas.getBoundingClientRect();\n      const col = Math.floor((e.clientX - rect.left) / cellW);\n      const row = Math.floor((e.clientY - rect.top) / cellH);\n      model.send({ type: \"mouse_click\", col, row, button: e.button });\n    }\n    pointerDown = false;\n    isDragging = false;\n    canvas.style.cursor = \"grab\";\n  });\n}\n\n// js/index.ts\nfunction render({ model, el }) {\n  const scratch = document.createElement(\"canvas\");\n  const scratchCtx = scratch.getContext(\"2d\");\n  const grid = makeGridMetrics(scratchCtx);\n  const wrapper = document.createElement(\"div\");\n  wrapper.style.cssText = \"position: relative; display: inline-block; line-height: 0;\";\n  const canvas = document.createElement(\"canvas\");\n  canvas.style.cssText = `display: block; cursor: ${true ? \"grab\" : \"default\"}; border: 2px solid #45475a;`;\n  wrapper.appendChild(canvas);\n  el.appendChild(wrapper);\n  const ctx = canvas.getContext(\"2d\");\n  paintFrame(ctx, canvas, grid, model.get(\"frame\"));\n  if (true) {\n    let nodeCells = /* @__PURE__ */ new Set();\n    let frozen = false;\n    model.on(\"change:frame\", () => {\n      nodeCells = paintFrame(ctx, canvas, grid, model.get(\"frame\"));\n    });\n    const sharedBtnStyle = [\n      \"width: 24px\",\n      \"height: 24px\",\n      \"font-size: 16px\",\n      \"line-height: 1\",\n      \"cursor: pointer\",\n      \"background: rgba(30,30,46,0.85)\",\n      \"color: #cdd6f4\",\n      \"border: 1px solid #45475a\",\n      \"border-radius: 4px\",\n      \"display: flex\",\n      \"align-items: center\",\n      \"justify-content: center\",\n      \"user-select: none\",\n      \"padding: 0\"\n    ].join(\"; \");\n    const btnContainer = document.createElement(\"div\");\n    btnContainer.style.cssText = \"position: absolute; bottom: 8px; right: 8px; display: flex; flex-direction: column; gap: 4px; z-index: 1;\";\n    const zoomInBtn = document.createElement(\"button\");\n    zoomInBtn.textContent = \"+\";\n    zoomInBtn.setAttribute(\"style\", sharedBtnStyle);\n    zoomInBtn.title = \"Zoom in (+)\";\n    const zoomOutBtn = document.createElement(\"button\");\n    zoomOutBtn.textContent = \"\\u2212\";\n    zoomOutBtn.setAttribute(\"style\", sharedBtnStyle);\n    zoomOutBtn.title = \"Zoom out (-)\";\n    btnContainer.appendChild(zoomInBtn);\n    btnContainer.appendChild(zoomOutBtn);\n    wrapper.appendChild(btnContainer);\n    model.on(\"msg:custom\", (msg) => {\n      if (msg.type !== \"freeze\") return;\n      frozen = true;\n      btnContainer.style.display = \"none\";\n      canvas.style.cursor = \"default\";\n      wrapper.style.border = \"none\";\n      const dataUrl = canvas.toDataURL(\"image/png\");\n      const img = document.createElement(\"img\");\n      img.src = dataUrl;\n      img.width = canvas.width;\n      img.height = canvas.height;\n      img.style.cssText = \"display:block;cursor:default;font-family:monospace\";\n      el.replaceChild(img, wrapper);\n      model.send({ type: \"snapshot\", data: dataUrl });\n    });\n    zoomInBtn.addEventListener(\"mousedown\", (e) => e.preventDefault());\n    zoomOutBtn.addEventListener(\"mousedown\", (e) => e.preventDefault());\n    zoomInBtn.addEventListener(\"click\", () => model.send({ type: \"zoom\", direction: \"in\" }));\n    zoomOutBtn.addEventListener(\"click\", () => model.send({ type: \"zoom\", direction: \"out\" }));\n    attachInteraction(canvas, model, grid, () => nodeCells, () => frozen);\n  }\n}\nvar index_default = { render };\nexport {\n  index_default as default\n};\n//# sourceMappingURL=jupyter_widget.js.map\n",
-       "_model_module": "anywidget",
-       "_model_module_version": "~0.9.*",
-       "_model_name": "AnyModel",
-       "_view_count": null,
-       "_view_module": "anywidget",
-       "_view_module_version": "~0.9.*",
-       "_view_name": "AnyView",
-       "cols": 120,
-       "frame": {
-        "cells": [
-         {
-          "text": "╟",
-          "x": 5,
-          "y": 5
-         },
-         {
-          "text": "─",
-          "x": 6,
-          "y": 5
-         },
-         {
-          "bg": "#cdd6f4",
-          "fg": "#1e1e2e",
-          "text": "A",
-          "x": 7,
-          "y": 5
-         },
-         {
-          "bg": "#cdd6f4",
-          "fg": "#1e1e2e",
-          "text": "T",
-          "x": 8,
-          "y": 5
-         },
-         {
-          "bg": "#cdd6f4",
-          "fg": "#1e1e2e",
-          "text": "C",
-          "x": 9,
-          "y": 5
-         },
-         {
-          "bg": "#cdd6f4",
-          "fg": "#1e1e2e",
-          "text": "G",
-          "x": 10,
-          "y": 5
-         },
-         {
-          "bg": "#cdd6f4",
-          "fg": "#1e1e2e",
-          "text": "A",
-          "x": 11,
-          "y": 5
-         },
-         {
-          "bg": "#cdd6f4",
-          "fg": "#1e1e2e",
-          "text": ".",
-          "x": 12,
-          "y": 5
-         },
-         {
-          "bg": "#cdd6f4",
-          "fg": "#1e1e2e",
-          "text": ".",
-          "x": 13,
-          "y": 5
-         },
-         {
-          "bg": "#cdd6f4",
-          "fg": "#1e1e2e",
-          "text": ".",
-          "x": 14,
-          "y": 5
-         },
-         {
-          "bg": "#cdd6f4",
-          "fg": "#1e1e2e",
-          "text": "A",
-          "x": 15,
-          "y": 5
-         },
-         {
-          "bg": "#cdd6f4",
-          "fg": "#1e1e2e",
-          "text": "G",
-          "x": 16,
-          "y": 5
-         },
-         {
-          "bg": "#cdd6f4",
-          "fg": "#1e1e2e",
-          "text": "A",
-          "x": 17,
-          "y": 5
-         },
-         {
-          "bg": "#cdd6f4",
-          "fg": "#1e1e2e",
-          "text": "G",
-          "x": 18,
-          "y": 5
-         },
-         {
-          "bg": "#cdd6f4",
-          "fg": "#1e1e2e",
-          "text": "A",
-          "x": 19,
-          "y": 5
-         },
-         {
-          "text": "─",
-          "x": 20,
-          "y": 5
-         },
-         {
-          "text": "╢",
-          "x": 21,
-          "y": 5
-         }
-        ],
-        "cols": 120,
-        "neutral_bg": "#1e1e2e",
-        "neutral_fg": "#cdd6f4",
-        "rows": 12
-       },
-       "layout": "IPY_MODEL_852e84c500a24fc989e33eaaf4e4a497",
-       "rows": 12,
-       "tabbable": null,
-       "tooltip": null
-      }
-     }
-    },
-    "version_major": 2,
-    "version_minor": 0
-   }
   }
  },
  "nbformat": 4,

--- a/gen-python/js/grid.ts
+++ b/gen-python/js/grid.ts
@@ -30,6 +30,8 @@ export interface GridMetrics {
   boxDrawY: number;
   textX: number;
   textBaseline: number;
+  textSize: number;
+  cellSize: number;
 }
 
 export function cellFont(size: number, cell: Pick<Cell, "bold" | "italic">): string {
@@ -54,19 +56,23 @@ export function isBoxLike(ch: string): boolean {
   );
 }
 
-export function makeGridMetrics(ctx: CanvasRenderingContext2D): GridMetrics {
-  const block = measure(ctx, BOX_FONT, "\u2588");
+export function makeGridMetrics(ctx: CanvasRenderingContext2D, scale = 1): GridMetrics {
+  const textSize = TEXT_SIZE * scale;
+  const cellSize = Math.round(textSize / 0.875);
+  const boxFont = `${cellSize}px ${FONT_FAMILY}`;
+  const textFont = `${textSize}px ${FONT_FAMILY}`;
+  const block = measure(ctx, boxFont, "\u2588");
   const cellW = Math.ceil(block.actualBoundingBoxLeft + block.actualBoundingBoxRight);
   const cellH = Math.ceil(block.actualBoundingBoxAscent + block.actualBoundingBoxDescent);
   const boxDrawX = block.actualBoundingBoxLeft;
   const boxDrawY = block.actualBoundingBoxAscent;
-  const textProbe = measure(ctx, TEXT_FONT, "Mg");
-  const textMono = measure(ctx, TEXT_FONT, "M");
+  const textProbe = measure(ctx, textFont, "Mg");
+  const textMono = measure(ctx, textFont, "M");
   const textAscent =
     textProbe.emHeightAscent ?? textProbe.fontBoundingBoxAscent ?? textProbe.actualBoundingBoxAscent;
   const textDescent =
     textProbe.emHeightDescent ?? textProbe.fontBoundingBoxDescent ?? textProbe.actualBoundingBoxDescent;
   const textX = Math.round((cellW - textMono.width) / 2);
   const textBaseline = Math.round((cellH + textAscent - textDescent) / 2) + 1;
-  return { cellW, cellH, boxDrawX, boxDrawY, textX, textBaseline };
+  return { cellW, cellH, boxDrawX, boxDrawY, textX, textBaseline, textSize, cellSize };
 }

--- a/gen-python/js/index.ts
+++ b/gen-python/js/index.ts
@@ -16,7 +16,7 @@ interface RenderContext {
   el: HTMLElement;
 }
 
-function render({ model, el }: RenderContext): void {
+function render({ model, el }: RenderContext): { destroy(): void } | void {
   const scratch = document.createElement("canvas");
   const scratchCtx = scratch.getContext("2d")!;
   const grid = makeGridMetrics(scratchCtx);
@@ -25,7 +25,7 @@ function render({ model, el }: RenderContext): void {
   wrapper.style.cssText = "position: relative; display: inline-block; line-height: 0;";
 
   const canvas = document.createElement("canvas");
-  canvas.style.cssText = `display: block; cursor: ${INTERACTIVE ? "grab" : "default"}; border: 2px solid #45475a;`;
+  canvas.style.cssText = `display: block; cursor: ${INTERACTIVE ? "grab" : "default"}; box-shadow: inset 0 0 0 2px #45475a;`;
 
   wrapper.appendChild(canvas);
   el.appendChild(wrapper);
@@ -37,8 +37,7 @@ function render({ model, el }: RenderContext): void {
   if (INTERACTIVE) {
     let nodeCells = new Set<string>();
     let frozen = false;
-
-    model.on("change:frame", () => { nodeCells = paintFrame(ctx, canvas, grid, model.get("frame")); });
+    let snapshotTimer: ReturnType<typeof setTimeout> | null = null;
 
     const sharedBtnStyle = [
       "width: 24px",
@@ -59,44 +58,101 @@ function render({ model, el }: RenderContext): void {
 
     const btnContainer = document.createElement("div");
     btnContainer.style.cssText =
-      "position: absolute; bottom: 8px; right: 8px; display: flex; flex-direction: column; gap: 4px; z-index: 1;";
+      "position: absolute; top: 8px; right: 8px; display: flex; flex-direction: row; gap: 4px; z-index: 1;";
 
     const zoomInBtn = document.createElement("button");
-    zoomInBtn.textContent = "+";
+    zoomInBtn.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+  <circle cx="10" cy="10" r="7" stroke-width="1.2" />
+  <line x1="16" y1="16" x2="21" y2="21" stroke-width="2.5" />
+  <line x1="10" y1="6" x2="10" y2="14" />
+  <line x1="6" y1="10" x2="14" y2="10" />
+</svg>`;
     zoomInBtn.setAttribute("style", sharedBtnStyle);
     zoomInBtn.title = "Zoom in (+)";
 
     const zoomOutBtn = document.createElement("button");
-    zoomOutBtn.textContent = "\u2212";
+    zoomOutBtn.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+  <circle cx="10" cy="10" r="7" stroke-width="1.2" />
+  <line x1="16" y1="16" x2="21" y2="21" stroke-width="2.5" />
+  <line x1="6" y1="10" x2="14" y2="10" />
+</svg>`;
     zoomOutBtn.setAttribute("style", sharedBtnStyle);
     zoomOutBtn.title = "Zoom out (-)";
 
-    btnContainer.appendChild(zoomInBtn);
+    const freezeBtn = document.createElement("button");
+    freezeBtn.innerHTML = `
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="14" height="14" fill="currentColor">
+  <rect x="5" y="10" width="14" height="11" rx="2" />
+  <path d="M8 10V7a4 4 0 0 1 8 0v3" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" />
+</svg>
+`;
+    freezeBtn.setAttribute("style", sharedBtnStyle);
+    freezeBtn.title = "Freeze as static image";
+
     btnContainer.appendChild(zoomOutBtn);
+    btnContainer.appendChild(zoomInBtn);
+    btnContainer.appendChild(freezeBtn);
     wrapper.appendChild(btnContainer);
 
-    model.on("msg:custom", (msg) => {
-      if (msg.type !== "freeze") return;
+    function captureHiRes(): { dataUrl: string; width: number; height: number } {
+      const dpr = window.devicePixelRatio || 1;
+      const hiResGrid = makeGridMetrics(scratchCtx, dpr);
+      const offscreen = document.createElement("canvas");
+      const offCtx = offscreen.getContext("2d")!;
+      paintFrame(offCtx, offscreen, hiResGrid, model.get("frame"));
+      return { dataUrl: offscreen.toDataURL("image/png"), width: canvas.width, height: canvas.height };
+    }
+
+    function sendSnapshot(): void {
+      const { dataUrl, width, height } = captureHiRes();
+      model.send({ type: "snapshot", data: dataUrl, width, height });
+    }
+
+    function scheduleSnapshot(): void {
+      if (snapshotTimer) clearTimeout(snapshotTimer);
+      snapshotTimer = setTimeout(sendSnapshot, 1000);
+    }
+
+    function repaint(frame: Frame): void {
+      nodeCells = paintFrame(ctx, canvas, grid, frame);
+    }
+
+    repaint(model.get("frame"));
+    model.on("change:frame", () => { repaint(model.get("frame")); scheduleSnapshot(); });
+
+    function doFreeze(): void {
+      if (snapshotTimer) { clearTimeout(snapshotTimer); snapshotTimer = null; }
       frozen = true;
       btnContainer.style.display = "none";
       canvas.style.cursor = "default";
-      wrapper.style.border = "none";
-      const dataUrl = canvas.toDataURL("image/png");
+      canvas.style.boxShadow = "none";
+      const { dataUrl, width, height } = captureHiRes();
       const img = document.createElement("img");
       img.src = dataUrl;
-      img.width = canvas.width;
-      img.height = canvas.height;
-      img.style.cssText = "display:block;cursor:default;font-family:monospace";
-      el.replaceChild(img, wrapper);
-      model.send({ type: "snapshot", data: dataUrl });
+      img.style.cssText = `display:block;cursor:default;width:${width}px;height:${height}px`;
+      wrapper.replaceChild(img, canvas);
+      model.send({ type: "freeze", data: dataUrl, width, height });
+    }
+
+    model.on("msg:custom", (msg) => {
+      if (msg.type === "freeze") doFreeze();
     });
 
     zoomInBtn.addEventListener("mousedown", (e) => e.preventDefault());
     zoomOutBtn.addEventListener("mousedown", (e) => e.preventDefault());
+    freezeBtn.addEventListener("mousedown", (e) => e.preventDefault());
     zoomInBtn.addEventListener("click", () => model.send({ type: "zoom", direction: "in" }));
     zoomOutBtn.addEventListener("click", () => model.send({ type: "zoom", direction: "out" }));
+    freezeBtn.addEventListener("click", () => doFreeze());
 
-    attachInteraction(canvas, model, grid, () => nodeCells, () => frozen);
+    const detachInteraction = attachInteraction(canvas, model, grid, () => nodeCells, () => frozen);
+
+    return {
+      destroy() {
+        if (snapshotTimer) clearTimeout(snapshotTimer);
+        detachInteraction();
+      },
+    };
   }
 }
 

--- a/gen-python/js/interaction.ts
+++ b/gen-python/js/interaction.ts
@@ -12,11 +12,11 @@ export function attachInteraction(
   grid: GridMetrics,
   getNodeCells: () => Set<string>,
   isFrozen: () => boolean,
-): void {
+): () => void {
   const { cellW, cellH } = grid;
 
   canvas.addEventListener("mousemove", (e) => {
-    if (isFrozen()) return;
+    if (isFrozen()) { canvas.style.cursor = "default"; return; }
     if (pointerDown) return;
     const rect = canvas.getBoundingClientRect();
     const col = Math.floor((e.clientX - rect.left) / cellW);
@@ -44,7 +44,7 @@ export function attachInteraction(
     e.preventDefault();
   });
 
-  window.addEventListener("mousemove", (e) => {
+  const onWindowMouseMove = (e: MouseEvent) => {
     if (!pointerDown) return;
     const totalDx = e.clientX - dragStartX;
     const totalDy = e.clientY - dragStartY;
@@ -65,9 +65,9 @@ export function attachInteraction(
     }
     lastDragX = e.clientX;
     lastDragY = e.clientY;
-  });
+  };
 
-  window.addEventListener("mouseup", (e) => {
+  const onWindowMouseUp = (e: MouseEvent) => {
     if (!pointerDown || e.button !== 0) return;
     if (!isDragging) {
       const rect = canvas.getBoundingClientRect();
@@ -78,5 +78,13 @@ export function attachInteraction(
     pointerDown = false;
     isDragging = false;
     canvas.style.cursor = "grab";
-  });
+  };
+
+  window.addEventListener("mousemove", onWindowMouseMove);
+  window.addEventListener("mouseup", onWindowMouseUp);
+
+  return () => {
+    window.removeEventListener("mousemove", onWindowMouseMove);
+    window.removeEventListener("mouseup", onWindowMouseUp);
+  };
 }

--- a/gen-python/js/renderer.ts
+++ b/gen-python/js/renderer.ts
@@ -1,4 +1,4 @@
-import { CELL_SIZE, TEXT_SIZE, BOX_SCALE, cellFont, isBoxLike, Cell, GridMetrics } from "./grid";
+import { BOX_SCALE, cellFont, isBoxLike, Cell, GridMetrics } from "./grid";
 import { GLYPH_SPLIT, NODE_GLYPH_CP } from "./glyphs";
 
 export interface Frame {
@@ -75,7 +75,7 @@ export function paintFrame(
   const nodeCells = new Set<string>();
   if (!frame?.cells) return nodeCells;
 
-  const { cellW, cellH, boxDrawX, boxDrawY, textX, textBaseline } = grid;
+  const { cellW, cellH, boxDrawX, boxDrawY, textX, textBaseline, textSize, cellSize } = grid;
   const { cols, rows, cells, neutral_fg = "#cdd6f4", neutral_bg = "#1e1e2e" } = frame;
 
   canvas.width = cols * cellW;
@@ -118,12 +118,12 @@ export function paintFrame(
     if (split !== undefined) {
       // Mixed/pure-heavy box char: decompose into heavy + light sub-glyphs.
       const [heavyCp, lightCp] = split;
-      const boxFont = cellFont(CELL_SIZE, { bold: false, italic: !!cell.italic });
+      const boxFont = cellFont(cellSize, { bold: false, italic: !!cell.italic });
       drawSplitGlyph(ctx, heavyCp, lightCp, px, py, cellW, cellH, boxDrawX, boxDrawY, fg, neutral_fg, boxFont);
     } else if (isBoxLike(text)) {
       // Plain box-drawing / block element: render at BOX_SCALE in cell fg.
       ctx.fillStyle = fg;
-      ctx.font = cellFont(CELL_SIZE, cell);
+      ctx.font = cellFont(cellSize, cell);
       ctx.save();
       ctx.beginPath();
       ctx.rect(px, py, cellW, cellH);
@@ -135,7 +135,7 @@ export function paintFrame(
     } else {
       // Regular text cell.
       ctx.fillStyle = fg;
-      ctx.font = cellFont(TEXT_SIZE, cell);
+      ctx.font = cellFont(textSize, cell);
       ctx.fillText(text, px + textX, py + textBaseline);
     }
 

--- a/gen-python/python/gen/jupyter_widget.py
+++ b/gen-python/python/gen/jupyter_widget.py
@@ -25,6 +25,8 @@ DEFAULT_ROWS = 12
 
 _ESM = pathlib.Path(__file__).parent / "static" / "jupyter_widget.js"
 
+# All live widget instances, so that module-level helpers can operate on them.
+
 
 class GenGraphWidget(anywidget.AnyWidget):
     """Jupyter widget that displays a Gen graph using the native Rust renderer.
@@ -80,27 +82,26 @@ class GenGraphWidget(anywidget.AnyWidget):
     # ── Display ───────────────────────────────────────────────────────────────
 
     def _ipython_display_(self, **kwargs):
-        """Display the widget and store a handle so freeze() can replace it."""
-        from IPython.display import display, HTML
+        """Clone the controller and display an independent widget in this cell.
 
-        if self._frozen and self._static_png:
-            display(
-                HTML(
-                    f'<img src="{self._static_png}" style="display:block;font-family:monospace" />'
-                )
-            )
-            return
-        # Build the mime bundle manually and pass raw=True to avoid recursion
-        # (display(self, ...) would re-enter this method).
+        Each cell gets its own copy of the graph and computed layouts so that
+        programmatic changes to the original widget (in another cell) do not
+        affect previously displayed outputs.  Mouse interaction and canvas
+        buttons work on the per-cell clone.
+        """
+        from IPython.display import display
+
+        cloned_ctrl = self._controller.clone_controller()
+        snapshot = GenGraphWidget(cloned_ctrl, cols=self.cols, rows=self.rows)
         data = {
-            "text/plain": repr(self),
+            "text/plain": repr(snapshot),
             "application/vnd.jupyter.widget-view+json": {
                 "version_major": 2,
                 "version_minor": 0,
-                "model_id": self._model_id,
+                "model_id": snapshot._model_id,
             },
         }
-        self._display_handle = display(data, raw=True, display_id=True)
+        snapshot._display_handle = display(data, raw=True, display_id=True)
 
     # ── Internal helpers ──────────────────────────────────────────────────────
 
@@ -121,16 +122,40 @@ class GenGraphWidget(anywidget.AnyWidget):
         msg_type = msg.get("type")
 
         if msg_type == "snapshot":
-            self._static_png = msg.get("data", "")
+            data_url = msg.get("data", "")
+            self._static_png = data_url
+            if self._display_handle is not None and data_url.startswith(
+                "data:image/png;base64,"
+            ):
+                b64 = data_url.split(",", 1)[1]
+                self._display_handle.update(
+                    {
+                        "application/vnd.jupyter.widget-view+json": {
+                            "version_major": 2,
+                            "version_minor": 0,
+                            "model_id": self._model_id,
+                        },
+                        "image/png": b64,
+                        "text/plain": repr(self),
+                    },
+                    raw=True,
+                )
+            return
+
+        if msg_type == "freeze":
+            data_url = msg.get("data", "")
+            self._static_png = data_url
+            self._frozen = True
             if self._display_handle is not None:
                 from IPython.display import HTML
 
+                w, h = msg.get("width"), msg.get("height")
+                size = f";width:{w}px;height:{h}px" if w and h else ""
                 self._display_handle.update(
                     HTML(
-                        f'<img src="{self._static_png}" style="display:block;font-family:monospace" />'
+                        f'<img src="{data_url}" style="display:block;font-family:monospace{size}" />'
                     )
                 )
-                self._display_handle = None
             return
 
         if msg_type == "mouse_click":
@@ -175,17 +200,6 @@ class GenGraphWidget(anywidget.AnyWidget):
             return
         self._controller.move_by(dx, dy)
         self._render()
-
-    def freeze(self) -> None:
-        """Capture current canvas as static PNG, disable interactivity.
-
-        After calling this the widget becomes a static snapshot.  The canvas
-        border indicator is hidden and all interaction methods become no-ops.
-        The captured PNG appears in the cell output as an ``<img>`` tag — it
-        updates in-place once the frontend responds with the snapshot.
-        """
-        self._frozen = True
-        self.send({"type": "freeze"})
 
     def go_to(self, target) -> None:
         """Instantly move the camera to a graph position, locus, or annotation.

--- a/gen-python/python/gen/static/jupyter_widget.js
+++ b/gen-python/python/gen/static/jupyter_widget.js
@@ -24,19 +24,23 @@ function isBoxLike(ch) {
   cp >= 9600 && cp <= 9631 || // block elements
   cp >= 10240 && cp <= 10495;
 }
-function makeGridMetrics(ctx) {
-  const block = measure(ctx, BOX_FONT, "\u2588");
+function makeGridMetrics(ctx, scale = 1) {
+  const textSize = TEXT_SIZE * scale;
+  const cellSize = Math.round(textSize / 0.875);
+  const boxFont = `${cellSize}px ${FONT_FAMILY}`;
+  const textFont = `${textSize}px ${FONT_FAMILY}`;
+  const block = measure(ctx, boxFont, "\u2588");
   const cellW = Math.ceil(block.actualBoundingBoxLeft + block.actualBoundingBoxRight);
   const cellH = Math.ceil(block.actualBoundingBoxAscent + block.actualBoundingBoxDescent);
   const boxDrawX = block.actualBoundingBoxLeft;
   const boxDrawY = block.actualBoundingBoxAscent;
-  const textProbe = measure(ctx, TEXT_FONT, "Mg");
-  const textMono = measure(ctx, TEXT_FONT, "M");
+  const textProbe = measure(ctx, textFont, "Mg");
+  const textMono = measure(ctx, textFont, "M");
   const textAscent = textProbe.emHeightAscent ?? textProbe.fontBoundingBoxAscent ?? textProbe.actualBoundingBoxAscent;
   const textDescent = textProbe.emHeightDescent ?? textProbe.fontBoundingBoxDescent ?? textProbe.actualBoundingBoxDescent;
   const textX = Math.round((cellW - textMono.width) / 2);
   const textBaseline = Math.round((cellH + textAscent - textDescent) / 2) + 1;
-  return { cellW, cellH, boxDrawX, boxDrawY, textX, textBaseline };
+  return { cellW, cellH, boxDrawX, boxDrawY, textX, textBaseline, textSize, cellSize };
 }
 
 // js/glyphs.ts
@@ -142,7 +146,7 @@ function drawSplitGlyph(ctx, heavyCp, lightCp, px, py, cellW, cellH, boxDrawX, b
 function paintFrame(ctx, canvas, grid, frame) {
   const nodeCells = /* @__PURE__ */ new Set();
   if (!frame?.cells) return nodeCells;
-  const { cellW, cellH, boxDrawX, boxDrawY, textX, textBaseline } = grid;
+  const { cellW, cellH, boxDrawX, boxDrawY, textX, textBaseline, textSize, cellSize } = grid;
   const { cols, rows, cells, neutral_fg = "#cdd6f4", neutral_bg = "#1e1e2e" } = frame;
   canvas.width = cols * cellW;
   canvas.height = rows * cellH;
@@ -177,11 +181,11 @@ function paintFrame(ctx, canvas, grid, frame) {
     const split = GLYPH_SPLIT.get(cp);
     if (split !== void 0) {
       const [heavyCp, lightCp] = split;
-      const boxFont = cellFont(CELL_SIZE, { bold: false, italic: !!cell.italic });
+      const boxFont = cellFont(cellSize, { bold: false, italic: !!cell.italic });
       drawSplitGlyph(ctx, heavyCp, lightCp, px, py, cellW, cellH, boxDrawX, boxDrawY, fg, neutral_fg, boxFont);
     } else if (isBoxLike(text)) {
       ctx.fillStyle = fg;
-      ctx.font = cellFont(CELL_SIZE, cell);
+      ctx.font = cellFont(cellSize, cell);
       ctx.save();
       ctx.beginPath();
       ctx.rect(px, py, cellW, cellH);
@@ -192,7 +196,7 @@ function paintFrame(ctx, canvas, grid, frame) {
       ctx.restore();
     } else {
       ctx.fillStyle = fg;
-      ctx.font = cellFont(TEXT_SIZE, cell);
+      ctx.font = cellFont(textSize, cell);
       ctx.fillText(text, px + textX, py + textBaseline);
     }
     if (cell.underline) {
@@ -209,7 +213,10 @@ var DRAG_THRESHOLD = 4;
 function attachInteraction(canvas, model, grid, getNodeCells, isFrozen) {
   const { cellW, cellH } = grid;
   canvas.addEventListener("mousemove", (e) => {
-    if (isFrozen()) return;
+    if (isFrozen()) {
+      canvas.style.cursor = "default";
+      return;
+    }
     if (pointerDown) return;
     const rect = canvas.getBoundingClientRect();
     const col = Math.floor((e.clientX - rect.left) / cellW);
@@ -234,7 +241,7 @@ function attachInteraction(canvas, model, grid, getNodeCells, isFrozen) {
     dragRemY = 0;
     e.preventDefault();
   });
-  window.addEventListener("mousemove", (e) => {
+  const onWindowMouseMove = (e) => {
     if (!pointerDown) return;
     const totalDx = e.clientX - dragStartX;
     const totalDy = e.clientY - dragStartY;
@@ -255,8 +262,8 @@ function attachInteraction(canvas, model, grid, getNodeCells, isFrozen) {
     }
     lastDragX = e.clientX;
     lastDragY = e.clientY;
-  });
-  window.addEventListener("mouseup", (e) => {
+  };
+  const onWindowMouseUp = (e) => {
     if (!pointerDown || e.button !== 0) return;
     if (!isDragging) {
       const rect = canvas.getBoundingClientRect();
@@ -267,7 +274,13 @@ function attachInteraction(canvas, model, grid, getNodeCells, isFrozen) {
     pointerDown = false;
     isDragging = false;
     canvas.style.cursor = "grab";
-  });
+  };
+  window.addEventListener("mousemove", onWindowMouseMove);
+  window.addEventListener("mouseup", onWindowMouseUp);
+  return () => {
+    window.removeEventListener("mousemove", onWindowMouseMove);
+    window.removeEventListener("mouseup", onWindowMouseUp);
+  };
 }
 
 // js/index.ts
@@ -278,17 +291,47 @@ function render({ model, el }) {
   const wrapper = document.createElement("div");
   wrapper.style.cssText = "position: relative; display: inline-block; line-height: 0;";
   const canvas = document.createElement("canvas");
-  canvas.style.cssText = `display: block; cursor: ${true ? "grab" : "default"}; border: 2px solid #45475a;`;
+  canvas.style.cssText = `display: block; cursor: ${true ? "grab" : "default"}; box-shadow: inset 0 0 0 2px #45475a;`;
   wrapper.appendChild(canvas);
   el.appendChild(wrapper);
   const ctx = canvas.getContext("2d");
   paintFrame(ctx, canvas, grid, model.get("frame"));
   if (true) {
+    let captureHiRes2 = function() {
+      const dpr = window.devicePixelRatio || 1;
+      const hiResGrid = makeGridMetrics(scratchCtx, dpr);
+      const offscreen = document.createElement("canvas");
+      const offCtx = offscreen.getContext("2d");
+      paintFrame(offCtx, offscreen, hiResGrid, model.get("frame"));
+      return { dataUrl: offscreen.toDataURL("image/png"), width: canvas.width, height: canvas.height };
+    }, sendSnapshot2 = function() {
+      const { dataUrl, width, height } = captureHiRes2();
+      model.send({ type: "snapshot", data: dataUrl, width, height });
+    }, scheduleSnapshot2 = function() {
+      if (snapshotTimer) clearTimeout(snapshotTimer);
+      snapshotTimer = setTimeout(sendSnapshot2, 1e3);
+    }, repaint2 = function(frame) {
+      nodeCells = paintFrame(ctx, canvas, grid, frame);
+    }, doFreeze2 = function() {
+      if (snapshotTimer) {
+        clearTimeout(snapshotTimer);
+        snapshotTimer = null;
+      }
+      frozen = true;
+      btnContainer.style.display = "none";
+      canvas.style.cursor = "default";
+      canvas.style.boxShadow = "none";
+      const { dataUrl, width, height } = captureHiRes2();
+      const img = document.createElement("img");
+      img.src = dataUrl;
+      img.style.cssText = `display:block;cursor:default;width:${width}px;height:${height}px`;
+      wrapper.replaceChild(img, canvas);
+      model.send({ type: "freeze", data: dataUrl, width, height });
+    };
+    var captureHiRes = captureHiRes2, sendSnapshot = sendSnapshot2, scheduleSnapshot = scheduleSnapshot2, repaint = repaint2, doFreeze = doFreeze2;
     let nodeCells = /* @__PURE__ */ new Set();
     let frozen = false;
-    model.on("change:frame", () => {
-      nodeCells = paintFrame(ctx, canvas, grid, model.get("frame"));
-    });
+    let snapshotTimer = null;
     const sharedBtnStyle = [
       "width: 24px",
       "height: 24px",
@@ -306,38 +349,58 @@ function render({ model, el }) {
       "padding: 0"
     ].join("; ");
     const btnContainer = document.createElement("div");
-    btnContainer.style.cssText = "position: absolute; bottom: 8px; right: 8px; display: flex; flex-direction: column; gap: 4px; z-index: 1;";
+    btnContainer.style.cssText = "position: absolute; top: 8px; right: 8px; display: flex; flex-direction: row; gap: 4px; z-index: 1;";
     const zoomInBtn = document.createElement("button");
-    zoomInBtn.textContent = "+";
+    zoomInBtn.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+  <circle cx="10" cy="10" r="7" stroke-width="1.2" />
+  <line x1="16" y1="16" x2="21" y2="21" stroke-width="2.5" />
+  <line x1="10" y1="6" x2="10" y2="14" />
+  <line x1="6" y1="10" x2="14" y2="10" />
+</svg>`;
     zoomInBtn.setAttribute("style", sharedBtnStyle);
     zoomInBtn.title = "Zoom in (+)";
     const zoomOutBtn = document.createElement("button");
-    zoomOutBtn.textContent = "\u2212";
+    zoomOutBtn.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+  <circle cx="10" cy="10" r="7" stroke-width="1.2" />
+  <line x1="16" y1="16" x2="21" y2="21" stroke-width="2.5" />
+  <line x1="6" y1="10" x2="14" y2="10" />
+</svg>`;
     zoomOutBtn.setAttribute("style", sharedBtnStyle);
     zoomOutBtn.title = "Zoom out (-)";
-    btnContainer.appendChild(zoomInBtn);
+    const freezeBtn = document.createElement("button");
+    freezeBtn.innerHTML = `
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="14" height="14" fill="currentColor">
+  <rect x="5" y="10" width="14" height="11" rx="2" />
+  <path d="M8 10V7a4 4 0 0 1 8 0v3" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" />
+</svg>
+`;
+    freezeBtn.setAttribute("style", sharedBtnStyle);
+    freezeBtn.title = "Freeze as static image";
     btnContainer.appendChild(zoomOutBtn);
+    btnContainer.appendChild(zoomInBtn);
+    btnContainer.appendChild(freezeBtn);
     wrapper.appendChild(btnContainer);
+    repaint2(model.get("frame"));
+    model.on("change:frame", () => {
+      repaint2(model.get("frame"));
+      scheduleSnapshot2();
+    });
     model.on("msg:custom", (msg) => {
-      if (msg.type !== "freeze") return;
-      frozen = true;
-      btnContainer.style.display = "none";
-      canvas.style.cursor = "default";
-      wrapper.style.border = "none";
-      const dataUrl = canvas.toDataURL("image/png");
-      const img = document.createElement("img");
-      img.src = dataUrl;
-      img.width = canvas.width;
-      img.height = canvas.height;
-      img.style.cssText = "display:block;cursor:default;font-family:monospace";
-      el.replaceChild(img, wrapper);
-      model.send({ type: "snapshot", data: dataUrl });
+      if (msg.type === "freeze") doFreeze2();
     });
     zoomInBtn.addEventListener("mousedown", (e) => e.preventDefault());
     zoomOutBtn.addEventListener("mousedown", (e) => e.preventDefault());
+    freezeBtn.addEventListener("mousedown", (e) => e.preventDefault());
     zoomInBtn.addEventListener("click", () => model.send({ type: "zoom", direction: "in" }));
     zoomOutBtn.addEventListener("click", () => model.send({ type: "zoom", direction: "out" }));
-    attachInteraction(canvas, model, grid, () => nodeCells, () => frozen);
+    freezeBtn.addEventListener("click", () => doFreeze2());
+    const detachInteraction = attachInteraction(canvas, model, grid, () => nodeCells, () => frozen);
+    return {
+      destroy() {
+        if (snapshotTimer) clearTimeout(snapshotTimer);
+        detachInteraction();
+      }
+    };
   }
 }
 var index_default = { render };

--- a/gen-python/src/python_api/jupyter_widget.rs
+++ b/gen-python/src/python_api/jupyter_widget.rs
@@ -236,8 +236,8 @@ fn locus_from_span_and_pos_map(
     GraphLocus { slices }
 }
 
-/// A span annotated onto the graph canvas — either a named inline annotation
-/// (track is Some) or an unnamed highlight (track is None, span.name is "").
+/// A span annotated onto the graph canvas, with or without a label (highlight), optionally associated with a specific track.
+#[derive(Clone)]
 struct GraphOverlay {
     span: AnnotationSpan,
     track: Option<String>,
@@ -258,6 +258,7 @@ struct GraphOverlay {
 /// `!Send`, so we store only the DB path and open a fresh connection per operation
 /// instead of holding a live handle.
 #[pyclass]
+#[derive(Clone)]
 pub struct PyGraphController {
     db_path: PathBuf,
     pub(crate) block_group_id: Option<HashId>,
@@ -374,6 +375,11 @@ impl PyGraphController {
 
 #[pymethods]
 impl PyGraphController {
+    /// Deep-clone this controller (graph topology + computed layouts + view state).
+    fn clone_controller(&self) -> Self {
+        self.clone()
+    }
+
     /// Create a `GraphController` from a `Repository` and a `PyBlockGroup`.
     #[classmethod]
     fn from_block_group(

--- a/gen-python/src/python_api/jupyter_widget.rs
+++ b/gen-python/src/python_api/jupyter_widget.rs
@@ -574,6 +574,7 @@ impl PyGraphController {
         self.controller.go_to_node(domain_idx, (frac_x, 0.5));
         self.controller.queue_snap_left();
         self.controller.hide_cursor();
+        self.reapply_highlights();
     }
 
     /// Highlight the path of nodes covered by `match_obj` in the given colour.

--- a/gen-r/inst/widget/genplot.esm.js
+++ b/gen-r/inst/widget/genplot.esm.js
@@ -16,9 +16,9 @@ function isBoxLike(ch) {
   cp >= 9600 && cp <= 9631 || // block elements
   cp >= 10240 && cp <= 10495;
 }
-function makeGridMetrics(ctx) {
-  let block = measure(ctx, BOX_FONT, "\u2588"), cellW = Math.ceil(block.actualBoundingBoxLeft + block.actualBoundingBoxRight), cellH = Math.ceil(block.actualBoundingBoxAscent + block.actualBoundingBoxDescent), boxDrawX = block.actualBoundingBoxLeft, boxDrawY = block.actualBoundingBoxAscent, textProbe = measure(ctx, TEXT_FONT, "Mg"), textMono = measure(ctx, TEXT_FONT, "M"), textAscent = textProbe.emHeightAscent ?? textProbe.fontBoundingBoxAscent ?? textProbe.actualBoundingBoxAscent, textDescent = textProbe.emHeightDescent ?? textProbe.fontBoundingBoxDescent ?? textProbe.actualBoundingBoxDescent, textX = Math.round((cellW - textMono.width) / 2), textBaseline = Math.round((cellH + textAscent - textDescent) / 2) + 1;
-  return { cellW, cellH, boxDrawX, boxDrawY, textX, textBaseline };
+function makeGridMetrics(ctx, scale = 1) {
+  let textSize = 14 * scale, cellSize = Math.round(textSize / 0.875), boxFont = `${cellSize}px ${FONT_FAMILY}`, textFont = `${textSize}px ${FONT_FAMILY}`, block = measure(ctx, boxFont, "\u2588"), cellW = Math.ceil(block.actualBoundingBoxLeft + block.actualBoundingBoxRight), cellH = Math.ceil(block.actualBoundingBoxAscent + block.actualBoundingBoxDescent), boxDrawX = block.actualBoundingBoxLeft, boxDrawY = block.actualBoundingBoxAscent, textProbe = measure(ctx, textFont, "Mg"), textMono = measure(ctx, textFont, "M"), textAscent = textProbe.emHeightAscent ?? textProbe.fontBoundingBoxAscent ?? textProbe.actualBoundingBoxAscent, textDescent = textProbe.emHeightDescent ?? textProbe.fontBoundingBoxDescent ?? textProbe.actualBoundingBoxDescent, textX = Math.round((cellW - textMono.width) / 2), textBaseline = Math.round((cellH + textAscent - textDescent) / 2) + 1;
+  return { cellW, cellH, boxDrawX, boxDrawY, textX, textBaseline, textSize, cellSize };
 }
 
 // js/glyphs.ts
@@ -103,7 +103,7 @@ function drawSplitGlyph(ctx, heavyCp, lightCp, px, py, cellW, cellH, boxDrawX, b
 function paintFrame(ctx, canvas, grid, frame) {
   let nodeCells = /* @__PURE__ */ new Set();
   if (!frame?.cells) return nodeCells;
-  let { cellW, cellH, boxDrawX, boxDrawY, textX, textBaseline } = grid, { cols, rows, cells, neutral_fg = "#cdd6f4", neutral_bg = "#1e1e2e" } = frame;
+  let { cellW, cellH, boxDrawX, boxDrawY, textX, textBaseline, textSize, cellSize } = grid, { cols, rows, cells, neutral_fg = "#cdd6f4", neutral_bg = "#1e1e2e" } = frame;
   canvas.width = cols * cellW, canvas.height = rows * cellH, ctx.fillStyle = neutral_bg, ctx.fillRect(0, 0, canvas.width, canvas.height), ctx.textAlign = "left", ctx.textBaseline = "alphabetic";
   for (let cell of cells) {
     let { x: c, y: r, text } = cell, fg = cell.fg ?? neutral_fg, bg = cell.bg ?? neutral_bg, px = c * cellW, py = r * cellH;
@@ -116,9 +116,9 @@ function paintFrame(ctx, canvas, grid, frame) {
     bg !== neutral_bg && (ctx.fillStyle = bg, ctx.fillRect(px, py, cellW, cellH));
     let split = GLYPH_SPLIT.get(cp);
     if (split !== void 0) {
-      let [heavyCp, lightCp] = split, boxFont = cellFont(CELL_SIZE, { bold: !1, italic: !!cell.italic });
+      let [heavyCp, lightCp] = split, boxFont = cellFont(cellSize, { bold: !1, italic: !!cell.italic });
       drawSplitGlyph(ctx, heavyCp, lightCp, px, py, cellW, cellH, boxDrawX, boxDrawY, fg, neutral_fg, boxFont);
-    } else isBoxLike(text) ? (ctx.fillStyle = fg, ctx.font = cellFont(CELL_SIZE, cell), ctx.save(), ctx.beginPath(), ctx.rect(px, py, cellW, cellH), ctx.clip(), ctx.translate(px + cellW / 2, py + cellH / 2), ctx.scale(BOX_SCALE, BOX_SCALE), ctx.fillText(text, boxDrawX - cellW / 2, boxDrawY - cellH / 2), ctx.restore()) : (ctx.fillStyle = fg, ctx.font = cellFont(14, cell), ctx.fillText(text, px + textX, py + textBaseline));
+    } else isBoxLike(text) ? (ctx.fillStyle = fg, ctx.font = cellFont(cellSize, cell), ctx.save(), ctx.beginPath(), ctx.rect(px, py, cellW, cellH), ctx.clip(), ctx.translate(px + cellW / 2, py + cellH / 2), ctx.scale(BOX_SCALE, BOX_SCALE), ctx.fillText(text, boxDrawX - cellW / 2, boxDrawY - cellH / 2), ctx.restore()) : (ctx.fillStyle = fg, ctx.font = cellFont(textSize, cell), ctx.fillText(text, px + textX, py + textBaseline));
     if (cell.underline) {
       ctx.fillStyle = fg;
       let underlineY = Math.min(py + cellH - 1, py + textBaseline + 1);
@@ -133,9 +133,10 @@ function render({ model, el }) {
   let scratchCtx = document.createElement("canvas").getContext("2d"), grid = makeGridMetrics(scratchCtx), wrapper = document.createElement("div");
   wrapper.style.cssText = "position: relative; display: inline-block; line-height: 0;";
   let canvas = document.createElement("canvas");
-  canvas.style.cssText = "display: block; cursor: default; border: 2px solid #45475a;", wrapper.appendChild(canvas), el.appendChild(wrapper);
+  canvas.style.cssText = "display: block; cursor: default; box-shadow: inset 0 0 0 2px #45475a;", wrapper.appendChild(canvas), el.appendChild(wrapper);
   let ctx = canvas.getContext("2d");
-  paintFrame(ctx, canvas, grid, model.get("frame"));
+  if (paintFrame(ctx, canvas, grid, model.get("frame")), 0)
+    var captureHiRes, sendSnapshot, scheduleSnapshot, repaint, doFreeze;
 }
 var index_default = { render };
 export {

--- a/gen-tui/src/graph_controller.rs
+++ b/gen-tui/src/graph_controller.rs
@@ -39,6 +39,7 @@ pub struct GraphConfig {
 
 /// The controller is designed to be initialized outside the event loop for
 /// graph loading and layout computation, then used by widgets during rendering.
+#[derive(Clone)]
 pub struct GraphController<G, S>
 where
     G: GraphBase,

--- a/gen-tui/src/partition_controller.rs
+++ b/gen-tui/src/partition_controller.rs
@@ -43,6 +43,7 @@ impl Default for ControllerConfig {
 /// - Manages the sliding window cache of rendered partitions
 /// - Provides coordinate conversion between local and world space
 /// - Handles scale (level of detail) changes and layout computation
+#[derive(Clone)]
 pub struct PartitionController<G, S>
 where
     G: GraphBase,

--- a/gen-tui/src/partition_table.rs
+++ b/gen-tui/src/partition_table.rs
@@ -47,6 +47,7 @@ impl Default for PartitionConfig {
 ///     - Stored as Vec<(NodeIndex<u32>, NodeIndex<u32>, EdgeIndex<u32>)> where NodeIndex values
 ///       are domain indices that can be converted using the NodeIndexable trait
 /// - `metrics` contains a Vec of Fenwick trees for widths and rise, plus origin coordinates for each scale (indexed by VisualDetail::as_index()).
+#[derive(Clone)]
 pub struct PartitionTable<G>
 where
     G: GraphBase,
@@ -70,7 +71,7 @@ where
 /// - `rise` is a Fenwick tree that stores the vertical offset of each partition after layout.
 /// - `anchor_partition_idx` designates which partition's origin serves as the world coordinate system origin.
 ///   This allows coordinates to remain stable when new partitions are loaded to the left.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct UnifiedLayout {
     // TODO: rename "widths" to "run" so it matches its meaning
     // (run is to width like rise is to height)

--- a/gen-tui/src/viewport_state.rs
+++ b/gen-tui/src/viewport_state.rs
@@ -8,6 +8,7 @@ use crate::{
 };
 
 /// Controller for the Graph widget, managing camera and cursor positions, animations, and zones.
+#[derive(Clone)]
 pub struct ViewportState {
     /// Hard Zone as number of cells from the viewport edge
     /// Camera snaps immediately when cursor enters this zone (in # terminal cells from the sides, half cells on top and bottom)

--- a/src/views/annotation_track.rs
+++ b/src/views/annotation_track.rs
@@ -209,7 +209,7 @@ impl AnnotationTrack {
                 let Some(mut segments) = segments_by_annotation.get(idx).cloned() else {
                     continue;
                 };
-                segments.sort_by_key(|s| s.start_x());
+                segments.sort_by_key(|s| s.node_x1);
                 let mut prev_end: Option<i64> = None;
                 for seg in &segments {
                     let x1 = seg.start_x();

--- a/src/views/gen_graph_widget.rs
+++ b/src/views/gen_graph_widget.rs
@@ -25,6 +25,7 @@ pub mod label {
 
 /// Domain-specific node sizer for GenGraph that calculates visual dimensions
 /// based on genomic sequence length.
+#[derive(Clone)]
 pub struct GenGraphNodeSizer;
 
 impl NodeSizer<GenGraph> for GenGraphNodeSizer {


### PR DESCRIPTION
## Summary
- Add per-cell widget cloning so each Jupyter cell gets its own
  independent interactive graph instance
- Add freeze button to lock a widget as a static image
- Auto-snapshot with debounce sends PNG to Python on each frame change;
  freeze and snapshot use separate message types
- Fix window listener memory leaks on widget destroy
- Inset canvas border via `box-shadow` so toggling editable state
  causes no layout shift; swap canvas→img inside wrapper on freeze
  to reduce reflow jitter in content below