### PR TITLE
Update block group methods to return results as needed

### DIFF
--- a/gen-annotations/src/gff.rs
+++ b/gen-annotations/src/gff.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, fs::File, io, io::BufReader};
 
 use gen_models::{
-    block_group::BlockGroup,
+    block_group::{BlockGroup, BlockGroupError},
     db::GraphConnection,
     errors::PathError,
     path::{Annotation, Path},
@@ -15,6 +15,8 @@ pub enum PropagateGffError {
     Io(#[from] io::Error),
     #[error("Path error: {0}")]
     Path(#[from] PathError),
+    #[error("Block group error: {0}")]
+    BlockGroup(#[from] BlockGroupError),
 }
 
 pub fn gff_attribute_value_to_string(
@@ -57,12 +59,12 @@ pub fn propagate_gff(
     let target_block_groups = Sample::get_block_groups(conn, collection_name, to_sample_name);
     let source_paths_by_bg_name = source_block_groups
         .iter()
-        .map(|bg| (bg.name.clone(), BlockGroup::get_current_path(conn, &bg.id)))
-        .collect::<HashMap<String, Path>>();
+        .map(|bg| Ok((bg.name.clone(), BlockGroup::get_current_path(conn, &bg.id)?)))
+        .collect::<Result<HashMap<String, Path>, BlockGroupError>>()?;
     let target_paths_by_bg_name = target_block_groups
         .iter()
-        .map(|bg| (bg.name.clone(), BlockGroup::get_current_path(conn, &bg.id)))
-        .collect::<HashMap<String, Path>>();
+        .map(|bg| Ok((bg.name.clone(), BlockGroup::get_current_path(conn, &bg.id)?)))
+        .collect::<Result<HashMap<String, Path>, BlockGroupError>>()?;
 
     let mut path_mappings_by_bg_name = HashMap::new();
     for (name, target_path) in &target_paths_by_bg_name {
@@ -253,7 +255,7 @@ mod tests {
         )
         .expect("should create child block group")[0]
             .id;
-        let sample_path = BlockGroup::get_current_path(conn, &sample_bg_id);
+        let sample_path = BlockGroup::get_current_path(conn, &sample_bg_id).unwrap();
         let replacement_sequence = "AA";
 
         let replacement = Sequence::new()

--- a/gen-annotations/src/test_helpers.rs
+++ b/gen-annotations/src/test_helpers.rs
@@ -153,7 +153,7 @@ pub fn setup_test_data(conn: &GraphConnection) {
     )
     .expect("should create child block group")[0]
         .id;
-    let sample_path = BlockGroup::get_current_path(conn, &sample_bg_id);
+    let sample_path = BlockGroup::get_current_path(conn, &sample_bg_id).unwrap();
     let alt_seq = "C";
 
     let sequence = Sequence::new()

--- a/gen-annotations/src/translate/bed.rs
+++ b/gen-annotations/src/translate/bed.rs
@@ -74,7 +74,7 @@ where
             let projection = match paths.entry(bg.id) {
                 Entry::Occupied(entry) => entry.into_mut(),
                 Entry::Vacant(entry) => {
-                    let path = BlockGroup::get_current_path(conn, &bg.id);
+                    let path = BlockGroup::get_current_path(conn, &bg.id)?;
                     let graph = BlockGroup::get_graph(conn, &bg.id)?;
                     let mut tree = IntervalTree::default();
                     let mut position: i64 = 0;

--- a/gen-annotations/src/translate/gff.rs
+++ b/gen-annotations/src/translate/gff.rs
@@ -69,7 +69,7 @@ where
             let projection = match paths.entry(bg.id) {
                 Entry::Occupied(entry) => entry.into_mut(),
                 Entry::Vacant(entry) => {
-                    let path = BlockGroup::get_current_path(conn, &bg.id);
+                    let path = BlockGroup::get_current_path(conn, &bg.id)?;
                     let graph = BlockGroup::get_graph(conn, &bg.id)?;
                     let mut tree = IntervalTree::default();
                     let mut position: i64 = 0;

--- a/gen-models/src/annotations.rs
+++ b/gen-models/src/annotations.rs
@@ -592,7 +592,7 @@ pub fn add_annotation(
         .iter()
         .find(|bg| bg.name == parsed_region.name)
         .ok_or_else(|| anyhow!("Graph {} not found for sample {sample}", parsed_region.name))?;
-    let path = BlockGroup::get_current_path(graph_conn, &block_group.id);
+    let path = BlockGroup::get_current_path(graph_conn, &block_group.id)?;
     let path_length = path.length(graph_conn)?;
     if start < 0 || end < 0 || start > path_length || end > path_length {
         return Err(anyhow!("Region {region} is outside the path bounds (0-{path_length})").into());

--- a/gen-models/src/block_group.rs
+++ b/gen-models/src/block_group.rs
@@ -336,7 +336,12 @@ impl BlockGroup {
         }
     }
 
-    pub fn delete(conn: &GraphConnection, collection_name: &str, sample_name: &str, name: &str) {
+    pub fn delete(
+        conn: &GraphConnection,
+        collection_name: &str,
+        sample_name: &str,
+        name: &str,
+    ) -> Result<(), BlockGroupError> {
         let query = "delete from block_groups where collection_name = ?1 and sample_name = ?2 and name = ?3;";
         conn.execute(
             query,
@@ -345,8 +350,8 @@ impl BlockGroup {
                 sample_name.to_string(),
                 name.to_string()
             ],
-        )
-        .unwrap();
+        )?;
+        Ok(())
     }
 
     pub fn get_by_id(conn: &GraphConnection, id: &HashId) -> Result<BlockGroup, BlockGroupError> {
@@ -369,8 +374,8 @@ impl BlockGroup {
     pub fn get_reference_block_groups(
         conn: &GraphConnection,
         collection_name: &str,
-    ) -> Vec<BlockGroup> {
-        BlockGroup::query(
+    ) -> Result<Vec<BlockGroup>, BlockGroupError> {
+        Ok(BlockGroup::try_query(
             conn,
             "select bg.*
              from block_groups bg
@@ -378,7 +383,7 @@ impl BlockGroup {
              where bg.collection_name = ?1 and s.is_reference = 1
              order by bg.name, bg.sample_name, bg.created_on, bg.id;",
             params![collection_name],
-        )
+        )?)
     }
 
     fn copy_paths_and_accessions_into(
@@ -453,7 +458,7 @@ impl BlockGroup {
             sample_name,
             group_name,
             &parent_samples,
-        );
+        )?;
 
         if parent_block_groups.is_empty() {
             return Ok(vec![BlockGroup::create(
@@ -492,17 +497,17 @@ impl BlockGroup {
         sample_name: &str,
         group_name: &str,
         parent_samples: &[String],
-    ) -> Vec<BlockGroup> {
+    ) -> Result<Vec<BlockGroup>, BlockGroupError> {
         let parent_samples = if parent_samples.is_empty() {
             Sample::get_parent_names(conn, sample_name)
         } else {
             parent_samples.to_vec()
         };
         if parent_samples.is_empty() {
-            return vec![];
+            return Ok(vec![]);
         }
 
-        BlockGroup::query(
+        Ok(BlockGroup::try_query(
             conn,
             "select * from block_groups
              where collection_name = ?1 AND sample_name IN rarray(?2) AND name = ?3
@@ -518,7 +523,7 @@ impl BlockGroup {
                 ),
                 group_name
             ],
-        )
+        )?)
     }
 
     fn copy_contents_from(
@@ -1132,33 +1137,40 @@ impl BlockGroup {
         Ok(flatten_to_interval_tree(&graph, remove_ambiguous_positions))
     }
 
-    pub fn get_current_path(conn: &GraphConnection, block_group_id: &HashId) -> Path {
-        let paths = Path::query(
+    pub fn get_current_path(
+        conn: &GraphConnection,
+        block_group_id: &HashId,
+    ) -> Result<Path, BlockGroupError> {
+        let paths = Path::try_query(
             conn,
             "SELECT * FROM paths WHERE block_group_id = ?1 ORDER BY created_on DESC",
             params![block_group_id],
-        );
-        paths[0].clone()
+        )?;
+        paths.first().cloned().ok_or_else(|| {
+            BlockGroupError::QueryError(QueryError::ResultsNotFound(format!(
+                "No current path found for block group {block_group_id}"
+            )))
+        })
     }
 
     pub fn get_path_by_name(
         conn: &GraphConnection,
         block_group_id: &HashId,
         path_name: &str,
-    ) -> Option<Path> {
-        let paths = Path::query(
+    ) -> Result<Option<Path>, BlockGroupError> {
+        let paths = Path::try_query(
             conn,
             "SELECT * FROM paths WHERE block_group_id = ?1 ORDER BY created_on DESC",
             params![block_group_id],
-        );
+        )?;
 
         for path in &paths {
             if path.name == path_name {
-                return Some(path.clone());
+                return Ok(Some(path.clone()));
             }
         }
 
-        None
+        Ok(None)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1590,7 +1602,7 @@ mod tests {
         let bg1 = create_bg(conn, "test", "sample1", "hg19");
         let bg2 = create_bg(conn, "test", "sample2", "hg19");
 
-        BlockGroup::delete(conn, "test", &bg1.sample_name, &bg1.name);
+        BlockGroup::delete(conn, "test", &bg1.sample_name, &bg1.name).unwrap();
 
         let bgs = BlockGroup::all(conn);
         assert_eq!(bgs.len(), 1);

--- a/gen-models/src/block_group.rs
+++ b/gen-models/src/block_group.rs
@@ -375,7 +375,7 @@ impl BlockGroup {
         conn: &GraphConnection,
         collection_name: &str,
     ) -> Result<Vec<BlockGroup>, BlockGroupError> {
-        Ok(BlockGroup::try_query(
+        BlockGroup::try_query(
             conn,
             "select bg.*
              from block_groups bg
@@ -383,7 +383,8 @@ impl BlockGroup {
              where bg.collection_name = ?1 and s.is_reference = 1
              order by bg.name, bg.sample_name, bg.created_on, bg.id;",
             params![collection_name],
-        )?)
+        )
+        .map_err(BlockGroupError::from)
     }
 
     fn copy_paths_and_accessions_into(
@@ -507,7 +508,7 @@ impl BlockGroup {
             return Ok(vec![]);
         }
 
-        Ok(BlockGroup::try_query(
+        BlockGroup::try_query(
             conn,
             "select * from block_groups
              where collection_name = ?1 AND sample_name IN rarray(?2) AND name = ?3
@@ -523,7 +524,8 @@ impl BlockGroup {
                 ),
                 group_name
             ],
-        )?)
+        )
+        .map_err(BlockGroupError::from)
     }
 
     fn copy_contents_from(

--- a/gen-models/src/errors.rs
+++ b/gen-models/src/errors.rs
@@ -15,8 +15,10 @@ pub use crate::{
     sequence::SequenceError,
 };
 
-#[derive(Clone, Debug, Eq, Error, Hash, PartialEq)]
+#[derive(Debug, Error, PartialEq)]
 pub enum QueryError {
+    #[error("Database error: {0}")]
+    DatabaseError(#[from] rusqlite::Error),
     #[error("Results not found: {0}")]
     ResultsNotFound(String),
 }

--- a/gen-models/src/region.rs
+++ b/gen-models/src/region.rs
@@ -152,7 +152,7 @@ pub fn resolve_block_group(
         Err(RegionResolutionError::Ambiguous(name)) => return Err(GenRegionError::Ambiguous(name)),
         Err(RegionResolutionError::Lookup(err)) => return Err(err.into()),
     };
-    let path = BlockGroup::get_current_path(conn, &block_group.id);
+    let path = BlockGroup::get_current_path(conn, &block_group.id)?;
     let path_length = path.length(conn)?;
     resolve_target(
         region,

--- a/gen-models/src/traits.rs
+++ b/gen-models/src/traits.rs
@@ -33,6 +33,16 @@ pub trait Query {
         objs
     }
 
+    fn try_query(conn: &Connection, query: &str, params: impl Params) -> Result<Vec<Self::Model>> {
+        let mut stmt = conn.prepare(query)?;
+        let rows = stmt.query_map(params, |row| Ok(Self::process_row(row)))?;
+        let mut objs = vec![];
+        for row in rows {
+            objs.push(row?);
+        }
+        Ok(objs)
+    }
+
     fn get(conn: &Connection, query: &str, params: impl Params) -> Result<Self::Model> {
         let mut stmt = conn.prepare(query).unwrap();
         stmt.query_row(params, |row| Ok(Self::process_row(row)))

--- a/gen-models/src/traits.rs
+++ b/gen-models/src/traits.rs
@@ -1,7 +1,9 @@
 use std::rc::Rc;
 
 use itertools::Itertools;
-use rusqlite::{Connection, Params, Result, Row, limits::Limit, params, types::Value};
+use rusqlite::{Connection, Params, Result as SQLResult, Row, limits::Limit, params, types::Value};
+
+use crate::errors::QueryError;
 
 /// Returns the SQLite variable parameter limit for the provided connection.
 pub fn sqlite_parameter_limit(conn: &Connection) -> usize {
@@ -33,7 +35,11 @@ pub trait Query {
         objs
     }
 
-    fn try_query(conn: &Connection, query: &str, params: impl Params) -> Result<Vec<Self::Model>> {
+    fn try_query(
+        conn: &Connection,
+        query: &str,
+        params: impl Params,
+    ) -> Result<Vec<Self::Model>, QueryError> {
         let mut stmt = conn.prepare(query)?;
         let rows = stmt.query_map(params, |row| Ok(Self::process_row(row)))?;
         let mut objs = vec![];
@@ -43,7 +49,7 @@ pub trait Query {
         Ok(objs)
     }
 
-    fn get(conn: &Connection, query: &str, params: impl Params) -> Result<Self::Model> {
+    fn get(conn: &Connection, query: &str, params: impl Params) -> SQLResult<Self::Model> {
         let mut stmt = conn.prepare(query).unwrap();
         stmt.query_row(params, |row| Ok(Self::process_row(row)))
     }

--- a/gen-python/src/python_api/jupyter_widget.rs
+++ b/gen-python/src/python_api/jupyter_widget.rs
@@ -976,10 +976,7 @@ fn load_track_from_file(
 mod tests {
     use r#gen::test_helpers::{setup_block_group, setup_gen_on_disk};
     use gen_models::block_group::BlockGroup;
-    use pyo3::{
-        exceptions::{PyRuntimeError, PyValueError},
-        prelude::*,
-    };
+    use pyo3::{exceptions::PyValueError, prelude::*};
     use serde_json::Value;
 
     use super::{PyGraphController, current_theme};

--- a/gen-python/src/python_api/jupyter_widget.rs
+++ b/gen-python/src/python_api/jupyter_widget.rs
@@ -631,7 +631,8 @@ impl PyGraphController {
         let highlight_color = self.resolve_color(color)?;
         let conn = self.open_conn()?;
 
-        let path = BlockGroup::get_current_path(&conn, &block_group_id);
+        let path = BlockGroup::get_current_path(&conn, &block_group_id)
+            .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
         let path_blocks = path.blocks(&conn).unwrap_or_default();
         let projected_path = project_path(self.controller.graph(), &path_blocks);
 

--- a/gen-python/src/python_api/jupyter_widget.rs
+++ b/gen-python/src/python_api/jupyter_widget.rs
@@ -976,7 +976,10 @@ fn load_track_from_file(
 mod tests {
     use r#gen::test_helpers::{setup_block_group, setup_gen_on_disk};
     use gen_models::block_group::BlockGroup;
-    use pyo3::{exceptions::PyValueError, prelude::*};
+    use pyo3::{
+        exceptions::{PyRuntimeError, PyValueError},
+        prelude::*,
+    };
     use serde_json::Value;
 
     use super::{PyGraphController, current_theme};

--- a/src/commands/graph_operations/derive_chunks.rs
+++ b/src/commands/graph_operations/derive_chunks.rs
@@ -191,6 +191,7 @@ mod tests {
             .iter()
             .map(|bg| {
                 BlockGroup::get_current_path(conn, &bg.id)
+                    .unwrap()
                     .sequence(conn)
                     .unwrap()
             })

--- a/src/diffs/gfa.rs
+++ b/src/diffs/gfa.rs
@@ -7,7 +7,11 @@ use std::{
 
 use gen_core::{NodeIntervalBlock, range::Range};
 use gen_models::{
-    block_group::BlockGroup, db::GraphConnection, errors::PathError, path::Path, sample::Sample,
+    block_group::{BlockGroup, BlockGroupError},
+    db::GraphConnection,
+    errors::PathError,
+    path::Path,
+    sample::Sample,
 };
 use itertools::Itertools;
 use thiserror::Error;
@@ -20,6 +24,8 @@ pub enum GfaDiffError {
     Io(#[from] std::io::Error),
     #[error("Path error while generating GFA diff: {0}")]
     Path(#[from] PathError),
+    #[error("Block group error while generating GFA diff: {0}")]
+    BlockGroup(#[from] BlockGroupError),
 }
 
 pub fn gfa_sample_diff(
@@ -56,12 +62,12 @@ pub fn gfa_sample_diff(
 
     let source_paths_by_name = source_block_groups
         .iter()
-        .map(|bg| (bg.name.clone(), BlockGroup::get_current_path(conn, &bg.id)))
-        .collect::<HashMap<String, Path>>();
+        .map(|bg| Ok((bg.name.clone(), BlockGroup::get_current_path(conn, &bg.id)?)))
+        .collect::<Result<HashMap<String, Path>, BlockGroupError>>()?;
     let target_paths_by_name = target_block_groups
         .iter()
-        .map(|bg| (bg.name.clone(), BlockGroup::get_current_path(conn, &bg.id)))
-        .collect::<HashMap<String, Path>>();
+        .map(|bg| Ok((bg.name.clone(), BlockGroup::get_current_path(conn, &bg.id)?)))
+        .collect::<Result<HashMap<String, Path>, BlockGroupError>>()?;
 
     let mut segments = HashSet::new();
     let mut links = HashSet::new();
@@ -381,7 +387,8 @@ mod tests {
             })
             .collect::<Vec<BlockGroupEdgeData>>();
         BlockGroupEdge::bulk_create(conn, &child_block_group_edges);
-        let original_child_path = BlockGroup::get_current_path(conn, &child_block_group.id);
+        let original_child_path =
+            BlockGroup::get_current_path(conn, &child_block_group.id).unwrap();
         let _child_path = original_child_path.new_path_with(conn, 2, 6, &edge4, &edge5);
 
         let temp_dir = tempdir().unwrap();
@@ -466,7 +473,7 @@ mod tests {
             .collect::<Vec<BlockGroupEdgeData>>();
         BlockGroupEdge::bulk_create(conn, &grandchild_block_group_edges);
         let original_grandchild_path =
-            BlockGroup::get_current_path(conn, &grandchild_block_group.id);
+            BlockGroup::get_current_path(conn, &grandchild_block_group.id).unwrap();
         let _grandchild_path = original_grandchild_path.new_path_with(conn, 10, 14, &edge6, &edge7);
 
         let gfa_path = temp_dir.path().join("parent-grandchild-diff.gfa");
@@ -1198,7 +1205,8 @@ mod tests {
             })
             .collect::<Vec<BlockGroupEdgeData>>();
         BlockGroupEdge::bulk_create(conn, &child_block_group_edges);
-        let original_child_path = BlockGroup::get_current_path(conn, &child_block_group.id);
+        let original_child_path =
+            BlockGroup::get_current_path(conn, &child_block_group.id).unwrap();
         let _child_path = original_child_path.new_path_with(conn, 2, 6, &edge3, &edge4);
 
         let temp_dir = tempdir().unwrap();
@@ -1283,7 +1291,7 @@ mod tests {
             .collect::<Vec<BlockGroupEdgeData>>();
         BlockGroupEdge::bulk_create(conn, &grandchild_block_group_edges);
         let original_grandchild_path =
-            BlockGroup::get_current_path(conn, &grandchild_block_group.id);
+            BlockGroup::get_current_path(conn, &grandchild_block_group.id).unwrap();
         let _grandchild_path = original_grandchild_path.new_path_with(conn, 4, 10, &edge5, &edge6);
 
         let gfa_path = temp_dir.path().join("parent-grandchild-diff.gfa");

--- a/src/exports/fasta.rs
+++ b/src/exports/fasta.rs
@@ -1,7 +1,10 @@
 use std::{fs::File, path::PathBuf};
 
 use gen_models::{
-    block_group::BlockGroup, collection::Collection, db::GraphConnection, errors::PathError,
+    block_group::{BlockGroup, BlockGroupError},
+    collection::Collection,
+    db::GraphConnection,
+    errors::PathError,
     sample::Sample,
 };
 use noodles::fasta;
@@ -13,6 +16,8 @@ pub enum FastaExportError {
     Io(#[from] std::io::Error),
     #[error("Path error while exporting FASTA: {0}")]
     Path(#[from] PathError),
+    #[error("Block group error while exporting FASTA: {0}")]
+    BlockGroup(#[from] BlockGroupError),
 }
 
 pub fn export_fasta(
@@ -31,7 +36,7 @@ pub fn export_fasta(
     let mut writer = fasta::io::Writer::new(file);
 
     for block_group in block_groups {
-        let path = BlockGroup::get_current_path(conn, &block_group.id);
+        let path = BlockGroup::get_current_path(conn, &block_group.id)?;
 
         let definition = fasta::record::Definition::new(block_group.name, None);
         let sequence = fasta::record::Sequence::from(path.sequence(conn)?.into_bytes());

--- a/src/exports/genbank.rs
+++ b/src/exports/genbank.rs
@@ -18,7 +18,7 @@ use gen_graph::{GenGraph, GraphEdge, GraphNode, all_simple_paths};
 use gen_models::{
     accession::Accession,
     annotations::{Annotation, GenBankLocationOperator},
-    block_group::{BlockGroup, BlockGroupError},
+    block_group::BlockGroup,
     db::GraphConnection,
     errors::{AnnotationError, BlockGroupError, PathError, SequenceError},
     node::Node,

--- a/src/exports/genbank.rs
+++ b/src/exports/genbank.rs
@@ -18,7 +18,7 @@ use gen_graph::{GenGraph, GraphEdge, GraphNode, all_simple_paths};
 use gen_models::{
     accession::Accession,
     annotations::{Annotation, GenBankLocationOperator},
-    block_group::BlockGroup,
+    block_group::{BlockGroup, BlockGroupError},
     db::GraphConnection,
     errors::{AnnotationError, BlockGroupError, PathError, SequenceError},
     node::Node,
@@ -276,7 +276,7 @@ pub fn export_genbank(
     let mut writer = gb_io::writer::SeqWriter::new(writer);
 
     for block_group in block_groups.iter() {
-        let path = BlockGroup::get_current_path(conn, &block_group.id);
+        let path = BlockGroup::get_current_path(conn, &block_group.id)?;
         let path_blocks = path
             .blocks(conn)?
             .into_iter()

--- a/src/graphs.rs
+++ b/src/graphs.rs
@@ -76,7 +76,8 @@ pub fn load_block_group_chunk(conn: &GraphConnection, block_group_id: HashId) ->
         })
         .collect();
 
-    let path = BlockGroup::get_current_path(conn, &block_group_id);
+    let path = BlockGroup::get_current_path(conn, &block_group_id)
+        .expect("Block group chunk requires a current path");
     let path_edges = PathEdge::edges_for_path(conn, &path.id);
 
     let start_edge = path_edges[0].clone();

--- a/src/graphs/graph_search.rs
+++ b/src/graphs/graph_search.rs
@@ -793,7 +793,7 @@ mod tests {
         let conn = ctx.graph().conn();
         let _ = Collection::create(conn, "test");
         let (block_group_id, _path) = setup_block_group(conn);
-        let graph = BlockGroup::get_graph(conn, &block_group_id);
+        let graph = BlockGroup::get_graph(conn, &block_group_id).unwrap();
         GenGraphMatcher::new_ssdna(conn, graph)
     }
 

--- a/src/graphs/operators.rs
+++ b/src/graphs/operators.rs
@@ -50,7 +50,7 @@ pub fn get_path(
     let block_group_id = resolved_region.block_group.id;
 
     if let Some(backbone) = backbone {
-        let path = BlockGroup::get_path_by_name(conn, &block_group_id, backbone);
+        let path = BlockGroup::get_path_by_name(conn, &block_group_id, backbone)?;
         if path.is_none() {
             return Err(GraphOperationError::PathNotFound(format!(
                 "No path found with name {backbone}"
@@ -58,9 +58,10 @@ pub fn get_path(
         }
         Ok(path.unwrap())
     } else {
-        Ok(resolved_region
-            .path
-            .unwrap_or_else(|| BlockGroup::get_current_path(conn, &block_group_id)))
+        match resolved_region.path {
+            Some(path) => Ok(path),
+            None => Ok(BlockGroup::get_current_path(conn, &block_group_id)?),
+        }
     }
 }
 
@@ -585,7 +586,7 @@ mod tests {
             HashSet::from_iter(vec!["TTTTTCCCCC".to_string(), "TAAAAAAAAC".to_string(),])
         );
 
-        let new_path = BlockGroup::get_current_path(conn, &block_group2.id);
+        let new_path = BlockGroup::get_current_path(conn, &block_group2.id).unwrap();
         assert_eq!(new_path.sequence(conn).unwrap(), "TAAAAAAAAC");
     }
 
@@ -686,7 +687,7 @@ mod tests {
             HashSet::from_iter(vec!["TCAATCG".to_string(), "TCGATCG".to_string(),])
         );
 
-        let path2 = BlockGroup::get_current_path(conn, &block_group2.id);
+        let path2 = BlockGroup::get_current_path(conn, &block_group2.id).unwrap();
         assert_eq!(path2.sequence(conn).unwrap(), "TCAATCG");
 
         let block_group3 = block_groups.iter().find(|x| x.name == "m123.3").unwrap();
@@ -699,7 +700,7 @@ mod tests {
             ])
         );
 
-        let path3 = BlockGroup::get_current_path(conn, &block_group3.id);
+        let path3 = BlockGroup::get_current_path(conn, &block_group3.id).unwrap();
         assert_eq!(path3.sequence(conn).unwrap(), "ATCGATCAAGGAACACA");
     }
 
@@ -800,7 +801,7 @@ mod tests {
             HashSet::from_iter(vec!["TCAATCG".to_string(), "TCGATCG".to_string(),])
         );
 
-        let path2 = BlockGroup::get_current_path(conn, &block_group2.id);
+        let path2 = BlockGroup::get_current_path(conn, &block_group2.id).unwrap();
         assert_eq!(path2.sequence(conn).unwrap(), "TCAATCG");
 
         let block_group3 = block_groups.iter().find(|x| x.name == "m123.3").unwrap();
@@ -813,7 +814,7 @@ mod tests {
             ])
         );
 
-        let path3 = BlockGroup::get_current_path(conn, &block_group3.id);
+        let path3 = BlockGroup::get_current_path(conn, &block_group3.id).unwrap();
         assert_eq!(path3.sequence(conn).unwrap(), "ATCGATCAAGGAACACA");
 
         // Stitch the two main chunks back together in same order
@@ -844,7 +845,7 @@ mod tests {
             ])
         );
 
-        let path4 = BlockGroup::get_current_path(conn, &block_group4.id);
+        let path4 = BlockGroup::get_current_path(conn, &block_group4.id).unwrap();
         // path2 + path3 concatenated
         assert_eq!(path4.sequence(conn).unwrap(), "TCAATCGATCGATCAAGGAACACA");
 
@@ -876,7 +877,7 @@ mod tests {
             ])
         );
 
-        let path5 = BlockGroup::get_current_path(conn, &block_group5.id);
+        let path5 = BlockGroup::get_current_path(conn, &block_group5.id).unwrap();
         // path3 + path2 concatenated
         assert_eq!(path5.sequence(conn).unwrap(), "ATCGATCAAGGAACACATCAATCG");
     }

--- a/src/imports/library.rs
+++ b/src/imports/library.rs
@@ -176,7 +176,7 @@ mod tests {
         let actual_sequences = BlockGroup::get_all_sequences(conn, &block_group.id, false).unwrap();
         assert_eq!(actual_sequences, expected_sequences);
 
-        let current_path = BlockGroup::get_current_path(conn, &block_group.id);
+        let current_path = BlockGroup::get_current_path(conn, &block_group.id).unwrap();
         assert_eq!(
             current_path.sequence(conn).unwrap(),
             "TCTAGAGAAAGAGGGGACAAACTAGATGCGTAAAGGAGAAGAACTTTAA"

--- a/src/main.rs
+++ b/src/main.rs
@@ -183,7 +183,7 @@ fn call_cli() -> Result<(), Box<dyn std::error::Error>> {
                 match block_group {
                     Ok(bg) => {
                         let block_graph = BlockGroup::get_graph(graph_conn, &bg.id)?;
-                        let current_path = BlockGroup::get_current_path(graph_conn, &bg.id);
+                        let current_path = BlockGroup::get_current_path(graph_conn, &bg.id)?;
                         // Use a default height of 10 for now
                         match show_inline_gen_graph_widget(
                             graph_conn,
@@ -791,7 +791,7 @@ fn call_cli() -> Result<(), Box<dyn std::error::Error>> {
                 .ok_or_else(|| {
                     format!("Graph {parsed_graph_name} not found for {formatted_sample_name}")
                 })?;
-            let path = BlockGroup::get_current_path(graph_conn, &block_group.id);
+            let path = BlockGroup::get_current_path(graph_conn, &block_group.id)?;
             let sequence = path.sequence(graph_conn)?;
             if end_coordinate == -1 {
                 end_coordinate = sequence.len() as i64;

--- a/src/updates/fasta.rs
+++ b/src/updates/fasta.rs
@@ -85,7 +85,7 @@ pub fn update_with_fasta(
     let mut target_states = target_block_groups
         .iter()
         .map(|target_block_group| -> Result<_, FastaError> {
-            let path = BlockGroup::get_current_path(conn, &target_block_group.id);
+            let path = BlockGroup::get_current_path(conn, &target_block_group.id)?;
             Ok(TargetBlockGroupState {
                 block_group_id: target_block_group.id,
                 path,
@@ -343,8 +343,8 @@ mod tests {
 
         let child_blockgroup = get_sample_bg(conn, &collection, "child sample").id;
         let other_blockgroup = get_sample_bg(conn, &collection, "other sample").id;
-        let child_path = BlockGroup::get_current_path(conn, &child_blockgroup);
-        let other_path = BlockGroup::get_current_path(conn, &other_blockgroup);
+        let child_path = BlockGroup::get_current_path(conn, &child_blockgroup).unwrap();
+        let other_path = BlockGroup::get_current_path(conn, &other_blockgroup).unwrap();
         assert_eq!(
             child_path.sequence(conn).unwrap(),
             "ATAAAAAAAATCGATCGATCGATCGGGAACACACAGAGA"
@@ -813,7 +813,7 @@ mod tests {
             HashSet::from_iter(expected_sequences),
         );
 
-        let latest_path = BlockGroup::get_current_path(conn, &block_groups[0].id);
+        let latest_path = BlockGroup::get_current_path(conn, &block_groups[0].id).unwrap();
         assert_eq!(
             latest_path.sequence(conn).unwrap(),
             "ATTCGATCGATCGATCGGGAACACACAGAGA"

--- a/src/updates/gfa.rs
+++ b/src/updates/gfa.rs
@@ -58,7 +58,7 @@ pub fn update_with_gfa(
     let existing_paths = block_groups
         .iter()
         .map(|block_group| BlockGroup::get_current_path(conn, &block_group.id))
-        .collect::<Vec<Path>>();
+        .collect::<Result<Vec<Path>, _>>()?;
 
     let gfa: Gfa<String, (), ()> = Gfa::parse_gfa_file(gfa_path);
 

--- a/src/updates/library.rs
+++ b/src/updates/library.rs
@@ -368,7 +368,7 @@ mod tests {
             ])
         );
 
-        let path = BlockGroup::get_current_path(conn, &block_group.id);
+        let path = BlockGroup::get_current_path(conn, &block_group.id).unwrap();
         assert_eq!(
             path.sequence(conn).unwrap(),
             "ATCGATCGATCGATCGATCGGGAACACACAGAGA".to_string()

--- a/src/updates/sequence.rs
+++ b/src/updates/sequence.rs
@@ -74,7 +74,7 @@ pub fn update_with_sequence(
     }
 
     for target_block_group in &target_block_groups {
-        let path = BlockGroup::get_current_path(conn, &target_block_group.id);
+        let path = BlockGroup::get_current_path(conn, &target_block_group.id)?;
         let node_id = if sequence.is_empty() {
             let node_id = HashId::convert_str("");
             let path_block = PathBlock {
@@ -297,8 +297,8 @@ mod tests {
 
         let child_blockgroup = get_sample_bg(conn, &collection, "child sample").id;
         let other_blockgroup = get_sample_bg(conn, &collection, "other sample").id;
-        let child_path = BlockGroup::get_current_path(conn, &child_blockgroup);
-        let other_path = BlockGroup::get_current_path(conn, &other_blockgroup);
+        let child_path = BlockGroup::get_current_path(conn, &child_blockgroup).unwrap();
+        let other_path = BlockGroup::get_current_path(conn, &other_blockgroup).unwrap();
         assert_eq!(
             child_path.sequence(conn).unwrap(),
             "ATAAAAAAAATCGATCGATCGATCGGGAACACACAGAGA"
@@ -663,7 +663,7 @@ mod tests {
             HashSet::from_iter(expected_sequences),
         );
 
-        let latest_path = BlockGroup::get_current_path(conn, &block_groups[0].id);
+        let latest_path = BlockGroup::get_current_path(conn, &block_groups[0].id).unwrap();
         assert_eq!(
             latest_path.sequence(conn).unwrap(),
             "ATTCGATCGATCGATCGGGAACACACAGAGA"

--- a/src/views/annotation_groups.rs
+++ b/src/views/annotation_groups.rs
@@ -45,7 +45,8 @@ pub fn load_annotation_group_entries(
             &block_group.sample_name,
             &block_group.name,
             &ancestor_samples,
-        );
+        )
+        .unwrap_or_default();
         let mut grouped = HashMap::<String, Vec<BlockGroup>>::new();
         for ancestor_block_group in ancestor_block_groups {
             grouped


### PR DESCRIPTION
I noticed with the recent changes involving intervaltree, some BlockGroup methods should be returning Results but aren't.  This addresses that