### PR TITLE
Enforce relative paths for end_operation

### DIFF
--- a/gen-models/src/block_group.rs
+++ b/gen-models/src/block_group.rs
@@ -3237,7 +3237,7 @@ mod tests {
     #[test]
     fn test_blockgroup_interval_tree() {
         let conn = &get_connection(None).unwrap();
-        let (block_group_id, path) = setup_block_group(conn);
+        let (block_group_id, _path) = setup_block_group(conn);
         let _new_sample = Sample::get_or_create(
             conn,
             NewSample {

--- a/gen-models/src/operations.rs
+++ b/gen-models/src/operations.rs
@@ -431,6 +431,19 @@ impl OperationFile {
         self
     }
 
+    pub fn storage_file_path(
+        workspace: &Workspace,
+        path_or_uri: &str,
+        checksum: &HashId,
+        file_type: FileTypes,
+    ) -> Result<String, FileAdditionError> {
+        if LocalAssetUri::is_local_path_or_file_uri(path_or_uri) {
+            LocalAssetUri::operation_file_path(workspace, path_or_uri, checksum, file_type)
+        } else {
+            Ok(path_or_uri.to_string())
+        }
+    }
+
     pub fn get_files_for_operation(
         conn: &OperationsConnection,
         operation_hash: &HashId,
@@ -503,16 +516,12 @@ pub fn add_files_operation(
             let file_type = FileTypes::infer_from_path(path);
             let file_addition =
                 FileAddition::get_or_create(workspace, operation_conn, path, file_type, None)?;
-            let operation_file_path = if LocalAssetUri::is_local_path_or_file_uri(path) {
-                LocalAssetUri::operation_file_path(
-                    workspace,
-                    path,
-                    &file_addition.checksum,
-                    file_type,
-                )?
-            } else {
-                path.clone()
-            };
+            let operation_file_path = OperationFile::storage_file_path(
+                workspace,
+                path,
+                &file_addition.checksum,
+                file_type,
+            )?;
             Ok::<(FileAddition, String, String), FileAdditionError>((
                 file_addition,
                 OperationFile::new(path.clone()).filename,
@@ -2699,6 +2708,27 @@ mod tests {
         assert_eq!(operation_file.file_path, "fixtures/sample.gb");
         assert_eq!(operation_file.file_type, FileTypes::GenBank);
         assert_eq!(operation_file.checksum_override, None);
+    }
+
+    #[test]
+    fn test_operation_file_storage_path_normalizes_absolute_repo_path() {
+        let context = setup_gen();
+        let repo_root = context.workspace().repo_root().unwrap();
+        let absolute_path = repo_root.join("nested").join("sample.fa");
+
+        fs::create_dir_all(absolute_path.parent().unwrap()).unwrap();
+        fs::write(&absolute_path, b"sample").unwrap();
+
+        let checksum = calculate_file_checksum(&absolute_path).unwrap();
+        let storage_path = OperationFile::storage_file_path(
+            context.workspace(),
+            &absolute_path.to_string_lossy(),
+            &checksum,
+            FileTypes::Fasta,
+        )
+        .unwrap();
+
+        assert_eq!(storage_path, "nested/sample.fa");
     }
 
     #[test]

--- a/gen-models/src/operations.rs
+++ b/gen-models/src/operations.rs
@@ -157,17 +157,24 @@ impl Operation {
     }
 
     pub fn add_file(
+        workspace: &Workspace,
         conn: &OperationsConnection,
         operation_hash: &HashId,
-        file_addition_id: &HashId,
+        file_addition: &FileAddition,
         filename: &str,
         file_path: &str,
-    ) -> SQLResult<()> {
+    ) -> Result<(), FileAdditionError> {
+        let file_path = OperationFile::storage_file_path(
+            workspace,
+            file_path,
+            &file_addition.checksum,
+            file_addition.file_type,
+        )?;
         let query = "INSERT INTO operation_files (operation_hash, file_addition_id, filename, file_path) VALUES (?1, ?2, ?3, ?4)";
-        let mut stmt = conn.prepare(query).unwrap();
+        let mut stmt = conn.prepare(query)?;
         stmt.execute(params![
             operation_hash,
-            file_addition_id,
+            file_addition.id,
             filename,
             file_path
         ])?;
@@ -561,9 +568,10 @@ pub fn add_files_operation(
 
     for (file_addition, filename, file_path) in &unique_file_additions {
         Operation::add_file(
+            workspace,
             operation_conn,
             &operation.hash,
-            &file_addition.id,
+            file_addition,
             filename,
             file_path,
         )?;

--- a/gen-models/src/session_operations.rs
+++ b/gen-models/src/session_operations.rs
@@ -76,19 +76,13 @@ pub fn end_operation(
                     Ok(fa) => fa,
                     Err(err) => return Err(OperationError::SQLError(format!("{err}"))),
                 };
-                let storage_file_path = crate::operations::OperationFile::storage_file_path(
-                    context.workspace(),
-                    &op_file.file_path,
-                    &fa.checksum,
-                    op_file.file_type,
-                )
-                .map_err(|err| OperationError::SQLError(format!("{err}")))?;
                 Operation::add_file(
+                    context.workspace(),
                     operation_conn,
                     &operation.hash,
-                    &fa.id,
+                    &fa,
                     &op_file.filename,
-                    &storage_file_path,
+                    &op_file.file_path,
                 )
                 .map_err(|err| OperationError::SQLError(format!("{err}")))?;
                 if fa.file_type != FileTypes::Changeset && fa.file_type != FileTypes::None {

--- a/gen-models/src/session_operations.rs
+++ b/gen-models/src/session_operations.rs
@@ -76,12 +76,19 @@ pub fn end_operation(
                     Ok(fa) => fa,
                     Err(err) => return Err(OperationError::SQLError(format!("{err}"))),
                 };
+                let storage_file_path = crate::operations::OperationFile::storage_file_path(
+                    context.workspace(),
+                    &op_file.file_path,
+                    &fa.checksum,
+                    op_file.file_type,
+                )
+                .map_err(|err| OperationError::SQLError(format!("{err}")))?;
                 Operation::add_file(
                     operation_conn,
                     &operation.hash,
                     &fa.id,
                     &op_file.filename,
-                    &op_file.file_path,
+                    &storage_file_path,
                 )
                 .map_err(|err| OperationError::SQLError(format!("{err}")))?;
                 if fa.file_type != FileTypes::Changeset && fa.file_type != FileTypes::None {
@@ -332,11 +339,18 @@ impl<'a> Capnp<'a> for DependencyModels {
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
+
     use capnp::message::TypedBuilder;
     use gen_core::Strand;
 
     use super::*;
-    use crate::sequence::NewSequence;
+    use crate::{
+        files::GenDatabase,
+        operations::{Branch, OperationFile, OperationInfo, OperationState},
+        sequence::NewSequence,
+        test_helpers::{create_bg, setup_gen},
+    };
 
     #[test]
     fn test_dependency_models_capnp_serialization() {
@@ -408,5 +422,52 @@ mod tests {
         let deserialized = DependencyModels::read_capnp(root.into_reader());
 
         assert_eq!(dependency_models, deserialized);
+    }
+
+    #[test]
+    fn test_end_operation_stores_repo_relative_file_path_for_absolute_input() {
+        let context = setup_gen();
+        let graph_conn = context.graph().conn();
+        let operation_conn = context.operations().conn();
+
+        let db_uuid = metadata::get_db_uuid(graph_conn);
+        GenDatabase::create(operation_conn, &db_uuid, "default", "default.db").unwrap();
+        Branch::get_or_create(operation_conn, "main").unwrap();
+        OperationState::set_branch(operation_conn, "main");
+
+        let absolute_path = context
+            .workspace()
+            .repo_root()
+            .unwrap()
+            .join("nested/input.fa");
+        fs::create_dir_all(absolute_path.parent().unwrap()).unwrap();
+        fs::write(&absolute_path, b"test file content").unwrap();
+
+        let mut session = start_operation(graph_conn);
+        create_bg(graph_conn, "collection", "sample", "bg");
+
+        let operation = end_operation(
+            &context,
+            &mut session,
+            &OperationInfo {
+                files: vec![
+                    OperationFile::new(absolute_path.to_string_lossy().to_string())
+                        .set_file_type(FileTypes::Fasta),
+                ],
+                description: "test".to_string(),
+            },
+            "test operation",
+            None,
+        )
+        .unwrap();
+
+        let files = crate::operations::OperationFile::get_files_for_operation(
+            operation_conn,
+            &operation.hash,
+        )
+        .unwrap();
+
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].file_path, "nested/input.fa");
     }
 }

--- a/gen-models/src/session_operations.rs
+++ b/gen-models/src/session_operations.rs
@@ -347,7 +347,7 @@ mod tests {
     use super::*;
     use crate::{
         files::GenDatabase,
-        operations::{Branch, OperationFile, OperationInfo, OperationState},
+        operations::{OperationFile, OperationInfo},
         sequence::NewSequence,
         test_helpers::{create_bg, setup_gen},
     };
@@ -432,8 +432,6 @@ mod tests {
 
         let db_uuid = metadata::get_db_uuid(graph_conn);
         GenDatabase::create(operation_conn, &db_uuid, "default", "default.db").unwrap();
-        Branch::get_or_create(operation_conn, "main").unwrap();
-        OperationState::set_branch(operation_conn, "main");
 
         let absolute_path = context
             .workspace()

--- a/src/operation_management.rs
+++ b/src/operation_management.rs
@@ -681,9 +681,10 @@ fn apply_operations_to_remote(
                         None,
                     )?;
                     Operation::add_file(
+                        remote_workspace,
                         remote_op_conn,
                         &operation.hash,
-                        &remote_file_addition.id,
+                        &remote_file_addition,
                         &file_addition.filename,
                         &file_addition.file_path,
                     )?;
@@ -1139,9 +1140,10 @@ fn ingest_manifest_operation(
                     None,
                 )?;
                 Operation::add_file(
+                    workspace,
                     operation_conn,
                     &operation.hash,
-                    &local_file_addition.id,
+                    &local_file_addition,
                     &file_addition.filename,
                     &file_addition.file_path,
                 )?;


### PR DESCRIPTION
end_operation wasn't normalizing file paths. I updated add_file to enforce relative paths there so there's fewer places where paths we don't want sneak in.