### PR TITLE
refactor(python): clean up Node API surface

### DIFF
--- a/examples/human_variation_aware_alignment/Analysis.ipynb
+++ b/examples/human_variation_aware_alignment/Analysis.ipynb
@@ -1,1 +1,170 @@
-{"cells": [{"cell_type": "markdown", "metadata": {}, "source": ["# Human Variation-Aware Alignment \u2014 Python Walkthrough\n", "\n", "This notebook demonstrates the gen side of the variation-aware alignment workflow\n", "using small synthetic data so it runs without downloading the human reference genome.\n", "\n", "The full workflow (hg38 + GIAB data + vg alignment) is documented in `Analysis.md`.\n", "The gen steps are identical; only the scale of the input data differs."]}, {"cell_type": "code", "execution_count": null, "metadata": {"tags": ["skip-execution"]}, "outputs": [], "source": ["import os\n", "import tempfile\n", "\n", "import gen\n", "\n", "tmpdir = tempfile.mkdtemp()\n", "repo = gen.Repository(os.path.join(tmpdir, \"gen\"))"]}, {"cell_type": "markdown", "metadata": {}, "source": ["## Import a reference sequence\n", "\n", "In the full workflow this is a chromosome from hg38 (hundreds of MB).\n", "Here we use a short synthetic sequence to keep the notebook self-contained."]}, {"cell_type": "code", "execution_count": null, "metadata": {"tags": ["skip-execution"]}, "outputs": [], "source": "reference = (\n    \"ACGTACGTACGTACGTACGT\"\n    \"TTTTGGGGCCCCAAAATTTT\"\n    \"GCGCGCGCATATATATATAT\"\n    \"AAACCCGGGTTTAGCTAGCT\"\n)\n\nfasta_path = os.path.join(tmpdir, \"chr1_region.fa\")\nwith open(fasta_path, \"w\") as f:\n    f.write(f\">chr1\\n{reference}\\n\")\n\nresult = repo.import_reference_fasta(fasta_path, \"hg38\")\nprint(result)"}, {"cell_type": "markdown", "metadata": {}, "source": ["## Encode known variants into the graph\n", "\n", "In the full workflow we apply the GIAB benchmark VCF (~120 MB compressed).\n", "Here we encode two representative variants: a SNP and a small deletion."]}, {"cell_type": "code", "execution_count": null, "metadata": {"tags": ["skip-execution"]}, "outputs": [], "source": "vcf_path = os.path.join(tmpdir, \"known_variants.vcf\")\nwith open(vcf_path, \"w\") as f:\n    f.write(\n        \"##fileformat=VCFv4.1\\n\"\n        \"##contig=<ID=chr1,length=80>\\n\"\n        \"##FORMAT=<ID=GT,Number=1,Type=String,Description=\\\"Genotype\\\">\\n\"\n        \"#CHROM\\tPOS\\tID\\tREF\\tALT\\tQUAL\\tFILTER\\tINFO\\tFORMAT\\tNA12878\\n\"\n        \"chr1\\t5\\t.\\tC\\tT\\t50\\tPASS\\t.\\tGT\\t0/1\\n\"\n        \"chr1\\t25\\t.\\tGGG\\tG\\t50\\tPASS\\t.\\tGT\\t1/1\\n\"\n    )\n\nresult = repo.update_with_vcf(\n    vcf_path,\n    sample=\"NA12878\",\n    reference=\"hg38\",\n)\nprint(result)"}, {"cell_type": "markdown", "metadata": {}, "source": ["## Inspect the variant graph"]}, {"cell_type": "code", "execution_count": null, "metadata": {"tags": ["skip-execution"]}, "outputs": [], "source": ["bgs = repo.get_block_groups()\n", "print(f\"{len(bgs)} block group(s):\")\n", "for bg in bgs:\n", "    print(f\"  name={bg.name!r}  sample={bg.sample_name!r}\")"]}, {"cell_type": "markdown", "metadata": {}, "source": ["## Export to GFA for graph alignment\n", "\n", "In the full workflow the GFA is fed into `vg` for indexing and read alignment.\n", "The GFA encodes the full variant graph including all alternate paths.\n", "\n", "```sh\n", "# Full workflow continues with:\n", "# vg mod -X 32 graph.gfa > graph.mod.gfa\n", "# vg autoindex -p index -w map -g graph.mod.gfa\n", "# vg map -x index.xg -g index.gcsa -f R1.fq.gz -f R2.fq.gz > align.gam\n", "# vg pack -e -x index.xg -g align.sorted.gam -o aln.pack\n", "# vg call index.xg -k aln.pack > variants.vcf\n", "```"]}, {"cell_type": "code", "execution_count": null, "metadata": {"tags": ["skip-execution"]}, "outputs": [], "source": "gfa_path = os.path.join(tmpdir, \"graph.gfa\")\nrepo.export_gfa(gfa_path)\n\nwith open(gfa_path) as f:\n    lines = f.readlines()\n\nsegments = sum(1 for l in lines if l.startswith(\"S\"))\nlinks = sum(1 for l in lines if l.startswith(\"L\"))\nprint(f\"GFA: {segments} segments, {links} links\")"}, {"cell_type": "markdown", "metadata": {}, "source": ["## Search for sequence motifs across samples"]}, {"cell_type": "code", "execution_count": null, "metadata": {"tags": ["skip-execution"]}, "outputs": [], "source": ["query = \"ACGTACGT\"\n", "results = repo.search(query)\n", "\n", "print(f\"Matches for {query!r}:\")\n", "for bg, loci in results:\n", "    if loci:\n", "        print(f\"  sample={bg.sample_name!r}: {len(loci)} match(es)\")"]}], "metadata": {"kernelspec": {"display_name": "Python 3", "language": "python", "name": "python3"}, "language_info": {"name": "python", "version": "3.12.0"}}, "nbformat": 4, "nbformat_minor": 5}
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Human Variation-Aware Alignment \u2014 Python Walkthrough\n",
+    "\n",
+    "This notebook demonstrates the gen side of the variation-aware alignment workflow\n",
+    "using small synthetic data so it runs without downloading the human reference genome.\n",
+    "\n",
+    "The full workflow (hg38 + GIAB data + vg alignment) is documented in `Analysis.md`.\n",
+    "The gen steps are identical; only the scale of the input data differs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "skip-execution"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import tempfile\n",
+    "\n",
+    "import gen\n",
+    "\n",
+    "tmpdir = tempfile.mkdtemp()\n",
+    "repo = gen.Repository(os.path.join(tmpdir, \"gen\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Import a reference sequence\n",
+    "\n",
+    "In the full workflow this is a chromosome from hg38 (hundreds of MB).\n",
+    "Here we use a short synthetic sequence to keep the notebook self-contained."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "skip-execution"
+    ]
+   },
+   "outputs": [],
+   "source": "reference = (\n    \"ACGTACGTACGTACGTACGT\"\n    \"TTTTGGGGCCCCAAAATTTT\"\n    \"GCGCGCGCATATATATATAT\"\n    \"AAACCCGGGTTTAGCTAGCT\"\n)\n\nfasta_path = os.path.join(tmpdir, \"chr1_region.fa\")\nwith open(fasta_path, \"w\") as f:\n    f.write(f\">chr1\\n{reference}\\n\")\n\nresult = repo.import_reference_fasta(fasta_path, \"hg38\")\nprint(result)"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Encode known variants into the graph\n",
+    "\n",
+    "In the full workflow we apply the GIAB benchmark VCF (~120 MB compressed).\n",
+    "Here we encode two representative variants: a SNP and a small deletion."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "skip-execution"
+    ]
+   },
+   "outputs": [],
+   "source": "vcf_path = os.path.join(tmpdir, \"known_variants.vcf\")\nwith open(vcf_path, \"w\") as f:\n    f.write(\n        \"##fileformat=VCFv4.1\\n\"\n        \"##contig=<ID=chr1,length=80>\\n\"\n        \"##FORMAT=<ID=GT,Number=1,Type=String,Description=\\\"Genotype\\\">\\n\"\n        \"#CHROM\\tPOS\\tID\\tREF\\tALT\\tQUAL\\tFILTER\\tINFO\\tFORMAT\\tNA12878\\n\"\n        \"chr1\\t5\\t.\\tC\\tT\\t50\\tPASS\\t.\\tGT\\t0/1\\n\"\n        \"chr1\\t25\\t.\\tGGG\\tG\\t50\\tPASS\\t.\\tGT\\t1/1\\n\"\n    )\n\nresult = repo.update_with_vcf(\n    vcf_path,\n    sample=\"NA12878\",\n    reference=\"hg38\",\n)\nprint(result)"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Inspect the variant graph"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "skip-execution"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "sgs = repo.get_sequence_graphs()\n",
+    "print(f\"{len(sgs)} sequence graph(s):\")\n",
+    "for sg in sgs:\n",
+    "    print(f\"  name={sg.name!r}  sample={sg.sample_name!r}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Export to GFA for graph alignment\n",
+    "\n",
+    "In the full workflow the GFA is fed into `vg` for indexing and read alignment.\n",
+    "The GFA encodes the full variant graph including all alternate paths.\n",
+    "\n",
+    "```sh\n",
+    "# Full workflow continues with:\n",
+    "# vg mod -X 32 graph.gfa > graph.mod.gfa\n",
+    "# vg autoindex -p index -w map -g graph.mod.gfa\n",
+    "# vg map -x index.xg -g index.gcsa -f R1.fq.gz -f R2.fq.gz > align.gam\n",
+    "# vg pack -e -x index.xg -g align.sorted.gam -o aln.pack\n",
+    "# vg call index.xg -k aln.pack > variants.vcf\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "skip-execution"
+    ]
+   },
+   "outputs": [],
+   "source": "gfa_path = os.path.join(tmpdir, \"graph.gfa\")\nrepo.export_gfa(gfa_path)\n\nwith open(gfa_path) as f:\n    lines = f.readlines()\n\nsegments = sum(1 for l in lines if l.startswith(\"S\"))\nlinks = sum(1 for l in lines if l.startswith(\"L\"))\nprint(f\"GFA: {segments} segments, {links} links\")"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Search for sequence motifs across samples"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "skip-execution"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "query = \"ACGTACGT\"\n",
+    "results = repo.search(query)\n",
+    "\n",
+    "print(f\"Matches for {query!r}:\")\n",
+    "for sg, loci in results:\n",
+    "    if loci:\n",
+    "        print(f\"  sample={sg.sample_name!r}: {len(loci)} match(es)\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/misc_commands/list-and-show.ipynb
+++ b/examples/misc_commands/list-and-show.ipynb
@@ -1,1 +1,113 @@
-{"cells": [{"cell_type": "markdown", "metadata": {}, "source": ["# List and Show\n", "\n", "Demonstrating how to list samples and graphs and retrieve sequences using the Python API.\n", "See `list-and-show.md` for the equivalent CLI workflow."]}, {"cell_type": "code", "execution_count": null, "metadata": {}, "outputs": [], "source": ["import os\n", "import tempfile\n", "\n", "import gen\n", "\n", "tmpdir = tempfile.mkdtemp()\n", "repo = gen.Repository(os.path.join(tmpdir, \"gen\"))"]}, {"cell_type": "code", "execution_count": null, "metadata": {}, "outputs": [], "source": "fasta_path = os.path.join(tmpdir, \"simple.fa\")\nwith open(fasta_path, \"w\") as f:\n    f.write(\">m123\\nATCGATCGATCGATCGATCGGGAACACACAGAGA\\n\")\n\nvcf_path = os.path.join(tmpdir, \"simple.vcf\")\nwith open(vcf_path, \"w\") as f:\n    f.write(\n        \"##fileformat=VCFv4.1\\n\"\n        \"##contig=<ID=m123,length=34>\\n\"\n        '##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">\\n'\n        \"#CHROM\\tPOS\\tID\\tREF\\tALT\\tQUAL\\tFILTER\\tINFO\\tFORMAT\\tunknown\\tG1\\tfoo\\n\"\n        \"m123\\t3\\t.\\tCG\\tC\\t.\\t.\\t.\\tGT\\t1/1\\t1/1\\t1/1\\n\"\n        \"m123\\t10\\t.\\tT\\tTAGA\\t.\\t.\\t.\\tGT\\t1/1\\t0/0\\t0/0\\n\"\n    )\n\nrepo.import_reference_fasta(fasta_path, \"reference\")\n# Apply the full VCF at once \u2014 all samples processed together\nrepo.update_with_vcf(vcf_path, reference=\"reference\")\nprint(\"Import and update complete.\")\n"}, {"cell_type": "markdown", "metadata": {}, "source": ["## List samples\n", "\n", "Equivalent to `gen list-samples`. No dedicated Python method exists;\n", "derive the sample list from `get_block_groups()`."]}, {"cell_type": "code", "execution_count": null, "metadata": {}, "outputs": [], "source": ["bgs = repo.get_block_groups()\n", "samples = sorted(set(bg.sample_name for bg in bgs))\n", "print(\"Samples:\")\n", "for s in samples:\n", "    print(f\"  {s}\")"]}, {"cell_type": "markdown", "metadata": {}, "source": ["## List graphs for a sample\n", "\n", "Equivalent to `gen list-graphs --sample foo`. No dedicated Python method exists;\n", "filter `get_block_groups()` by sample name."]}, {"cell_type": "code", "execution_count": null, "metadata": {}, "outputs": [], "source": ["foo_graphs = [bg.name for bg in bgs if bg.sample_name == \"foo\"]\n", "print(\"Graphs for sample 'foo':\")\n", "for g in foo_graphs:\n", "    print(f\"  {g}\")"]}, {"cell_type": "markdown", "metadata": {}, "source": ["## Get a sequence\n", "\n", "Equivalent to `gen get-sequence --sample foo --graph m123`.\n", "\n", "`get-sequence` and its `--start`/`--end` variant have no direct Python API equivalent yet.\n", "The closest approach is to export to FASTA and read it back."]}, {"cell_type": "code", "execution_count": null, "metadata": {}, "outputs": [], "source": "fasta_out = os.path.join(tmpdir, \"foo.fa\")\nrepo.export_fasta(fasta_out, sample=\"foo\")\n\nwith open(fasta_out) as f:\n    print(f.read())"}], "metadata": {"kernelspec": {"display_name": "Python 3", "language": "python", "name": "python3"}, "language_info": {"name": "python", "version": "3.12.0"}}, "nbformat": 4, "nbformat_minor": 5}
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# List and Show\n",
+    "\n",
+    "Demonstrating how to list samples and graphs and retrieve sequences using the Python API.\n",
+    "See `list-and-show.md` for the equivalent CLI workflow."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import tempfile\n",
+    "\n",
+    "import gen\n",
+    "\n",
+    "tmpdir = tempfile.mkdtemp()\n",
+    "repo = gen.Repository(os.path.join(tmpdir, \"gen\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "fasta_path = os.path.join(tmpdir, \"simple.fa\")\nwith open(fasta_path, \"w\") as f:\n    f.write(\">m123\\nATCGATCGATCGATCGATCGGGAACACACAGAGA\\n\")\n\nvcf_path = os.path.join(tmpdir, \"simple.vcf\")\nwith open(vcf_path, \"w\") as f:\n    f.write(\n        \"##fileformat=VCFv4.1\\n\"\n        \"##contig=<ID=m123,length=34>\\n\"\n        '##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">\\n'\n        \"#CHROM\\tPOS\\tID\\tREF\\tALT\\tQUAL\\tFILTER\\tINFO\\tFORMAT\\tunknown\\tG1\\tfoo\\n\"\n        \"m123\\t3\\t.\\tCG\\tC\\t.\\t.\\t.\\tGT\\t1/1\\t1/1\\t1/1\\n\"\n        \"m123\\t10\\t.\\tT\\tTAGA\\t.\\t.\\t.\\tGT\\t1/1\\t0/0\\t0/0\\n\"\n    )\n\nrepo.import_reference_fasta(fasta_path, \"reference\")\n# Apply the full VCF at once \u2014 all samples processed together\nrepo.update_with_vcf(vcf_path, reference=\"reference\")\nprint(\"Import and update complete.\")\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## List samples\n",
+    "\n",
+    "Equivalent to `gen list-samples`. No dedicated Python method exists;\n",
+    "derive the sample list from `get_sequence_graphs()`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sgs = repo.get_sequence_graphs()\n",
+    "samples = sorted(set(sg.sample_name for sg in sgs))\n",
+    "print(\"Samples:\")\n",
+    "for s in samples:\n",
+    "    print(f\"  {s}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## List graphs for a sample\n",
+    "\n",
+    "Equivalent to `gen list-graphs --sample foo`. No dedicated Python method exists;\n",
+    "filter `get_sequence_graphs()` by sample name."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "foo_graphs = [sg.name for sg in sgs if sg.sample_name == \"foo\"]\n",
+    "print(\"Graphs for sample 'foo':\")\n",
+    "for g in foo_graphs:\n",
+    "    print(f\"  {g}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Get a sequence\n",
+    "\n",
+    "Equivalent to `gen get-sequence --sample foo --graph m123`.\n",
+    "\n",
+    "`get-sequence` and its `--start`/`--end` variant have no direct Python API equivalent yet.\n",
+    "The closest approach is to export to FASTA and read it back."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "fasta_out = os.path.join(tmpdir, \"foo.fa\")\nrepo.export_fasta(fasta_out, sample=\"foo\")\n\nwith open(fasta_out) as f:\n    print(f.read())"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gen-python/examples/annotations.ipynb
+++ b/gen-python/examples/annotations.ipynb
@@ -36,31 +36,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "import-genbank",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Block group: sequence-222046-\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Adjust this path if running from outside the project root.\n",
-    "FIXTURE = os.path.abspath(\"../../fixtures/puc19.gb\")\n",
-    "\n",
-    "tmp = tempfile.mkdtemp()\n",
-    "repo = gen.Repository(os.path.join(tmp, \".gen\"))\n",
-    "repo.import_genbank(FIXTURE)\n",
-    "\n",
-    "bg = repo.get_block_groups()[0]\n",
-    "print(\"Block group:\", bg.name)\n",
-    "\n",
-    "fig = bg.plot(rows=24)"
-   ]
+   "outputs": [],
+   "source": "# Adjust this path if running from outside the project root.\nFIXTURE = os.path.abspath(\"../../fixtures/puc19.gb\")\n\ntmp = tempfile.mkdtemp()\nrepo = gen.Repository(os.path.join(tmp, \".gen\"))\nrepo.import_genbank(FIXTURE)\n\nbg = repo.get_sequence_graphs()[0]\nprint(\"Sequence graph:\", bg.name)\n\nfig = bg.plot(rows=24)"
   },
   {
    "cell_type": "markdown",

--- a/gen-python/examples/demo_notebook.ipynb
+++ b/gen-python/examples/demo_notebook.ipynb
@@ -48,19 +48,14 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "The repository can be queried through methods like get_block_groups() (recommended), or direct database access."
-   ]
+   "source": "The repository can be queried through methods like get_sequence_graphs() (recommended), or direct database access."
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "bgs = repo.get_block_groups()\n",
-    "print(f\"Number of block groups: {len(bgs)}\")"
-   ]
+   "source": "bgs = repo.get_sequence_graphs()\nprint(f\"Number of sequence graphs: {len(bgs)}\")"
   },
   {
    "cell_type": "code",
@@ -75,28 +70,14 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## Working with Graphs\n",
-    "\n",
-    "Gen organizes genomic data in sequence graphs. Let's explore how to access and work with graphs. Internally, these are called block_groups. (Method names will be updated to refer to 'sequence graphs' in a future release)\n",
-    "\n",
-    "### Interactive graph widget\n",
-    "\n",
-    "`display(block_group)` renders a navigable terminal-style graph viewer directly in the notebook, use the mouse to navigate.\n",
-    "You can also control the widget programatically for more control."
-   ]
+   "source": "## Working with Graphs\n\nGen organizes genomic data in sequence graphs. Let's explore how to access and work with graphs.\n\n### Interactive graph widget\n\n`display(sequence_graph)` renders a navigable terminal-style graph viewer directly in the notebook, use the mouse to navigate.\nYou can also control the widget programatically for more control."
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "bgs = repo.get_block_groups()\n",
-    "bg = bgs[0]\n",
-    "\n",
-    "bg"
-   ]
+   "source": "bgs = repo.get_sequence_graphs()\nbg = bgs[0]\n\nbg"
   },
   {
    "cell_type": "markdown",
@@ -140,7 +121,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "dict_repr = bg.to_dict()\nprint(\n    \"Edges are keyed by pairs of node tuples (node_id, start, end):\"\n)\ndisplay(dict_repr[\"edges\"])\n\n\nprint(\"Node identifiers are also stored as node attributes:\")\ndisplay(dict_repr[\"nodes\"])"
+   "source": "dict_repr = bg.to_dict()\nprint(\"Edges are keyed by (Node, Node) tuples:\")\ndisplay(dict_repr[\"edges\"])\nprint(\"Nodes:\")\ndisplay(dict_repr[\"nodes\"])"
   },
   {
    "cell_type": "markdown",

--- a/gen-python/examples/introduction.ipynb
+++ b/gen-python/examples/introduction.ipynb
@@ -4,21 +4,7 @@
    "cell_type": "markdown",
    "id": "00-intro",
    "metadata": {},
-   "source": [
-    "# Introduction to gen: design, track, and discover\n",
-    "\n",
-    "Gen is a sequence version control system built around a graph database.\n",
-    "Rather than storing sequences as flat strings, Gen stores them as a\n",
-    "sequence graph where every sample is a named path through that graph.\n",
-    "Edits branch the graph rather than overwriting it, so every version of a\n",
-    "sequence coexists in the same database and their differences are always\n",
-    "queryable.\n",
-    "\n",
-    "This notebook walks through a concrete lab scenario that shows where\n",
-    "that design pays off: you design an edit, apply it, confirm it with\n",
-    "search, export for sequencing — and then discover an unintended mutation\n",
-    "in the result."
-   ]
+   "source": "# Introduction to gen: design, track, and discover\n\nGen is a sequence version control system built around a graph database.\nRather than storing a sequence as a flat string, Gen breaks it into\nnodes, each holding a short subsequence, connected by edges into a\ngraph. A path through that graph reconstructs a full sequence. When a\nchange is recorded, Gen adds new nodes and edges to represent the\naltered subsequence and the new junctions around it. A path can then\ntake an alternative route through the new nodes, or skip nodes entirely\nin the case of a deletion. Changes can be naturally occurring or\ndeliberately engineered. What makes this especially powerful is that the\ngraph does not just capture changes over time: it can represent the full\nset of expected or observed variants across haplotypes, design libraries,\nor a pangenome, all coexisting in one database with their differences\nalways queryable.\n\nThis notebook walks through a concrete lab scenario that shows where\nthat design pays off: you design an edit, apply it, confirm it with\nsearch, export for sequencing, and then discover an unintended mutation\nin the result."
   },
   {
    "cell_type": "markdown",
@@ -42,9 +28,8 @@
     "\n",
     "import gen\n",
     "\n",
-    "# Locate fixture files bundled with the repo\n",
-    "REPO_ROOT = pathlib.Path(gen.__file__).parents[3]\n",
-    "FX = REPO_ROOT / \"fixtures\"\n",
+    "# Locate fixture files bundled with this examples directory\n",
+    "EXAMPLES_DIR = pathlib.Path(__file__).parent if \"__file__\" in dir() else pathlib.Path(\".\").resolve()\n",
     "\n",
     "# Create a fresh workspace directory and open a repository handle\n",
     "WORK_DIR = pathlib.Path(tempfile.mkdtemp(prefix=\"gen-puc19-\"))\n",
@@ -81,7 +66,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gbk_path = FX / \"puc19.gb\"\n",
+    "gbk_path = EXAMPLES_DIR / \"puc19.gbk\"\n",
     "repo.import_genbank(str(gbk_path), sample=\"wt\")"
    ]
   },
@@ -114,7 +99,7 @@
     "\n",
     "Calling `.plot()` on a sequence graph returns an interactive widget that\n",
     "renders directly in the notebook.  You can pan and zoom with the mouse.\n",
-    "The widget can also be controlled programmatically — useful for\n",
+    "The widget can also be controlled programmatically \u2014 useful for\n",
     "reproducible navigation in a shared notebook."
    ]
   },
@@ -124,13 +109,27 @@
    "id": "09-plot-wt",
    "metadata": {},
    "outputs": [],
-   "source": "w_wt = bg_wt.plot()\n\n# Navigate to the MCS — annotated features are first-class, so you can\n# jump directly to any named feature rather than specifying coordinates.\nannotations = w_wt.list_annotations()\nmcs = [\n    a for a in annotations\n    if any(k in a.name.lower() for k in [\"mcs\", \"misc_feature\", \"multiple cloning\"])\n]\nif mcs:\n    w_wt.go_to(mcs[0])\n\nw_wt"
+   "source": [
+    "w_wt = bg_wt.plot()\n",
+    "\n",
+    "# Navigate to the MCS \u2014 annotated features are first-class, so you can\n",
+    "# jump directly to any named feature rather than specifying coordinates.\n",
+    "annotations = w_wt.list_annotations()\n",
+    "mcs = [\n",
+    "    a for a in annotations\n",
+    "    if any(k in a.name.lower() for k in [\"mcs\", \"misc_feature\", \"multiple cloning\"])\n",
+    "]\n",
+    "if mcs:\n",
+    "    w_wt.go_to(mcs[0])\n",
+    "\n",
+    "w_wt"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "10-plot-note",
    "metadata": {},
-   "source": "The widget renders a live snapshot of the sequence graph.  Annotations\nfrom the GenBank file (lacZα, bla, the MCS) appear as coloured tracks\nbelow the sequence.  `list_annotations()` returns all named features in\nthe database; passing one to `go_to()` centres the viewport on that\nfeature — no coordinate look-up required.\n\nFor a fully interactive, pannable, zoomable view from the command line,\nrun `gen view` in the same workspace."
+   "source": "The widget renders a live snapshot of the sequence graph.  Annotations\nfrom the GenBank file (lacZ\u03b1, bla, the MCS) appear as coloured tracks\nbelow the sequence.  `list_annotations()` returns all named features in\nthe database; passing one to `go_to()` centres the viewport on that\nfeature \u2014 no coordinate look-up required.\n\nFor a fully interactive, pannable, zoomable view from the command line,\nrun `gen view` in the same workspace."
   },
   {
    "cell_type": "markdown",
@@ -139,9 +138,9 @@
    "source": [
     "## Design a Golden Gate conversion\n",
     "\n",
-    "The pUC19 multiple cloning site (MCS, positions 396–452) contains a set\n",
+    "The pUC19 multiple cloning site (MCS, positions 396\u2013452) contains a set\n",
     "of traditional type-II restriction sites.  We want to replace it with a\n",
-    "minimal Golden Gate entry site — two BsaI recognition sequences (GGTCTC)\n",
+    "minimal Golden Gate entry site \u2014 two BsaI recognition sequences (GGTCTC)\n",
     "flanking a stuffer, oriented to cut inward and expose compatible 4-nt\n",
     "overhangs for assembly.\n",
     "\n",
@@ -151,7 +150,7 @@
     "#   EcoRI SacI  KpnI  SmaI  BamHI XbaI    SalI   PstI SphI HindIII\n",
     "#\n",
     "# Replacement: two BsaI sites flanking a stuffer, retaining EcoRI/HindIII ends.\n",
-    "#   GAATTC [BsaI→ GGTCTCA] [AATG overhang] [stuffer] [GCAT overhang] [←BsaI TGAGACC] AAGCTT\n",
+    "#   GAATTC [BsaI\u2192 GGTCTCA] [AATG overhang] [stuffer] [GCAT overhang] [\u2190BsaI TGAGACC] AAGCTT\n",
     "```"
    ]
   },
@@ -225,7 +224,7 @@
     "# GGTCTC is the BsaI recognition sequence (cuts 1 nt downstream on sense strand).\n",
     "# DNA-mode search finds both the forward site and its reverse-complement counterpart.\n",
     "hits = repo.search(\"GGTCTC\", bgs=[bg_gg], sequence_kind=\"dna\")\n",
-    "loci = hits[0][1]  # [(SequenceGraph, [Locus]), ...] — take the loci from the first match\n",
+    "loci = hits[0][1]  # [(SequenceGraph, [Locus]), ...] \u2014 take the loci from the first match\n",
     "print(f\"BsaI sites found: {len(loci)}\")"
    ]
   },
@@ -235,7 +234,11 @@
    "id": "18-plot-gg",
    "metadata": {},
    "outputs": [],
-   "source": "w_gg = bg_gg.plot()\nw_gg.go_to(loci[0])\nw_gg"
+   "source": [
+    "w_gg = bg_gg.plot()\n",
+    "w_gg.go_to(loci[0])\n",
+    "w_gg"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -267,9 +270,9 @@
    "id": "21-wt-search-note",
    "metadata": {},
    "source": [
-    "The wild-type already carries one BsaI site — on the reverse strand at\n",
+    "The wild-type already carries one BsaI site \u2014 on the reverse strand at\n",
     "position 1765, inside the **bla** coding sequence.  The design added\n",
-    "exactly two new sites (3 − 1 = 2), so the flanking Golden Gate sites are\n",
+    "exactly two new sites (3 \u2212 1 = 2), so the flanking Golden Gate sites are\n",
     "present and correctly oriented.  The pre-existing site is the problem: if\n",
     "left in place it will be cut alongside the intended assembly sites,\n",
     "fragmenting the AmpR cassette.  It needs to be silently mutated out\n",
@@ -279,7 +282,7 @@
     "query by recognition sequence directly without pre-computing all\n",
     "variants.  For example, EcoRI's sequence `GAATTC` is unambiguous, but a\n",
     "site like HincII (`GTYRAC`, where Y = C/T and R = A/G) expands to four\n",
-    "possible hexamers — pass the IUPAC string and `search()` matches all of\n",
+    "possible hexamers \u2014 pass the IUPAC string and `search()` matches all of\n",
     "them:"
    ]
   },
@@ -309,7 +312,23 @@
    "cell_type": "markdown",
    "id": "24-highlight-header",
    "metadata": {},
-   "source": "### Navigate and highlight search results\n\nEach element of the list returned by `search()` is a `Locus` with\n`.start()` / `.end()` (`Position` objects) and `.slices`.  Pass a locus\ndirectly to `go_to()` to centre the viewport on it, and to\n`highlight_match()` to colour it on the canvas.\n\n`go_to()` accepts `Position`, `Locus`, and `Annotation` objects — the\nsame call works for search results and annotation records.  Annotations\nfrom one sample can be used to navigate a widget for a different sample\n— this is safe and stable because annotations are stored as references\nto graph nodes, not as linear sequence coordinates.  Nodes are shared\nacross samples in the same repository, so an annotation created for the\n`\"wt\"` sample points to exactly the same graph nodes that appear in the\n`\"gg_design\"` or `\"sequenced\"` graphs."
+   "source": [
+    "### Navigate and highlight search results\n",
+    "\n",
+    "Each element of the list returned by `search()` is a `Locus` with\n",
+    "`.start()` / `.end()` (`Position` objects) and `.slices`.  Pass a locus\n",
+    "directly to `go_to()` to centre the viewport on it, and to\n",
+    "`highlight_match()` to colour it on the canvas.\n",
+    "\n",
+    "`go_to()` accepts `Position`, `Locus`, and `Annotation` objects \u2014 the\n",
+    "same call works for search results and annotation records.  Annotations\n",
+    "from one sample can be used to navigate a widget for a different sample\n",
+    "\u2014 this is safe and stable because annotations are stored as references\n",
+    "to graph nodes, not as linear sequence coordinates.  Nodes are shared\n",
+    "across samples in the same repository, so an annotation created for the\n",
+    "`\"wt\"` sample points to exactly the same graph nodes that appear in the\n",
+    "`\"gg_design\"` or `\"sequenced\"` graphs."
+   ]
   },
   {
    "cell_type": "code",
@@ -317,7 +336,13 @@
    "id": "25-highlight-bsai",
    "metadata": {},
    "outputs": [],
-   "source": "# Jump to the first BsaI site and highlight both sites.\nw_gg.go_to(loci[0])\nw_gg.highlight_match(loci[0], color=\"cyan\")\nw_gg.highlight_match(loci[1], color=\"cyan\")\nw_gg"
+   "source": [
+    "# Jump to the first BsaI site and highlight both sites.\n",
+    "w_gg.go_to(loci[0])\n",
+    "w_gg.highlight_match(loci[0], color=\"cyan\")\n",
+    "w_gg.highlight_match(loci[1], color=\"cyan\")\n",
+    "w_gg"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -366,7 +391,7 @@
     "You send `pUC19_gg_design.fa` to your synthesis provider.  A few days\n",
     "later sequencing results arrive as a VCF.\n",
     "\n",
-    "## Import the sequencing result — and find a surprise"
+    "## Import the sequencing result \u2014 and find a surprise"
    ]
   },
   {
@@ -376,7 +401,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "vcf_path = REPO_ROOT / \"gen-r\" / \"inst\" / \"extdata\" / \"puc19_sequenced.vcf\"\n",
+    "vcf_path = EXAMPLES_DIR / \"puc19_sequenced.vcf\"\n",
     "\n",
     "repo.update_with_vcf(\n",
     "    str(vcf_path),\n",
@@ -411,9 +436,9 @@
    "id": "34-sequenced-note",
    "metadata": {},
    "source": [
-    "The graph now shows a branch at position 1904 — outside the MCS, inside\n",
-    "the **bla** (β-lactamase / AmpR) coding sequence.  The sequencing run\n",
-    "picked up a C→T substitution that was not in the design.  Because Gen\n",
+    "The graph now shows a branch at position 1904 \u2014 outside the MCS, inside\n",
+    "the **bla** (\u03b2-lactamase / AmpR) coding sequence.  The sequencing run\n",
+    "picked up a C\u2192T substitution that was not in the design.  Because Gen\n",
     "stores every sample as a path through the same graph, the mutation shows\n",
     "up as a new node rather than a silent overwrite: the `gg_design` path\n",
     "and the `sequenced` path diverge exactly here.\n",
@@ -451,7 +476,7 @@
     "\n",
     "The Python bindings and the CLI share the same database, so you can\n",
     "design a construct in a notebook, push it from the terminal, and a\n",
-    "colleague can pull the graph and visualise it in their own session —\n",
+    "colleague can pull the graph and visualise it in their own session \u2014\n",
     "with the full annotation and variant history intact.\n",
     "\n",
     "To learn more about the CLI, run `gen --help` or visit the project\n",
@@ -642,7 +667,7 @@
     "column becomes a path through the resulting graph.\n",
     "\n",
     "The example below designs an expression cassette with three promoters,\n",
-    "three RBS variants, and two CDSes — 18 unique combinations:"
+    "three RBS variants, and two CDSes \u2014 18 unique combinations:"
    ]
   },
   {
@@ -813,7 +838,7 @@
    "cell_type": "markdown",
    "id": "62-tracks-header",
    "metadata": {},
-   "source": "### Annotation tracks\n\nAny widget can display additional annotation panels below the sequence\ngraph.  `add_annotation_track()` is the unified entry point — supply\nexactly one of `file`, `group`, or `annotations`:\n\n- `file=` loads a GFF3 or BED file; `from_sample=` translates coordinates\n  from the given sample's path space.\n- `group=` loads an annotation group stored in the repository (created\n  automatically on GenBank import).\n- `annotations=` renders a list of `Annotation` objects you built manually."
+   "source": "### Annotation tracks\n\nAny widget can display additional annotation panels below the sequence\ngraph.  `add_annotation_track()` is the unified entry point \u2014 supply\nexactly one of `file`, `group`, or `annotations`:\n\n- `file=` loads a GFF3 or BED file; `from_sample=` translates coordinates\n  from the given sample's path space.\n- `group=` loads an annotation group stored in the repository (created\n  automatically on GenBank import).\n- `annotations=` renders a list of `Annotation` objects you built manually."
   },
   {
    "cell_type": "code",

--- a/gen-python/examples/introduction.ipynb
+++ b/gen-python/examples/introduction.ipynb
@@ -1,0 +1,886 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "00-intro",
+   "metadata": {},
+   "source": [
+    "# Introduction to gen: design, track, and discover\n",
+    "\n",
+    "Gen is a sequence version control system built around a graph database.\n",
+    "Rather than storing sequences as flat strings, Gen stores them as a\n",
+    "sequence graph where every sample is a named path through that graph.\n",
+    "Edits branch the graph rather than overwriting it, so every version of a\n",
+    "sequence coexists in the same database and their differences are always\n",
+    "queryable.\n",
+    "\n",
+    "This notebook walks through a concrete lab scenario that shows where\n",
+    "that design pays off: you design an edit, apply it, confirm it with\n",
+    "search, export for sequencing — and then discover an unintended mutation\n",
+    "in the result."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "01-setup-header",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "Import the package, then initialise a workspace and open a repository handle."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "02-setup",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pathlib\n",
+    "import tempfile\n",
+    "\n",
+    "import gen\n",
+    "\n",
+    "# Locate fixture files bundled with the repo\n",
+    "REPO_ROOT = pathlib.Path(gen.__file__).parents[3]\n",
+    "FX = REPO_ROOT / \"fixtures\"\n",
+    "\n",
+    "# Create a fresh workspace directory and open a repository handle\n",
+    "WORK_DIR = pathlib.Path(tempfile.mkdtemp(prefix=\"gen-puc19-\"))\n",
+    "repo = gen.Repository(str(WORK_DIR))\n",
+    "print(f\"Repository at: {WORK_DIR}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "03-setup-note",
+   "metadata": {},
+   "source": [
+    "`Repository()` discovers the `.gen/` directory from the path argument (or the\n",
+    "current working directory when omitted) and opens the graph and operations\n",
+    "databases.  All subsequent operations go through this object."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "04-import-header",
+   "metadata": {},
+   "source": [
+    "## Import an annotated vector\n",
+    "\n",
+    "We start with a fully annotated pUC19 sequence from NEB.  The GenBank\n",
+    "format carries feature annotations (genes, promoters, the MCS) that will\n",
+    "be preserved in the graph and displayed in the viewer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "05-import",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gbk_path = FX / \"puc19.gb\"\n",
+    "repo.import_genbank(str(gbk_path), sample=\"wt\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "06-list-bgs-header",
+   "metadata": {},
+   "source": [
+    "List the sequence graphs in the repository to confirm the import:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "07-list-bgs",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bgs = repo.get_sequence_graphs()\n",
+    "bg_wt = bgs[0]\n",
+    "print(f\"Sequence graph: {bg_wt.name} | sample: {bg_wt.sample_name}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "08-plot-header",
+   "metadata": {},
+   "source": [
+    "## Visualise the reference\n",
+    "\n",
+    "Calling `.plot()` on a sequence graph returns an interactive widget that\n",
+    "renders directly in the notebook.  You can pan and zoom with the mouse.\n",
+    "The widget can also be controlled programmatically — useful for\n",
+    "reproducible navigation in a shared notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "09-plot-wt",
+   "metadata": {},
+   "outputs": [],
+   "source": "w_wt = bg_wt.plot()\n\n# Navigate to the MCS — annotated features are first-class, so you can\n# jump directly to any named feature rather than specifying coordinates.\nannotations = w_wt.list_annotations()\nmcs = [\n    a for a in annotations\n    if any(k in a.name.lower() for k in [\"mcs\", \"misc_feature\", \"multiple cloning\"])\n]\nif mcs:\n    w_wt.go_to(mcs[0])\n\nw_wt"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10-plot-note",
+   "metadata": {},
+   "source": "The widget renders a live snapshot of the sequence graph.  Annotations\nfrom the GenBank file (lacZα, bla, the MCS) appear as coloured tracks\nbelow the sequence.  `list_annotations()` returns all named features in\nthe database; passing one to `go_to()` centres the viewport on that\nfeature — no coordinate look-up required.\n\nFor a fully interactive, pannable, zoomable view from the command line,\nrun `gen view` in the same workspace."
+  },
+  {
+   "cell_type": "markdown",
+   "id": "11-design-header",
+   "metadata": {},
+   "source": [
+    "## Design a Golden Gate conversion\n",
+    "\n",
+    "The pUC19 multiple cloning site (MCS, positions 396–452) contains a set\n",
+    "of traditional type-II restriction sites.  We want to replace it with a\n",
+    "minimal Golden Gate entry site — two BsaI recognition sequences (GGTCTC)\n",
+    "flanking a stuffer, oriented to cut inward and expose compatible 4-nt\n",
+    "overhangs for assembly.\n",
+    "\n",
+    "```\n",
+    "# Original MCS (1-based 396..452):\n",
+    "#   GAATTCGAGCTCGGTACCCGGGGATCCTCTAGAGTCGACCTGCAGGCATGCAAGCTT\n",
+    "#   EcoRI SacI  KpnI  SmaI  BamHI XbaI    SalI   PstI SphI HindIII\n",
+    "#\n",
+    "# Replacement: two BsaI sites flanking a stuffer, retaining EcoRI/HindIII ends.\n",
+    "#   GAATTC [BsaI→ GGTCTCA] [AATG overhang] [stuffer] [GCAT overhang] [←BsaI TGAGACC] AAGCTT\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "12-design-gg",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "golden_gate_mcs = \"GAATTCGGTCTCAAATGCATCATCATCATGCATTGAGACCAAGCTT\"\n",
+    "\n",
+    "repo.update_with_sequence(\n",
+    "    golden_gate_mcs,\n",
+    "    sample=\"wt\",\n",
+    "    new_sample=\"gg_design\",\n",
+    "    # MCS coordinates from the GenBank misc_feature annotation (1-based 396..452),\n",
+    "    # converted to 0-based half-open interval for the region string.\n",
+    "    region_name=\"pUC19:395-452\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "13-design-note",
+   "metadata": {},
+   "source": [
+    "`update_with_sequence` creates a new sample (`\"gg_design\"`) that shares\n",
+    "the entire graph with `\"wt\"` except at the edited region, where the path\n",
+    "diverges through the new MCS nodes."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "14-inspect-header",
+   "metadata": {},
+   "source": [
+    "## Inspect the design"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "15-get-gg-bg",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bg_gg = next(bg for bg in repo.get_sequence_graphs() if bg.sample_name == \"gg_design\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "16-search-header",
+   "metadata": {},
+   "source": [
+    "### Confirm the BsaI sites with search\n",
+    "\n",
+    "Before synthesis, we verify the Golden Gate sites landed correctly by\n",
+    "searching for the BsaI recognition sequence on both strands.  `search()`\n",
+    "uses `sequence_kind=\"dna\"` by default, which automatically searches\n",
+    "the reverse complement as well as the forward sequence."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "17-search-bsai",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# GGTCTC is the BsaI recognition sequence (cuts 1 nt downstream on sense strand).\n",
+    "# DNA-mode search finds both the forward site and its reverse-complement counterpart.\n",
+    "hits = repo.search(\"GGTCTC\", bgs=[bg_gg], sequence_kind=\"dna\")\n",
+    "loci = hits[0][1]  # [(SequenceGraph, [Locus]), ...] — take the loci from the first match\n",
+    "print(f\"BsaI sites found: {len(loci)}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "18-plot-gg",
+   "metadata": {},
+   "outputs": [],
+   "source": "w_gg = bg_gg.plot()\nw_gg.go_to(loci[0])\nw_gg"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "19-plot-gg-note",
+   "metadata": {},
+   "source": [
+    "The widget centres on the first BsaI site, which sits at the boundary of\n",
+    "the new Golden Gate MCS.  Both paths are visible: the wild-type MCS and\n",
+    "the new Golden Gate site diverge at position 395 and reconverge 57 bp\n",
+    "later (original) or 46 bp later (new design).\n",
+    "\n",
+    "Three hits.  To understand why, run the same search against the wild-type:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "20-search-wt",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hits_wt = repo.search(\"GGTCTC\", bgs=[bg_wt], sequence_kind=\"dna\")\n",
+    "wt_count = len(hits_wt[0][1]) if hits_wt else 0\n",
+    "print(f\"BsaI sites in wild-type: {wt_count}\")  # 1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "21-wt-search-note",
+   "metadata": {},
+   "source": [
+    "The wild-type already carries one BsaI site — on the reverse strand at\n",
+    "position 1765, inside the **bla** coding sequence.  The design added\n",
+    "exactly two new sites (3 − 1 = 2), so the flanking Golden Gate sites are\n",
+    "present and correctly oriented.  The pre-existing site is the problem: if\n",
+    "left in place it will be cut alongside the intended assembly sites,\n",
+    "fragmenting the AmpR cassette.  It needs to be silently mutated out\n",
+    "before the construct goes to synthesis.\n",
+    "\n",
+    "The `search()` method also accepts degenerate IUPAC codes, so you can\n",
+    "query by recognition sequence directly without pre-computing all\n",
+    "variants.  For example, EcoRI's sequence `GAATTC` is unambiguous, but a\n",
+    "site like HincII (`GTYRAC`, where Y = C/T and R = A/G) expands to four\n",
+    "possible hexamers — pass the IUPAC string and `search()` matches all of\n",
+    "them:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "22-search-iupac",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hits_hincii = repo.search(\"GTYRAC\", bgs=[bg_gg], sequence_kind=\"dna\")\n",
+    "hincii_count = len(hits_hincii[0][1]) if hits_hincii else 0\n",
+    "print(f\"HincII sites found: {hincii_count}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "23-iupac-note",
+   "metadata": {},
+   "source": [
+    "For large genomes, consider calling `bg.build_index()` before\n",
+    "searching.  The index speeds up exact queries; degenerate IUPAC patterns\n",
+    "always use a full scan regardless."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "24-highlight-header",
+   "metadata": {},
+   "source": "### Navigate and highlight search results\n\nEach element of the list returned by `search()` is a `Locus` with\n`.start()` / `.end()` (`Position` objects) and `.slices`.  Pass a locus\ndirectly to `go_to()` to centre the viewport on it, and to\n`highlight_match()` to colour it on the canvas.\n\n`go_to()` accepts `Position`, `Locus`, and `Annotation` objects — the\nsame call works for search results and annotation records.  Annotations\nfrom one sample can be used to navigate a widget for a different sample\n— this is safe and stable because annotations are stored as references\nto graph nodes, not as linear sequence coordinates.  Nodes are shared\nacross samples in the same repository, so an annotation created for the\n`\"wt\"` sample points to exactly the same graph nodes that appear in the\n`\"gg_design\"` or `\"sequenced\"` graphs."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "25-highlight-bsai",
+   "metadata": {},
+   "outputs": [],
+   "source": "# Jump to the first BsaI site and highlight both sites.\nw_gg.go_to(loci[0])\nw_gg.highlight_match(loci[0], color=\"cyan\")\nw_gg.highlight_match(loci[1], color=\"cyan\")\nw_gg"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "26-clear-header",
+   "metadata": {},
+   "source": [
+    "`clear_highlights()` removes all highlights without affecting the viewport:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "27-clear-highlights",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "w_gg.clear_highlights()\n",
+    "w_gg"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "28-export-header",
+   "metadata": {},
+   "source": [
+    "## Export and send for sequencing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "29-export",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "out_fa = WORK_DIR / \"pUC19_gg_design.fa\"\n",
+    "repo.export_fasta(str(out_fa), sample=\"gg_design\")\n",
+    "print(f\"Exported to {out_fa}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "30-vcf-header",
+   "metadata": {},
+   "source": [
+    "You send `pUC19_gg_design.fa` to your synthesis provider.  A few days\n",
+    "later sequencing results arrive as a VCF.\n",
+    "\n",
+    "## Import the sequencing result — and find a surprise"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "31-update-vcf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vcf_path = REPO_ROOT / \"gen-r\" / \"inst\" / \"extdata\" / \"puc19_sequenced.vcf\"\n",
+    "\n",
+    "repo.update_with_vcf(\n",
+    "    str(vcf_path),\n",
+    "    reference=\"gg_design\",\n",
+    "    sample=\"sequenced\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "32-get-sequenced-bg",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bg_seq = next(bg for bg in repo.get_sequence_graphs() if bg.sample_name == \"sequenced\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "33-plot-sequenced",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "w_seq = bg_seq.plot()\n",
+    "w_seq"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "34-sequenced-note",
+   "metadata": {},
+   "source": [
+    "The graph now shows a branch at position 1904 — outside the MCS, inside\n",
+    "the **bla** (β-lactamase / AmpR) coding sequence.  The sequencing run\n",
+    "picked up a C→T substitution that was not in the design.  Because Gen\n",
+    "stores every sample as a path through the same graph, the mutation shows\n",
+    "up as a new node rather than a silent overwrite: the `gg_design` path\n",
+    "and the `sequenced` path diverge exactly here.\n",
+    "\n",
+    "This is the kind of mutation that is easy to miss in a flat-file\n",
+    "workflow.  Gen surfaces it because \"what changed between two samples\" is\n",
+    "a native database query, not a diff of exported files."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "35-cli-header",
+   "metadata": {},
+   "source": [
+    "## Version control on the command line\n",
+    "\n",
+    "Everything above runs inside Python.  Gen also ships a command-line\n",
+    "interface that adds the operations that make it a true version control\n",
+    "system:\n",
+    "\n",
+    "```sh\n",
+    "gen init\n",
+    "gen import --fasta reference.fa --sample wt\n",
+    "gen checkout -b gg_design\n",
+    "gen apply --vcf site.vcf\n",
+    "gen push origin gg_design\n",
+    "gen pull\n",
+    "gen log\n",
+    "```\n",
+    "\n",
+    "`push`, `pull`, `checkout`, `log`, and `merge` work like their git\n",
+    "equivalents but operate on sequence graphs rather than text files.  A\n",
+    "Gen remote holds the full graph history: who edited which sample, when,\n",
+    "and how the paths diverged.\n",
+    "\n",
+    "The Python bindings and the CLI share the same database, so you can\n",
+    "design a construct in a notebook, push it from the terminal, and a\n",
+    "colleague can pull the graph and visualise it in their own session —\n",
+    "with the full annotation and variant history intact.\n",
+    "\n",
+    "To learn more about the CLI, run `gen --help` or visit the project\n",
+    "documentation."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "36-further-header",
+   "metadata": {},
+   "source": [
+    "## Further capabilities\n",
+    "\n",
+    "The sections below cover additional API surface.  All examples are\n",
+    "self-contained and assume a repository initialised with\n",
+    "`gen init` (or the Python equivalent shown in Setup above)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "37-gfa-header",
+   "metadata": {},
+   "source": [
+    "### Additional import formats\n",
+    "\n",
+    "#### GFA\n",
+    "\n",
+    "GFA (Graphical Fragment Assembly) files encode sequence graphs directly.\n",
+    "Import a `.gfa` file as a new sample:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "38-import-gfa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# repo.import_gfa(str(FX / \"assembly.gfa\"), sample=\"assembly\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "39-export-gfa-header",
+   "metadata": {},
+   "source": [
+    "Export any sample back to GFA.  The optional `node_max` argument splits\n",
+    "nodes longer than the given length, useful for tools that expect bounded\n",
+    "node sizes:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "40-export-gfa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# repo.export_gfa(\"output.gfa\", sample=\"assembly\", node_max=1000)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "41-ref-fasta-header",
+   "metadata": {},
+   "source": [
+    "#### Reference FASTA\n",
+    "\n",
+    "`import_reference_fasta()` differs from `import_fasta()` in that it\n",
+    "marks the imported sample as a *reference* in the database.  This is the\n",
+    "right starting point when you plan to call variants relative to an\n",
+    "external aligner's reference: subsequent `update_with_vcf()` calls can\n",
+    "name this sample in the `reference` argument without ambiguity."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "42-ref-fasta",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# repo.import_reference_fasta(\"hg38.fa\", reference=\"hg38\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "43-genbank-update-header",
+   "metadata": {},
+   "source": [
+    "#### GenBank updates and export\n",
+    "\n",
+    "`update_with_genbank()` applies sequence edits and annotation changes\n",
+    "encoded in a GenBank file to an existing sample.  Set\n",
+    "`create_missing=True` to auto-create block groups for features not yet\n",
+    "in the database:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "44-genbank-update",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# repo.update_with_genbank(\n",
+    "#     \"corrected_annotation.gb\",\n",
+    "#     sample=\"wt\",\n",
+    "#     create_missing=True,\n",
+    "# )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "45-genbank-export-header",
+   "metadata": {},
+   "source": [
+    "Export any sample's annotations and sequence to GenBank format:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "46-genbank-export",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# repo.export_genbank(\"pUC19_gg_design.gb\", sample=\"gg_design\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "47-networkx-header",
+   "metadata": {},
+   "source": [
+    "### Graph export\n",
+    "\n",
+    "Sequence graphs can be exported to popular Python graph libraries for\n",
+    "further analysis or visualisation.  Both NetworkX and RustworkX are\n",
+    "supported."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "48-networkx",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import networkx as nx\n",
+    "\n",
+    "    nx_graph = bg_gg.to_networkx()\n",
+    "    print(f\"NetworkX DiGraph: {nx_graph.number_of_nodes()} nodes, {nx_graph.number_of_edges()} edges\")\n",
+    "    print(f\"Average degree: {sum(d for _, d in nx_graph.degree()) / nx_graph.number_of_nodes():.2f}\")\n",
+    "except ImportError:\n",
+    "    print(\"NetworkX not installed. Run: pip install networkx\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "49-rustworkx",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import rustworkx as rx\n",
+    "    import rustworkx.visualization as rxv\n",
+    "\n",
+    "    rx_graph = bg_gg.to_rustworkx()\n",
+    "    print(f\"RustworkX PyDiGraph: {rx_graph.num_nodes()} nodes, {rx_graph.num_edges()} edges\")\n",
+    "    display(rxv.graphviz_draw(rx_graph))\n",
+    "except ImportError:\n",
+    "    print(\"RustworkX not installed. Run: pip install rustworkx\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "50-library-header",
+   "metadata": {},
+   "source": [
+    "### Combinatorial library design\n",
+    "\n",
+    "`import_library()` builds a combinatorial block group from a list of\n",
+    "part columns.  Each column is a list of `SequencePart` objects where\n",
+    "each part has a name and a sequence.  Every combination of one part per\n",
+    "column becomes a path through the resulting graph.\n",
+    "\n",
+    "The example below designs an expression cassette with three promoters,\n",
+    "three RBS variants, and two CDSes — 18 unique combinations:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "51-import-library",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "parts_list = [\n",
+    "    [gen.SequencePart(\"upstream\", \"AATTCGGATCCAAGCTT\")],\n",
+    "    [\n",
+    "        gen.SequencePart(\"pTrc\", \"TTGACAATTAATCATCCGGCTCGTATAATGTGTGG\"),\n",
+    "        gen.SequencePart(\"pT7\",  \"TAATACGACTCACTATA\"),\n",
+    "        gen.SequencePart(\"pLac\", \"AATTGTGAGCGGATAACAATT\"),\n",
+    "    ],\n",
+    "    [\n",
+    "        gen.SequencePart(\"rbs_strong\", \"AAAGAGGAGAAA\"),\n",
+    "        gen.SequencePart(\"rbs_medium\", \"AAGAGGAG\"),\n",
+    "        gen.SequencePart(\"rbs_weak\",   \"AGGAG\"),\n",
+    "    ],\n",
+    "    [\n",
+    "        gen.SequencePart(\"gfp\", \"ATGAGTAAAGGAGAAGAACTTTTCACTGG\"),\n",
+    "        gen.SequencePart(\"rfp\", \"ATGGCTTCCTCCGAAGACGTTATCAAAGAG\"),\n",
+    "    ],\n",
+    "    [gen.SequencePart(\"terminator_T1\", \"GCGCAACGCAATTAATGTGAGTTAGCTCACTCATTAGGCACCCCAGGC\")],\n",
+    "]\n",
+    "\n",
+    "lib_repo = gen.Repository(str(WORK_DIR / \"library\"))\n",
+    "lib_repo.import_library(\"expression-cassette\", parts_list)\n",
+    "\n",
+    "cassette_bgs = [\n",
+    "    bg for bg in lib_repo.get_sequence_graphs()\n",
+    "    if bg.name == \"expression-cassette\"\n",
+    "]\n",
+    "print(f\"Paths in library graph: checking plot...\")\n",
+    "cassette_bgs[0].plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "52-update-library-header",
+   "metadata": {},
+   "source": [
+    "#### Applying a library update to an existing sample\n",
+    "\n",
+    "`update_with_library()` works like `update_with_sequence()` but replaces\n",
+    "a region with a set of combinatorial variants.  The `path_name` argument\n",
+    "selects the region using the same `\"<name>:<start>-<end>\"` format as\n",
+    "other update functions:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "53-update-library",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# repo.update_with_library(\n",
+    "#     sample=\"gg_design\",\n",
+    "#     new_sample_name=\"gg_tagged\",\n",
+    "#     path_name=\"pUC19:1200-1270\",\n",
+    "#     parts_list=[\n",
+    "#         [gen.SequencePart(\"tag_a\", \"ATGATGATG\"), gen.SequencePart(\"tag_b\", \"TGATGATGA\")],\n",
+    "#     ],\n",
+    "# )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "54-subgraph-header",
+   "metadata": {},
+   "source": [
+    "### Graph partitioning\n",
+    "\n",
+    "#### Subgraphs\n",
+    "\n",
+    "`derive_subgraph()` creates a new block group that is a coordinate slice\n",
+    "of an existing one.  The `region` argument uses\n",
+    "`\"<name>:<start>-<end>\"` (0-based half-open) or just `\"<name>\"` for the\n",
+    "full sequence:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "55-derive-subgraph",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# repo.derive_subgraph(\n",
+    "#     sample=\"gg_design\",\n",
+    "#     new_sample=\"mcs_region\",\n",
+    "#     region=\"pUC19:390-460\",\n",
+    "# )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "56-bg-subgraph-header",
+   "metadata": {},
+   "source": [
+    "Sequence graphs expose `subgraph()` as a shorthand that returns the new\n",
+    "sequence graph immediately:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "57-bg-subgraph",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mcs_bg = bg_gg.subgraph(\"mcs_v2\", 390, 460)\n",
+    "mcs_bg.plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "58-chunks-header",
+   "metadata": {},
+   "source": [
+    "#### Chunks and stitching\n",
+    "\n",
+    "`bg.chunks()` splits a block group into contiguous fragments and returns\n",
+    "them as a list of block groups.  Supply `chunk_size` for uniform splits\n",
+    "or `breakpoints` (a list of positions) for explicit cut points:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "59-derive-chunks",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "chunks = bg_gg.chunks(\"gg_500bp_chunks\", chunk_size=500)\n",
+    "print(f\"Chunks created: {len(chunks)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "60-stitch-header",
+   "metadata": {},
+   "source": [
+    "`repo.stitch()` reverses the operation, concatenating a list of\n",
+    "sequence graph objects end-to-end into a new block group:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "61-stitch",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "reassembled = repo.stitch(\n",
+    "    bgs=chunks,\n",
+    "    new_sample=\"gg_reassembled\",\n",
+    "    new_region=\"pUC19.reassembled\",\n",
+    ")\n",
+    "print(f\"Stitched: {reassembled.name} in sample '{reassembled.sample_name}'\")\n",
+    "reassembled.plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "62-tracks-header",
+   "metadata": {},
+   "source": "### Annotation tracks\n\nAny widget can display additional annotation panels below the sequence\ngraph.  `add_annotation_track()` is the unified entry point — supply\nexactly one of `file`, `group`, or `annotations`:\n\n- `file=` loads a GFF3 or BED file; `from_sample=` translates coordinates\n  from the given sample's path space.\n- `group=` loads an annotation group stored in the repository (created\n  automatically on GenBank import).\n- `annotations=` renders a list of `Annotation` objects you built manually."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "63-add-track-file",
+   "metadata": {},
+   "outputs": [],
+   "source": "# w_gg.add_annotation_track(file=\"features.gff3\", name=\"Features\", from_sample=\"gg_design\")\n# w_gg"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "64-add-track-group-header",
+   "metadata": {},
+   "source": [
+    "Annotation groups stored in the database (created automatically on\n",
+    "GenBank import) can be added by group name:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "65-add-track-group",
+   "metadata": {},
+   "outputs": [],
+   "source": "# w_gg.add_annotation_track(group=\"GenBank annotations\")\n# w_gg"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "66-clear-tracks-header",
+   "metadata": {},
+   "source": [
+    "`clear_all_annotations()` removes all track panels without affecting the\n",
+    "viewport or highlights:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "67-clear-tracks",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# w_gg.clear_all_annotations()\n",
+    "# w_gg"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbformat": 4,
+   "nbformat_minor": 5,
+   "pygments_lexer": "ipython3",
+   "version": "3.13.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gen-python/examples/puc19.gbk
+++ b/gen-python/examples/puc19.gbk
@@ -1,0 +1,124 @@
+LOCUS       pUC19                   2686 bp    DNA     circular     18-OCT-2007
+DEFINITION  Cloning vector pUC19, complete sequence.
+ACCESSION
+VERSION
+KEYWORDS    .
+SOURCE      Cloning vector pUC19
+  ORGANISM  Cloning vector pUC19
+            other sequences; artificial sequences; vectors.
+REFERENCE   1  (bases 1 to 2686)
+  AUTHORS   New England Biolabs.
+  TITLE     Direct Submission
+  JOURNAL   Submitted (18-OCT-2007) Research Department, New England Biolabs,
+            240 County Road, Ipswich, MA 01938, USA
+COMMENT     See also GenBank accession L09137.
+FEATURES             Location/Qualifiers
+     source          1..2686
+                     /organism="Cloning vector pUC19"
+                     /mol_type="other DNA"
+     gene            complement(146..469)
+                     /gene="lacZalpha"
+     CDS             complement(146..469)
+                     /gene="lacZalpha"
+                     /codon_start=1
+                     /product="beta-galactosidase alpha fragment"
+                     /translation="MTMITPSLHACRSTLEDPRVPSSNSLAVVLQRRDWENPGVTQLN
+                     RLAAHPPFASWRNSEEARTDRPSQQLRSLNGEWRLMRYFLLTHLCGISHRIWCTLSTI
+                     CSDAA"
+     misc_feature    396..452
+                     /gene="lacZalpha"
+                     /label=MCS
+                     /note="multiple cloning site (EcoRI-HindIII)"
+     -10_signal      complement(514..519)
+                     /note="Plac promoter (drives lacZalpha;
+                     counter-clockwise); TATGTT"
+     -35_signal      complement(538..543)
+                     /note="Plac promoter (drives lacZalpha;
+                     counter-clockwise); TTTACA"
+     protein_bind    complement(563..575)
+                     /note="CAP protein binding site"
+                     /bound_moiety="catabolite activator protein (CAP)"
+     rep_origin      complement(867..1455)
+                     /note="pMB1 origin of replication (counter-clockwise)
+                     (RNAII -35 to RNA/DNA switch point)"
+     misc_RNA        complement(867..1419)
+                     /note="RNAII transcript (complementary strand)"
+     -35_signal      1273..1278
+                     /note="RNAI promoter (clockwise); TTGAAG"
+     -10_signal      1295..1300
+                     /note="RNAI promoter (clockwise); GCTACA"
+     misc_RNA        1309..1416
+                     /note="RNAI transcript"
+     -10_signal      complement(1429..1434)
+                     /note="RNAII promoter (counter-clockwise); CGTAAT"
+     -35_signal      complement(1450..1455)
+                     /note="RNAII promoter (counter-clockwise); TTGAGA"
+     gene            complement(1626..2486)
+                     /gene="bla"
+     CDS             complement(1626..2486)
+                     /gene="bla"
+                     /note="ampR (confers resistance to ampicillin)"
+                     /codon_start=1
+                     /product="beta-lactamase"
+                     /translation="MSIQHFRVALIPFFAAFCLPVFAHPETLVKVKDAEDQLGARVGY
+                     IELDLNSGKILESFRPEERFPMMSTFKVLLCGAVLSRIDAGQEQLGRRIHYSQNDLVE
+                     YSPVTEKHLTDGMTVRELCSAAITMSDNTAANLLLTTIGGPKELTAFLHNMGDHVTRL
+                     DRWEPELNEAIPNDERDTTMPVAMATTLRKLLTGELLTLASRQQLIDWMEADKVAGPL
+                     LRSALPAGWFIADKSGAGERGSRGIIAALGPDGKPSRIVVIYTTGSQATMDERNRQIA
+                     EIGASLIKHW"
+     sig_peptide     complement(2418..2486)
+                     /gene="bla"
+                     /note="required for secretion to the periplasm; cleaved
+                     off to form the mature beta-lactamase protein."
+     -10_signal      complement(2530..2535)
+                     /note="bla promoter (counter-clockwise); GAGACA"
+     -35_signal      complement(2551..2556)
+                     /note="bla promoter (counter-clockwise); TTCAAA"
+BASE COUNT      667 a    675 c    685 g    659 t
+ORIGIN
+        1 tcgcgcgttt cggtgatgac ggtgaaaacc tctgacacat gcagctcccg gagacggtca
+       61 cagcttgtct gtaagcggat gccgggagca gacaagcccg tcagggcgcg tcagcgggtg
+      121 ttggcgggtg tcggggctgg cttaactatg cggcatcaga gcagattgta ctgagagtgc
+      181 accatatgcg gtgtgaaata ccgcacagat gcgtaaggag aaaataccgc atcaggcgcc
+      241 attcgccatt caggctgcgc aactgttggg aagggcgatc ggtgcgggcc tcttcgctat
+      301 tacgccagct ggcgaaaggg ggatgtgctg caaggcgatt aagttgggta acgccagggt
+      361 tttcccagtc acgacgttgt aaaacgacgg ccagtgaatt cgagctcggt acccggggat
+      421 cctctagagt cgacctgcag gcatgcaagc ttggcgtaat catggtcata gctgtttcct
+      481 gtgtgaaatt gttatccgct cacaattcca cacaacatac gagccggaag cataaagtgt
+      541 aaagcctggg gtgcctaatg agtgagctaa ctcacattaa ttgcgttgcg ctcactgccc
+      601 gctttccagt cgggaaacct gtcgtgccag ctgcattaat gaatcggcca acgcgcgggg
+      661 agaggcggtt tgcgtattgg gcgctcttcc gcttcctcgc tcactgactc gctgcgctcg
+      721 gtcgttcggc tgcggcgagc ggtatcagct cactcaaagg cggtaatacg gttatccaca
+      781 gaatcagggg ataacgcagg aaagaacatg tgagcaaaag gccagcaaaa ggccaggaac
+      841 cgtaaaaagg ccgcgttgct ggcgtttttc cataggctcc gcccccctga cgagcatcac
+      901 aaaaatcgac gctcaagtca gaggtggcga aacccgacag gactataaag ataccaggcg
+      961 tttccccctg gaagctccct cgtgcgctct cctgttccga ccctgccgct taccggatac
+     1021 ctgtccgcct ttctcccttc gggaagcgtg gcgctttctc atagctcacg ctgtaggtat
+     1081 ctcagttcgg tgtaggtcgt tcgctccaag ctgggctgtg tgcacgaacc ccccgttcag
+     1141 cccgaccgct gcgccttatc cggtaactat cgtcttgagt ccaacccggt aagacacgac
+     1201 ttatcgccac tggcagcagc cactggtaac aggattagca gagcgaggta tgtaggcggt
+     1261 gctacagagt tcttgaagtg gtggcctaac tacggctaca ctagaagaac agtatttggt
+     1321 atctgcgctc tgctgaagcc agttaccttc ggaaaaagag ttggtagctc ttgatccggc
+     1381 aaacaaacca ccgctggtag cggtggtttt tttgtttgca agcagcagat tacgcgcaga
+     1441 aaaaaaggat ctcaagaaga tcctttgatc ttttctacgg ggtctgacgc tcagtggaac
+     1501 gaaaactcac gttaagggat tttggtcatg agattatcaa aaaggatctt cacctagatc
+     1561 cttttaaatt aaaaatgaag ttttaaatca atctaaagta tatatgagta aacttggtct
+     1621 gacagttacc aatgcttaat cagtgaggca cctatctcag cgatctgtct atttcgttca
+     1681 tccatagttg cctgactccc cgtcgtgtag ataactacga tacgggaggg cttaccatct
+     1741 ggccccagtg ctgcaatgat accgcgagac ccacgctcac cggctccaga tttatcagca
+     1801 ataaaccagc cagccggaag ggccgagcgc agaagtggtc ctgcaacttt atccgcctcc
+     1861 atccagtcta ttaattgttg ccgggaagct agagtaagta gttcgccagt taatagtttg
+     1921 cgcaacgttg ttgccattgc tacaggcatc gtggtgtcac gctcgtcgtt tggtatggct
+     1981 tcattcagct ccggttccca acgatcaagg cgagttacat gatcccccat gttgtgcaaa
+     2041 aaagcggtta gctccttcgg tcctccgatc gttgtcagaa gtaagttggc cgcagtgtta
+     2101 tcactcatgg ttatggcagc actgcataat tctcttactg tcatgccatc cgtaagatgc
+     2161 ttttctgtga ctggtgagta ctcaaccaag tcattctgag aatagtgtat gcggcgaccg
+     2221 agttgctctt gcccggcgtc aatacgggat aataccgcgc cacatagcag aactttaaaa
+     2281 gtgctcatca ttggaaaacg ttcttcgggg cgaaaactct caaggatctt accgctgttg
+     2341 agatccagtt cgatgtaacc cactcgtgca cccaactgat cttcagcatc ttttactttc
+     2401 accagcgttt ctgggtgagc aaaaacagga aggcaaaatg ccgcaaaaaa gggaataagg
+     2461 gcgacacgga aatgttgaat actcatactc ttcctttttc aatattattg aagcatttat
+     2521 cagggttatt gtctcatgag cggatacata tttgaatgta tttagaaaaa taaacaaata
+     2581 ggggttccgc gcacatttcc ccgaaaagtg ccacctgacg tctaagaaac cattattatc
+     2641 atgacattaa cctataaaaa taggcgtatc acgaggccct ttcgtc
+//

--- a/gen-python/examples/puc19_sequenced.vcf
+++ b/gen-python/examples/puc19_sequenced.vcf
@@ -1,0 +1,8 @@
+##fileformat=VCFv4.1
+##reference=puc19.gbk
+##contig=<ID=pUC19,length=2686>
+##INFO=<ID=TYPE,Number=A,Type=String,Description="The type of allele, either snp, mnp, ins, del, or complex.">
+##FILTER=<ID=PASS,Description="All filters passed">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	sequenced
+pUC19	1904	.	C	T	48	PASS	TYPE=snp	GT	1/1

--- a/gen-python/examples/repository_api.ipynb
+++ b/gen-python/examples/repository_api.ipynb
@@ -69,7 +69,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "05-import-fasta",
    "metadata": {
     "execution": {
@@ -79,39 +79,8 @@
      "shell.execute_reply": "2026-05-27T21:12:14.541500Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Block groups after FASTA imports: 10\n",
-      "  reference / m123\n",
-      "  parts_sample / p1\n",
-      "  parts_sample / p2\n",
-      "  parts_sample / p3\n",
-      "  parts_sample / cds1\n",
-      "  parts_sample / cds2\n",
-      "  parts_sample / cds3\n",
-      "  multi / m1\n",
-      "  multi / m2\n",
-      "  multi / m3\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Minimal: only the filename is required\n",
-    "repo.import_fasta(str(FX / \"simple.fa\"))\n",
-    "\n",
-    "# With an explicit sample name\n",
-    "repo.import_fasta(str(FX / \"parts.fa\"), sample=\"parts_sample\")\n",
-    "\n",
-    "repo.import_fasta(str(FX / \"multiseq.fa\"), sample=\"multi\")\n",
-    "\n",
-    "bgs = repo.get_block_groups()\n",
-    "print(f\"Block groups after FASTA imports: {len(bgs)}\")\n",
-    "for bg in bgs:\n",
-    "    print(f\"  {bg.sample_name} / {bg.name}\")"
-   ]
+   "outputs": [],
+   "source": "# Minimal: only the filename is required\nrepo.import_fasta(str(FX / \"simple.fa\"))\n\n# With an explicit sample name\nrepo.import_fasta(str(FX / \"parts.fa\"), sample=\"parts_sample\")\n\nrepo.import_fasta(str(FX / \"multiseq.fa\"), sample=\"multi\")\n\nbgs = repo.get_sequence_graphs()\nprint(f\"Sequence graphs after FASTA imports: {len(bgs)}\")\nfor bg in bgs:\n    print(f\"  {bg.sample_name} / {bg.name}\")"
   },
   {
    "cell_type": "markdown",
@@ -125,7 +94,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "07-import-gfa",
    "metadata": {
     "execution": {
@@ -135,34 +104,8 @@
      "shell.execute_reply": "2026-05-27T21:12:14.556863Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Block groups after GFA import: 11\n",
-      "  m123 (sample=reference)\n",
-      "  p1 (sample=parts_sample)\n",
-      "  p2 (sample=parts_sample)\n",
-      "  p3 (sample=parts_sample)\n",
-      "  cds1 (sample=parts_sample)\n",
-      "  cds2 (sample=parts_sample)\n",
-      "  cds3 (sample=parts_sample)\n",
-      "  m1 (sample=multi)\n",
-      "  m2 (sample=multi)\n",
-      "  m3 (sample=multi)\n",
-      "   (sample=gfa_sample)\n"
-     ]
-    }
-   ],
-   "source": [
-    "repo.import_gfa(str(FX / \"anderson_promoters.gfa\"), sample=\"gfa_sample\")\n",
-    "\n",
-    "bgs = repo.get_block_groups()\n",
-    "print(f\"Block groups after GFA import: {len(bgs)}\")\n",
-    "for bg in bgs:\n",
-    "    print(f\"  {bg.name} (sample={bg.sample_name})\")"
-   ]
+   "outputs": [],
+   "source": "repo.import_gfa(str(FX / \"anderson_promoters.gfa\"), sample=\"gfa_sample\")\n\nbgs = repo.get_sequence_graphs()\nprint(f\"Sequence graphs after GFA import: {len(bgs)}\")\nfor bg in bgs:\n    print(f\"  {bg.name} (sample={bg.sample_name})\")"
   },
   {
    "cell_type": "code",
@@ -210,7 +153,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "10-import-genbank",
    "metadata": {
     "execution": {
@@ -220,35 +163,8 @@
      "shell.execute_reply": "2026-05-27T21:12:14.574438Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Block groups after GenBank import: 12\n",
-      "  m123\n",
-      "  p1\n",
-      "  p2\n",
-      "  p3\n",
-      "  cds1\n",
-      "  cds2\n",
-      "  cds3\n",
-      "  m1\n",
-      "  m2\n",
-      "  m3\n",
-      "  \n",
-      "  sequence-222046-\n"
-     ]
-    }
-   ],
-   "source": [
-    "repo.import_genbank(str(FX / \"puc19.gb\"), sample=\"genbank_sample\")\n",
-    "\n",
-    "bgs_gb = repo.get_block_groups()\n",
-    "print(f\"Block groups after GenBank import: {len(bgs_gb)}\")\n",
-    "for bg in bgs_gb:\n",
-    "    print(f\"  {bg.name}\")"
-   ]
+   "outputs": [],
+   "source": "repo.import_genbank(str(FX / \"puc19.gb\"), sample=\"genbank_sample\")\n\nbgs_gb = repo.get_sequence_graphs()\nprint(f\"Sequence graphs after GenBank import: {len(bgs_gb)}\")\nfor bg in bgs_gb:\n    print(f\"  {bg.name}\")"
   },
   {
    "cell_type": "markdown",
@@ -263,7 +179,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "12-import-library",
    "metadata": {
     "execution": {
@@ -273,32 +189,12 @@
      "shell.execute_reply": "2026-05-27T21:12:14.578813Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Block groups after library import: 13\n"
-     ]
-    }
-   ],
-   "source": [
-    "# import_library: build parts programmatically\n",
-    "parts_list = [\n",
-    "    [gen.SequencePart(\"p1\", \"AAAA\"), gen.SequencePart(\"cds1\", \"ATGATAA\")],\n",
-    "    [gen.SequencePart(\"p2\", \"TAAT\"), gen.SequencePart(\"cds2\", \"ATGTTAA\")],\n",
-    "    [gen.SequencePart(\"p3\", \"CAAC\"), gen.SequencePart(\"cds3\", \"ATGCTAA\")],\n",
-    "]\n",
-    "\n",
-    "repo.import_library(\"my_library\", parts_list)\n",
-    "\n",
-    "bgs_lib = repo.get_block_groups()\n",
-    "print(f\"Block groups after library import: {len(bgs_lib)}\")"
-   ]
+   "outputs": [],
+   "source": "# import_library: build parts programmatically\nparts_list = [\n    [gen.SequencePart(\"p1\", \"AAAA\"), gen.SequencePart(\"cds1\", \"ATGATAA\")],\n    [gen.SequencePart(\"p2\", \"TAAT\"), gen.SequencePart(\"cds2\", \"ATGTTAA\")],\n    [gen.SequencePart(\"p3\", \"CAAC\"), gen.SequencePart(\"cds3\", \"ATGCTAA\")],\n]\n\nrepo.import_library(\"my_library\", parts_list)\n\nbgs_lib = repo.get_sequence_graphs()\nprint(f\"Sequence graphs after library import: {len(bgs_lib)}\")"
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "13-import-library-files",
    "metadata": {
     "execution": {
@@ -308,25 +204,8 @@
      "shell.execute_reply": "2026-05-27T21:12:14.594383Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Block groups after library-files import: 14\n"
-     ]
-    }
-   ],
-   "source": [
-    "# import_library_files: read parts and layout from CSV files\n",
-    "PARTS_CSV   = FX / \"parts.fa\"\n",
-    "LAYOUT_CSV  = FX / \"combinatorial_design.csv\"\n",
-    "\n",
-    "repo.import_library_files(\"csv_library\", str(PARTS_CSV), str(LAYOUT_CSV))\n",
-    "\n",
-    "bgs_lib2 = repo.get_block_groups()\n",
-    "print(f\"Block groups after library-files import: {len(bgs_lib2)}\")"
-   ]
+   "outputs": [],
+   "source": "# import_library_files: read parts and layout from CSV files\nPARTS_CSV   = FX / \"parts.fa\"\nLAYOUT_CSV  = FX / \"combinatorial_design.csv\"\n\nrepo.import_library_files(\"csv_library\", str(PARTS_CSV), str(LAYOUT_CSV))\n\nbgs_lib2 = repo.get_sequence_graphs()\nprint(f\"Sequence graphs after library-files import: {len(bgs_lib2)}\")"
   },
   {
    "cell_type": "markdown",
@@ -517,7 +396,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "24-update-fasta",
    "metadata": {
     "execution": {
@@ -527,35 +406,8 @@
      "shell.execute_reply": "2026-05-27T21:12:14.648879Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Block groups after update: 2Updated with fasta file: /Users/bvh/git/gen/fixtures/parts.fa\n",
-      "\n",
-      "  ref / m123\n",
-      "  fasta_updated / m123\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Work on a fresh repo so the updates have a clean baseline\n",
-    "update_repo = gen.Repository(str(WORK_DIR / \"updates\"))\n",
-    "update_repo.import_fasta(str(FX / \"simple.fa\"), sample=\"ref\")\n",
-    "\n",
-    "update_repo.update_with_fasta(\n",
-    "    str(FX / \"parts.fa\"),\n",
-    "    sample=\"ref\",\n",
-    "    new_sample=\"fasta_updated\",\n",
-    "    region_name=\"m123:3-10\",\n",
-    ")\n",
-    "\n",
-    "bgs = update_repo.get_block_groups()\n",
-    "print(f\"Block groups after update: {len(bgs)}\")\n",
-    "for bg in bgs:\n",
-    "    print(f\"  {bg.sample_name} / {bg.name}\")"
-   ]
+   "outputs": [],
+   "source": "# Work on a fresh repo so the updates have a clean baseline\nupdate_repo = gen.Repository(str(WORK_DIR / \"updates\"))\nupdate_repo.import_fasta(str(FX / \"simple.fa\"), sample=\"ref\")\n\nupdate_repo.update_with_fasta(\n    str(FX / \"parts.fa\"),\n    sample=\"ref\",\n    new_sample=\"fasta_updated\",\n    region_name=\"m123:3-10\",\n)\n\nbgs = update_repo.get_sequence_graphs()\nprint(f\"Sequence graphs after update: {len(bgs)}\")\nfor bg in bgs:\n    print(f\"  {bg.sample_name} / {bg.name}\")"
   },
   {
    "cell_type": "code",
@@ -605,7 +457,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "id": "27-update-sequence",
    "metadata": {
     "execution": {
@@ -615,42 +467,8 @@
      "shell.execute_reply": "2026-05-27T21:12:14.678534Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Updated with sequence.\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8aab9beaf5624b1f81eb01c309cf66f7",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "<gen.jupyter_widget.GenGraphWidget object at 0x10a86f890>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "update_repo.update_with_sequence(\n",
-    "    \"TTTTTTTT\",\n",
-    "    sample=\"ref\",\n",
-    "    new_sample=\"seq_updated\",\n",
-    "    region_name=\"m123:5-15\",\n",
-    ")\n",
-    "\n",
-    "bg_seq = [bg for bg in update_repo.get_block_groups() if bg.sample_name == \"seq_updated\"][0]\n",
-    "w = bg_seq.plot()\n",
-    "w.show_path()\n",
-    "w"
-   ]
+   "outputs": [],
+   "source": "update_repo.update_with_sequence(\n    \"TTTTTTTT\",\n    sample=\"ref\",\n    new_sample=\"seq_updated\",\n    region_name=\"m123:5-15\",\n)\n\nbg_seq = [bg for bg in update_repo.get_sequence_graphs() if bg.sample_name == \"seq_updated\"][0]\nw = bg_seq.plot()\nw.show_path()\nw"
   },
   {
    "cell_type": "markdown",
@@ -664,7 +482,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "id": "29-update-vcf",
    "metadata": {
     "execution": {
@@ -674,56 +492,8 @@
      "shell.execute_reply": "2026-05-27T21:12:14.719889Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Block groups after VCF update: 4\n",
-      "  ref / m123\n",
-      "  unknown / m123\n",
-      "  G1 / m123\n",
-      "  foo / m123\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b3911b60b8bb4380b8144a6aedadb7fa",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "<gen.jupyter_widget.GenGraphWidget object at 0x10a862ea0>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "# Use a dedicated repo so state is clean\n",
-    "vcf_repo = gen.Repository(str(WORK_DIR / \"vcf_simple\"))\n",
-    "vcf_repo.import_fasta(str(FX / \"simple.fa\"), sample=\"ref\")\n",
-    "\n",
-    "# reference= names the parent sample to update from\n",
-    "# genotype= fixes a specific GT to apply (e.g. \"1/1\" = hom alt only)\n",
-    "# sample=  selects a VCF sample column for genotype info\n",
-    "vcf_repo.update_with_vcf(\n",
-    "    str(FX / \"simple.vcf\"),\n",
-    "    reference=\"ref\",\n",
-    ")\n",
-    "\n",
-    "bgs = vcf_repo.get_block_groups()\n",
-    "print(f\"Block groups after VCF update: {len(bgs)}\")\n",
-    "for bg in bgs:\n",
-    "    print(f\"  {bg.sample_name} / {bg.name}\")\n",
-    "\n",
-    "updated_bg = [bg for bg in bgs if bg.sample_name != \"ref\"][0]\n",
-    "w = updated_bg.plot()\n",
-    "w.show_path()\n",
-    "w"
-   ]
+   "outputs": [],
+   "source": "# Use a dedicated repo so state is clean\nvcf_repo = gen.Repository(str(WORK_DIR / \"vcf_simple\"))\nvcf_repo.import_fasta(str(FX / \"simple.fa\"), sample=\"ref\")\n\n# reference= names the parent sample to update from\n# genotype= fixes a specific GT to apply (e.g. \"1/1\" = hom alt only)\n# sample=  selects a VCF sample column for genotype info\nvcf_repo.update_with_vcf(\n    str(FX / \"simple.vcf\"),\n    reference=\"ref\",\n)\n\nbgs = vcf_repo.get_sequence_graphs()\nprint(f\"Sequence graphs after VCF update: {len(bgs)}\")\nfor bg in bgs:\n    print(f\"  {bg.sample_name} / {bg.name}\")\n\nupdated_bg = [bg for bg in bgs if bg.sample_name != \"ref\"][0]\nw = updated_bg.plot()\nw.show_path()\nw"
   },
   {
    "cell_type": "markdown",
@@ -737,7 +507,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "id": "32-update-gfa",
    "metadata": {
     "execution": {
@@ -747,53 +517,8 @@
      "shell.execute_reply": "2026-05-27T21:12:14.753229Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Warning: No path found that matches path 291344 from input GFA, skipping\n",
-      "Block groups after GFA update: 2\n",
-      "  ref / \n",
-      "  gfa_merged / \n",
-      "Updated with GFA file: /Users/bvh/git/gen/fixtures/walk.gfa\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "da2e8ca312db4dd8b4c3cc2e89b63a81",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "<gen.jupyter_widget.GenGraphWidget object at 0x10a863100>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "gfa_update_repo = gen.Repository(str(WORK_DIR / \"gfa_update\"))\n",
-    "gfa_update_repo.import_gfa(str(FX / \"simple.gfa\"), sample=\"ref\")\n",
-    "\n",
-    "gfa_update_repo.update_with_gfa(\n",
-    "    str(FX / \"walk.gfa\"),\n",
-    "    sample=\"ref\",\n",
-    "    new_sample=\"gfa_merged\",\n",
-    ")\n",
-    "\n",
-    "merged_bgs = gfa_update_repo.get_block_groups()\n",
-    "print(f\"Block groups after GFA update: {len(merged_bgs)}\")\n",
-    "for bg in merged_bgs:\n",
-    "    print(f\"  {bg.sample_name} / {bg.name}\")\n",
-    "\n",
-    "merged_bg = [bg for bg in merged_bgs if bg.sample_name == \"gfa_merged\"][0]\n",
-    "w = merged_bg.plot()\n",
-    "w.show_path()\n",
-    "w"
-   ]
+   "outputs": [],
+   "source": "gfa_update_repo = gen.Repository(str(WORK_DIR / \"gfa_update\"))\ngfa_update_repo.import_gfa(str(FX / \"simple.gfa\"), sample=\"ref\")\n\ngfa_update_repo.update_with_gfa(\n    str(FX / \"walk.gfa\"),\n    sample=\"ref\",\n    new_sample=\"gfa_merged\",\n)\n\nmerged_bgs = gfa_update_repo.get_sequence_graphs()\nprint(f\"Sequence graphs after GFA update: {len(merged_bgs)}\")\nfor bg in merged_bgs:\n    print(f\"  {bg.sample_name} / {bg.name}\")\n\nmerged_bg = [bg for bg in merged_bgs if bg.sample_name == \"gfa_merged\"][0]\nw = merged_bg.plot()\nw.show_path()\nw"
   },
   {
    "cell_type": "markdown",
@@ -807,7 +532,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "id": "36-update-gaf",
    "metadata": {
     "execution": {
@@ -817,53 +542,8 @@
      "shell.execute_reply": "2026-05-27T21:12:14.835715Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Block groups after GAF update: 3\n",
-      "  ref / test_left\n",
-      "  ref / test_right\n",
-      "  ref / \n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "5ac9038167bd4490b56531f13c95c7d3",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "<gen.jupyter_widget.GenGraphWidget object at 0x10a8e5490>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "gaf_repo = gen.Repository(str(WORK_DIR / \"gaf_demo\"))\n",
-    "gaf_repo.import_fasta(str(FX / \"chr22_het.fa\"), sample=\"ref\")\n",
-    "gaf_repo.import_gfa(str(FX / \"chr22_het.gfa\"), sample=\"ref\")\n",
-    "\n",
-    "# csv: path to the insert-flanks CSV that describes insertions in the GAF\n",
-    "gaf_repo.update_with_gaf(\n",
-    "    str(FX / \"chr22_het.gaf\"),\n",
-    "    csv=str(FX / \"chr22_insert.csv\"),\n",
-    "    sample=\"gaf_sample\",\n",
-    ")\n",
-    "\n",
-    "bgs = gaf_repo.get_block_groups()\n",
-    "print(f\"Block groups after GAF update: {len(bgs)}\")\n",
-    "for bg in bgs:\n",
-    "    print(f\"  {bg.sample_name} / {bg.name}\")\n",
-    "\n",
-    "w = bgs[0].plot()\n",
-    "w.show_path()\n",
-    "w"
-   ]
+   "outputs": [],
+   "source": "gaf_repo = gen.Repository(str(WORK_DIR / \"gaf_demo\"))\ngaf_repo.import_fasta(str(FX / \"chr22_het.fa\"), sample=\"ref\")\ngaf_repo.import_gfa(str(FX / \"chr22_het.gfa\"), sample=\"ref\")\n\n# csv: path to the insert-flanks CSV that describes insertions in the GAF\ngaf_repo.update_with_gaf(\n    str(FX / \"chr22_het.gaf\"),\n    csv=str(FX / \"chr22_insert.csv\"),\n    sample=\"gaf_sample\",\n)\n\nbgs = gaf_repo.get_sequence_graphs()\nprint(f\"Sequence graphs after GAF update: {len(bgs)}\")\nfor bg in bgs:\n    print(f\"  {bg.sample_name} / {bg.name}\")\n\nw = bgs[0].plot()\nw.show_path()\nw"
   },
   {
    "cell_type": "markdown",
@@ -877,7 +557,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "id": "38-update-library",
    "metadata": {
     "execution": {
@@ -887,62 +567,12 @@
      "shell.execute_reply": "2026-05-27T21:12:14.854181Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Block groups after library update: 2\n",
-      "  ref / m123\n",
-      "  lib_updated / lib_updated\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "0a1777726b2740b5b0d92785edd5c737",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "<gen.jupyter_widget.GenGraphWidget object at 0x10a8f96a0>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "lib_update_repo = gen.Repository(str(WORK_DIR / \"lib_update\"))\n",
-    "lib_update_repo.import_fasta(str(FX / \"simple.fa\"), sample=\"ref\")\n",
-    "\n",
-    "# Build the replacement library inline\n",
-    "parts_list = [\n",
-    "    [gen.SequencePart(\"p1\", \"AAAA\"), gen.SequencePart(\"cds1\", \"ATGATAA\")],\n",
-    "    [gen.SequencePart(\"p2\", \"TAAT\"), gen.SequencePart(\"cds2\", \"ATGTTAA\")],\n",
-    "]\n",
-    "\n",
-    "lib_update_repo.update_with_library(\n",
-    "    sample=\"ref\",\n",
-    "    new_sample_name=\"lib_updated\",\n",
-    "    path_name=\"m123:5-20\",\n",
-    "    parts_list=parts_list,\n",
-    ")\n",
-    "\n",
-    "bgs = lib_update_repo.get_block_groups()\n",
-    "print(f\"Block groups after library update: {len(bgs)}\")\n",
-    "for bg in bgs:\n",
-    "    print(f\"  {bg.sample_name} / {bg.name}\")\n",
-    "\n",
-    "updated_bg = [bg for bg in bgs if bg.sample_name == \"lib_updated\"][0]\n",
-    "w = updated_bg.plot()\n",
-    "w.show_path()\n",
-    "w"
-   ]
+   "outputs": [],
+   "source": "lib_update_repo = gen.Repository(str(WORK_DIR / \"lib_update\"))\nlib_update_repo.import_fasta(str(FX / \"simple.fa\"), sample=\"ref\")\n\n# Build the replacement library inline\nparts_list = [\n    [gen.SequencePart(\"p1\", \"AAAA\"), gen.SequencePart(\"cds1\", \"ATGATAA\")],\n    [gen.SequencePart(\"p2\", \"TAAT\"), gen.SequencePart(\"cds2\", \"ATGTTAA\")],\n]\n\nlib_update_repo.update_with_library(\n    sample=\"ref\",\n    new_sample_name=\"lib_updated\",\n    path_name=\"m123:5-20\",\n    parts_list=parts_list,\n)\n\nbgs = lib_update_repo.get_sequence_graphs()\nprint(f\"Sequence graphs after library update: {len(bgs)}\")\nfor bg in bgs:\n    print(f\"  {bg.sample_name} / {bg.name}\")\n\nupdated_bg = [bg for bg in bgs if bg.sample_name == \"lib_updated\"][0]\nw = updated_bg.plot()\nw.show_path()\nw"
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "id": "39-update-library-files",
    "metadata": {
     "execution": {
@@ -952,28 +582,8 @@
      "shell.execute_reply": "2026-05-27T21:12:14.870238Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Block groups after library-files update: 3\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Same operation, but reading parts from CSV files\n",
-    "lib_update_repo.update_with_library_files(\n",
-    "    sample=\"ref\",\n",
-    "    new_sample=\"lib_file_updated\",\n",
-    "    path_name=\"m123:5-20\",\n",
-    "    library=str(FX / \"combinatorial_design.csv\"),\n",
-    "    parts=str(FX / \"parts.fa\"),\n",
-    ")\n",
-    "\n",
-    "bgs = lib_update_repo.get_block_groups()\n",
-    "print(f\"Block groups after library-files update: {len(bgs)}\")"
-   ]
+   "outputs": [],
+   "source": "# Same operation, but reading parts from CSV files\nlib_update_repo.update_with_library_files(\n    sample=\"ref\",\n    new_sample=\"lib_file_updated\",\n    path_name=\"m123:5-20\",\n    library=str(FX / \"combinatorial_design.csv\"),\n    parts=str(FX / \"parts.fa\"),\n)\n\nbgs = lib_update_repo.get_sequence_graphs()\nprint(f\"Sequence graphs after library-files update: {len(bgs)}\")"
   },
   {
    "cell_type": "markdown",
@@ -988,7 +598,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "id": "41-graph-ops-setup",
    "metadata": {
     "execution": {
@@ -998,29 +608,8 @@
      "shell.execute_reply": "2026-05-27T21:12:14.884236Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Base block groups: 2\n",
-      "  test_left (ref)\n",
-      "  test_right (ref)\n"
-     ]
-    }
-   ],
-   "source": [
-    "# chr22_het.fa has several linear ~50bp sequences — good for subgraph and chunk demos\n",
-    "ops_repo = gen.Repository(str(WORK_DIR / \"graph_ops\"))\n",
-    "ops_repo.import_fasta(str(FX / \"chr22_het.fa\"), sample=\"ref\")\n",
-    "\n",
-    "bgs = ops_repo.get_block_groups()\n",
-    "print(f\"Base block groups: {len(bgs)}\")\n",
-    "for bg in bgs:\n",
-    "    print(f\"  {bg.name} ({bg.sample_name})\")\n",
-    "\n",
-    "region_name = bgs[0].name"
-   ]
+   "outputs": [],
+   "source": "# chr22_het.fa has several linear ~50bp sequences — good for subgraph and chunk demos\nops_repo = gen.Repository(str(WORK_DIR / \"graph_ops\"))\nops_repo.import_fasta(str(FX / \"chr22_het.fa\"), sample=\"ref\")\n\nbgs = ops_repo.get_sequence_graphs()\nprint(f\"Base sequence graphs: {len(bgs)}\")\nfor bg in bgs:\n    print(f\"  {bg.name} ({bg.sample_name})\")\n\nregion_name = bgs[0].name"
   },
   {
    "cell_type": "markdown",
@@ -1034,7 +623,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "id": "43-derive-subgraph",
    "metadata": {
     "execution": {
@@ -1044,41 +633,8 @@
      "shell.execute_reply": "2026-05-27T21:12:14.889746Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Derived subgraph block groups: 1\n",
-      "Derive subgraph succeeded.\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "dc0c0264fd974ccd8c04edb39ae09317",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "<gen.jupyter_widget.GenGraphWidget object at 0x10a8f9ae0>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "ops_repo.derive_subgraph(\n",
-    "    sample=\"ref\",\n",
-    "    new_sample=\"subgraph_sample\",\n",
-    "    region=f\"{region_name}:0-25\",\n",
-    ")\n",
-    "\n",
-    "sub_bgs = [bg for bg in ops_repo.get_block_groups() if bg.sample_name == \"subgraph_sample\"]\n",
-    "print(f\"Derived subgraph block groups: {len(sub_bgs)}\")\n",
-    "sub_bgs[0].plot()"
-   ]
+   "outputs": [],
+   "source": "ops_repo.derive_subgraph(\n    sample=\"ref\",\n    new_sample=\"subgraph_sample\",\n    region=f\"{region_name}:0-25\",\n)\n\nsub_bgs = [bg for bg in ops_repo.get_sequence_graphs() if bg.sample_name == \"subgraph_sample\"]\nprint(f\"Derived subgraph sequence graphs: {len(sub_bgs)}\")\nsub_bgs[0].plot()"
   },
   {
    "cell_type": "markdown",
@@ -1092,7 +648,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "id": "45-derive-chunks",
    "metadata": {
     "execution": {
@@ -1102,48 +658,8 @@
      "shell.execute_reply": "2026-05-27T21:12:14.895300Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Chunks created: 2\n",
-      "  test_left.1\n",
-      "  test_left.2\n",
-      "Derive chunks succeeded.\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7efda27e8c4a423e9fcf9a8f30a20769",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "<gen.jupyter_widget.GenGraphWidget object at 0x10a964a50>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "# breakpoints is a list of integer coordinates along the path\n",
-    "ops_repo.derive_chunks(\n",
-    "    sample=\"ref\",\n",
-    "    new_sample=\"chunks_sample\",\n",
-    "    region=region_name,\n",
-    "    breakpoints=[25],   # split at position 25 → two chunks [0,25] and [25,end]\n",
-    ")\n",
-    "\n",
-    "chunk_bgs = [bg for bg in ops_repo.get_block_groups() if bg.sample_name == \"chunks_sample\"]\n",
-    "print(f\"Chunks created: {len(chunk_bgs)}\")\n",
-    "for bg in chunk_bgs:\n",
-    "    print(f\"  {bg.name}\")\n",
-    "\n",
-    "chunk_bgs[0].plot()"
-   ]
+   "outputs": [],
+   "source": "# breakpoints is a list of integer coordinates along the path\nops_repo.derive_chunks(\n    sample=\"ref\",\n    new_sample=\"chunks_sample\",\n    region=region_name,\n    breakpoints=[25],   # split at position 25 → two chunks [0,25] and [25,end]\n)\n\nchunk_bgs = [bg for bg in ops_repo.get_sequence_graphs() if bg.sample_name == \"chunks_sample\"]\nprint(f\"Chunks created: {len(chunk_bgs)}\")\nfor bg in chunk_bgs:\n    print(f\"  {bg.name}\")\n\nchunk_bgs[0].plot()"
   },
   {
    "cell_type": "markdown",
@@ -1157,7 +673,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "id": "47-make-stitch",
    "metadata": {
     "execution": {
@@ -1167,55 +683,14 @@
      "shell.execute_reply": "2026-05-27T21:12:14.900533Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Stitched block groups: 1\n",
-      "Stitched chunks successfully into new region stitched_region in sample stitched_sample.\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "bdede99c51cd499fb050314c382ead0c",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "<gen.jupyter_widget.GenGraphWidget object at 0x10a964b50>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "# Stitch the first three chunks back into one region\n",
-    "stitch_names = \",\".join(bg.name for bg in chunk_bgs[:3])\n",
-    "\n",
-    "ops_repo.make_stitch(\n",
-    "    sample=\"chunks_sample\",\n",
-    "    new_sample=\"stitched_sample\",\n",
-    "    regions=stitch_names,\n",
-    "    new_region=\"stitched_region\",\n",
-    ")\n",
-    "\n",
-    "stitched = [bg for bg in ops_repo.get_block_groups() if bg.sample_name == \"stitched_sample\"]\n",
-    "print(f\"Stitched block groups: {len(stitched)}\")\n",
-    "stitched[0].plot()"
-   ]
+   "outputs": [],
+   "source": "# Stitch the first three chunks back into one region\nstitch_names = \",\".join(bg.name for bg in chunk_bgs[:3])\n\nops_repo.make_stitch(\n    sample=\"chunks_sample\",\n    new_sample=\"stitched_sample\",\n    regions=stitch_names,\n    new_region=\"stitched_region\",\n)\n\nstitched = [bg for bg in ops_repo.get_sequence_graphs() if bg.sample_name == \"stitched_sample\"]\nprint(f\"Stitched sequence graphs: {len(stitched)}\")\nstitched[0].plot()"
   },
   {
    "cell_type": "markdown",
    "id": "48-stitch-header",
    "metadata": {},
-   "source": [
-    "### 4.4 `stitch` (typed helper)\n",
-    "\n",
-    "Same as `make_stitch` but accepts `BlockGroup` objects directly instead of name strings."
-   ]
+   "source": "### 4.4 `stitch` (typed helper)\n\nSame as `make_stitch` but accepts `SequenceGraph` objects directly instead of name strings."
   },
   {
    "cell_type": "code",
@@ -1268,22 +743,11 @@
    "cell_type": "markdown",
    "id": "50-collection-header",
    "metadata": {},
-   "source": [
-    "---\n",
-    "## 5. Using the `collection` parameter\n",
-    "\n",
-    "A single `gen` repository can hold data from multiple analyses on the same organism.\n",
-    "Collections let you organise block groups by analysis type while still sharing the same samples —\n",
-    "for example, genomics, transcriptomics, and proteomics data can all live in one repo and\n",
-    "be queried independently or jointly.\n",
-    "\n",
-    "Pass `collection=` to any import/export/update call to tag block groups, then retrieve them\n",
-    "with `get_block_groups_by_collection`."
-   ]
+   "source": "---\n## 5. Using the `collection` parameter\n\nA single `gen` repository can hold data from multiple analyses on the same organism.\nCollections let you organise sequence graphs by analysis type while still sharing the same samples —\nfor example, genomics, transcriptomics, and proteomics data can all live in one repo and\nbe queried independently or jointly.\n\nPass `collection=` to any import/export/update call to tag sequence graphs, then retrieve them\nwith `get_sequence_graphs_by_collection`."
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "id": "51-collection-demo",
    "metadata": {
     "execution": {
@@ -1293,49 +757,8 @@
      "shell.execute_reply": "2026-05-27T21:12:14.940677Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "genomics:        4 block group(s)"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "transcriptomics: 6 block group(s)\n",
-      "proteomics:      3 block group(s)\n",
-      "\n",
-      "  [genomics] wt / m123\n",
-      "  [genomics] mut / m1\n",
-      "  [genomics] mut / m2\n",
-      "  [genomics] mut / m3\n"
-     ]
-    }
-   ],
-   "source": [
-    "multi_repo = gen.Repository(str(WORK_DIR / \"multi_omics\"))\n",
-    "\n",
-    "# Each analysis type gets its own collection — same repo, same samples\n",
-    "multi_repo.import_fasta(str(FX / \"simple.fa\"),   sample=\"wt\", collection=\"genomics\")\n",
-    "multi_repo.import_fasta(str(FX / \"parts.fa\"),    sample=\"wt\", collection=\"transcriptomics\")\n",
-    "multi_repo.import_fasta(str(FX / \"multiseq.fa\"), sample=\"wt\", collection=\"proteomics\")\n",
-    "multi_repo.import_fasta(str(FX / \"multiseq.fa\"), sample=\"mut\", collection=\"genomics\")\n",
-    "\n",
-    "genomics      = multi_repo.get_block_groups_by_collection(\"genomics\")\n",
-    "transcriptomics = multi_repo.get_block_groups_by_collection(\"transcriptomics\")\n",
-    "proteomics    = multi_repo.get_block_groups_by_collection(\"proteomics\")\n",
-    "\n",
-    "print(f\"genomics:        {len(genomics)} block group(s)\")\n",
-    "print(f\"transcriptomics: {len(transcriptomics)} block group(s)\")\n",
-    "print(f\"proteomics:      {len(proteomics)} block group(s)\")\n",
-    "print()\n",
-    "for bg in genomics:\n",
-    "    print(f\"  [genomics] {bg.sample_name} / {bg.name}\")"
-   ]
+   "outputs": [],
+   "source": "multi_repo = gen.Repository(str(WORK_DIR / \"multi_omics\"))\n\n# Each analysis type gets its own collection — same repo, same samples\nmulti_repo.import_fasta(str(FX / \"simple.fa\"),   sample=\"wt\", collection=\"genomics\")\nmulti_repo.import_fasta(str(FX / \"parts.fa\"),    sample=\"wt\", collection=\"transcriptomics\")\nmulti_repo.import_fasta(str(FX / \"multiseq.fa\"), sample=\"wt\", collection=\"proteomics\")\nmulti_repo.import_fasta(str(FX / \"multiseq.fa\"), sample=\"mut\", collection=\"genomics\")\n\ngenomics      = multi_repo.get_sequence_graphs_by_collection(\"genomics\")\ntranscriptomics = multi_repo.get_sequence_graphs_by_collection(\"transcriptomics\")\nproteomics    = multi_repo.get_sequence_graphs_by_collection(\"proteomics\")\n\nprint(f\"genomics:        {len(genomics)} sequence graph(s)\")\nprint(f\"transcriptomics: {len(transcriptomics)} sequence graph(s)\")\nprint(f\"proteomics:      {len(proteomics)} sequence graph(s)\")\nprint()\nfor bg in genomics:\n    print(f\"  [genomics] {bg.sample_name} / {bg.name}\")"
   }
  ],
  "metadata": {

--- a/gen-python/python/gen/__init__.py
+++ b/gen-python/python/gen/__init__.py
@@ -13,31 +13,31 @@ except PackageNotFoundError:
 # Directly from Rust
 from .gen import (
     Annotation,
-    BlockGroup,
     HashId,
+    Locus,
     Node,
     NodeSlice,
-    GraphPos,
-    GraphLocus,
-    SequencePart,
+    Position,
     Repository,
+    SequenceGraph,
+    SequencePart,
 )
 
 # Jupyter widget — only available with `pip install gen[jupyter]`
 try:
-    from .jupyter_widget import GenGraphWidget
+    from .jupyter_widget import GraphWidget
 except ImportError:
-    GenGraphWidget = None
+    GraphWidget = None
 
 __all__ = [
     "Annotation",
-    "BlockGroup",
-    "GenGraphWidget",
-    "GraphLocus",
-    "GraphPos",
+    "GraphWidget",
     "HashId",
+    "Locus",
     "Node",
     "NodeSlice",
+    "Position",
     "Repository",
+    "SequenceGraph",
     "SequencePart",
 ]

--- a/gen-python/python/gen/jupyter_widget.py
+++ b/gen-python/python/gen/jupyter_widget.py
@@ -4,7 +4,7 @@ Architecture
 ------------
 - Native Rust (GraphController) owns all state, performs layout, renders into
   a ratatui Buffer, and serialises the result to a RenderedFrame JSON string.
-- Python (GenGraphWidget) is a thin bridge: it holds the Rust controller,
+- Python (GraphWidget) is a thin bridge: it holds the Rust controller,
   requests frames, and syncs them to the frontend via the `frame` traitlet.
 - The frontend (static/jupyter_widget.js) is a dumb canvas painter that also sends
   mouse events back as custom messages.
@@ -28,7 +28,7 @@ _ESM = pathlib.Path(__file__).parent / "static" / "jupyter_widget.js"
 # All live widget instances, so that module-level helpers can operate on them.
 
 
-class GenGraphWidget(anywidget.AnyWidget):
+class GraphWidget(anywidget.AnyWidget):
     """Jupyter widget that displays a Gen graph using the native Rust renderer.
 
     Usage
@@ -36,8 +36,8 @@ class GenGraphWidget(anywidget.AnyWidget):
     ::
 
         repo   = gen.Repository()
-        bg     = repo.get_block_groups()[0]
-        widget = repo.plot(bg)   # or bg.plot()
+        sg     = repo.get_sequence_graphs()[0]
+        widget = repo.plot(sg)   # or sg.plot()
         widget  # display in Jupyter cell
 
         # Optionally send commands from Python afterwards:
@@ -62,7 +62,7 @@ class GenGraphWidget(anywidget.AnyWidget):
         ----------
         controller:
             A ``gen.PyGraphController`` instance.  Normally obtained via
-            ``repo.plot(bg)`` or ``bg.plot()``.
+            ``repo.plot(sg)`` or ``sg.plot()``.
         """
         super().__init__(**kwargs)
         self._controller = controller
@@ -92,7 +92,7 @@ class GenGraphWidget(anywidget.AnyWidget):
         from IPython.display import display
 
         cloned_ctrl = self._controller.clone_controller()
-        snapshot = GenGraphWidget(cloned_ctrl, cols=self.cols, rows=self.rows)
+        snapshot = GraphWidget(cloned_ctrl, cols=self.cols, rows=self.rows)
         data = {
             "text/plain": repr(snapshot),
             "application/vnd.jupyter.widget-view+json": {
@@ -207,8 +207,8 @@ class GenGraphWidget(anywidget.AnyWidget):
         Parameters
         ----------
         target:
-            A ``GraphPos`` (from ``locus.start()`` / ``locus.end()``),
-            a ``GraphLocus`` (from ``repo.search()``), or
+            A ``Position`` (from ``locus.start()`` / ``locus.end()``),
+            a ``Locus`` (from ``repo.search()``), or
             an ``Annotation`` object (e.g. from ``widget.list_annotations()``).
 
         Example
@@ -224,11 +224,11 @@ class GenGraphWidget(anywidget.AnyWidget):
         """
         if self._frozen:
             return
-        from gen import Annotation, GraphLocus  # noqa: PLC0415
+        from gen import Annotation, Locus  # noqa: PLC0415
 
         if isinstance(target, Annotation):
             self._controller.go_to_annotation_obj(target)
-        elif isinstance(target, GraphLocus):
+        elif isinstance(target, Locus):
             self._controller.go_to_locus(target)
         else:
             self._controller.go_to_pos(target)
@@ -240,7 +240,7 @@ class GenGraphWidget(anywidget.AnyWidget):
         Parameters
         ----------
         target:
-            A ``GraphLocus`` returned by ``repo.search()``, or an ``Annotation``
+            A ``Locus`` returned by ``repo.search()``, or an ``Annotation``
             object (e.g. from ``widget.list_annotations()``).
         color:
             Optional highlight colour.  Accepts named colours
@@ -276,7 +276,7 @@ class GenGraphWidget(anywidget.AnyWidget):
         Parameters
         ----------
         locus:
-            A ``GraphLocus`` returned by ``repo.search()``.
+            A ``Locus`` returned by ``repo.search()``.
         color:
             Optional colour for the highlight.  Accepts named colours
             (``"yellow"``, ``"cyan"``, ``"red"``, …) or a CSS hex string

--- a/gen-python/src/python_api.rs
+++ b/gen-python/src/python_api.rs
@@ -1,7 +1,7 @@
 use pyo3::{Bound, prelude::*, types::PyModule};
 
-pub mod block;
 pub mod block_group;
+pub mod graph_node;
 pub mod graph_search;
 pub mod hash_id;
 pub mod jupyter_widget;
@@ -10,8 +10,8 @@ pub mod sequence_part;
 pub mod utils;
 
 use crate::python_api::{
-    block::{PyGraphNode, PyGraphNodeSlice},
-    block_group::PyBlockGroup,
+    block_group::PySequenceGraph,
+    graph_node::{PyGraphNode, PyGraphNodeSlice},
     graph_search::{PyAnnotation, PyGraphLocus, PyGraphPos},
     hash_id::PyHashId,
     jupyter_widget::PyGraphController,
@@ -25,7 +25,7 @@ use crate::python_api::{
 #[pymodule]
 pub fn r#gen(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyRepository>()?;
-    m.add_class::<PyBlockGroup>()?;
+    m.add_class::<PySequenceGraph>()?;
     m.add_class::<PyHashId>()?;
     m.add_class::<PyGraphNode>()?;
     m.add_class::<PyGraphNodeSlice>()?;

--- a/gen-python/src/python_api/block_group.rs
+++ b/gen-python/src/python_api/block_group.rs
@@ -9,7 +9,7 @@ use r#gen::{
     graphs::graph_search::{GenGraphMatcher, SeedIndex, SequenceKind},
 };
 use gen_graph::GraphNode;
-use gen_models::{block_group::BlockGroup, db::DbContext, sample::Sample};
+use gen_models::{block_group::BlockGroup, db::DbContext, node::Node, sample::Sample};
 use pyo3::{exceptions::PyRuntimeError, prelude::*, types::PyDict};
 
 use super::{
@@ -285,21 +285,38 @@ impl PySequenceGraph {
         Ok(())
     }
 
+    /// Return the sequence for a graph node.
+    ///
+    /// Parameters
+    /// ----------
+    /// node : Node
+    ///     A ``Node`` obtained from ``to_dict()["nodes"]``, ``search()`` results,
+    ///     or any other API that returns graph nodes.
+    ///
+    /// Raises ``RuntimeError`` if this sequence graph was not created via a
+    /// ``Repository``.
+    fn get_node_sequence(&self, node: &PyGraphNode) -> PyResult<String> {
+        let conn = self.require_context("get_node_sequence()")?.graph().conn();
+        let sequences = Node::get_sequences_by_node_ids(conn, &[node.node_id]);
+        let sequence = sequences.get(&node.node_id).ok_or_else(|| {
+            pyo3::exceptions::PyValueError::new_err(format!(
+                "Node with id {:?} not found",
+                node.node_id
+            ))
+        })?;
+        Ok(sequence
+            .get_sequence(node.sequence_start, node.sequence_end)
+            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?)
+    }
+
     fn to_dict(&self, py: Python<'_>) -> PyResult<PyObject> {
         let conn = self.require_context("to_dict()")?.graph().conn();
         let graph = BlockGroup::get_graph(conn, &self.id).map_err(block_group_err_to_pyerr)?;
         let dict = PyDict::new(py);
-        let nodes = PyDict::new(py);
-        for node in graph.nodes() {
-            let node_dict = PyDict::new(py);
-            node_dict.set_item("parent_node_id", node.node_id)?;
-            node_dict.set_item("sequence_start", node.sequence_start)?;
-            node_dict.set_item("sequence_end", node.sequence_end)?;
-            nodes.set_item(
-                PyGraphNode::new(node.node_id, node.sequence_start, node.sequence_end),
-                node_dict,
-            )?;
-        }
+        let nodes: Vec<PyGraphNode> = graph
+            .nodes()
+            .map(|node| PyGraphNode::new(node.node_id, node.sequence_start, node.sequence_end))
+            .collect();
         dict.set_item("nodes", nodes)?;
         let edges = PyDict::new(py);
         for (src, dst, edge_weights) in graph.all_edges() {
@@ -340,9 +357,6 @@ impl PySequenceGraph {
             let mut node_map: HashMap<GraphNode, usize> = HashMap::new();
             for node in graph.nodes() {
                 let node_data = PyDict::new(py);
-                node_data.set_item("parent_node_id", node.node_id)?;
-                node_data.set_item("sequence_start", node.sequence_start)?;
-                node_data.set_item("sequence_end", node.sequence_end)?;
                 node_data.set_item(
                     "key",
                     PyGraphNode::new(node.node_id, node.sequence_start, node.sequence_end),
@@ -382,12 +396,6 @@ impl PySequenceGraph {
             })?;
             let nx_digraph = networkx.getattr("DiGraph")?.call0()?;
             for node in graph.nodes() {
-                let node_data = PyDict::new(py);
-                node_data.set_item("parent_node_id", node.node_id)?;
-                node_data.set_item("sequence_start", node.sequence_start)?;
-                node_data.set_item("sequence_end", node.sequence_end)?;
-                let kwargs = PyDict::new(py);
-                kwargs.set_item("attr_dict", node_data)?;
                 nx_digraph.call_method(
                     "add_node",
                     (PyGraphNode::new(
@@ -395,7 +403,7 @@ impl PySequenceGraph {
                         node.sequence_start,
                         node.sequence_end,
                     ),),
-                    Some(&kwargs),
+                    None,
                 )?;
             }
             for (src, dst, edge_weights) in graph.all_edges() {

--- a/gen-python/src/python_api/block_group.rs
+++ b/gen-python/src/python_api/block_group.rs
@@ -13,7 +13,7 @@ use gen_models::{block_group::BlockGroup, db::DbContext, sample::Sample};
 use pyo3::{exceptions::PyRuntimeError, prelude::*, types::PyDict};
 
 use super::{
-    block::PyGraphNode,
+    graph_node::PyGraphNode,
     hash_id::PyHashId,
     jupyter_widget::{PyGraphController, build_widget},
     utils::block_group_err_to_pyerr,
@@ -31,25 +31,25 @@ pub(crate) fn parse_sequence_kind(s: &str) -> PyResult<SequenceKind> {
     }
 }
 
-/// A block group returned by a ``Repository``.
+/// A sequence graph returned by a ``Repository``.
 ///
-/// ``BlockGroup`` objects cannot be shared across threads because they hold a
+/// ``SequenceGraph`` objects cannot be shared across threads because they hold a
 /// reference to the database connection of the ``Repository`` that created them.
 ///
-/// To use a block group's identity in another thread, capture its ``id``,
+/// To use a sequence graph's identity in another thread, capture its ``id``,
 /// open a fresh ``Repository`` in that thread, and look it up by id::
 ///
-///     bg_id = bg.id
+///     sg_id = sg.id
 ///     path  = str(repo.db_path)
 ///
 ///     def worker():
 ///         r = gen.Repository(path)
-///         bg = r.get_block_group_by_id(bg_id)
+///         sg = r.get_sequence_graph_by_id(sg_id)
 ///         ...
 // unsendable because DbContext contains Rc (rusqlite::Connection is !Sync)
-#[pyclass(name = "BlockGroup", unsendable)]
+#[pyclass(name = "SequenceGraph", unsendable)]
 #[derive(Clone)]
-pub struct PyBlockGroup {
+pub struct PySequenceGraph {
     pub id: HashId,
     #[pyo3(get)]
     pub collection_name: String,
@@ -61,10 +61,10 @@ pub struct PyBlockGroup {
 }
 
 #[pymethods]
-impl PyBlockGroup {
+impl PySequenceGraph {
     #[new]
     pub fn new(id: HashId, collection_name: String, name: String, sample_name: String) -> Self {
-        PyBlockGroup {
+        PySequenceGraph {
             id,
             collection_name,
             sample_name,
@@ -80,7 +80,7 @@ impl PyBlockGroup {
 
     fn __repr__(&self) -> PyResult<String> {
         Ok(format!(
-            "BlockGroup({}, collection={:?}, sample={:?}, name={:?})",
+            "SequenceGraph({}, collection={:?}, sample={:?}, name={:?})",
             self.id, self.collection_name, self.sample_name, self.name
         ))
     }
@@ -94,7 +94,7 @@ impl PyBlockGroup {
     }
 
     fn __eq__(&self, other: &Bound<'_, PyAny>) -> PyResult<bool> {
-        if let Ok(other_bg) = other.extract::<PyRef<PyBlockGroup>>() {
+        if let Ok(other_bg) = other.extract::<PyRef<PySequenceGraph>>() {
             Ok(self.id == other_bg.id
                 && self.collection_name == other_bg.collection_name
                 && self.sample_name == other_bg.sample_name
@@ -104,13 +104,13 @@ impl PyBlockGroup {
         }
     }
 
-    /// Plot this block group's graph as an interactive Jupyter widget.
+    /// Plot this sequence graph as an interactive Jupyter widget.
     ///
     /// Displays the widget immediately and returns it for further use.
     /// Outside of an IPython/Jupyter environment the display call is silently
     /// skipped and only the widget is returned.
     ///
-    /// Raises ``RuntimeError`` if this block group was not created via a
+    /// Raises ``RuntimeError`` if this sequence graph was not created via a
     /// ``Repository``.
     ///
     /// Parameters
@@ -125,7 +125,7 @@ impl PyBlockGroup {
     ///     shows the smallest representation.
     #[pyo3(signature = (rows=None, cols=None, detail=None))]
     fn plot(
-        slf: &Bound<'_, PyBlockGroup>,
+        slf: &Bound<'_, PySequenceGraph>,
         rows: Option<u32>,
         cols: Option<u32>,
         detail: Option<&str>,
@@ -138,7 +138,7 @@ impl PyBlockGroup {
                 Some(ctx) => (ctx, bg.id),
                 None => {
                     return Err(PyRuntimeError::new_err(
-                        "plot() requires a Repository context; obtain BlockGroups via Repository by query or id.",
+                        "plot() requires a Repository context; obtain SequenceGraphs via Repository by query or id.",
                     ));
                 }
             }
@@ -160,10 +160,10 @@ impl PyBlockGroup {
         build_widget(py, ctrl, rows, cols)
     }
 
-    /// Search for exact occurrences of `query` in this block group.
+    /// Search for exact occurrences of `query` in this sequence graph.
     ///
-    /// Returns a list of `GraphLocus` objects. Each locus exposes:
-    ///   - `.start()` / `.end()` → `GraphPos` (node + byte offset)
+    /// Returns a list of `Locus` objects. Each locus exposes:
+    ///   - `.start()` / `.end()` → `Position` (node + byte offset)
     ///   - `.slices` → `list[NodeSlice]`
     ///
     /// Parameters
@@ -183,7 +183,7 @@ impl PyBlockGroup {
         let kind = parse_sequence_kind(sequence_kind)?;
         let context = self.context.as_ref().ok_or_else(|| {
             PyRuntimeError::new_err(
-                "search() requires a Repository context; obtain BlockGroup via Repository",
+                "search() requires a Repository context; obtain SequenceGraph via Repository",
             )
         })?;
         let conn = context.graph().conn();
@@ -212,20 +212,20 @@ impl PyBlockGroup {
             .collect())
     }
 
-    /// IPython display hook — called when a cell ends with a BlockGroup.
-    fn _ipython_display_(slf: &Bound<'_, PyBlockGroup>) -> PyResult<()> {
+    /// IPython display hook — called when a cell ends with a SequenceGraph.
+    fn _ipython_display_(slf: &Bound<'_, PySequenceGraph>) -> PyResult<()> {
         let py = slf.py();
         let widget = slf.call_method0("plot")?;
         PyModule::import(py, "IPython.display")?.call_method1("display", (widget,))?;
         Ok(())
     }
 
-    /// Build a junction-aware k-mer seed index for this block group.
+    /// Build a junction-aware k-mer seed index for this sequence graph.
     ///
     /// Saves the index to `.gen/search_index/{id}.bin` so that subsequent
     /// calls to `Repository.search()` load it automatically.
     ///
-    /// Raises ``RuntimeError`` if this block group was not created via a
+    /// Raises ``RuntimeError`` if this sequence graph was not created via a
     /// ``Repository``.
     ///
     /// Parameters
@@ -241,7 +241,7 @@ impl PyBlockGroup {
         let kind = parse_sequence_kind(sequence_kind)?;
         let context = self.context.as_ref().ok_or_else(|| {
             PyRuntimeError::new_err(
-                "build_index() requires a Repository context; obtain BlockGroup via Repository",
+                "build_index() requires a Repository context; obtain SequenceGraph via Repository",
             )
         })?;
         let gen_dir = context.workspace().ensure_gen_dir();
@@ -262,16 +262,16 @@ impl PyBlockGroup {
         Ok(())
     }
 
-    /// Clear the search index for this block group.
+    /// Clear the search index for this sequence graph.
     ///
     /// Removes `.gen/search_index/{id}.bin` if it exists.
     ///
-    /// Raises ``RuntimeError`` if this block group was not created via a
+    /// Raises ``RuntimeError`` if this sequence graph was not created via a
     /// ``Repository``.
     pub fn clear_index(&self) -> PyResult<()> {
         let context = self.context.as_ref().ok_or_else(|| {
             PyRuntimeError::new_err(
-                "clear_index() requires a Repository context; obtain BlockGroup via Repository",
+                "clear_index() requires a Repository context; obtain SequenceGraph via Repository",
             )
         })?;
         let gen_dir = context.workspace().ensure_gen_dir();
@@ -428,8 +428,8 @@ impl PyBlockGroup {
 }
 
 #[pymethods]
-impl PyBlockGroup {
-    /// Export all block groups in this block group's sample to FASTA.
+impl PySequenceGraph {
+    /// Export all sequence graphs in this sequence graph's sample to FASTA.
     ///
     /// Parameters
     /// ----------
@@ -447,7 +447,7 @@ impl PyBlockGroup {
         .map_err(|e| PyRuntimeError::new_err(format!("Failed to export FASTA '{}': {e}", filename)))
     }
 
-    /// Export all block groups in this block group's sample to GFA.
+    /// Export all sequence graphs in this sequence graph's sample to GFA.
     ///
     /// Parameters
     /// ----------
@@ -469,7 +469,7 @@ impl PyBlockGroup {
         .map_err(|e| PyRuntimeError::new_err(format!("Failed to export GFA '{}': {e}", filename)))
     }
 
-    /// Export all block groups in this block group's sample to GenBank.
+    /// Export all sequence graphs in this sequence graph's sample to GenBank.
     ///
     /// Parameters
     /// ----------
@@ -487,18 +487,18 @@ impl PyBlockGroup {
     }
 }
 
-impl PyBlockGroup {
+impl PySequenceGraph {
     fn require_context(&self, method: &str) -> PyResult<&DbContext> {
         self.context.as_ref().ok_or_else(|| {
             PyRuntimeError::new_err(format!(
-                "{method} requires a Repository context; obtain BlockGroup via Repository"
+                "{method} requires a Repository context; obtain SequenceGraph via Repository"
             ))
         })
     }
 
-    /// Wraps a raw `BlockGroup` model with this block group's database context.
+    /// Wraps a raw `BlockGroup` model with this sequence graph's database context.
     fn into_py_block_group(&self, bg: BlockGroup) -> Self {
-        PyBlockGroup {
+        PySequenceGraph {
             id: bg.id,
             collection_name: bg.collection_name,
             sample_name: bg.sample_name,
@@ -509,13 +509,13 @@ impl PyBlockGroup {
 }
 
 #[pymethods]
-impl PyBlockGroup {
-    /// Derive a coordinate-bounded subgraph from this block group.
+impl PySequenceGraph {
+    /// Derive a coordinate-bounded subgraph from this sequence graph.
     ///
     /// Parameters
     /// ----------
     /// new_sample : str
-    ///     Sample name for the derived block group.
+    ///     Sample name for the derived sequence graph.
     /// start : int
     ///     Start coordinate along the path (inclusive).
     /// end : int
@@ -529,7 +529,7 @@ impl PyBlockGroup {
         start: i64,
         end: i64,
         backbone: Option<String>,
-    ) -> PyResult<PyBlockGroup> {
+    ) -> PyResult<PySequenceGraph> {
         let ctx = self.require_context("subgraph()")?;
         let region = format!("{}:{}-{}", self.name, start, end);
         derive_subgraph_operation(
@@ -553,12 +553,12 @@ impl PyBlockGroup {
         Ok(self.into_py_block_group(found))
     }
 
-    /// Split this block group into coordinate-bounded subgraphs.
+    /// Split this sequence graph into coordinate-bounded subgraphs.
     ///
     /// Parameters
     /// ----------
     /// new_sample : str
-    ///     Sample name for the derived block groups.
+    ///     Sample name for the derived sequence graphs.
     /// breakpoints : str, optional
     ///     Comma-separated coordinate values at which to split.
     /// chunk_size : int, optional
@@ -572,7 +572,7 @@ impl PyBlockGroup {
         breakpoints: Option<Vec<i64>>,
         chunk_size: Option<i64>,
         backbone: Option<String>,
-    ) -> PyResult<Vec<PyBlockGroup>> {
+    ) -> PyResult<Vec<PySequenceGraph>> {
         let ctx = self.require_context("chunks()")?;
         derive_chunks_operation(
             ctx,

--- a/gen-python/src/python_api/graph_node.rs
+++ b/gen-python/src/python_api/graph_node.rs
@@ -85,7 +85,7 @@ impl PyGraphNodeSlice {
 #[pymethods]
 impl PyGraphNodeSlice {
     #[getter]
-    fn block(&self) -> PyGraphNode {
+    fn node(&self) -> PyGraphNode {
         PyGraphNode::new(
             self.inner.block.node_id,
             self.inner.block.sequence_start,

--- a/gen-python/src/python_api/graph_node.rs
+++ b/gen-python/src/python_api/graph_node.rs
@@ -67,6 +67,12 @@ impl PyGraphNode {
             Ok(false)
         }
     }
+
+    /// Length of this node's sequence in bytes.
+    #[getter]
+    fn length(&self) -> i64 {
+        self.sequence_end - self.sequence_start
+    }
 }
 
 /// A slice of a single graph block with local byte offsets and strand.

--- a/gen-python/src/python_api/graph_search.rs
+++ b/gen-python/src/python_api/graph_search.rs
@@ -6,14 +6,14 @@ use gen_core::Strand;
 use gen_models::locus::GraphLocus;
 use pyo3::prelude::*;
 
-use super::block::{PyGraphNode, PyGraphNodeSlice};
+use super::graph_node::{PyGraphNode, PyGraphNodeSlice};
 
 /// A position in the graph: a specific node plus a byte offset within that
 /// node's local text (`0..node.length()`).
 ///
-/// Returned by `PyGraphLocus.start()` and `PyGraphLocus.end()`.
-/// Pass directly to `GenGraphWidget.go_to()`.
-#[pyclass(name = "GraphPos")]
+/// Returned by `Locus.start()` and `Locus.end()`.
+/// Pass directly to `GraphWidget.go_to()`.
+#[pyclass(name = "Position")]
 #[derive(Clone)]
 pub struct PyGraphPos {
     pub inner: GraphPos,
@@ -31,7 +31,7 @@ impl PyGraphPos {
 impl PyGraphPos {
     /// The graph node this position is inside.
     #[getter]
-    fn block(&self) -> PyGraphNode {
+    fn node(&self) -> PyGraphNode {
         let n = self.inner.block;
         PyGraphNode::new(n.node_id, n.sequence_start, n.sequence_end)
     }
@@ -81,9 +81,9 @@ impl PyGraphPos {
 
 /// A linear sequence of nodes in graph space, anchored by byte offsets.
 ///
-/// Obtain via `repo.search(block_group, query)`.
+/// Obtain via `sg.search(query)` or `repo.search(query)`.
 /// Pass `.start()` or `.end()` to `widget.go_to()`.
-#[pyclass(name = "GraphLocus")]
+#[pyclass(name = "Locus")]
 pub struct PyGraphLocus {
     pub inner: GraphLocus,
 }
@@ -165,7 +165,7 @@ impl PyGraphLocus {
                 }
             })
             .collect();
-        format!("GraphLocus([{}], strand='{}')", segs.join(", "), strand)
+        format!("Locus([{}], strand='{}')", segs.join(", "), strand)
     }
 
     fn __str__(&self) -> String {
@@ -210,12 +210,10 @@ impl PyGraphLocus {
     }
 }
 
-/// A named annotation in graph space, built from one or more `GraphLocus` objects.
+/// A named annotation in graph space, built from one or more `Locus` objects.
 ///
-/// Create with ``Annotation(locus, name)`` for a single hit or
-/// ``Annotation([locus1, locus2], name)`` to combine multiple hits into one
-/// named span.  Pass a list of ``Annotation`` objects to
-/// ``widget.add_annotation_track()``.
+/// Create with ``Annotation(locus, name)`` for a single hit.
+/// Pass a list of ``Annotation`` objects to ``widget.add_annotation_track()``.
 #[pyclass(name = "Annotation")]
 #[derive(Clone)]
 pub struct PyAnnotation {
@@ -235,9 +233,7 @@ impl PyAnnotation {
 
     /// The graph-space locus covered by this annotation.
     ///
-    /// Provides ``.blocks`` (list of ``Block`` objects with
-    /// ``node_id``, ``sequence_start``, ``sequence_end``),
-    /// ``.start()`` / ``.end()`` (``GraphPos``), and ``.strand``.
+    /// Provides ``.start()`` / ``.end()`` (``Position``) and ``.strand``.
     #[getter]
     fn locus(&self) -> PyGraphLocus {
         PyGraphLocus::from_locus(self.locus.clone())

--- a/gen-python/src/python_api/jupyter_widget.rs
+++ b/gen-python/src/python_api/jupyter_widget.rs
@@ -45,7 +45,7 @@ use ratatui::{
 use serde::Serialize;
 
 use crate::python_api::{
-    block_group::PyBlockGroup,
+    block_group::PySequenceGraph,
     graph_search::{PyAnnotation, PyGraphLocus, PyGraphPos},
     repository::PyRepository,
     utils::block_group_err_to_pyerr,
@@ -248,7 +248,7 @@ struct GraphOverlay {
 /// Internal graph controller for the Jupyter notebook widget.
 ///
 /// Not intended for direct use from Python — users should call
-/// `repo.plot(bg)` or `bg.plot()` which return a `GenGraphWidget`.
+/// `repo.plot(sg)` or `sg.plot()` which return a `GraphWidget`.
 ///
 /// # Thread safety
 ///
@@ -258,7 +258,7 @@ struct GraphOverlay {
 /// so it must be `Send`.  `GraphHandle` contains `Rc<GraphConnection>` which is
 /// `!Send`, so we store only the DB path and open a fresh connection per operation
 /// instead of holding a live handle.
-#[pyclass]
+#[pyclass(name = "GraphWidget")]
 #[derive(Clone)]
 pub struct PyGraphController {
     db_path: PathBuf,
@@ -381,12 +381,12 @@ impl PyGraphController {
         self.clone()
     }
 
-    /// Create a `GraphController` from a `Repository` and a `PyBlockGroup`.
+    /// Create a `GraphController` from a `Repository` and a `PySequenceGraph`.
     #[classmethod]
     fn from_block_group(
         _cls: &Bound<'_, PyType>,
         repo: &PyRepository,
-        block_group: &PyBlockGroup,
+        block_group: &PySequenceGraph,
     ) -> PyResult<Self> {
         let bg_id = block_group.id;
         let conn = repo.context.graph().conn();
@@ -1048,8 +1048,8 @@ mod tests {
     }
 }
 
-/// Instantiate a `GenGraphWidget` from a controller and optional viewport
-/// Shared by `PyBlockGroup::plot` and `PyRepository::plot`.
+/// Instantiate a `GraphWidget` from a controller and optional viewport
+/// Shared by `PySequenceGraph::plot` and `PyRepository::plot`.
 pub fn build_widget(
     py: Python<'_>,
     ctrl: Py<PyGraphController>,
@@ -1057,7 +1057,7 @@ pub fn build_widget(
     cols: Option<u32>,
 ) -> PyResult<PyObject> {
     let gen_module = py.import("gen")?;
-    let widget_cls = gen_module.getattr("GenGraphWidget")?;
+    let widget_cls = gen_module.getattr("GraphWidget")?;
     let kwargs = PyDict::new(py);
     if let Some(r) = rows {
         kwargs.set_item("rows", r)?;

--- a/gen-python/src/python_api/repository/graph_ops.rs
+++ b/gen-python/src/python_api/repository/graph_ops.rs
@@ -6,7 +6,7 @@ use gen_models::block_group::BlockGroup;
 use pyo3::{exceptions::PyRuntimeError, prelude::*};
 
 use super::PyRepository;
-use crate::python_api::block_group::PyBlockGroup;
+use crate::python_api::block_group::PySequenceGraph;
 
 #[pymethods]
 impl PyRepository {
@@ -107,10 +107,10 @@ impl PyRepository {
     #[pyo3(signature = (bgs, new_sample, new_region))]
     fn stitch(
         &self,
-        bgs: Vec<PyBlockGroup>,
+        bgs: Vec<PySequenceGraph>,
         new_sample: String,
         new_region: String,
-    ) -> PyResult<PyBlockGroup> {
+    ) -> PyResult<PySequenceGraph> {
         if bgs.is_empty() {
             return Err(PyRuntimeError::new_err(
                 "stitch() requires at least one block group",

--- a/gen-python/src/python_api/repository/mod.rs
+++ b/gen-python/src/python_api/repository/mod.rs
@@ -9,8 +9,8 @@ use gen_models::{
 use pyo3::{exceptions::PyRuntimeError, prelude::*};
 
 use super::{
-    block::PyGraphNode,
-    block_group::PyBlockGroup,
+    block_group::PySequenceGraph,
+    graph_node::PyGraphNode,
     hash_id::PyHashId,
     jupyter_widget::{PyGraphController, build_widget},
     utils::{block_group_err_to_pyerr, path_to_py_path, py_query, sqlite_err_to_pyerr},
@@ -94,8 +94,8 @@ impl PyRepository {
             .unwrap_or_else(|| "default".to_string())
     }
 
-    pub(crate) fn into_py_block_group(&self, bg: BlockGroup) -> PyBlockGroup {
-        PyBlockGroup {
+    pub(crate) fn into_py_block_group(&self, bg: BlockGroup) -> PySequenceGraph {
+        PySequenceGraph {
             id: bg.id,
             collection_name: bg.collection_name,
             sample_name: bg.sample_name,
@@ -207,17 +207,17 @@ impl PyRepository {
     }
 
     // -------------------------------------------------------------------------
-    // BlockGroup queries
+    // SequenceGraph queries
     // -------------------------------------------------------------------------
 
-    fn get_block_group_by_id(&self, id: &PyHashId) -> PyResult<PyBlockGroup> {
+    fn get_sequence_graph_by_id(&self, id: &PyHashId) -> PyResult<PySequenceGraph> {
         let conn = self.context.graph().conn();
         let block_group =
             BlockGroup::get_by_id(conn, &id.hash_id).map_err(block_group_err_to_pyerr)?;
         Ok(self.into_py_block_group(block_group))
     }
 
-    fn get_block_groups(&self) -> PyResult<Vec<PyBlockGroup>> {
+    fn get_sequence_graphs(&self) -> PyResult<Vec<PySequenceGraph>> {
         let conn = self.context.graph().conn();
         Ok(BlockGroup::all(conn)
             .into_iter()
@@ -225,7 +225,10 @@ impl PyRepository {
             .collect())
     }
 
-    fn get_block_groups_by_collection(&self, collection_name: &str) -> PyResult<Vec<PyBlockGroup>> {
+    fn get_sequence_graphs_by_collection(
+        &self,
+        collection_name: &str,
+    ) -> PyResult<Vec<PySequenceGraph>> {
         let conn = self.context.graph().conn();
         Ok(Collection::get_block_groups(conn, collection_name)
             .into_iter()
@@ -237,11 +240,11 @@ impl PyRepository {
     // Plot
     // -------------------------------------------------------------------------
 
-    #[pyo3(signature = (block_group, rows=None, cols=None, detail=None))]
+    #[pyo3(signature = (sequence_graph, rows=None, cols=None, detail=None))]
     fn plot(
         &self,
         py: Python<'_>,
-        block_group: &PyBlockGroup,
+        sequence_graph: &PySequenceGraph,
         rows: Option<u32>,
         cols: Option<u32>,
         detail: Option<&str>,
@@ -252,9 +255,9 @@ impl PyRepository {
             .map(std::path::PathBuf::from)
             .ok_or_else(|| PyRuntimeError::new_err("graph DB has no file path"))?;
         let graph =
-            BlockGroup::get_graph(graph_conn, &block_group.id).map_err(block_group_err_to_pyerr)?;
+            BlockGroup::get_graph(graph_conn, &sequence_graph.id).map_err(block_group_err_to_pyerr)?;
         let mut ctrl = PyGraphController::new(db_path, graph);
-        ctrl.block_group_id = Some(block_group.id);
+        ctrl.block_group_id = Some(sequence_graph.id);
         ctrl.auto_load_annotation_groups(graph_conn);
         if let Some(node_detail) = detail {
             ctrl.set_detail(node_detail)?;
@@ -263,7 +266,7 @@ impl PyRepository {
         build_widget(py, ctrl, rows, cols)
     }
 
-    fn get_block_sequence(&self, node_key: &PyGraphNode) -> PyResult<String> {
+    fn get_node_sequence(&self, node_key: &PyGraphNode) -> PyResult<String> {
         let sequences_by_node_id =
             Node::get_sequences_by_node_ids(self.context.graph().conn(), &[node_key.node_id]);
         let sequence = sequences_by_node_id.get(&node_key.node_id).ok_or_else(|| {
@@ -350,7 +353,7 @@ mod python_tests {
                 )
                 .unwrap();
 
-            let block_groups = py_repo.borrow(py).get_block_groups().unwrap();
+            let block_groups = py_repo.borrow(py).get_sequence_graphs().unwrap();
             assert_eq!(block_groups.len(), 1);
             assert_eq!(block_groups[0].name, "chr1");
         });
@@ -415,7 +418,7 @@ mod python_tests {
 
             PyRepository::__exit__(py_repo.borrow_mut(py), None, None, None).unwrap();
 
-            let block_groups = py_repo.borrow(py).get_block_groups().unwrap();
+            let block_groups = py_repo.borrow(py).get_sequence_graphs().unwrap();
             assert_eq!(
                 block_groups.len(),
                 2,
@@ -491,7 +494,7 @@ mod python_tests {
                 )
                 .unwrap();
 
-            let block_groups = py_repo.borrow(py).get_block_groups().unwrap();
+            let block_groups = py_repo.borrow(py).get_sequence_graphs().unwrap();
             let bg = &block_groups[0];
 
             py_repo.borrow(py).build_index("dna", 4, None).unwrap();
@@ -552,7 +555,7 @@ mod python_tests {
                 )
                 .unwrap();
 
-            let block_groups = py_repo.borrow(py).get_block_groups().unwrap();
+            let block_groups = py_repo.borrow(py).get_sequence_graphs().unwrap();
             let bg = &block_groups[0];
 
             py_repo.borrow(py).build_index("dna", 4, None).unwrap();
@@ -591,7 +594,7 @@ mod python_tests {
                 )
                 .unwrap();
 
-            let block_groups = py_repo.borrow(py).get_block_groups().unwrap();
+            let block_groups = py_repo.borrow(py).get_sequence_graphs().unwrap();
             let bg = &block_groups[0];
             let bg_id = bg.id;
 
@@ -606,13 +609,13 @@ mod python_tests {
             bg.build_index("protein", 4).unwrap();
             assert!(
                 index_file.exists(),
-                "Index should exist after PyBlockGroup::build_index"
+                "Index should exist after PySequenceGraph::build_index"
             );
 
             bg.clear_index().unwrap();
             assert!(
                 !index_file.exists(),
-                "Index should be gone after PyBlockGroup::clear_index"
+                "Index should be gone after PySequenceGraph::clear_index"
             );
         });
     }
@@ -641,10 +644,10 @@ mod python_tests {
             let fake_exc = py.None().into_bound(py);
             PyRepository::__exit__(py_repo.borrow_mut(py), Some(&fake_exc), None, None).unwrap();
 
-            let block_groups = py_repo.borrow(py).get_block_groups().unwrap();
+            let block_groups = py_repo.borrow(py).get_sequence_graphs().unwrap();
             assert!(
                 block_groups.is_empty(),
-                "Import should have been rolled back, but found {} block group(s)",
+                "Import should have been rolled back, but found {} sequence graph(s)",
                 block_groups.len()
             );
         });

--- a/gen-python/src/python_api/repository/search.rs
+++ b/gen-python/src/python_api/repository/search.rs
@@ -6,24 +6,24 @@ use pyo3::{exceptions::PyRuntimeError, prelude::*};
 
 use super::PyRepository;
 use crate::python_api::{
-    block_group::{PyBlockGroup, parse_sequence_kind},
+    block_group::{PySequenceGraph, parse_sequence_kind},
     graph_search::PyGraphLocus,
     utils::block_group_err_to_pyerr,
 };
 
 #[pymethods]
 impl PyRepository {
-    /// Build a junction-aware k-mer seed index for `block_group` and save it
+    /// Build a junction-aware k-mer seed index for a sequence graph and save it
     /// to `.gen/search_index/{block_group_id}.bin`.
     ///
-    /// If `block_groups` is None or empty, indexes all block groups.
+    /// If `sgs` is None or empty, indexes all sequence graphs.
     /// Subsequent calls to `search()` will load this index automatically.
     #[pyo3(signature = (sequence_kind="dna", k=16, bgs=None))]
     pub fn build_index(
         &self,
         sequence_kind: &str,
         k: usize,
-        bgs: Option<Vec<PyBlockGroup>>,
+        bgs: Option<Vec<PySequenceGraph>>,
     ) -> PyResult<()> {
         let kind = parse_sequence_kind(sequence_kind)?;
         let normalized = kind != SequenceKind::Exact;
@@ -60,14 +60,14 @@ impl PyRepository {
 
     /// Search for exact occurrences of `query`.
     ///
-    /// Returns a list of tuples `(block_group, matches)` where:
-    ///   - `block_group` is a `PyBlockGroup` object
+    /// Returns a list of `(SequenceGraph, list[Locus])` tuples — one entry per
+    ///   - graph that contains at least one match
     ///   - `matches` is a list of `GraphLocus` objects. Each locus exposes:
     ///       - `.start()` / `.end()` → `GraphPos` (node + byte offset) — pass
     ///         directly to `widget.go_to()`
     ///       - `.slices` → `list[NodeSlice]`
     ///
-    /// If `bgs` is None or empty, searches all block groups.
+    /// If `sgs` is None or empty, searches all sequence graphs.
     /// If a seed index was previously built with `build_index()`, it is loaded
     /// automatically to accelerate the search. Falls back to a full scan
     /// when no index is found.
@@ -75,9 +75,9 @@ impl PyRepository {
     pub fn search(
         &self,
         query: &str,
-        bgs: Option<Vec<PyBlockGroup>>,
+        bgs: Option<Vec<PySequenceGraph>>,
         sequence_kind: &str,
-    ) -> PyResult<Vec<(PyBlockGroup, Vec<PyGraphLocus>)>> {
+    ) -> PyResult<Vec<(PySequenceGraph, Vec<PyGraphLocus>)>> {
         let kind = parse_sequence_kind(sequence_kind)?;
         let conn = self.context.graph().conn();
 
@@ -124,10 +124,10 @@ impl PyRepository {
 
     /// Clear the search index cache.
     ///
-    /// If `block_groups` is None or empty, clears all indices in `.gen/search_index/`.
-    /// Otherwise, clears only the specified block group indices.
+    /// If `sgs` is None or empty, clears all indices in `.gen/search_index/`.
+    /// Otherwise, clears only the specified sequence graph indices.
     #[pyo3(signature = (bgs=None))]
-    pub fn clear_index(&self, bgs: Option<Vec<PyBlockGroup>>) -> PyResult<()> {
+    pub fn clear_index(&self, bgs: Option<Vec<PySequenceGraph>>) -> PyResult<()> {
         let index_dir = self
             .context
             .workspace()


### PR DESCRIPTION
## Summary

- **Rename Python API surface**: `BlockGroup→SequenceGraph`, `GraphLocus→Locus`, `GraphPos→Position`, `GenGraphWidget→GraphWidget`; `NodeSlice.block→.node`, `get_block_group*→get_sequence_graph*`, `get_block_sequence→get_node_sequence`
- **Opaque `Node` type**: `to_dict()["nodes"]` is now `list[Node]` instead of `{Node: raw_dict}`; `to_rustworkx()`/`to_networkx()` node data no longer leak `parent_node_id`/`sequence_start`/`sequence_end`
- **`Node.length` property**: `sequence_end - sequence_start`, so users can inspect node size without internals
- **`SequenceGraph.get_node_sequence(node)`**: no longer need a `Repository` reference to fetch a node's sequence
- **Fix all example notebooks**: updated 5 notebooks to use the new API names

## Test plan

- [ ] `cd gen-python && make pyenv-test` — 14/14 pass
- [ ] `cd gen-python && make notebook-test` — 3/3 pass
- [ ] `pytest --nbmake examples/misc_commands/list-and-show.ipynb examples/human_variation_aware_alignment/Analysis.ipynb` — 2/2 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)