### PR TITLE
Graph fix

### DIFF
--- a/gen-annotations/src/translate/bed.rs
+++ b/gen-annotations/src/translate/bed.rs
@@ -9,7 +9,7 @@ use gen_graph::{GraphNode, project_path};
 use gen_models::{
     block_group::BlockGroup,
     db::GraphConnection,
-    errors::PathError,
+    errors::{BlockGroupError, PathError},
     reference_alias::{ReferenceAlias, ReferenceAliasError},
     sample::Sample,
 };
@@ -29,6 +29,8 @@ pub enum BedError {
     ReferenceAliasError(#[from] ReferenceAliasError),
     #[error("Error loading path blocks: {0}")]
     PathError(#[from] PathError),
+    #[error("Error loading block group graph: {0}")]
+    BlockGroupError(#[from] BlockGroupError),
 }
 
 pub fn translate_bed<R, W>(
@@ -73,7 +75,7 @@ where
                 Entry::Occupied(entry) => entry.into_mut(),
                 Entry::Vacant(entry) => {
                     let path = BlockGroup::get_current_path(conn, &bg.id);
-                    let graph = BlockGroup::get_graph(conn, &bg.id);
+                    let graph = BlockGroup::get_graph(conn, &bg.id)?;
                     let mut tree = IntervalTree::default();
                     let mut position: i64 = 0;
                     for (node, strand) in project_path(&graph, &path.blocks(conn)?) {

--- a/gen-annotations/src/translate/gff.rs
+++ b/gen-annotations/src/translate/gff.rs
@@ -9,7 +9,7 @@ use gen_graph::{GraphNode, project_path};
 use gen_models::{
     block_group::BlockGroup,
     db::GraphConnection,
-    errors::PathError,
+    errors::{BlockGroupError, PathError},
     reference_alias::{ReferenceAlias, ReferenceAliasError},
     sample::Sample,
 };
@@ -25,6 +25,8 @@ pub enum GffError {
     ReferenceAliasError(#[from] ReferenceAliasError),
     #[error("Error loading path blocks: {0}")]
     PathError(#[from] PathError),
+    #[error("Error loading block group graph: {0}")]
+    BlockGroupError(#[from] BlockGroupError),
 }
 
 pub fn translate_gff<R, W>(
@@ -68,7 +70,7 @@ where
                 Entry::Occupied(entry) => entry.into_mut(),
                 Entry::Vacant(entry) => {
                     let path = BlockGroup::get_current_path(conn, &bg.id);
-                    let graph = BlockGroup::get_graph(conn, &bg.id);
+                    let graph = BlockGroup::get_graph(conn, &bg.id)?;
                     let mut tree = IntervalTree::default();
                     let mut position: i64 = 0;
                     for (node, strand) in project_path(&graph, &path.blocks(conn)?) {

--- a/gen-models/src/block_group.rs
+++ b/gen-models/src/block_group.rs
@@ -221,11 +221,7 @@ impl IntervalTreeSource for BlockGroupTreeSource {
         &self,
         conn: &GraphConnection,
     ) -> Result<IntervalTree<i64, NodeIntervalBlock>, BlockGroupError> {
-        Ok(BlockGroup::intervaltree_for(
-            conn,
-            &self.block_group_id,
-            self.remove_ambiguous_positions,
-        ))
+        BlockGroup::intervaltree_for(conn, &self.block_group_id, self.remove_ambiguous_positions)
     }
 }
 
@@ -559,11 +555,14 @@ impl BlockGroup {
         )))
     }
 
-    pub fn get_graph(conn: &GraphConnection, block_group_id: &HashId) -> GenGraph {
+    pub fn get_graph(
+        conn: &GraphConnection,
+        block_group_id: &HashId,
+    ) -> Result<GenGraph, BlockGroupError> {
         let edges = BlockGroupEdge::edges_for_block_group(conn, block_group_id);
-        let blocks = Edge::blocks_from_edges(conn, block_group_id, &edges);
+        let blocks = Edge::blocks_from_edges(conn, block_group_id, &edges)?;
         let (graph, _) = Edge::build_graph(&edges, &blocks);
-        graph
+        Ok(graph)
     }
 
     pub fn prune_graph(graph: &mut GenGraph) {
@@ -625,12 +624,12 @@ impl BlockGroup {
         conn: &GraphConnection,
         block_group_id: &HashId,
         _prune: bool,
-    ) -> HashSet<String> {
+    ) -> Result<HashSet<String>, BlockGroupError> {
         let edges = BlockGroupEdge::edges_for_block_group(conn, block_group_id)
             .into_iter()
             .filter(|edge| edge.chromosome_index != PRESERVE_EDIT_SITE_CHROMOSOME_INDEX)
             .collect::<Vec<_>>();
-        let blocks = Edge::blocks_from_edges(conn, block_group_id, &edges);
+        let blocks = Edge::blocks_from_edges(conn, block_group_id, &edges)?;
 
         let (mut graph, _) = Edge::build_graph(&edges, &blocks);
         BlockGroup::prune_graph(&mut graph);
@@ -681,7 +680,7 @@ impl BlockGroup {
             }
         }
 
-        sequences
+        Ok(sequences)
     }
 
     pub fn add_accession(
@@ -1125,11 +1124,11 @@ impl BlockGroup {
         conn: &GraphConnection,
         block_group_id: &HashId,
         remove_ambiguous_positions: bool,
-    ) -> IntervalTree<i64, NodeIntervalBlock> {
+    ) -> Result<IntervalTree<i64, NodeIntervalBlock>, BlockGroupError> {
         // make a tree where every node has a span in the graph.
-        let mut graph = BlockGroup::get_graph(conn, block_group_id);
+        let mut graph = BlockGroup::get_graph(conn, block_group_id)?;
         BlockGroup::prune_graph(&mut graph);
-        flatten_to_interval_tree(&graph, remove_ambiguous_positions)
+        Ok(flatten_to_interval_tree(&graph, remove_ambiguous_positions))
     }
 
     pub fn get_current_path(conn: &GraphConnection, block_group_id: &HashId) -> Path {
@@ -1174,7 +1173,7 @@ impl BlockGroup {
         target_block_group_id: &HashId,
         create_terminal_edges: bool,
     ) -> Result<HashMap<HashId, HashId>, BlockGroupError> {
-        let current_graph = BlockGroup::get_graph(conn, source_block_group_id);
+        let current_graph = BlockGroup::get_graph(conn, source_block_group_id)?;
         let start_node = current_graph
             .nodes()
             .find(|node| {
@@ -1800,15 +1799,15 @@ mod tests {
         );
 
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &child_a.id, false),
+            BlockGroup::get_all_sequences(conn, &child_a.id, false).unwrap(),
             HashSet::from_iter(vec!["AAAA".to_string()])
         );
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &child_b.id, false),
+            BlockGroup::get_all_sequences(conn, &child_b.id, false).unwrap(),
             HashSet::from_iter(vec!["CCCC".to_string()])
         );
         assert_eq!(
-            Sample::get_all_sequences(conn, "test", "child", false),
+            Sample::get_all_sequences(conn, "test", "child", false).unwrap(),
             HashSet::from_iter(vec!["AAAA".to_string(), "CCCC".to_string()])
         );
     }
@@ -2019,7 +2018,7 @@ mod tests {
         .collect::<Vec<_>>();
 
         BlockGroupEdge::bulk_create(&conn, &block_group_edges);
-        let graph = BlockGroup::get_graph(&conn, &bg.id);
+        let graph = BlockGroup::get_graph(&conn, &bg.id).unwrap();
 
         // 5 non-terminal nodes: AAA, GGG, TTT, CCC, ATC
         // 2 terminal blocks: START, END
@@ -2378,7 +2377,7 @@ mod tests {
         };
 
         BlockGroup::insert_change(&conn, &change).unwrap();
-        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
+        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false).unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec![
@@ -2432,7 +2431,7 @@ mod tests {
         };
 
         BlockGroup::insert_change(&conn, &change).unwrap();
-        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
+        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false).unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec![
@@ -2475,7 +2474,7 @@ mod tests {
         };
         BlockGroup::insert_change(&conn, &change).unwrap();
 
-        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
+        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false).unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec![
@@ -2514,7 +2513,7 @@ mod tests {
         };
         // take out an entire block.
         BlockGroup::insert_change(&conn, &change).unwrap();
-        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
+        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false).unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec![
@@ -2559,7 +2558,7 @@ mod tests {
         };
         BlockGroup::insert_change(&conn, &change).unwrap();
 
-        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
+        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false).unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec![
@@ -2602,7 +2601,7 @@ mod tests {
         };
         BlockGroup::insert_change(&conn, &change).unwrap();
 
-        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
+        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false).unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec![
@@ -2645,7 +2644,7 @@ mod tests {
         };
         BlockGroup::insert_change(&conn, &change).unwrap();
 
-        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
+        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false).unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec![
@@ -2688,7 +2687,7 @@ mod tests {
         };
         BlockGroup::insert_change(&conn, &change).unwrap();
 
-        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
+        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false).unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec![
@@ -2731,7 +2730,7 @@ mod tests {
         };
         BlockGroup::insert_change(&conn, &change).unwrap();
 
-        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
+        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false).unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec![
@@ -2774,7 +2773,7 @@ mod tests {
         };
         BlockGroup::insert_change(&conn, &change).unwrap();
 
-        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
+        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false).unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec![
@@ -2817,7 +2816,7 @@ mod tests {
         };
         BlockGroup::insert_change(&conn, &change).unwrap();
 
-        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
+        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false).unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec![
@@ -2860,7 +2859,7 @@ mod tests {
         };
         BlockGroup::insert_change(&conn, &change).unwrap();
 
-        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
+        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false).unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec![
@@ -2905,7 +2904,7 @@ mod tests {
 
         // take out an entire block.
         BlockGroup::insert_change(&conn, &change).unwrap();
-        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
+        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false).unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec![
@@ -2948,7 +2947,7 @@ mod tests {
         };
         BlockGroup::insert_change(&conn, &change).unwrap();
 
-        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
+        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false).unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec![
@@ -2958,7 +2957,7 @@ mod tests {
         );
         BlockGroup::insert_change(&conn, &change).unwrap();
 
-        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
+        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false).unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec![
@@ -3001,7 +3000,7 @@ mod tests {
         };
         BlockGroup::insert_change(&conn, &change).unwrap();
 
-        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
+        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false).unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec![
@@ -3044,7 +3043,7 @@ mod tests {
         };
         BlockGroup::insert_change(&conn, &change).unwrap();
 
-        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
+        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false).unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec![
@@ -3087,7 +3086,7 @@ mod tests {
         };
         BlockGroup::insert_change(&conn, &change).unwrap();
 
-        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
+        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false).unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec![
@@ -3130,7 +3129,7 @@ mod tests {
         };
         BlockGroup::insert_change(&conn, &change).unwrap();
 
-        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
+        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false).unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec![
@@ -3173,7 +3172,7 @@ mod tests {
         };
         BlockGroup::insert_change(&conn, &change).unwrap();
 
-        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
+        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false).unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec![
@@ -3216,7 +3215,7 @@ mod tests {
         };
         BlockGroup::insert_change(&conn, &change).unwrap();
 
-        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
+        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false).unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec![
@@ -3259,7 +3258,7 @@ mod tests {
         };
         BlockGroup::insert_change(&conn, &change).unwrap();
 
-        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
+        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false).unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec![
@@ -3350,7 +3349,7 @@ mod tests {
         };
         BlockGroup::insert_change(&conn, &change).unwrap();
 
-        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
+        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false).unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec![
@@ -3393,7 +3392,7 @@ mod tests {
         };
         BlockGroup::insert_change(&conn, &change).unwrap();
 
-        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false);
+        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false).unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec![
@@ -3457,8 +3456,8 @@ mod tests {
         };
         BlockGroup::insert_change(conn, &change).unwrap();
 
-        let tree = BlockGroup::intervaltree_for(conn, &block_group_id, false);
-        let tree2 = BlockGroup::intervaltree_for(conn, &block_group_id, true);
+        let tree = BlockGroup::intervaltree_for(conn, &block_group_id, false).unwrap();
+        let tree2 = BlockGroup::intervaltree_for(conn, &block_group_id, true).unwrap();
         interval_tree_verify(
             &tree,
             3,
@@ -3509,8 +3508,8 @@ mod tests {
         );
 
         // This blockgroup has a change from positions 7-15 of 4 base pairs -- so any changes after this will be ambiguous
-        let tree = BlockGroup::intervaltree_for(conn, &new_bg_id, false);
-        let tree2 = BlockGroup::intervaltree_for(conn, &new_bg_id, true);
+        let tree = BlockGroup::intervaltree_for(conn, &new_bg_id, false).unwrap();
+        let tree2 = BlockGroup::intervaltree_for(conn, &new_bg_id, true).unwrap();
         interval_tree_verify(
             &tree,
             3,
@@ -3631,7 +3630,7 @@ mod tests {
         };
         // note we are making our change against the new blockgroup, and not the parent blockgroup
         BlockGroup::insert_change(conn, &change).unwrap();
-        let all_sequences = BlockGroup::get_all_sequences(conn, &new_bg_id, true);
+        let all_sequences = BlockGroup::get_all_sequences(conn, &new_bg_id, true).unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec!["AAAAAAANNNNTTTTTCCCCCCCCCCGGGGGGGGGG".to_string(),])
@@ -3684,7 +3683,7 @@ mod tests {
         };
         // take out an entire block.
         BlockGroup::insert_change(conn, &change).unwrap();
-        let all_sequences = BlockGroup::get_all_sequences(conn, &gc_bg_id, true);
+        let all_sequences = BlockGroup::get_all_sequences(conn, &gc_bg_id, true).unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec!["AAAAAAANNNNTCCCCCCCCCCGGGGGGGGGG".to_string(),])
@@ -3743,7 +3742,7 @@ mod tests {
         };
         // note we are making our change against the new blockgroup, and not the parent blockgroup
         BlockGroup::insert_change(conn, &change).unwrap();
-        let all_sequences = BlockGroup::get_all_sequences(conn, &new_bg_id, true);
+        let all_sequences = BlockGroup::get_all_sequences(conn, &new_bg_id, true).unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec![
@@ -3811,7 +3810,7 @@ mod tests {
         };
         // take out an entire block.
         BlockGroup::insert_change(conn, &change).unwrap();
-        let all_sequences = BlockGroup::get_all_sequences(conn, &gc_bg_id, true);
+        let all_sequences = BlockGroup::get_all_sequences(conn, &gc_bg_id, true).unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec![
@@ -3877,7 +3876,7 @@ mod tests {
         };
         // note we are making our change against the new blockgroup, and not the parent blockgroup
         BlockGroup::insert_change(conn, &change).unwrap();
-        let all_sequences = BlockGroup::get_all_sequences(conn, &new_bg_id, true);
+        let all_sequences = BlockGroup::get_all_sequences(conn, &new_bg_id, true).unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec![
@@ -4048,7 +4047,8 @@ mod tests {
                 "AAAAAAAAAATTTTTTAAAAAAAACCCCCCGGGGGGGGGG"
             );
 
-            let all_sequences = BlockGroup::get_all_sequences(conn, &block_group1_id, false);
+            let all_sequences =
+                BlockGroup::get_all_sequences(conn, &block_group1_id, false).unwrap();
             assert_eq!(
                 all_sequences,
                 HashSet::from_iter(vec![
@@ -4081,7 +4081,8 @@ mod tests {
                 true,
             )
             .unwrap();
-            let all_sequences2 = BlockGroup::get_all_sequences(conn, &block_group2.id, false);
+            let all_sequences2 =
+                BlockGroup::get_all_sequences(conn, &block_group2.id, false).unwrap();
             assert_eq!(
                 all_sequences2,
                 HashSet::from_iter(vec!["TTTTTCCCCC".to_string(), "TAAAAAAAAC".to_string(),])
@@ -4267,7 +4268,8 @@ mod tests {
                 "AAAAAAAAAATTTTTTAAAAAAAACCTTTTTTTTGGGGGG"
             );
 
-            let all_sequences = BlockGroup::get_all_sequences(conn, &block_group1_id, false);
+            let all_sequences =
+                BlockGroup::get_all_sequences(conn, &block_group1_id, false).unwrap();
             assert_eq!(
                 all_sequences,
                 HashSet::from_iter(vec![
@@ -4302,7 +4304,8 @@ mod tests {
                 true,
             )
             .unwrap();
-            let all_sequences2 = BlockGroup::get_all_sequences(conn, &block_group2.id, false);
+            let all_sequences2 =
+                BlockGroup::get_all_sequences(conn, &block_group2.id, false).unwrap();
             assert_eq!(
                 all_sequences2,
                 HashSet::from_iter(vec![
@@ -4547,7 +4550,8 @@ mod tests {
             ];
             BlockGroupEdge::bulk_create(conn, &block_group_edges);
 
-            let all_sequences = BlockGroup::get_all_sequences(conn, &block_group1_id, false);
+            let all_sequences =
+                BlockGroup::get_all_sequences(conn, &block_group1_id, false).unwrap();
             assert_eq!(
                 all_sequences,
                 HashSet::from_iter(vec![
@@ -4583,7 +4587,8 @@ mod tests {
                 true,
             )
             .unwrap();
-            let all_sequences2 = BlockGroup::get_all_sequences(conn, &block_group2.id, false);
+            let all_sequences2 =
+                BlockGroup::get_all_sequences(conn, &block_group2.id, false).unwrap();
             assert_eq!(
                 all_sequences2,
                 // The deletion is not included in the cloned subgraph since one end of it is

--- a/gen-models/src/block_group.rs
+++ b/gen-models/src/block_group.rs
@@ -1948,19 +1948,78 @@ mod tests {
         let e_ttt_atc =
             Edge::create(&conn, n_ttt, 3, Strand::Forward, n_atc, 0, Strand::Forward).unwrap();
 
-        let block_group_edges = [e_aaa_ttt, e_ggg_ttt, e_ttt_ccc, e_ttt_atc]
-            .iter()
-            .map(|edge_id| BlockGroupEdgeData {
-                block_group_id: bg.id,
-                edge_id: edge_id.id,
-                chromosome_index: 0,
-                phased: 0,
-            })
-            .collect::<Vec<_>>();
+        let expected_edges = [
+            (
+                GraphNode {
+                    node_id: n_aaa,
+                    sequence_start: 3,
+                    sequence_end: 3,
+                },
+                GraphNode {
+                    node_id: n_ttt,
+                    sequence_start: 0,
+                    sequence_end: 3,
+                },
+                e_aaa_ttt.id,
+            ),
+            (
+                GraphNode {
+                    node_id: n_ggg,
+                    sequence_start: 3,
+                    sequence_end: 3,
+                },
+                GraphNode {
+                    node_id: n_ttt,
+                    sequence_start: 0,
+                    sequence_end: 3,
+                },
+                e_ggg_ttt.id,
+            ),
+            (
+                GraphNode {
+                    node_id: n_ttt,
+                    sequence_start: 0,
+                    sequence_end: 3,
+                },
+                GraphNode {
+                    node_id: n_ccc,
+                    sequence_start: 0,
+                    sequence_end: 0,
+                },
+                e_ttt_ccc.id,
+            ),
+            (
+                GraphNode {
+                    node_id: n_ttt,
+                    sequence_start: 0,
+                    sequence_end: 3,
+                },
+                GraphNode {
+                    node_id: n_atc,
+                    sequence_start: 0,
+                    sequence_end: 0,
+                },
+                e_ttt_atc.id,
+            ),
+        ];
+
+        let block_group_edges = [
+            e_aaa_ttt.clone(),
+            e_ggg_ttt.clone(),
+            e_ttt_ccc.clone(),
+            e_ttt_atc.clone(),
+        ]
+        .iter()
+        .map(|edge_id| BlockGroupEdgeData {
+            block_group_id: bg.id,
+            edge_id: edge_id.id,
+            chromosome_index: 0,
+            phased: 0,
+        })
+        .collect::<Vec<_>>();
 
         BlockGroupEdge::bulk_create(&conn, &block_group_edges);
         let graph = BlockGroup::get_graph(&conn, &bg.id);
-        dbg!(&graph);
 
         // 5 non-terminal nodes: AAA, GGG, TTT, CCC, ATC
         // 2 terminal blocks: START, END
@@ -1971,6 +2030,23 @@ mod tests {
             "expected 7 blocks (5 nodes + 2 terminals), got {}",
             graph.nodes().len()
         );
+
+        assert_eq!(
+            graph.all_edges().count(),
+            expected_edges.len(),
+            "expected exactly the 4 branch edges"
+        );
+        for (source, target, edge_id) in expected_edges {
+            let weights = graph
+                .edge_weight(source, target)
+                .unwrap_or_else(|| panic!("missing graph edge {source:?} -> {target:?}"));
+            assert_eq!(
+                weights.len(),
+                1,
+                "expected a single edge weight for {source:?} -> {target:?}"
+            );
+            assert_eq!(weights[0].edge_id, edge_id);
+        }
     }
 
     #[test]

--- a/gen-models/src/block_group.rs
+++ b/gen-models/src/block_group.rs
@@ -1881,6 +1881,99 @@ mod tests {
     }
 
     #[test]
+    fn test_get_graph_branched_graph() {
+        // Branched graph: {AAA,GGG} → TTT → {CCC,ATC}
+        // TTT has 2 incoming edges and 2 outgoing edges.
+        // All sequences are length 3.
+        let conn = get_connection(None).unwrap();
+        Collection::get_or_create(&conn, "test").unwrap();
+        crate::sample::Sample::get_or_create(
+            &conn,
+            crate::sample::NewSample {
+                name: "test",
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let bg = BlockGroup::create(
+            &conn,
+            crate::block_group::NewBlockGroup {
+                collection_name: "test",
+                sample_name: "test",
+                name: "branched",
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let seq_aaa = Sequence::new()
+            .sequence_type("DNA")
+            .sequence("AAA")
+            .save(&conn)
+            .unwrap();
+        let seq_ggg = Sequence::new()
+            .sequence_type("DNA")
+            .sequence("GGG")
+            .save(&conn)
+            .unwrap();
+        let seq_ttt = Sequence::new()
+            .sequence_type("DNA")
+            .sequence("TTT")
+            .save(&conn)
+            .unwrap();
+        let seq_ccc = Sequence::new()
+            .sequence_type("DNA")
+            .sequence("CCC")
+            .save(&conn)
+            .unwrap();
+        let seq_atc = Sequence::new()
+            .sequence_type("DNA")
+            .sequence("ATC")
+            .save(&conn)
+            .unwrap();
+
+        let n_aaa = Node::create(&conn, &seq_aaa.hash, &HashId::convert_str("node-aaa")).unwrap();
+        let n_ggg = Node::create(&conn, &seq_ggg.hash, &HashId::convert_str("node-ggg")).unwrap();
+        let n_ttt = Node::create(&conn, &seq_ttt.hash, &HashId::convert_str("node-ttt")).unwrap();
+        let n_ccc = Node::create(&conn, &seq_ccc.hash, &HashId::convert_str("node-ccc")).unwrap();
+        let n_atc = Node::create(&conn, &seq_atc.hash, &HashId::convert_str("node-atc")).unwrap();
+
+        // Edges: AAA→TTT, GGG→TTT, TTT→CCC, TTT→ATC
+        let e_aaa_ttt =
+            Edge::create(&conn, n_aaa, 3, Strand::Forward, n_ttt, 0, Strand::Forward).unwrap();
+        let e_ggg_ttt =
+            Edge::create(&conn, n_ggg, 3, Strand::Forward, n_ttt, 0, Strand::Forward).unwrap();
+        let e_ttt_ccc =
+            Edge::create(&conn, n_ttt, 3, Strand::Forward, n_ccc, 0, Strand::Forward).unwrap();
+        let e_ttt_atc =
+            Edge::create(&conn, n_ttt, 3, Strand::Forward, n_atc, 0, Strand::Forward).unwrap();
+
+        let block_group_edges = vec![e_aaa_ttt, e_ggg_ttt, e_ttt_ccc, e_ttt_atc]
+            .iter()
+            .map(|edge_id| BlockGroupEdgeData {
+                block_group_id: bg.id,
+                edge_id: edge_id.id,
+                chromosome_index: 0,
+                phased: 0,
+            })
+            .collect::<Vec<_>>();
+
+        BlockGroupEdge::bulk_create(&conn, &block_group_edges);
+        let graph = BlockGroup::get_graph(&conn, &bg.id);
+        dbg!(&graph);
+
+        // 5 non-terminal nodes: AAA, GGG, TTT, CCC, ATC
+        // 2 terminal blocks: START, END
+        // Total: 7
+        assert_eq!(
+            graph.nodes().len(),
+            7,
+            "expected 7 blocks (5 nodes + 2 terminals), got {}",
+            graph.nodes().len()
+        );
+    }
+
+    #[test]
     fn test_blockgroup_merge_from_multiple_parents_preserves_paths_and_accessions() {
         let conn = &get_connection(None).unwrap();
         Collection::create(conn, "test").unwrap();

--- a/gen-models/src/block_group.rs
+++ b/gen-models/src/block_group.rs
@@ -561,7 +561,7 @@ impl BlockGroup {
 
     pub fn get_graph(conn: &GraphConnection, block_group_id: &HashId) -> GenGraph {
         let edges = BlockGroupEdge::edges_for_block_group(conn, block_group_id);
-        let blocks = Edge::blocks_from_edges(conn, &edges);
+        let blocks = Edge::blocks_from_edges(conn, block_group_id, &edges);
         let (graph, _) = Edge::build_graph(&edges, &blocks);
         graph
     }
@@ -630,7 +630,7 @@ impl BlockGroup {
             .into_iter()
             .filter(|edge| edge.chromosome_index != PRESERVE_EDIT_SITE_CHROMOSOME_INDEX)
             .collect::<Vec<_>>();
-        let blocks = Edge::blocks_from_edges(conn, &edges);
+        let blocks = Edge::blocks_from_edges(conn, block_group_id, &edges);
 
         let (mut graph, _) = Edge::build_graph(&edges, &blocks);
         BlockGroup::prune_graph(&mut graph);
@@ -1938,6 +1938,26 @@ mod tests {
         let n_ccc = Node::create(&conn, &seq_ccc.hash, &HashId::convert_str("node-ccc")).unwrap();
         let n_atc = Node::create(&conn, &seq_atc.hash, &HashId::convert_str("node-atc")).unwrap();
 
+        let e_start_aaa = Edge::create(
+            &conn,
+            PATH_START_NODE_ID,
+            -1,
+            Strand::Forward,
+            n_aaa,
+            0,
+            Strand::Forward,
+        )
+        .unwrap();
+        let e_start_ggg = Edge::create(
+            &conn,
+            PATH_START_NODE_ID,
+            -1,
+            Strand::Forward,
+            n_ggg,
+            0,
+            Strand::Forward,
+        )
+        .unwrap();
         // Edges: AAA→TTT, GGG→TTT, TTT→CCC, TTT→ATC
         let e_aaa_ttt =
             Edge::create(&conn, n_aaa, 3, Strand::Forward, n_ttt, 0, Strand::Forward).unwrap();
@@ -1947,16 +1967,45 @@ mod tests {
             Edge::create(&conn, n_ttt, 3, Strand::Forward, n_ccc, 0, Strand::Forward).unwrap();
         let e_ttt_atc =
             Edge::create(&conn, n_ttt, 3, Strand::Forward, n_atc, 0, Strand::Forward).unwrap();
+        let e_ccc_end = Edge::create(
+            &conn,
+            n_ccc,
+            3,
+            Strand::Forward,
+            PATH_END_NODE_ID,
+            -1,
+            Strand::Forward,
+        )
+        .unwrap();
+        let e_atc_end = Edge::create(
+            &conn,
+            n_atc,
+            3,
+            Strand::Forward,
+            PATH_END_NODE_ID,
+            -1,
+            Strand::Forward,
+        )
+        .unwrap();
 
-        let block_group_edges = vec![e_aaa_ttt, e_ggg_ttt, e_ttt_ccc, e_ttt_atc]
-            .iter()
-            .map(|edge_id| BlockGroupEdgeData {
-                block_group_id: bg.id,
-                edge_id: edge_id.id,
-                chromosome_index: 0,
-                phased: 0,
-            })
-            .collect::<Vec<_>>();
+        let block_group_edges = [
+            e_start_aaa,
+            e_start_ggg,
+            e_aaa_ttt,
+            e_ggg_ttt,
+            e_ttt_ccc,
+            e_ttt_atc,
+            e_ccc_end,
+            e_atc_end,
+        ]
+        .iter()
+        .map(|edge_id| BlockGroupEdgeData {
+            block_group_id: bg.id,
+            edge_id: edge_id.id,
+            chromosome_index: 0,
+            phased: 0,
+        })
+        .collect::<Vec<_>>();
 
         BlockGroupEdge::bulk_create(&conn, &block_group_edges);
         let graph = BlockGroup::get_graph(&conn, &bg.id);

--- a/gen-models/src/block_group.rs
+++ b/gen-models/src/block_group.rs
@@ -1884,7 +1884,7 @@ mod tests {
     fn test_get_graph_branched_graph() {
         // Branched graph: {AAA,GGG} → TTT → {CCC,ATC}
         // TTT has 2 incoming edges and 2 outgoing edges.
-        // All sequences are length 3.
+        // There are explicitly no start/end nodes to ensure we can build graphs purely from coordinates
         let conn = get_connection(None).unwrap();
         Collection::get_or_create(&conn, "test").unwrap();
         crate::sample::Sample::get_or_create(
@@ -1938,26 +1938,6 @@ mod tests {
         let n_ccc = Node::create(&conn, &seq_ccc.hash, &HashId::convert_str("node-ccc")).unwrap();
         let n_atc = Node::create(&conn, &seq_atc.hash, &HashId::convert_str("node-atc")).unwrap();
 
-        let e_start_aaa = Edge::create(
-            &conn,
-            PATH_START_NODE_ID,
-            -1,
-            Strand::Forward,
-            n_aaa,
-            0,
-            Strand::Forward,
-        )
-        .unwrap();
-        let e_start_ggg = Edge::create(
-            &conn,
-            PATH_START_NODE_ID,
-            -1,
-            Strand::Forward,
-            n_ggg,
-            0,
-            Strand::Forward,
-        )
-        .unwrap();
         // Edges: AAA→TTT, GGG→TTT, TTT→CCC, TTT→ATC
         let e_aaa_ttt =
             Edge::create(&conn, n_aaa, 3, Strand::Forward, n_ttt, 0, Strand::Forward).unwrap();
@@ -1967,45 +1947,16 @@ mod tests {
             Edge::create(&conn, n_ttt, 3, Strand::Forward, n_ccc, 0, Strand::Forward).unwrap();
         let e_ttt_atc =
             Edge::create(&conn, n_ttt, 3, Strand::Forward, n_atc, 0, Strand::Forward).unwrap();
-        let e_ccc_end = Edge::create(
-            &conn,
-            n_ccc,
-            3,
-            Strand::Forward,
-            PATH_END_NODE_ID,
-            -1,
-            Strand::Forward,
-        )
-        .unwrap();
-        let e_atc_end = Edge::create(
-            &conn,
-            n_atc,
-            3,
-            Strand::Forward,
-            PATH_END_NODE_ID,
-            -1,
-            Strand::Forward,
-        )
-        .unwrap();
 
-        let block_group_edges = [
-            e_start_aaa,
-            e_start_ggg,
-            e_aaa_ttt,
-            e_ggg_ttt,
-            e_ttt_ccc,
-            e_ttt_atc,
-            e_ccc_end,
-            e_atc_end,
-        ]
-        .iter()
-        .map(|edge_id| BlockGroupEdgeData {
-            block_group_id: bg.id,
-            edge_id: edge_id.id,
-            chromosome_index: 0,
-            phased: 0,
-        })
-        .collect::<Vec<_>>();
+        let block_group_edges = [e_aaa_ttt, e_ggg_ttt, e_ttt_ccc, e_ttt_atc]
+            .iter()
+            .map(|edge_id| BlockGroupEdgeData {
+                block_group_id: bg.id,
+                edge_id: edge_id.id,
+                chromosome_index: 0,
+                phased: 0,
+            })
+            .collect::<Vec<_>>();
 
         BlockGroupEdge::bulk_create(&conn, &block_group_edges);
         let graph = BlockGroup::get_graph(&conn, &bg.id);

--- a/gen-models/src/edge.rs
+++ b/gen-models/src/edge.rs
@@ -332,6 +332,20 @@ impl Edge {
             .collect::<Vec<i64>>()
     }
 
+    fn get_block_intervals(
+        source_edges: Option<&Vec<&Edge>>,
+        target_edges: Option<&Vec<&Edge>>,
+        sequence_length: i64,
+    ) -> Vec<(i64, i64)> {
+        let mut block_boundaries = Edge::get_block_boundaries(source_edges, target_edges);
+        block_boundaries.push(0);
+        block_boundaries.push(sequence_length);
+        block_boundaries.sort();
+        block_boundaries.dedup();
+
+        block_boundaries.into_iter().tuple_windows().collect()
+    }
+
     pub fn blocks_from_edges(conn: &GraphConnection, edges: &[AugmentedEdge]) -> Vec<GroupBlock> {
         let mut node_ids = IndexSet::new();
         let mut edges_by_source_node_id: HashMap<HashId, Vec<&Edge>> = HashMap::new();
@@ -367,25 +381,14 @@ impl Edge {
             .iter()
             .sorted_by_key(|(_node_id, seq)| seq.hash)
         {
-            let block_boundaries = Edge::get_block_boundaries(
+            let block_intervals = Edge::get_block_intervals(
                 edges_by_source_node_id.get(node_id),
                 edges_by_target_node_id.get(node_id),
+                sequence.length,
             );
 
-            if !block_boundaries.is_empty() {
-                for (start, end) in block_boundaries.clone().into_iter().tuple_windows() {
-                    let block = GroupBlock::new(block_index, *node_id, sequence, start, end);
-                    blocks.push(block);
-                    block_index += 1;
-                }
-            } else {
-                blocks.push(GroupBlock::new(
-                    block_index,
-                    *node_id,
-                    sequence,
-                    0,
-                    sequence.length,
-                ));
+            for (start, end) in block_intervals {
+                blocks.push(GroupBlock::new(block_index, *node_id, sequence, start, end));
                 block_index += 1;
             }
         }
@@ -636,6 +639,148 @@ mod tests {
             let edge = Edge::get_by_id(conn, id).unwrap();
             assert_eq!(EdgeData::from(&edge), edges[index]);
         }
+    }
+
+    #[test]
+    fn test_blocks_from_edges_branched_graph() {
+        // Branched graph: {AAA,GGG} → TTT → {CCC,ATC}
+        // TTT has 2 incoming edges and 2 outgoing edges.
+        // All sequences are length 3.
+        let conn = get_connection(None).unwrap();
+        Collection::get_or_create(&conn, "test").unwrap();
+        crate::sample::Sample::get_or_create(
+            &conn,
+            crate::sample::NewSample {
+                name: "test",
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let _bg = BlockGroup::create(
+            &conn,
+            crate::block_group::NewBlockGroup {
+                collection_name: "test",
+                sample_name: "test",
+                name: "branched",
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let seq_aaa = Sequence::new()
+            .sequence_type("DNA")
+            .sequence("AAA")
+            .save(&conn)
+            .unwrap();
+        let seq_ggg = Sequence::new()
+            .sequence_type("DNA")
+            .sequence("GGG")
+            .save(&conn)
+            .unwrap();
+        let seq_ttt = Sequence::new()
+            .sequence_type("DNA")
+            .sequence("TTT")
+            .save(&conn)
+            .unwrap();
+        let seq_ccc = Sequence::new()
+            .sequence_type("DNA")
+            .sequence("CCC")
+            .save(&conn)
+            .unwrap();
+        let seq_atc = Sequence::new()
+            .sequence_type("DNA")
+            .sequence("ATC")
+            .save(&conn)
+            .unwrap();
+
+        let n_aaa = Node::create(&conn, &seq_aaa.hash, &HashId::convert_str("node-aaa")).unwrap();
+        let n_ggg = Node::create(&conn, &seq_ggg.hash, &HashId::convert_str("node-ggg")).unwrap();
+        let n_ttt = Node::create(&conn, &seq_ttt.hash, &HashId::convert_str("node-ttt")).unwrap();
+        let n_ccc = Node::create(&conn, &seq_ccc.hash, &HashId::convert_str("node-ccc")).unwrap();
+        let n_atc = Node::create(&conn, &seq_atc.hash, &HashId::convert_str("node-atc")).unwrap();
+
+        // Edges: AAA→TTT, GGG→TTT, TTT→CCC, TTT→ATC
+        let e_aaa_ttt =
+            Edge::create(&conn, n_aaa, 3, Strand::Forward, n_ttt, 0, Strand::Forward).unwrap();
+        let e_ggg_ttt =
+            Edge::create(&conn, n_ggg, 3, Strand::Forward, n_ttt, 0, Strand::Forward).unwrap();
+        let e_ttt_ccc =
+            Edge::create(&conn, n_ttt, 3, Strand::Forward, n_ccc, 0, Strand::Forward).unwrap();
+        let e_ttt_atc =
+            Edge::create(&conn, n_ttt, 3, Strand::Forward, n_atc, 0, Strand::Forward).unwrap();
+
+        let augmented_edges = vec![
+            AugmentedEdge {
+                edge: e_aaa_ttt,
+                chromosome_index: 0,
+                phased: 0,
+                created_on: 0,
+            },
+            AugmentedEdge {
+                edge: e_ggg_ttt,
+                chromosome_index: 0,
+                phased: 0,
+                created_on: 0,
+            },
+            AugmentedEdge {
+                edge: e_ttt_ccc,
+                chromosome_index: 0,
+                phased: 0,
+                created_on: 0,
+            },
+            AugmentedEdge {
+                edge: e_ttt_atc,
+                chromosome_index: 0,
+                phased: 0,
+                created_on: 0,
+            },
+        ];
+
+        let blocks = Edge::blocks_from_edges(&conn, &augmented_edges);
+
+        // 5 non-terminal nodes: AAA, GGG, TTT, CCC, ATC
+        // 2 terminal blocks: START, END
+        // Total: 7
+        assert_eq!(
+            blocks.len(),
+            7,
+            "expected 7 blocks (5 nodes + 2 terminals), got {}",
+            blocks.len()
+        );
+
+        // Verify all 5 non-terminal nodes have blocks
+        let block_node_ids: Vec<HashId> = blocks
+            .iter()
+            .filter(|b| {
+                b.node_id != gen_core::PATH_START_NODE_ID && b.node_id != gen_core::PATH_END_NODE_ID
+            })
+            .map(|b| b.node_id)
+            .collect();
+        assert!(block_node_ids.contains(&n_aaa), "AAA block missing");
+        assert!(block_node_ids.contains(&n_ggg), "GGG block missing");
+        assert!(block_node_ids.contains(&n_ttt), "TTT block missing");
+        assert!(block_node_ids.contains(&n_ccc), "CCC block missing");
+        assert!(block_node_ids.contains(&n_atc), "ATC block missing");
+
+        // Verify TTT block has correct boundaries (0..3)
+        let ttt_block = blocks.iter().find(|b| b.node_id == n_ttt).unwrap();
+        assert_eq!(ttt_block.start, 0, "TTT block start should be 0");
+        assert_eq!(ttt_block.end, 3, "TTT block end should be 3");
+
+        // Verify AAA block has correct boundaries (0..3)
+        let aaa_block = blocks.iter().find(|b| b.node_id == n_aaa).unwrap();
+        assert_eq!(aaa_block.start, 0, "AAA block start should be 0");
+        assert_eq!(aaa_block.end, 3, "AAA block end should be 3");
+
+        // Verify CCC block has correct boundaries (0..3)
+        let ccc_block = blocks.iter().find(|b| b.node_id == n_ccc).unwrap();
+        assert_eq!(ccc_block.start, 0, "CCC block start should be 0");
+        assert_eq!(ccc_block.end, 3, "CCC block end should be 3");
+
+        // Verify ATC block has correct boundaries (0..3)
+        let atc_block = blocks.iter().find(|b| b.node_id == n_atc).unwrap();
+        assert_eq!(atc_block.start, 0, "ATC block start should be 0");
+        assert_eq!(atc_block.end, 3, "ATC block end should be 3");
     }
 
     #[test]

--- a/gen-models/src/edge.rs
+++ b/gen-models/src/edge.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::{
-    block_group_edge::AugmentedEdge,
+    block_group_edge::{AugmentedEdge, BlockGroupEdge},
     db::GraphConnection,
     errors::NodeError,
     gen_models_capnp::edge,
@@ -310,6 +310,7 @@ impl Edge {
         }
     }
 
+    #[cfg(test)]
     fn get_block_boundaries(
         source_edges: Option<&Vec<&Edge>>,
         target_edges: Option<&Vec<&Edge>>,
@@ -332,40 +333,67 @@ impl Edge {
             .collect::<Vec<i64>>()
     }
 
-    fn get_block_intervals(
-        source_edges: Option<&Vec<&Edge>>,
-        target_edges: Option<&Vec<&Edge>>,
-        sequence_length: i64,
-    ) -> Vec<(i64, i64)> {
-        let mut block_boundaries = Edge::get_block_boundaries(source_edges, target_edges);
-        block_boundaries.push(0);
-        block_boundaries.push(sequence_length);
-        block_boundaries.sort();
-        block_boundaries.dedup();
+    fn get_block_intervals(starts: &HashSet<i64>, ends: &HashSet<i64>) -> Vec<(i64, i64)> {
+        let coordinates = starts.union(ends).sorted().copied().collect::<Vec<_>>();
+        if coordinates.len() < 2 {
+            panic!("Cannot build blocks from starts {starts:?} and ends {ends:?}");
+        }
 
-        block_boundaries.into_iter().tuple_windows().collect()
+        coordinates.into_iter().tuple_windows().collect()
     }
 
-    pub fn blocks_from_edges(conn: &GraphConnection, edges: &[AugmentedEdge]) -> Vec<GroupBlock> {
+    pub fn blocks_from_edges(
+        conn: &GraphConnection,
+        block_group_id: &HashId,
+        edges: &[AugmentedEdge],
+    ) -> Vec<GroupBlock> {
         let mut node_ids = IndexSet::new();
-        let mut edges_by_source_node_id: HashMap<HashId, Vec<&Edge>> = HashMap::new();
-        let mut edges_by_target_node_id: HashMap<HashId, Vec<&Edge>> = HashMap::new();
+        let mut starts_by_node_id: HashMap<HashId, HashSet<i64>> = HashMap::new();
+        let mut ends_by_node_id: HashMap<HashId, HashSet<i64>> = HashMap::new();
         for edge in edges.iter().map(|edge| &edge.edge) {
             if !is_start_node(edge.source_node_id) {
                 node_ids.insert(edge.source_node_id);
+                ends_by_node_id
+                    .entry(edge.source_node_id)
+                    .or_default()
+                    .insert(edge.source_coordinate);
             }
-            edges_by_source_node_id
-                .entry(edge.source_node_id)
-                .and_modify(|edges| edges.push(edge))
-                .or_insert(vec![edge]);
 
             if !is_end_node(edge.target_node_id) {
                 node_ids.insert(edge.target_node_id);
+                starts_by_node_id
+                    .entry(edge.target_node_id)
+                    .or_default()
+                    .insert(edge.target_coordinate);
             }
-            edges_by_target_node_id
-                .entry(edge.target_node_id)
-                .and_modify(|edges| edges.push(edge))
-                .or_insert(vec![edge]);
+        }
+
+        let incomplete_node_ids = node_ids
+            .iter()
+            .copied()
+            .filter(|node_id| {
+                starts_by_node_id.get(node_id).map_or(0, HashSet::len)
+                    != ends_by_node_id.get(node_id).map_or(0, HashSet::len)
+            })
+            .collect::<HashSet<_>>();
+        if !incomplete_node_ids.is_empty() {
+            for edge in BlockGroupEdge::edges_for_block_group(conn, block_group_id)
+                .iter()
+                .map(|augmented_edge| &augmented_edge.edge)
+            {
+                if incomplete_node_ids.contains(&edge.source_node_id) {
+                    ends_by_node_id
+                        .entry(edge.source_node_id)
+                        .or_default()
+                        .insert(edge.source_coordinate);
+                }
+                if incomplete_node_ids.contains(&edge.target_node_id) {
+                    starts_by_node_id
+                        .entry(edge.target_node_id)
+                        .or_default()
+                        .insert(edge.target_coordinate);
+                }
+            }
         }
 
         let sequences_by_node_id = Node::get_sequences_by_node_ids(
@@ -381,11 +409,11 @@ impl Edge {
             .iter()
             .sorted_by_key(|(_node_id, seq)| seq.hash)
         {
-            let block_intervals = Edge::get_block_intervals(
-                edges_by_source_node_id.get(node_id),
-                edges_by_target_node_id.get(node_id),
-                sequence.length,
-            );
+            let empty_starts = HashSet::new();
+            let empty_ends = HashSet::new();
+            let starts = starts_by_node_id.get(node_id).unwrap_or(&empty_starts);
+            let ends = ends_by_node_id.get(node_id).unwrap_or(&empty_ends);
+            let block_intervals = Edge::get_block_intervals(starts, ends);
 
             for (start, end) in block_intervals {
                 blocks.push(GroupBlock::new(block_index, *node_id, sequence, start, end));
@@ -510,7 +538,7 @@ mod tests {
     use super::*;
     use crate::{
         block_group::{BlockGroup, PathChange},
-        block_group_edge::BlockGroupEdge,
+        block_group_edge::{BlockGroupEdge, BlockGroupEdgeData},
         collection::Collection,
         sequence::Sequence,
         test_helpers::{get_connection, setup_block_group},
@@ -656,7 +684,7 @@ mod tests {
             },
         )
         .unwrap();
-        let _bg = BlockGroup::create(
+        let bg = BlockGroup::create(
             &conn,
             crate::block_group::NewBlockGroup {
                 collection_name: "test",
@@ -699,6 +727,26 @@ mod tests {
         let n_ccc = Node::create(&conn, &seq_ccc.hash, &HashId::convert_str("node-ccc")).unwrap();
         let n_atc = Node::create(&conn, &seq_atc.hash, &HashId::convert_str("node-atc")).unwrap();
 
+        let e_start_aaa = Edge::create(
+            &conn,
+            PATH_START_NODE_ID,
+            -1,
+            Strand::Forward,
+            n_aaa,
+            0,
+            Strand::Forward,
+        )
+        .unwrap();
+        let e_start_ggg = Edge::create(
+            &conn,
+            PATH_START_NODE_ID,
+            -1,
+            Strand::Forward,
+            n_ggg,
+            0,
+            Strand::Forward,
+        )
+        .unwrap();
         // Edges: AAA→TTT, GGG→TTT, TTT→CCC, TTT→ATC
         let e_aaa_ttt =
             Edge::create(&conn, n_aaa, 3, Strand::Forward, n_ttt, 0, Strand::Forward).unwrap();
@@ -708,6 +756,46 @@ mod tests {
             Edge::create(&conn, n_ttt, 3, Strand::Forward, n_ccc, 0, Strand::Forward).unwrap();
         let e_ttt_atc =
             Edge::create(&conn, n_ttt, 3, Strand::Forward, n_atc, 0, Strand::Forward).unwrap();
+        let e_ccc_end = Edge::create(
+            &conn,
+            n_ccc,
+            3,
+            Strand::Forward,
+            PATH_END_NODE_ID,
+            -1,
+            Strand::Forward,
+        )
+        .unwrap();
+        let e_atc_end = Edge::create(
+            &conn,
+            n_atc,
+            3,
+            Strand::Forward,
+            PATH_END_NODE_ID,
+            -1,
+            Strand::Forward,
+        )
+        .unwrap();
+
+        let block_group_edges = [
+            e_start_aaa.clone(),
+            e_start_ggg.clone(),
+            e_aaa_ttt.clone(),
+            e_ggg_ttt.clone(),
+            e_ttt_ccc.clone(),
+            e_ttt_atc.clone(),
+            e_ccc_end.clone(),
+            e_atc_end.clone(),
+        ]
+        .iter()
+        .map(|edge| BlockGroupEdgeData {
+            block_group_id: bg.id,
+            edge_id: edge.id,
+            chromosome_index: 0,
+            phased: 0,
+        })
+        .collect::<Vec<_>>();
+        BlockGroupEdge::bulk_create(&conn, &block_group_edges);
 
         let augmented_edges = vec![
             AugmentedEdge {
@@ -736,7 +824,7 @@ mod tests {
             },
         ];
 
-        let blocks = Edge::blocks_from_edges(&conn, &augmented_edges);
+        let blocks = Edge::blocks_from_edges(&conn, &bg.id, &augmented_edges);
 
         // 5 non-terminal nodes: AAA, GGG, TTT, CCC, ATC
         // 2 terminal blocks: START, END
@@ -781,6 +869,98 @@ mod tests {
         let atc_block = blocks.iter().find(|b| b.node_id == n_atc).unwrap();
         assert_eq!(atc_block.start, 0, "ATC block start should be 0");
         assert_eq!(atc_block.end, 3, "ATC block end should be 3");
+    }
+
+    #[test]
+    fn test_blocks_from_edges_uses_edge_coordinates_not_backing_sequence_length() {
+        let conn = get_connection(None).unwrap();
+        Collection::get_or_create(&conn, "test").unwrap();
+        crate::sample::Sample::get_or_create(
+            &conn,
+            crate::sample::NewSample {
+                name: "test",
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let bg = BlockGroup::create(
+            &conn,
+            crate::block_group::NewBlockGroup {
+                collection_name: "test",
+                sample_name: "test",
+                name: "slice",
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let backing_sequence = Sequence::new()
+            .sequence_type("DNA")
+            .sequence("AAATTT")
+            .save(&conn)
+            .unwrap();
+        let node_id =
+            Node::create(&conn, &backing_sequence.hash, &HashId::convert_str("slice")).unwrap();
+
+        let into_slice = Edge::create(
+            &conn,
+            PATH_START_NODE_ID,
+            -1,
+            Strand::Forward,
+            node_id,
+            3,
+            Strand::Forward,
+        )
+        .unwrap();
+        let out_of_slice = Edge::create(
+            &conn,
+            node_id,
+            4,
+            Strand::Forward,
+            PATH_END_NODE_ID,
+            -1,
+            Strand::Forward,
+        )
+        .unwrap();
+        let block_group_edges = [into_slice.clone(), out_of_slice.clone()]
+            .iter()
+            .map(|edge| BlockGroupEdgeData {
+                block_group_id: bg.id,
+                edge_id: edge.id,
+                chromosome_index: 0,
+                phased: 0,
+            })
+            .collect::<Vec<_>>();
+        BlockGroupEdge::bulk_create(&conn, &block_group_edges);
+
+        let augmented_edges = vec![
+            AugmentedEdge {
+                edge: into_slice,
+                chromosome_index: 0,
+                phased: 0,
+                created_on: 0,
+            },
+            AugmentedEdge {
+                edge: out_of_slice,
+                chromosome_index: 0,
+                phased: 0,
+                created_on: 0,
+            },
+        ];
+
+        let blocks = Edge::blocks_from_edges(&conn, &bg.id, &augmented_edges);
+        let node_blocks = blocks
+            .iter()
+            .filter(|block| block.node_id == node_id)
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            node_blocks.len(),
+            1,
+            "expected one edge-delimited block, got {node_blocks:?}"
+        );
+        assert_eq!(node_blocks[0].start, 3);
+        assert_eq!(node_blocks[0].end, 4);
     }
 
     #[test]
@@ -873,7 +1053,7 @@ mod tests {
         let (block_group_id, path) = setup_block_group(&conn);
 
         let edges = BlockGroupEdge::edges_for_block_group(&conn, &block_group_id);
-        let blocks = Edge::blocks_from_edges(&conn, &edges);
+        let blocks = Edge::blocks_from_edges(&conn, &block_group_id, &edges);
 
         // 4 actual sequences: 10-length ones of all A, all T, all C, all G
         // 2 terminal node blocks (start/end)
@@ -910,7 +1090,7 @@ mod tests {
         BlockGroup::insert_change(&conn, &change).unwrap();
         let mut edges = BlockGroupEdge::edges_for_block_group(&conn, &block_group_id);
 
-        let blocks = Edge::blocks_from_edges(&conn, &edges);
+        let blocks = Edge::blocks_from_edges(&conn, &block_group_id, &edges);
 
         // 2 10-length sequences of all C, all G
         // 1 inserted NNNN sequence
@@ -921,7 +1101,7 @@ mod tests {
 
         // Confirm that ordering doesn't matter
         edges.reverse();
-        let blocks = Edge::blocks_from_edges(&conn, &edges);
+        let blocks = Edge::blocks_from_edges(&conn, &block_group_id, &edges);
 
         // 2 10-length sequences of all C, all G
         // 1 inserted NNNN sequence

--- a/gen-models/src/edge.rs
+++ b/gen-models/src/edge.rs
@@ -421,8 +421,13 @@ impl Edge {
             |node_id: &HashId,
              starts_by_node_id: &HashMap<HashId, HashSet<i64>>,
              ends_by_node_id: &HashMap<HashId, HashSet<i64>>| {
-                starts_by_node_id.get(node_id).map_or(0, HashSet::len)
-                    != ends_by_node_id.get(node_id).map_or(0, HashSet::len)
+                let has_starts = starts_by_node_id
+                    .get(node_id)
+                    .is_some_and(|starts| !starts.is_empty());
+                let has_ends = ends_by_node_id
+                    .get(node_id)
+                    .is_some_and(|ends| !ends.is_empty());
+                has_starts != has_ends
             };
         let mut queried_node_ids = HashSet::new();
         let mut incomplete_node_ids = node_ids
@@ -1183,6 +1188,130 @@ mod tests {
         );
         assert_eq!(node_blocks[0].start, 3);
         assert_eq!(node_blocks[0].end, 4);
+    }
+
+    #[test]
+    fn test_blocks_from_edges_does_not_treat_asymmetric_boundaries_as_incomplete() {
+        // It's possible that the passed in set of edges is deliberately incomplete.
+        // This asserts we do not expand the graph if node information is present.
+        let conn = get_connection(None).unwrap();
+        Collection::get_or_create(&conn, "test").unwrap();
+        crate::sample::Sample::get_or_create(
+            &conn,
+            crate::sample::NewSample {
+                name: "test",
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let bg = BlockGroup::create(
+            &conn,
+            crate::block_group::NewBlockGroup {
+                collection_name: "test",
+                sample_name: "test",
+                name: "asymmetric",
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let seq_src = Sequence::new()
+            .sequence_type("DNA")
+            .sequence("AAA")
+            .save(&conn)
+            .unwrap();
+        let seq_mid = Sequence::new()
+            .sequence_type("DNA")
+            .sequence("AAACCCGGG")
+            .save(&conn)
+            .unwrap();
+        let seq_a = Sequence::new()
+            .sequence_type("DNA")
+            .sequence("CCC")
+            .save(&conn)
+            .unwrap();
+        let seq_b = Sequence::new()
+            .sequence_type("DNA")
+            .sequence("GGG")
+            .save(&conn)
+            .unwrap();
+        let seq_extra = Sequence::new()
+            .sequence_type("DNA")
+            .sequence("TTT")
+            .save(&conn)
+            .unwrap();
+
+        let n_src = Node::create(&conn, &seq_src.hash, &HashId::convert_str("node-src")).unwrap();
+        let n_mid = Node::create(&conn, &seq_mid.hash, &HashId::convert_str("node-mid")).unwrap();
+        let n_a = Node::create(&conn, &seq_a.hash, &HashId::convert_str("node-a")).unwrap();
+        let n_b = Node::create(&conn, &seq_b.hash, &HashId::convert_str("node-b")).unwrap();
+        let n_extra =
+            Node::create(&conn, &seq_extra.hash, &HashId::convert_str("node-extra")).unwrap();
+
+        let e_src_mid =
+            Edge::create(&conn, n_src, 3, Strand::Forward, n_mid, 0, Strand::Forward).unwrap();
+        let e_mid_a =
+            Edge::create(&conn, n_mid, 3, Strand::Forward, n_a, 0, Strand::Forward).unwrap();
+        let e_mid_b =
+            Edge::create(&conn, n_mid, 6, Strand::Forward, n_b, 0, Strand::Forward).unwrap();
+        // We exclude this edge from graph construction
+        let e_mid_extra = Edge::create(
+            &conn,
+            n_mid,
+            9,
+            Strand::Forward,
+            n_extra,
+            0,
+            Strand::Forward,
+        )
+        .unwrap();
+
+        let block_group_edges = [
+            e_src_mid.clone(),
+            e_mid_a.clone(),
+            e_mid_b.clone(),
+            e_mid_extra,
+        ]
+        .iter()
+        .map(|edge| BlockGroupEdgeData {
+            block_group_id: bg.id,
+            edge_id: edge.id,
+            chromosome_index: 0,
+            phased: 0,
+        })
+        .collect::<Vec<_>>();
+        BlockGroupEdge::bulk_create(&conn, &block_group_edges);
+
+        let augmented_edges = vec![
+            AugmentedEdge {
+                edge: e_src_mid,
+                chromosome_index: 0,
+                phased: 0,
+                created_on: 0,
+            },
+            AugmentedEdge {
+                edge: e_mid_a,
+                chromosome_index: 0,
+                phased: 0,
+                created_on: 0,
+            },
+            AugmentedEdge {
+                edge: e_mid_b,
+                chromosome_index: 0,
+                phased: 0,
+                created_on: 0,
+            },
+        ];
+
+        let blocks = Edge::blocks_from_edges(&conn, &bg.id, &augmented_edges).unwrap();
+        let mid_intervals = blocks
+            .iter()
+            .filter(|block| block.node_id == n_mid)
+            .map(|block| (block.start, block.end))
+            .collect::<Vec<_>>();
+
+        assert_eq!(mid_intervals, vec![(0, 3), (3, 6)]);
+        assert!(!blocks.iter().any(|block| block.node_id == n_extra));
     }
 
     #[test]

--- a/gen-models/src/edge.rs
+++ b/gen-models/src/edge.rs
@@ -206,6 +206,11 @@ pub enum EdgeError {
     NodeError(#[from] NodeError),
     #[error("Sequence error: {0}")]
     SequenceError(#[from] SequenceError),
+    #[error("Cannot build blocks from starts {starts:?} and ends {ends:?}")]
+    BlockIntervalError {
+        starts: HashSet<i64>,
+        ends: HashSet<i64>,
+    },
 }
 
 impl Edge {
@@ -315,9 +320,9 @@ impl Edge {
         conn: &GraphConnection,
         block_group_id: &HashId,
         node_ids: &[HashId],
-    ) -> Vec<AugmentedEdge> {
+    ) -> Result<Vec<AugmentedEdge>, EdgeError> {
         if node_ids.is_empty() {
-            return vec![];
+            return Ok(vec![]);
         }
 
         let mut edges = vec![];
@@ -342,49 +347,55 @@ impl Edge {
 
         for chunk in node_ids.chunks(batch_size) {
             let values = chunk.iter().copied().map(Value::from).collect::<Vec<_>>();
-            let mut stmt = conn.prepare_cached(query).unwrap();
-            let rows = stmt
-                .query_map(params![block_group_id, Rc::new(values)], |row| {
-                    Ok(AugmentedEdge {
-                        edge: Edge {
-                            id: row.get(0)?,
-                            source_node_id: row.get(1)?,
-                            source_coordinate: row.get(2)?,
-                            source_strand: row.get(3)?,
-                            target_node_id: row.get(4)?,
-                            target_coordinate: row.get(5)?,
-                            target_strand: row.get(6)?,
-                        },
-                        chromosome_index: row.get(7)?,
-                        phased: row.get(8)?,
-                        created_on: row.get(9)?,
-                    })
+            let mut stmt = conn.prepare_cached(query)?;
+            let rows = stmt.query_map(params![block_group_id, Rc::new(values)], |row| {
+                Ok(AugmentedEdge {
+                    edge: Edge {
+                        id: row.get(0)?,
+                        source_node_id: row.get(1)?,
+                        source_coordinate: row.get(2)?,
+                        source_strand: row.get(3)?,
+                        target_node_id: row.get(4)?,
+                        target_coordinate: row.get(5)?,
+                        target_strand: row.get(6)?,
+                    },
+                    chromosome_index: row.get(7)?,
+                    phased: row.get(8)?,
+                    created_on: row.get(9)?,
                 })
-                .unwrap();
+            })?;
 
-            edges.extend(rows.map(|row| row.unwrap()));
+            for row in rows {
+                edges.push(row?);
+            }
         }
 
-        edges
+        Ok(edges)
     }
 
-    fn get_block_intervals(starts: &HashSet<i64>, ends: &HashSet<i64>) -> Vec<(i64, i64)> {
+    fn get_block_intervals(
+        starts: &HashSet<i64>,
+        ends: &HashSet<i64>,
+    ) -> Result<Vec<(i64, i64)>, EdgeError> {
         let coordinates = starts.union(ends).sorted().copied().collect::<Vec<_>>();
         if coordinates.is_empty() {
-            panic!("Cannot build blocks from starts {starts:?} and ends {ends:?}");
+            return Err(EdgeError::BlockIntervalError {
+                starts: starts.clone(),
+                ends: ends.clone(),
+            });
         }
         if coordinates.len() == 1 {
-            return vec![(coordinates[0], coordinates[0])];
+            return Ok(vec![(coordinates[0], coordinates[0])]);
         }
 
-        coordinates.into_iter().tuple_windows().collect()
+        Ok(coordinates.into_iter().tuple_windows().collect())
     }
 
     pub fn blocks_from_edges(
         conn: &GraphConnection,
         block_group_id: &HashId,
         edges: &[AugmentedEdge],
-    ) -> Vec<GroupBlock> {
+    ) -> Result<Vec<GroupBlock>, EdgeError> {
         let mut node_ids = IndexSet::new();
         let mut starts_by_node_id: HashMap<HashId, HashSet<i64>> = HashMap::new();
         let mut ends_by_node_id: HashMap<HashId, HashSet<i64>> = HashMap::new();
@@ -425,7 +436,7 @@ impl Edge {
             let mut next_incomplete_node_ids = HashSet::new();
 
             for edge in
-                Edge::edges_for_block_group_nodes(conn, block_group_id, &incomplete_node_ids)
+                Edge::edges_for_block_group_nodes(conn, block_group_id, &incomplete_node_ids)?
                     .iter()
                     .map(|augmented_edge| &augmented_edge.edge)
             {
@@ -475,7 +486,7 @@ impl Edge {
             let empty_ends = HashSet::new();
             let starts = starts_by_node_id.get(node_id).unwrap_or(&empty_starts);
             let ends = ends_by_node_id.get(node_id).unwrap_or(&empty_ends);
-            let block_intervals = Edge::get_block_intervals(starts, ends);
+            let block_intervals = Edge::get_block_intervals(starts, ends)?;
 
             for (start, end) in block_intervals {
                 blocks.push(GroupBlock::new(block_index, *node_id, sequence, start, end));
@@ -503,7 +514,7 @@ impl Edge {
             0,
         );
         blocks.push(end_block);
-        blocks
+        Ok(blocks)
     }
 
     pub fn build_graph(
@@ -626,6 +637,34 @@ mod tests {
             .into_iter()
             .sorted_by(|c1, c2| Ord::cmp(&c1, &c2))
             .collect::<Vec<i64>>()
+    }
+
+    #[test]
+    fn test_get_block_intervals_splits_sorted_unique_coordinates() {
+        let starts = HashSet::from([5, 0, 5]);
+        let ends = HashSet::from([10, 3]);
+
+        let intervals = Edge::get_block_intervals(&starts, &ends).unwrap();
+
+        assert_eq!(intervals, vec![(0, 3), (3, 5), (5, 10)]);
+    }
+
+    #[test]
+    fn test_get_block_intervals_single_coordinate_creates_anchor_block() {
+        let starts = HashSet::from([3]);
+        let ends = HashSet::new();
+
+        let intervals = Edge::get_block_intervals(&starts, &ends).unwrap();
+
+        assert_eq!(intervals, vec![(3, 3)]);
+    }
+
+    #[test]
+    fn test_get_block_intervals_errors_without_coordinates() {
+        assert!(matches!(
+            Edge::get_block_intervals(&HashSet::new(), &HashSet::new()),
+            Err(EdgeError::BlockIntervalError { .. })
+        ));
     }
 
     #[test]
@@ -839,7 +878,7 @@ mod tests {
             .collect::<Vec<_>>();
         BlockGroupEdge::bulk_create(&conn, &block_group_edges);
 
-        let edges = Edge::edges_for_block_group_nodes(&conn, &bg.id, &[n_a]);
+        let edges = Edge::edges_for_block_group_nodes(&conn, &bg.id, &[n_a]).unwrap();
         let edge_ids = edges
             .iter()
             .map(|augmented_edge| augmented_edge.edge.id)
@@ -1007,7 +1046,7 @@ mod tests {
             },
         ];
 
-        let blocks = Edge::blocks_from_edges(&conn, &bg.id, &augmented_edges);
+        let blocks = Edge::blocks_from_edges(&conn, &bg.id, &augmented_edges).unwrap();
 
         // 5 non-terminal nodes: AAA, GGG, TTT, CCC, ATC
         // 2 terminal blocks: START, END
@@ -1131,7 +1170,7 @@ mod tests {
             },
         ];
 
-        let blocks = Edge::blocks_from_edges(&conn, &bg.id, &augmented_edges);
+        let blocks = Edge::blocks_from_edges(&conn, &bg.id, &augmented_edges).unwrap();
         let node_blocks = blocks
             .iter()
             .filter(|block| block.node_id == node_id)
@@ -1219,7 +1258,8 @@ mod tests {
                 phased: 0,
                 created_on: 0,
             }],
-        );
+        )
+        .unwrap();
 
         let b_block = blocks.iter().find(|block| block.node_id == n_b).unwrap();
         assert_eq!(b_block.start, 0);
@@ -1320,7 +1360,7 @@ mod tests {
         let (block_group_id, path) = setup_block_group(&conn);
 
         let edges = BlockGroupEdge::edges_for_block_group(&conn, &block_group_id);
-        let blocks = Edge::blocks_from_edges(&conn, &block_group_id, &edges);
+        let blocks = Edge::blocks_from_edges(&conn, &block_group_id, &edges).unwrap();
 
         // 4 actual sequences: 10-length ones of all A, all T, all C, all G
         // 2 terminal node blocks (start/end)
@@ -1357,7 +1397,7 @@ mod tests {
         BlockGroup::insert_change(&conn, &change).unwrap();
         let mut edges = BlockGroupEdge::edges_for_block_group(&conn, &block_group_id);
 
-        let blocks = Edge::blocks_from_edges(&conn, &block_group_id, &edges);
+        let blocks = Edge::blocks_from_edges(&conn, &block_group_id, &edges).unwrap();
 
         // 2 10-length sequences of all C, all G
         // 1 inserted NNNN sequence
@@ -1368,7 +1408,7 @@ mod tests {
 
         // Confirm that ordering doesn't matter
         edges.reverse();
-        let blocks = Edge::blocks_from_edges(&conn, &block_group_id, &edges);
+        let blocks = Edge::blocks_from_edges(&conn, &block_group_id, &edges).unwrap();
 
         // 2 10-length sequences of all C, all G
         // 1 inserted NNNN sequence

--- a/gen-models/src/edge.rs
+++ b/gen-models/src/edge.rs
@@ -1,21 +1,22 @@
 use std::{
     collections::{HashMap, HashSet},
     hash::Hash,
+    rc::Rc,
 };
 
 use gen_core::{
-    HashId, PATH_END_NODE_ID, PATH_START_NODE_ID, Strand, calculate_hash, is_end_node,
-    is_start_node, traits::Capnp,
+    HashId, PATH_END_NODE_ID, PATH_START_NODE_ID, Strand, calculate_hash, is_terminal,
+    traits::Capnp,
 };
 use gen_graph::{GenGraph, GraphEdge, GraphNode};
 use indexmap::IndexSet;
 use itertools::Itertools;
-use rusqlite::{Row, params};
+use rusqlite::{Row, params, types::Value};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::{
-    block_group_edge::{AugmentedEdge, BlockGroupEdge},
+    block_group_edge::AugmentedEdge,
     db::GraphConnection,
     errors::NodeError,
     gen_models_capnp::edge,
@@ -310,33 +311,70 @@ impl Edge {
         }
     }
 
-    #[cfg(test)]
-    fn get_block_boundaries(
-        source_edges: Option<&Vec<&Edge>>,
-        target_edges: Option<&Vec<&Edge>>,
-    ) -> Vec<i64> {
-        let mut block_boundary_coordinates = HashSet::new();
-        if let Some(actual_source_edges) = source_edges {
-            for source_edge in actual_source_edges {
-                block_boundary_coordinates.insert(source_edge.source_coordinate);
-            }
-        }
-        if let Some(actual_target_edges) = target_edges {
-            for target_edge in actual_target_edges {
-                block_boundary_coordinates.insert(target_edge.target_coordinate);
-            }
+    pub fn edges_for_block_group_nodes(
+        conn: &GraphConnection,
+        block_group_id: &HashId,
+        node_ids: &[HashId],
+    ) -> Vec<AugmentedEdge> {
+        if node_ids.is_empty() {
+            return vec![];
         }
 
-        block_boundary_coordinates
-            .into_iter()
-            .sorted_by(|c1, c2| Ord::cmp(&c1, &c2))
-            .collect::<Vec<i64>>()
+        let mut edges = vec![];
+        let batch_size = max_rows_per_batch(conn, 1);
+        let query = "\
+            SELECT
+                e.id,
+                e.source_node_id,
+                e.source_coordinate,
+                e.source_strand,
+                e.target_node_id,
+                e.target_coordinate,
+                e.target_strand,
+                bge.chromosome_index,
+                bge.phased,
+                bge.created_on
+            FROM block_group_edges bge
+            JOIN edges e ON e.id = bge.edge_id
+            WHERE bge.block_group_id = ?1
+              AND (e.source_node_id IN rarray(?2) OR e.target_node_id IN rarray(?2))
+            ORDER BY bge.created_on DESC;";
+
+        for chunk in node_ids.chunks(batch_size) {
+            let values = chunk.iter().copied().map(Value::from).collect::<Vec<_>>();
+            let mut stmt = conn.prepare_cached(query).unwrap();
+            let rows = stmt
+                .query_map(params![block_group_id, Rc::new(values)], |row| {
+                    Ok(AugmentedEdge {
+                        edge: Edge {
+                            id: row.get(0)?,
+                            source_node_id: row.get(1)?,
+                            source_coordinate: row.get(2)?,
+                            source_strand: row.get(3)?,
+                            target_node_id: row.get(4)?,
+                            target_coordinate: row.get(5)?,
+                            target_strand: row.get(6)?,
+                        },
+                        chromosome_index: row.get(7)?,
+                        phased: row.get(8)?,
+                        created_on: row.get(9)?,
+                    })
+                })
+                .unwrap();
+
+            edges.extend(rows.map(|row| row.unwrap()));
+        }
+
+        edges
     }
 
     fn get_block_intervals(starts: &HashSet<i64>, ends: &HashSet<i64>) -> Vec<(i64, i64)> {
         let coordinates = starts.union(ends).sorted().copied().collect::<Vec<_>>();
-        if coordinates.len() < 2 {
+        if coordinates.is_empty() {
             panic!("Cannot build blocks from starts {starts:?} and ends {ends:?}");
+        }
+        if coordinates.len() == 1 {
+            return vec![(coordinates[0], coordinates[0])];
         }
 
         coordinates.into_iter().tuple_windows().collect()
@@ -351,21 +389,21 @@ impl Edge {
         let mut starts_by_node_id: HashMap<HashId, HashSet<i64>> = HashMap::new();
         let mut ends_by_node_id: HashMap<HashId, HashSet<i64>> = HashMap::new();
         for edge in edges.iter().map(|edge| &edge.edge) {
-            if !is_start_node(edge.source_node_id) {
+            if !is_terminal(edge.source_node_id) {
                 node_ids.insert(edge.source_node_id);
-                ends_by_node_id
-                    .entry(edge.source_node_id)
-                    .or_default()
-                    .insert(edge.source_coordinate);
             }
+            ends_by_node_id
+                .entry(edge.source_node_id)
+                .or_default()
+                .insert(edge.source_coordinate);
 
-            if !is_end_node(edge.target_node_id) {
+            if !is_terminal(edge.target_node_id) {
                 node_ids.insert(edge.target_node_id);
-                starts_by_node_id
-                    .entry(edge.target_node_id)
-                    .or_default()
-                    .insert(edge.target_coordinate);
             }
+            starts_by_node_id
+                .entry(edge.target_node_id)
+                .or_default()
+                .insert(edge.target_coordinate);
         }
 
         let incomplete_node_ids = node_ids
@@ -377,9 +415,11 @@ impl Edge {
             })
             .collect::<HashSet<_>>();
         if !incomplete_node_ids.is_empty() {
-            for edge in BlockGroupEdge::edges_for_block_group(conn, block_group_id)
-                .iter()
-                .map(|augmented_edge| &augmented_edge.edge)
+            let incomplete_node_ids = incomplete_node_ids.iter().copied().collect::<Vec<_>>();
+            for edge in
+                Edge::edges_for_block_group_nodes(conn, block_group_id, &incomplete_node_ids)
+                    .iter()
+                    .map(|augmented_edge| &augmented_edge.edge)
             {
                 if incomplete_node_ids.contains(&edge.source_node_id) {
                     ends_by_node_id
@@ -544,6 +584,28 @@ mod tests {
         test_helpers::{get_connection, setup_block_group},
     };
 
+    fn get_block_boundaries(
+        source_edges: Option<&Vec<&Edge>>,
+        target_edges: Option<&Vec<&Edge>>,
+    ) -> Vec<i64> {
+        let mut block_boundary_coordinates = HashSet::new();
+        if let Some(actual_source_edges) = source_edges {
+            for source_edge in actual_source_edges {
+                block_boundary_coordinates.insert(source_edge.source_coordinate);
+            }
+        }
+        if let Some(actual_target_edges) = target_edges {
+            for target_edge in actual_target_edges {
+                block_boundary_coordinates.insert(target_edge.target_coordinate);
+            }
+        }
+
+        block_boundary_coordinates
+            .into_iter()
+            .sorted_by(|c1, c2| Ord::cmp(&c1, &c2))
+            .collect::<Vec<i64>>()
+    }
+
     #[test]
     fn test_bulk_create() {
         let conn = &mut get_connection(None).unwrap();
@@ -667,6 +729,105 @@ mod tests {
             let edge = Edge::get_by_id(conn, id).unwrap();
             assert_eq!(EdgeData::from(&edge), edges[index]);
         }
+    }
+
+    #[test]
+    fn test_edges_for_block_group_nodes_filters_by_block_group_and_node_ids() {
+        let conn = get_connection(None).unwrap();
+        Collection::get_or_create(&conn, "test").unwrap();
+        crate::sample::Sample::get_or_create(
+            &conn,
+            crate::sample::NewSample {
+                name: "test",
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let bg = BlockGroup::create(
+            &conn,
+            crate::block_group::NewBlockGroup {
+                collection_name: "test",
+                sample_name: "test",
+                name: "query-bg",
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let other_bg = BlockGroup::create(
+            &conn,
+            crate::block_group::NewBlockGroup {
+                collection_name: "test",
+                sample_name: "test",
+                name: "other-bg",
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let seq_a = Sequence::new()
+            .sequence_type("DNA")
+            .sequence("AAA")
+            .save(&conn)
+            .unwrap();
+        let seq_b = Sequence::new()
+            .sequence_type("DNA")
+            .sequence("CCC")
+            .save(&conn)
+            .unwrap();
+        let seq_c = Sequence::new()
+            .sequence_type("DNA")
+            .sequence("GGG")
+            .save(&conn)
+            .unwrap();
+        let n_a = Node::create(&conn, &seq_a.hash, &HashId::convert_str("node-a")).unwrap();
+        let n_b = Node::create(&conn, &seq_b.hash, &HashId::convert_str("node-b")).unwrap();
+        let n_c = Node::create(&conn, &seq_c.hash, &HashId::convert_str("node-c")).unwrap();
+
+        let source_match =
+            Edge::create(&conn, n_a, 3, Strand::Forward, n_b, 0, Strand::Forward).unwrap();
+        let target_match =
+            Edge::create(&conn, n_c, 3, Strand::Forward, n_a, 0, Strand::Forward).unwrap();
+        let no_match =
+            Edge::create(&conn, n_b, 3, Strand::Forward, n_c, 0, Strand::Forward).unwrap();
+        let other_bg_match = Edge::create(
+            &conn,
+            PATH_START_NODE_ID,
+            -1,
+            Strand::Forward,
+            n_a,
+            0,
+            Strand::Forward,
+        )
+        .unwrap();
+
+        let block_group_edges = [source_match.clone(), target_match.clone(), no_match.clone()]
+            .iter()
+            .map(|edge| BlockGroupEdgeData {
+                block_group_id: bg.id,
+                edge_id: edge.id,
+                chromosome_index: 0,
+                phased: 0,
+            })
+            .chain(std::iter::once(BlockGroupEdgeData {
+                block_group_id: other_bg.id,
+                edge_id: other_bg_match.id,
+                chromosome_index: 0,
+                phased: 0,
+            }))
+            .collect::<Vec<_>>();
+        BlockGroupEdge::bulk_create(&conn, &block_group_edges);
+
+        let edges = Edge::edges_for_block_group_nodes(&conn, &bg.id, &[n_a]);
+        let edge_ids = edges
+            .iter()
+            .map(|augmented_edge| augmented_edge.edge.id)
+            .collect::<HashSet<_>>();
+
+        assert_eq!(edge_ids.len(), 2);
+        assert!(edge_ids.contains(&source_match.id));
+        assert!(edge_ids.contains(&target_match.id));
+        assert!(!edge_ids.contains(&no_match.id));
+        assert!(!edge_ids.contains(&other_bg_match.id));
     }
 
     #[test]
@@ -1151,7 +1312,7 @@ mod tests {
         )
         .unwrap();
 
-        let boundaries = Edge::get_block_boundaries(Some(&vec![&edge1]), Some(&vec![&edge2]));
+        let boundaries = get_block_boundaries(Some(&vec![&edge1]), Some(&vec![&edge2]));
         assert_eq!(boundaries, vec![2, 3]);
     }
 
@@ -1203,9 +1364,9 @@ mod tests {
         )
         .unwrap();
 
-        let outgoing_boundaries = Edge::get_block_boundaries(Some(&vec![&edge1]), None);
+        let outgoing_boundaries = get_block_boundaries(Some(&vec![&edge1]), None);
         assert_eq!(outgoing_boundaries, vec![2]);
-        let incoming_boundaries = Edge::get_block_boundaries(None, Some(&vec![&edge2]));
+        let incoming_boundaries = get_block_boundaries(None, Some(&vec![&edge2]));
         assert_eq!(incoming_boundaries, vec![3]);
     }
 

--- a/gen-models/src/edge.rs
+++ b/gen-models/src/edge.rs
@@ -406,34 +406,56 @@ impl Edge {
                 .insert(edge.target_coordinate);
         }
 
-        let incomplete_node_ids = node_ids
-            .iter()
-            .copied()
-            .filter(|node_id| {
+        let is_incomplete =
+            |node_id: &HashId,
+             starts_by_node_id: &HashMap<HashId, HashSet<i64>>,
+             ends_by_node_id: &HashMap<HashId, HashSet<i64>>| {
                 starts_by_node_id.get(node_id).map_or(0, HashSet::len)
                     != ends_by_node_id.get(node_id).map_or(0, HashSet::len)
-            })
-            .collect::<HashSet<_>>();
-        if !incomplete_node_ids.is_empty() {
-            let incomplete_node_ids = incomplete_node_ids.iter().copied().collect::<Vec<_>>();
+            };
+        let mut queried_node_ids = HashSet::new();
+        let mut incomplete_node_ids = node_ids
+            .iter()
+            .copied()
+            .filter(|node_id| is_incomplete(node_id, &starts_by_node_id, &ends_by_node_id))
+            .collect::<Vec<_>>();
+
+        while !incomplete_node_ids.is_empty() {
+            queried_node_ids.extend(incomplete_node_ids.iter().copied());
+            let mut next_incomplete_node_ids = HashSet::new();
+
             for edge in
                 Edge::edges_for_block_group_nodes(conn, block_group_id, &incomplete_node_ids)
                     .iter()
                     .map(|augmented_edge| &augmented_edge.edge)
             {
-                if incomplete_node_ids.contains(&edge.source_node_id) {
-                    ends_by_node_id
-                        .entry(edge.source_node_id)
-                        .or_default()
-                        .insert(edge.source_coordinate);
+                if !is_terminal(edge.source_node_id) {
+                    node_ids.insert(edge.source_node_id);
                 }
-                if incomplete_node_ids.contains(&edge.target_node_id) {
-                    starts_by_node_id
-                        .entry(edge.target_node_id)
-                        .or_default()
-                        .insert(edge.target_coordinate);
+                ends_by_node_id
+                    .entry(edge.source_node_id)
+                    .or_default()
+                    .insert(edge.source_coordinate);
+
+                if !is_terminal(edge.target_node_id) {
+                    node_ids.insert(edge.target_node_id);
+                }
+                starts_by_node_id
+                    .entry(edge.target_node_id)
+                    .or_default()
+                    .insert(edge.target_coordinate);
+
+                for candidate_node_id in [edge.source_node_id, edge.target_node_id] {
+                    if !is_terminal(candidate_node_id)
+                        && !queried_node_ids.contains(&candidate_node_id)
+                        && is_incomplete(&candidate_node_id, &starts_by_node_id, &ends_by_node_id)
+                    {
+                        next_incomplete_node_ids.insert(candidate_node_id);
+                    }
                 }
             }
+
+            incomplete_node_ids = next_incomplete_node_ids.into_iter().collect();
         }
 
         let sequences_by_node_id = Node::get_sequences_by_node_ids(
@@ -1122,6 +1144,90 @@ mod tests {
         );
         assert_eq!(node_blocks[0].start, 3);
         assert_eq!(node_blocks[0].end, 4);
+    }
+
+    #[test]
+    fn test_blocks_from_edges_resolves_incomplete_nodes_created_by_lookup() {
+        let conn = get_connection(None).unwrap();
+        Collection::get_or_create(&conn, "test").unwrap();
+        crate::sample::Sample::get_or_create(
+            &conn,
+            crate::sample::NewSample {
+                name: "test",
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let bg = BlockGroup::create(
+            &conn,
+            crate::block_group::NewBlockGroup {
+                collection_name: "test",
+                sample_name: "test",
+                name: "recursive-incomplete",
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let seq_a = Sequence::new()
+            .sequence_type("DNA")
+            .sequence("AAA")
+            .save(&conn)
+            .unwrap();
+        let seq_b = Sequence::new()
+            .sequence_type("DNA")
+            .sequence("BBB")
+            .save(&conn)
+            .unwrap();
+        let seq_c = Sequence::new()
+            .sequence_type("DNA")
+            .sequence("CCC")
+            .save(&conn)
+            .unwrap();
+        let seq_d = Sequence::new()
+            .sequence_type("DNA")
+            .sequence("DDD")
+            .save(&conn)
+            .unwrap();
+
+        let n_a = Node::create(&conn, &seq_a.hash, &HashId::convert_str("node-a")).unwrap();
+        let n_b = Node::create(&conn, &seq_b.hash, &HashId::convert_str("node-b")).unwrap();
+        let n_c = Node::create(&conn, &seq_c.hash, &HashId::convert_str("node-c")).unwrap();
+        let n_d = Node::create(&conn, &seq_d.hash, &HashId::convert_str("node-d")).unwrap();
+
+        let e_a_b = Edge::create(&conn, n_a, 3, Strand::Forward, n_b, 0, Strand::Forward).unwrap();
+        let e_b_c = Edge::create(&conn, n_b, 3, Strand::Forward, n_c, 0, Strand::Forward).unwrap();
+        let e_c_d = Edge::create(&conn, n_c, 3, Strand::Forward, n_d, 0, Strand::Forward).unwrap();
+
+        let block_group_edges = [e_a_b.clone(), e_b_c.clone(), e_c_d.clone()]
+            .iter()
+            .map(|edge| BlockGroupEdgeData {
+                block_group_id: bg.id,
+                edge_id: edge.id,
+                chromosome_index: 0,
+                phased: 0,
+            })
+            .collect::<Vec<_>>();
+        BlockGroupEdge::bulk_create(&conn, &block_group_edges);
+
+        let blocks = Edge::blocks_from_edges(
+            &conn,
+            &bg.id,
+            &[AugmentedEdge {
+                edge: e_a_b,
+                chromosome_index: 0,
+                phased: 0,
+                created_on: 0,
+            }],
+        );
+
+        let b_block = blocks.iter().find(|block| block.node_id == n_b).unwrap();
+        assert_eq!(b_block.start, 0);
+        assert_eq!(b_block.end, 3);
+
+        let c_block = blocks.iter().find(|block| block.node_id == n_c).unwrap();
+        assert_eq!(c_block.start, 0);
+        assert_eq!(c_block.end, 3);
     }
 
     #[test]

--- a/gen-models/src/edge.rs
+++ b/gen-models/src/edge.rs
@@ -1100,6 +1100,10 @@ mod tests {
 
     #[test]
     fn test_blocks_from_edges_uses_edge_coordinates_not_backing_sequence_length() {
+        // This test ensures we do not use sequence_start or sequence_end to get coordinates by making
+        // a test case where the graph has no nodes that are the sequence length. This was leading to
+        // technically incorrect behavior by adding blocks of [0, sequence_length] when that was just
+        // a happy coincidence it worked
         let conn = get_connection(None).unwrap();
         Collection::get_or_create(&conn, "test").unwrap();
         crate::sample::Sample::get_or_create(
@@ -1316,6 +1320,8 @@ mod tests {
 
     #[test]
     fn test_blocks_from_edges_resolves_incomplete_nodes_created_by_lookup() {
+        // If a node is present as just a source or sink node, ensure we look it up to
+        // accurately add it to the graph.
         let conn = get_connection(None).unwrap();
         Collection::get_or_create(&conn, "test").unwrap();
         crate::sample::Sample::get_or_create(

--- a/gen-models/src/sample.rs
+++ b/gen-models/src/sample.rs
@@ -158,11 +158,15 @@ impl Sample {
         stmt.execute([name]).unwrap();
     }
 
-    pub fn get_graph(conn: &GraphConnection, collection: &str, name: &str) -> GenGraph {
+    pub fn get_graph(
+        conn: &GraphConnection,
+        collection: &str,
+        name: &str,
+    ) -> Result<GenGraph, SampleError> {
         let block_groups = Sample::get_block_groups(conn, collection, name);
         let mut sample_graph = GenGraph::new();
         for bg in block_groups {
-            let bg_graph = BlockGroup::get_graph(conn, &bg.id);
+            let bg_graph = BlockGroup::get_graph(conn, &bg.id)?;
             // Add nodes and edges from block group graph to sample graph
             for node in bg_graph.nodes() {
                 sample_graph.add_node(node);
@@ -175,7 +179,7 @@ impl Sample {
                 }
             }
         }
-        sample_graph
+        Ok(sample_graph)
     }
 
     pub fn get_all_sequences(
@@ -183,11 +187,12 @@ impl Sample {
         collection_name: &str,
         sample_name: &str,
         prune: bool,
-    ) -> HashSet<String> {
-        Sample::get_block_groups(conn, collection_name, sample_name)
-            .into_iter()
-            .flat_map(|block_group| BlockGroup::get_all_sequences(conn, &block_group.id, prune))
-            .collect()
+    ) -> Result<HashSet<String>, SampleError> {
+        let mut sequences = HashSet::new();
+        for block_group in Sample::get_block_groups(conn, collection_name, sample_name) {
+            sequences.extend(BlockGroup::get_all_sequences(conn, &block_group.id, prune)?);
+        }
+        Ok(sequences)
     }
 
     pub fn get_or_create_child(

--- a/gen-python/src/python_api/block_group.rs
+++ b/gen-python/src/python_api/block_group.rs
@@ -16,6 +16,7 @@ use super::{
     block::PyGraphNode,
     hash_id::PyHashId,
     jupyter_widget::{PyGraphController, build_widget},
+    utils::block_group_err_to_pyerr,
 };
 
 pub(crate) fn parse_sequence_kind(s: &str) -> PyResult<SequenceKind> {
@@ -148,7 +149,7 @@ impl PyBlockGroup {
             .path()
             .map(std::path::PathBuf::from)
             .ok_or_else(|| PyRuntimeError::new_err("graph DB has no file path"))?;
-        let graph = BlockGroup::get_graph(graph_conn, &bg_id);
+        let graph = BlockGroup::get_graph(graph_conn, &bg_id).map_err(block_group_err_to_pyerr)?;
         let mut ctrl = PyGraphController::new(db_path, graph);
         ctrl.block_group_id = Some(bg_id);
         ctrl.auto_load_annotation_groups(graph_conn);
@@ -186,7 +187,7 @@ impl PyBlockGroup {
             )
         })?;
         let conn = context.graph().conn();
-        let graph = BlockGroup::get_graph(conn, &self.id);
+        let graph = BlockGroup::get_graph(conn, &self.id).map_err(block_group_err_to_pyerr)?;
         let matcher = GenGraphMatcher::new_with_sequence_kind(conn, graph, kind);
 
         let gen_dir = context.workspace().ensure_gen_dir();
@@ -248,7 +249,7 @@ impl PyBlockGroup {
         fs::create_dir_all(&index_dir)
             .map_err(|e| PyRuntimeError::new_err(format!("Failed to create index dir: {e}")))?;
         let conn = context.graph().conn();
-        let graph = BlockGroup::get_graph(conn, &self.id);
+        let graph = BlockGroup::get_graph(conn, &self.id).map_err(block_group_err_to_pyerr)?;
         let matcher = GenGraphMatcher::new_with_sequence_kind(conn, graph, kind);
         let normalized = kind != SequenceKind::Exact;
         let index = SeedIndex::build(&matcher, k, normalized);
@@ -286,7 +287,7 @@ impl PyBlockGroup {
 
     fn to_dict(&self, py: Python<'_>) -> PyResult<PyObject> {
         let conn = self.require_context("to_dict()")?.graph().conn();
-        let graph = BlockGroup::get_graph(conn, &self.id);
+        let graph = BlockGroup::get_graph(conn, &self.id).map_err(block_group_err_to_pyerr)?;
         let dict = PyDict::new(py);
         let nodes = PyDict::new(py);
         for node in graph.nodes() {
@@ -328,7 +329,7 @@ impl PyBlockGroup {
 
     fn to_rustworkx(&self, py: Python<'_>) -> PyResult<PyObject> {
         let conn = self.require_context("to_rustworkx()")?.graph().conn();
-        let graph = BlockGroup::get_graph(conn, &self.id);
+        let graph = BlockGroup::get_graph(conn, &self.id).map_err(block_group_err_to_pyerr)?;
         {
             let rustworkx = PyModule::import(py, "rustworkx").map_err(|_| {
                 pyo3::exceptions::PyModuleNotFoundError::new_err(
@@ -372,7 +373,7 @@ impl PyBlockGroup {
 
     fn to_networkx(&self, py: Python<'_>) -> PyResult<PyObject> {
         let conn = self.require_context("to_networkx()")?.graph().conn();
-        let graph = BlockGroup::get_graph(conn, &self.id);
+        let graph = BlockGroup::get_graph(conn, &self.id).map_err(block_group_err_to_pyerr)?;
         {
             let networkx = PyModule::import(py, "networkx").map_err(|_| {
                 pyo3::exceptions::PyModuleNotFoundError::new_err(

--- a/gen-python/src/python_api/jupyter_widget.rs
+++ b/gen-python/src/python_api/jupyter_widget.rs
@@ -48,6 +48,7 @@ use crate::python_api::{
     block_group::PyBlockGroup,
     graph_search::{PyAnnotation, PyGraphLocus, PyGraphPos},
     repository::PyRepository,
+    utils::block_group_err_to_pyerr,
 };
 
 /// Convert a ratatui `Color` to a CSS hex string.
@@ -393,7 +394,7 @@ impl PyGraphController {
             .path()
             .map(PathBuf::from)
             .ok_or_else(|| PyRuntimeError::new_err("graph DB has no file path"))?;
-        let graph = BlockGroup::get_graph(conn, &bg_id);
+        let graph = BlockGroup::get_graph(conn, &bg_id).map_err(block_group_err_to_pyerr)?;
         let mut ctrl = Self::new(db_path, graph);
         ctrl.block_group_id = Some(bg_id);
         ctrl.auto_load_annotation_groups(conn);
@@ -988,7 +989,8 @@ mod tests {
             .map(std::path::PathBuf::from)
             .expect("test DB must be file-backed");
         let (bg_id, _) = setup_block_group(graph_handle.conn());
-        let graph = BlockGroup::get_graph(graph_handle.conn(), &bg_id);
+        let graph = BlockGroup::get_graph(graph_handle.conn(), &bg_id)
+            .map_err(crate::python_api::utils::block_group_err_to_pyerr)?;
         let mut ctrl = PyGraphController::new(db_path, graph);
         if let Some(node_detail) = detail {
             ctrl.set_detail(node_detail)?;

--- a/gen-python/src/python_api/repository/mod.rs
+++ b/gen-python/src/python_api/repository/mod.rs
@@ -251,7 +251,8 @@ impl PyRepository {
             .path()
             .map(std::path::PathBuf::from)
             .ok_or_else(|| PyRuntimeError::new_err("graph DB has no file path"))?;
-        let graph = BlockGroup::get_graph(graph_conn, &block_group.id);
+        let graph =
+            BlockGroup::get_graph(graph_conn, &block_group.id).map_err(block_group_err_to_pyerr)?;
         let mut ctrl = PyGraphController::new(db_path, graph);
         ctrl.block_group_id = Some(block_group.id);
         ctrl.auto_load_annotation_groups(graph_conn);

--- a/gen-python/src/python_api/repository/search.rs
+++ b/gen-python/src/python_api/repository/search.rs
@@ -8,6 +8,7 @@ use super::PyRepository;
 use crate::python_api::{
     block_group::{PyBlockGroup, parse_sequence_kind},
     graph_search::PyGraphLocus,
+    utils::block_group_err_to_pyerr,
 };
 
 #[pymethods]
@@ -44,7 +45,7 @@ impl PyRepository {
         };
 
         for bg in bgs {
-            let graph = BlockGroup::get_graph(conn, &bg.id);
+            let graph = BlockGroup::get_graph(conn, &bg.id).map_err(block_group_err_to_pyerr)?;
             let matcher = GenGraphMatcher::new_with_sequence_kind(conn, graph, kind);
             let index = SeedIndex::build(&matcher, k, normalized);
             let path = index_dir.join(format!("{}.bin", bg.id));
@@ -91,7 +92,7 @@ impl PyRepository {
         let query_bytes = query.as_bytes();
         let mut results = Vec::new();
         for bg in bgs {
-            let graph = BlockGroup::get_graph(conn, &bg.id);
+            let graph = BlockGroup::get_graph(conn, &bg.id).map_err(block_group_err_to_pyerr)?;
             let matcher = GenGraphMatcher::new_with_sequence_kind(conn, graph, kind);
 
             let index_path = self

--- a/gen-r/src/rust/src/lib.rs
+++ b/gen-r/src/rust/src/lib.rs
@@ -557,7 +557,7 @@ fn block_group_graph(
 ) -> std::result::Result<(GraphConnection, GenGraph), String> {
     let conn = open_repo_connection(db_path)?;
     let bg_id = hash_id_from_string(block_group_id)?;
-    let graph = BlockGroup::get_graph(&conn, &bg_id);
+    let graph = BlockGroup::get_graph(&conn, &bg_id).map_err(|e| e.to_string())?;
     Ok((conn, graph))
 }
 
@@ -1788,7 +1788,7 @@ fn repo_block_group_to_dict(
 ) -> std::result::Result<List, Error> {
     let conn = open_repo_connection(&db_path).map_err(Error::Other)?;
     let bg_id = hash_id_from_string(&block_group_id).map_err(Error::Other)?;
-    let graph = BlockGroup::get_graph(&conn, &bg_id);
+    let graph = BlockGroup::get_graph(&conn, &bg_id).map_err(|e| Error::Other(e.to_string()))?;
 
     let nodes = graph
         .nodes()
@@ -1965,7 +1965,8 @@ fn repo_build_index(
     };
 
     for bg in bgs {
-        let graph = BlockGroup::get_graph(&conn, &bg.id);
+        let graph =
+            BlockGroup::get_graph(&conn, &bg.id).map_err(|e| Error::Other(e.to_string()))?;
         let matcher = GenGraphMatcher::new_with_sequence_kind(&conn, graph, kind);
         let index = SeedIndex::build(&matcher, k as usize, normalized);
         let path = index_dir.join(format!("{}.bin", bg.id));
@@ -2003,7 +2004,8 @@ fn repo_search(
     let mut results = Vec::new();
 
     for bg in bgs {
-        let graph = BlockGroup::get_graph(&conn, &bg.id);
+        let graph =
+            BlockGroup::get_graph(&conn, &bg.id).map_err(|e| Error::Other(e.to_string()))?;
         let matcher = GenGraphMatcher::new_with_sequence_kind(&conn, graph, kind);
 
         let index_path = index_dir.join(format!("{}.bin", bg.id));
@@ -2312,7 +2314,7 @@ impl GenRepository {
     fn block_group_to_dict(&self, block_group_id: String) -> std::result::Result<List, Error> {
         let conn = self.context.graph().conn();
         let bg_id = hash_id_from_string(&block_group_id).map_err(Error::Other)?;
-        let graph = BlockGroup::get_graph(conn, &bg_id);
+        let graph = BlockGroup::get_graph(conn, &bg_id).map_err(|e| Error::Other(e.to_string()))?;
 
         let nodes = graph
             .nodes()
@@ -3130,7 +3132,8 @@ impl GenRepository {
                 .collect()
         };
         for bg in bgs {
-            let graph = BlockGroup::get_graph(conn, &bg.id);
+            let graph =
+                BlockGroup::get_graph(conn, &bg.id).map_err(|e| Error::Other(e.to_string()))?;
             let matcher = GenGraphMatcher::new_with_sequence_kind(conn, graph, kind);
             let index = SeedIndex::build(&matcher, k as usize, normalized);
             let path = index_dir.join(format!("{}.bin", bg.id));
@@ -3168,7 +3171,8 @@ impl GenRepository {
             .join("search_index");
         let mut results = Vec::new();
         for bg in bgs {
-            let graph = BlockGroup::get_graph(conn, &bg.id);
+            let graph =
+                BlockGroup::get_graph(conn, &bg.id).map_err(|e| Error::Other(e.to_string()))?;
             let matcher = GenGraphMatcher::new_with_sequence_kind(conn, graph, kind);
             let index_path = index_dir.join(format!("{}.bin", bg.id));
             let index = fs::read(&index_path)
@@ -3391,7 +3395,8 @@ impl GenBlockGroup {
             .join("search_index");
         fs::create_dir_all(&index_dir)
             .map_err(|e| Error::Other(format!("Failed to create index dir: {e}")))?;
-        let graph = BlockGroup::get_graph(conn, &self.id);
+        let graph =
+            BlockGroup::get_graph(conn, &self.id).map_err(|e| Error::Other(e.to_string()))?;
         let matcher = GenGraphMatcher::new_with_sequence_kind(conn, graph, kind);
         let index = SeedIndex::build(&matcher, k as usize, normalized);
         let path = index_dir.join(format!("{}.bin", self.id));
@@ -3404,7 +3409,8 @@ impl GenBlockGroup {
     fn search(&self, query: String, sequence_kind: String) -> std::result::Result<List, Error> {
         let kind = parse_sequence_kind_r(&sequence_kind).map_err(Error::Other)?;
         let conn = self.context.graph().conn();
-        let graph = BlockGroup::get_graph(conn, &self.id);
+        let graph =
+            BlockGroup::get_graph(conn, &self.id).map_err(|e| Error::Other(e.to_string()))?;
         let matcher = GenGraphMatcher::new_with_sequence_kind(conn, graph, kind);
         let index_dir = self
             .context
@@ -3521,7 +3527,8 @@ impl GenBlockGroup {
 
     fn block_group_to_dict(&self) -> std::result::Result<List, Error> {
         let conn = self.context.graph().conn();
-        let graph = BlockGroup::get_graph(conn, &self.id);
+        let graph =
+            BlockGroup::get_graph(conn, &self.id).map_err(|e| Error::Other(e.to_string()))?;
 
         let nodes = graph
             .nodes()

--- a/src/diffs/gfa.rs
+++ b/src/diffs/gfa.rs
@@ -406,7 +406,7 @@ mod tests {
             .pop()
             .unwrap();
         let all_child_sequences =
-            BlockGroup::get_all_sequences(conn, &new_child_block_group.id, false);
+            BlockGroup::get_all_sequences(conn, &new_child_block_group.id, false).unwrap();
 
         // We've replaced the middle AAAA with CCCC, so expect that as the child sequence
         assert_eq!(
@@ -489,7 +489,7 @@ mod tests {
             .pop()
             .unwrap();
         let all_grandchild_sequences =
-            BlockGroup::get_all_sequences(conn, &new_grandchild_block_group.id, false);
+            BlockGroup::get_all_sequences(conn, &new_grandchild_block_group.id, false).unwrap();
 
         // We've replaced the middle AAAA with CCCC and the middle TTTT with GGGG, so four possible sequences
         assert_eq!(
@@ -519,7 +519,7 @@ mod tests {
             .pop()
             .unwrap();
         let all_grandchild_sequences =
-            BlockGroup::get_all_sequences(conn, &new_grandchild_block_group.id, false);
+            BlockGroup::get_all_sequences(conn, &new_grandchild_block_group.id, false).unwrap();
 
         assert_eq!(
             all_grandchild_sequences,
@@ -628,7 +628,8 @@ mod tests {
         let new_block_group = Collection::get_block_groups(conn, "test collection 2")
             .pop()
             .unwrap();
-        let all_sequences = BlockGroup::get_all_sequences(conn, &new_block_group.id, false);
+        let all_sequences =
+            BlockGroup::get_all_sequences(conn, &new_block_group.id, false).unwrap();
 
         assert_eq!(
             all_sequences,
@@ -737,7 +738,8 @@ mod tests {
         let new_block_group = Collection::get_block_groups(conn, "test collection 2")
             .pop()
             .unwrap();
-        let all_sequences = BlockGroup::get_all_sequences(conn, &new_block_group.id, false);
+        let all_sequences =
+            BlockGroup::get_all_sequences(conn, &new_block_group.id, false).unwrap();
 
         assert_eq!(
             all_sequences,
@@ -905,7 +907,8 @@ mod tests {
         let new_block_group = Collection::get_block_groups(conn, "test collection 3")
             .pop()
             .unwrap();
-        let all_sequences = BlockGroup::get_all_sequences(conn, &new_block_group.id, false);
+        let all_sequences =
+            BlockGroup::get_all_sequences(conn, &new_block_group.id, false).unwrap();
 
         assert_eq!(
             all_sequences,
@@ -1074,7 +1077,8 @@ mod tests {
         let new_block_group = Collection::get_block_groups(conn, "test collection 3")
             .pop()
             .unwrap();
-        let all_sequences = BlockGroup::get_all_sequences(conn, &new_block_group.id, false);
+        let all_sequences =
+            BlockGroup::get_all_sequences(conn, &new_block_group.id, false).unwrap();
 
         assert_eq!(
             all_sequences,
@@ -1219,7 +1223,7 @@ mod tests {
             .pop()
             .unwrap();
         let all_child_sequences =
-            BlockGroup::get_all_sequences(conn, &new_child_block_group.id, false);
+            BlockGroup::get_all_sequences(conn, &new_child_block_group.id, false).unwrap();
 
         // We've replaced [2, 6) of AAAA with CCCC
         assert_eq!(
@@ -1303,7 +1307,7 @@ mod tests {
             .pop()
             .unwrap();
         let all_grandchild_sequences =
-            BlockGroup::get_all_sequences(conn, &new_grandchild_block_group.id, false);
+            BlockGroup::get_all_sequences(conn, &new_grandchild_block_group.id, false).unwrap();
 
         // Original is AAAAAAAAAAAAAAAA
         // Grandchild is AACCGGGGAAAAAA
@@ -1330,7 +1334,7 @@ mod tests {
             .pop()
             .unwrap();
         let all_grandchild_sequences =
-            BlockGroup::get_all_sequences(conn, &new_grandchild_block_group.id, false);
+            BlockGroup::get_all_sequences(conn, &new_grandchild_block_group.id, false).unwrap();
 
         // Child is      AACCCCAAAAAAAAAA
         // Grandchild is AACCGGGGAAAAAA

--- a/src/exports/genbank.rs
+++ b/src/exports/genbank.rs
@@ -20,7 +20,7 @@ use gen_models::{
     annotations::{Annotation, GenBankLocationOperator},
     block_group::BlockGroup,
     db::GraphConnection,
-    errors::{AnnotationError, PathError, SequenceError},
+    errors::{AnnotationError, BlockGroupError, PathError, SequenceError},
     node::Node,
     sample::Sample,
     traits::Query,
@@ -42,6 +42,8 @@ pub enum GenbankExportError {
     Sequence(#[from] SequenceError),
     #[error("Path error while exporting GenBank: {0}")]
     Path(#[from] PathError),
+    #[error("Block group error while exporting GenBank: {0}")]
+    BlockGroup(#[from] BlockGroupError),
 }
 
 fn build_annotation_location(
@@ -286,7 +288,7 @@ pub fn export_genbank(
         export_annotations(conn, &path, &path_blocks, &mut seq, sample_name)?;
 
         // Identify the node traversal corresponding to our path.
-        let graph = BlockGroup::get_graph(conn, &block_group.id);
+        let graph = BlockGroup::get_graph(conn, &block_group.id)?;
         let path_nodes = get_path_nodes(&graph, &path_blocks);
         let path_node_set: HashSet<&GraphNode> = HashSet::from_iter(&path_nodes);
         let mut node_it = path_nodes.iter().peekable();

--- a/src/exports/gfa.rs
+++ b/src/exports/gfa.rs
@@ -61,14 +61,21 @@ pub fn export_gfa(
             sample_name: sample_name.to_string(),
         });
     }
+    let mut blocks = vec![];
+    let mut seen_blocks = HashSet::new();
     for block_group in sample_block_groups {
         let block_group_edges = BlockGroupEdge::edges_for_block_group(conn, &block_group.id);
+        for mut block in Edge::blocks_from_edges(conn, &block_group.id, &block_group_edges) {
+            if seen_blocks.insert((block.node_id, block.start, block.end)) {
+                block.id = blocks.len() as i64;
+                blocks.push(block);
+            }
+        }
         edge_set.extend(block_group_edges);
     }
 
     let edges = edge_set.into_iter().collect::<Vec<_>>();
 
-    let mut blocks = Edge::blocks_from_edges(conn, &edges);
     blocks.sort_by(|a, b| a.node_id.cmp(&b.node_id));
 
     let (gen_graph, _edges_by_node_pair) = Edge::build_graph(&edges, &blocks);

--- a/src/exports/gfa.rs
+++ b/src/exports/gfa.rs
@@ -11,7 +11,7 @@ use gen_models::{
     block_group::BlockGroup,
     block_group_edge::BlockGroupEdge,
     db::GraphConnection,
-    edge::Edge,
+    edge::{Edge, EdgeError},
     errors::{PathError, SequenceError},
     path::Path,
     sample::Sample,
@@ -34,6 +34,11 @@ pub enum GfaExportError {
         path_name: String,
         #[source]
         source: PathError,
+    },
+    #[error("Edge error while exporting GFA: {source}")]
+    Edge {
+        #[source]
+        source: EdgeError,
     },
     #[error("No block groups found for collection {collection_name} and sample {sample_name}")]
     MissingBlockGroups {
@@ -65,7 +70,9 @@ pub fn export_gfa(
     let mut seen_blocks = HashSet::new();
     for block_group in sample_block_groups {
         let block_group_edges = BlockGroupEdge::edges_for_block_group(conn, &block_group.id);
-        for mut block in Edge::blocks_from_edges(conn, &block_group.id, &block_group_edges) {
+        for mut block in Edge::blocks_from_edges(conn, &block_group.id, &block_group_edges)
+            .map_err(|source| GfaExportError::Edge { source })?
+        {
             if seen_blocks.insert((block.node_id, block.start, block.end)) {
                 block.id = blocks.len() as i64;
                 blocks.push(block);
@@ -488,7 +495,7 @@ mod tests {
         )
         .unwrap();
 
-        let all_sequences = BlockGroup::get_all_sequences(conn, &block_group.id, false);
+        let all_sequences = BlockGroup::get_all_sequences(conn, &block_group.id, false).unwrap();
 
         let temp_dir = tempdir().expect("Couldn't get handle to temp directory");
         let mut gfa_path = PathBuf::from(temp_dir.path());
@@ -506,7 +513,7 @@ mod tests {
         let block_group2 = Collection::get_block_groups(conn, "test collection 2")
             .pop()
             .unwrap();
-        let all_sequences2 = BlockGroup::get_all_sequences(conn, &block_group2.id, false);
+        let all_sequences2 = BlockGroup::get_all_sequences(conn, &block_group2.id, false).unwrap();
 
         assert_eq!(all_sequences, all_sequences2);
 
@@ -546,7 +553,7 @@ mod tests {
         track_database(conn, op_conn).unwrap();
 
         let (bg_id, _path) = setup_block_group(conn);
-        let all_sequences = BlockGroup::get_all_sequences(conn, &bg_id, false);
+        let all_sequences = BlockGroup::get_all_sequences(conn, &bg_id, false).unwrap();
 
         let temp_dir = tempdir().expect("Couldn't get handle to temp directory");
         let gfa_path = PathBuf::from(temp_dir.path()).join("split.gfa");
@@ -563,11 +570,11 @@ mod tests {
         let block_group2 = Collection::get_block_groups(conn, "test collection 2")
             .pop()
             .unwrap();
-        let all_sequences2 = BlockGroup::get_all_sequences(conn, &block_group2.id, false);
+        let all_sequences2 = BlockGroup::get_all_sequences(conn, &block_group2.id, false).unwrap();
 
         assert_eq!(all_sequences, all_sequences2);
 
-        let graph = BlockGroup::get_graph(conn, &block_group2.id);
+        let graph = BlockGroup::get_graph(conn, &block_group2.id).unwrap();
         let graph_nodes = graph
             .nodes()
             .filter_map(|node| {
@@ -603,7 +610,7 @@ mod tests {
         let _ = import_gfa(&context, &gfa_path, &collection_name, Sample::DEFAULT_NAME);
 
         let block_group_id = BlockGroup::get_id(&collection_name, Sample::DEFAULT_NAME, "", None);
-        let all_sequences = BlockGroup::get_all_sequences(conn, &block_group_id, false);
+        let all_sequences = BlockGroup::get_all_sequences(conn, &block_group_id, false).unwrap();
 
         let temp_dir = tempdir().expect("Couldn't get handle to temp directory");
         let mut gfa_path = PathBuf::from(temp_dir.path());
@@ -627,7 +634,7 @@ mod tests {
         let block_group2 = Collection::get_block_groups(conn, "test collection 2")
             .pop()
             .unwrap();
-        let all_sequences2 = BlockGroup::get_all_sequences(conn, &block_group2.id, false);
+        let all_sequences2 = BlockGroup::get_all_sequences(conn, &block_group2.id, false).unwrap();
 
         assert_eq!(all_sequences, all_sequences2);
     }
@@ -646,7 +653,7 @@ mod tests {
         let _ = import_gfa(&context, &gfa_path, &collection_name, Sample::DEFAULT_NAME);
 
         let block_group_id = BlockGroup::get_id(&collection_name, Sample::DEFAULT_NAME, "", None);
-        let all_sequences = BlockGroup::get_all_sequences(conn, &block_group_id, false);
+        let all_sequences = BlockGroup::get_all_sequences(conn, &block_group_id, false).unwrap();
 
         let temp_dir = tempdir().expect("Couldn't get handle to temp directory");
         let mut gfa_path = PathBuf::from(temp_dir.path());
@@ -670,7 +677,7 @@ mod tests {
         let block_group2 = Collection::get_block_groups(conn, "anderson promoters 2")
             .pop()
             .unwrap();
-        let all_sequences2 = BlockGroup::get_all_sequences(conn, &block_group2.id, false);
+        let all_sequences2 = BlockGroup::get_all_sequences(conn, &block_group2.id, false).unwrap();
 
         assert_eq!(all_sequences, all_sequences2);
     }
@@ -689,7 +696,7 @@ mod tests {
         let _ = import_gfa(&context, &gfa_path, &collection_name, Sample::DEFAULT_NAME);
 
         let block_group_id = BlockGroup::get_id(&collection_name, Sample::DEFAULT_NAME, "", None);
-        let all_sequences = BlockGroup::get_all_sequences(conn, &block_group_id, false);
+        let all_sequences = BlockGroup::get_all_sequences(conn, &block_group_id, false).unwrap();
 
         let temp_dir = tempdir().expect("Couldn't get handle to temp directory");
         let mut gfa_path = PathBuf::from(temp_dir.path());
@@ -713,7 +720,7 @@ mod tests {
         let block_group2 = Collection::get_block_groups(conn, "test collection 2")
             .pop()
             .unwrap();
-        let all_sequences2 = BlockGroup::get_all_sequences(conn, &block_group2.id, false);
+        let all_sequences2 = BlockGroup::get_all_sequences(conn, &block_group2.id, false).unwrap();
 
         assert_eq!(all_sequences, all_sequences2);
     }

--- a/src/graphs/graph_search.rs
+++ b/src/graphs/graph_search.rs
@@ -761,7 +761,7 @@ mod tests {
         let conn = ctx.graph().conn();
         let _ = Collection::create(conn, "test");
         let (block_group_id, _path) = setup_block_group(conn);
-        let graph = BlockGroup::get_graph(conn, &block_group_id);
+        let graph = BlockGroup::get_graph(conn, &block_group_id).unwrap();
         GenGraphMatcher::new(conn, graph)
     }
 
@@ -770,7 +770,7 @@ mod tests {
         let conn = ctx.graph().conn();
         let _ = Collection::create(conn, "test");
         let (block_group_id, _path) = setup_block_group(conn);
-        let graph = BlockGroup::get_graph(conn, &block_group_id);
+        let graph = BlockGroup::get_graph(conn, &block_group_id).unwrap();
         GenGraphMatcher::new_protein(conn, graph)
     }
 
@@ -779,7 +779,7 @@ mod tests {
         let conn = ctx.graph().conn();
         let _ = Collection::create(conn, "test");
         let (block_group_id, _path) = setup_block_group(conn);
-        let graph = BlockGroup::get_graph(conn, &block_group_id);
+        let graph = BlockGroup::get_graph(conn, &block_group_id).unwrap();
         GenGraphMatcher::new_with_sequence_kind(conn, graph, SequenceKind::Exact)
     }
 

--- a/src/graphs/operators.rs
+++ b/src/graphs/operators.rs
@@ -554,7 +554,7 @@ mod tests {
             "AAAAAAAAAATTTTTTAAAAAAAACCCCCCGGGGGGGGGG"
         );
 
-        let all_sequences = BlockGroup::get_all_sequences(conn, &block_group1_id, false);
+        let all_sequences = BlockGroup::get_all_sequences(conn, &block_group1_id, false).unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec![
@@ -579,7 +579,7 @@ mod tests {
         let block_groups = Sample::get_block_groups(conn, "test", Sample::DEFAULT_NAME);
         let block_group2 = block_groups.iter().find(|x| x.name == "chr1").unwrap();
 
-        let all_sequences2 = BlockGroup::get_all_sequences(conn, &block_group2.id, false);
+        let all_sequences2 = BlockGroup::get_all_sequences(conn, &block_group2.id, false).unwrap();
         assert_eq!(
             all_sequences2,
             HashSet::from_iter(vec!["TTTTTCCCCC".to_string(), "TAAAAAAAAC".to_string(),])
@@ -639,7 +639,7 @@ mod tests {
             Sample::get_block_groups(conn, collection, Sample::DEFAULT_NAME);
         let original_block_group_id = &original_block_groups[0].id;
         let all_original_sequences =
-            BlockGroup::get_all_sequences(conn, original_block_group_id, false);
+            BlockGroup::get_all_sequences(conn, original_block_group_id, false).unwrap();
         assert_eq!(
             all_original_sequences,
             HashSet::from_iter(vec!["ATCGATCGATCGATCGATCGGGAACACACAGAGA".to_string(),])
@@ -648,7 +648,7 @@ mod tests {
         let grandchild_block_groups = Sample::get_block_groups(conn, collection, "test2");
         let grandchild_block_group_id = &grandchild_block_groups[0].id;
         let all_grandchild_sequences =
-            BlockGroup::get_all_sequences(conn, grandchild_block_group_id, false);
+            BlockGroup::get_all_sequences(conn, grandchild_block_group_id, false).unwrap();
         assert_eq!(
             all_grandchild_sequences,
             HashSet::from_iter(vec![
@@ -680,7 +680,7 @@ mod tests {
         let block_groups = Sample::get_block_groups(conn, collection, "test3");
         let block_group2 = block_groups.iter().find(|x| x.name == "m123.2").unwrap();
 
-        let all_sequences2 = BlockGroup::get_all_sequences(conn, &block_group2.id, false);
+        let all_sequences2 = BlockGroup::get_all_sequences(conn, &block_group2.id, false).unwrap();
         assert_eq!(
             all_sequences2,
             HashSet::from_iter(vec!["TCAATCG".to_string(), "TCGATCG".to_string(),])
@@ -690,7 +690,7 @@ mod tests {
         assert_eq!(path2.sequence(conn).unwrap(), "TCAATCG");
 
         let block_group3 = block_groups.iter().find(|x| x.name == "m123.3").unwrap();
-        let all_sequences3 = BlockGroup::get_all_sequences(conn, &block_group3.id, false);
+        let all_sequences3 = BlockGroup::get_all_sequences(conn, &block_group3.id, false).unwrap();
         assert_eq!(
             all_sequences3,
             HashSet::from_iter(vec![
@@ -753,7 +753,7 @@ mod tests {
             Sample::get_block_groups(conn, collection, Sample::DEFAULT_NAME);
         let original_block_group_id = &original_block_groups[0].id;
         let all_original_sequences =
-            BlockGroup::get_all_sequences(conn, original_block_group_id, false);
+            BlockGroup::get_all_sequences(conn, original_block_group_id, false).unwrap();
         assert_eq!(
             all_original_sequences,
             HashSet::from_iter(vec!["ATCGATCGATCGATCGATCGGGAACACACAGAGA".to_string(),])
@@ -762,7 +762,7 @@ mod tests {
         let grandchild_block_groups = Sample::get_block_groups(conn, collection, "test2");
         let grandchild_block_group_id = &grandchild_block_groups[0].id;
         let all_grandchild_sequences =
-            BlockGroup::get_all_sequences(conn, grandchild_block_group_id, false);
+            BlockGroup::get_all_sequences(conn, grandchild_block_group_id, false).unwrap();
         assert_eq!(
             all_grandchild_sequences,
             HashSet::from_iter(vec![
@@ -794,7 +794,7 @@ mod tests {
         let block_groups = Sample::get_block_groups(conn, collection, "test3");
         let block_group2 = block_groups.iter().find(|x| x.name == "m123.2").unwrap();
 
-        let all_sequences2 = BlockGroup::get_all_sequences(conn, &block_group2.id, false);
+        let all_sequences2 = BlockGroup::get_all_sequences(conn, &block_group2.id, false).unwrap();
         assert_eq!(
             all_sequences2,
             HashSet::from_iter(vec!["TCAATCG".to_string(), "TCGATCG".to_string(),])
@@ -804,7 +804,7 @@ mod tests {
         assert_eq!(path2.sequence(conn).unwrap(), "TCAATCG");
 
         let block_group3 = block_groups.iter().find(|x| x.name == "m123.3").unwrap();
-        let all_sequences3 = BlockGroup::get_all_sequences(conn, &block_group3.id, false);
+        let all_sequences3 = BlockGroup::get_all_sequences(conn, &block_group3.id, false).unwrap();
         assert_eq!(
             all_sequences3,
             HashSet::from_iter(vec![
@@ -833,7 +833,7 @@ mod tests {
             .find(|x| x.name == "m123.stitched")
             .unwrap();
 
-        let all_sequences4 = BlockGroup::get_all_sequences(conn, &block_group4.id, false);
+        let all_sequences4 = BlockGroup::get_all_sequences(conn, &block_group4.id, false).unwrap();
         assert_eq!(
             all_sequences4,
             HashSet::from_iter(vec![
@@ -865,7 +865,7 @@ mod tests {
             .find(|x| x.name == "m123.reverse-stitched")
             .unwrap();
 
-        let all_sequences5 = BlockGroup::get_all_sequences(conn, &block_group5.id, false);
+        let all_sequences5 = BlockGroup::get_all_sequences(conn, &block_group5.id, false).unwrap();
         assert_eq!(
             all_sequences5,
             HashSet::from_iter(vec![

--- a/src/imports/fasta.rs
+++ b/src/imports/fasta.rs
@@ -222,7 +222,7 @@ mod tests {
         .unwrap();
         let block_group_id = BlockGroup::get_id("test", Sample::DEFAULT_NAME, "m123", None);
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &block_group_id, false),
+            BlockGroup::get_all_sequences(conn, &block_group_id, false).unwrap(),
             HashSet::from_iter(vec!["ATCGATCGATCGATCGATCGGGAACACACAGAGA".to_string()])
         );
 
@@ -253,7 +253,7 @@ mod tests {
         .unwrap();
         let block_group_id = BlockGroup::get_id("test", Sample::DEFAULT_NAME, "m123", None);
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &block_group_id, false),
+            BlockGroup::get_all_sequences(conn, &block_group_id, false).unwrap(),
             HashSet::from_iter(vec!["ATCGATCGATCGATCGATCGGGAACACACAGAGA".to_string()])
         );
     }
@@ -304,7 +304,7 @@ mod tests {
         .unwrap();
         let block_group_id = BlockGroup::get_id("test", Sample::DEFAULT_NAME, "m123", None);
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &block_group_id, false),
+            BlockGroup::get_all_sequences(conn, &block_group_id, false).unwrap(),
             HashSet::from_iter(vec!["ATCGATCGATCGATCGATCGGGAACACACAGAGA".to_string()])
         );
     }
@@ -329,7 +329,7 @@ mod tests {
         .unwrap();
         let block_group_id = BlockGroup::get_id("test", "new-sample", "m123", None);
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &block_group_id, false),
+            BlockGroup::get_all_sequences(conn, &block_group_id, false).unwrap(),
             HashSet::from_iter(vec!["ATCGATCGATCGATCGATCGGGAACACACAGAGA".to_string()])
         );
 
@@ -364,7 +364,7 @@ mod tests {
         .unwrap();
         let block_group_id = BlockGroup::get_id("test", Sample::DEFAULT_NAME, "m123", None);
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &block_group_id, false),
+            BlockGroup::get_all_sequences(conn, &block_group_id, false).unwrap(),
             HashSet::from_iter(vec!["ATCGATCGATCGATCGATCGGGAACACACAGAGA".to_string()])
         );
 

--- a/src/imports/genbank.rs
+++ b/src/imports/genbank.rs
@@ -1236,7 +1236,7 @@ mod tests {
             let f = reader::parse_file(&path).unwrap();
             let seq = str::from_utf8(&f[0].seq).unwrap().to_string();
             let block_group_id = BlockGroup::get_id("", Sample::DEFAULT_NAME, "insertion", None);
-            let seqs = BlockGroup::get_all_sequences(conn, &block_group_id, false);
+            let seqs = BlockGroup::get_all_sequences(conn, &block_group_id, false).unwrap();
             assert_eq!(
                 seqs,
                 HashSet::from_iter([
@@ -1287,7 +1287,7 @@ mod tests {
         GATGCCATTGGGATATATCAACGGTGGTATATCCAGTGATTTTTTTCTCCAT",
             );
             let block_group_id = BlockGroup::get_id("", Sample::DEFAULT_NAME, "deletion", None);
-            let seqs = BlockGroup::get_all_sequences(conn, &block_group_id, false);
+            let seqs = BlockGroup::get_all_sequences(conn, &block_group_id, false).unwrap();
             assert_eq!(
                 seqs,
                 HashSet::from_iter([
@@ -1346,7 +1346,8 @@ mod tests {
                 conn,
                 &BlockGroup::get_id("", Sample::DEFAULT_NAME, "deletion_and_insertion", None),
                 false,
-            );
+            )
+            .unwrap();
             assert_eq!(
                 seqs,
                 HashSet::from_iter([
@@ -1407,7 +1408,8 @@ mod tests {
                 conn,
                 &BlockGroup::get_id("", Sample::DEFAULT_NAME, "substitution", None),
                 false,
-            );
+            )
+            .unwrap();
             assert_eq!(
                 seqs,
                 HashSet::from_iter([
@@ -1454,6 +1456,7 @@ mod tests {
                 &BlockGroup::get_id("", Sample::DEFAULT_NAME, "insertion", None),
                 false,
             )
+            .unwrap()
             .iter()
             .map(|s| s.to_lowercase())
             .collect();

--- a/src/imports/gfa.rs
+++ b/src/imports/gfa.rs
@@ -369,7 +369,7 @@ pub fn import_gfa(
     let bar = progress_bar.add(get_progress_bar(None));
     bar.set_message("Breaking cycles");
     let message_bar = progress_bar.add(get_message_bar());
-    let graph = BlockGroup::get_graph(conn, &block_group.id);
+    let graph = BlockGroup::get_graph(conn, &block_group.id)?;
     let mut undirected_graph: UnGraphMap<GraphNode, GraphEdge> = UnGraphMap::new();
     for node in graph.nodes() {
         undirected_graph.add_node(node);
@@ -552,7 +552,7 @@ mod tests {
         let _ = import_gfa(&context, &gfa_path, &collection_name, Sample::DEFAULT_NAME);
 
         let block_group_id = BlockGroup::get_id(&collection_name, Sample::DEFAULT_NAME, "", None);
-        let all_sequences = BlockGroup::get_all_sequences(conn, &block_group_id, false);
+        let all_sequences = BlockGroup::get_all_sequences(conn, &block_group_id, false).unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec!["AAAATTTTGGGGCCCC".to_string()])
@@ -712,7 +712,7 @@ mod tests {
                 }
             }
         }
-        let all_sequences = BlockGroup::get_all_sequences(conn, &block_group_id, false);
+        let all_sequences = BlockGroup::get_all_sequences(conn, &block_group_id, false).unwrap();
         assert_eq!(all_sequences.len(), 1024);
         assert_eq!(all_sequences, expected_sequences);
 
@@ -743,7 +743,7 @@ mod tests {
         let result = path.sequence(conn);
         assert_eq!(result.unwrap(), "AA");
 
-        let all_sequences = BlockGroup::get_all_sequences(conn, &block_group_id, false);
+        let all_sequences = BlockGroup::get_all_sequences(conn, &block_group_id, false).unwrap();
         assert_eq!(all_sequences, HashSet::from_iter(vec!["AA".to_string()]));
 
         let node_count = Node::query(conn, "select * from nodes", rusqlite::params!()).len() as i64;
@@ -764,7 +764,7 @@ mod tests {
 
         let block_group_id = BlockGroup::get_id(&collection_name, Sample::DEFAULT_NAME, "", None);
 
-        let all_sequences = BlockGroup::get_all_sequences(conn, &block_group_id, false);
+        let all_sequences = BlockGroup::get_all_sequences(conn, &block_group_id, false).unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec!["AAACCCTTTGGGACTCTA".to_string()])
@@ -787,7 +787,7 @@ mod tests {
 
         let block_group_id = BlockGroup::get_id(&collection_name, Sample::DEFAULT_NAME, "", None);
 
-        let all_sequences = BlockGroup::get_all_sequences(conn, &block_group_id, false);
+        let all_sequences = BlockGroup::get_all_sequences(conn, &block_group_id, false).unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec!["TTTGGGACTCTAAAACCC".to_string()])

--- a/src/imports/library.rs
+++ b/src/imports/library.rs
@@ -173,7 +173,7 @@ mod tests {
             }
         }
 
-        let actual_sequences = BlockGroup::get_all_sequences(conn, &block_group.id, false);
+        let actual_sequences = BlockGroup::get_all_sequences(conn, &block_group.id, false).unwrap();
         assert_eq!(actual_sequences, expected_sequences);
 
         let current_path = BlockGroup::get_current_path(conn, &block_group.id);
@@ -216,7 +216,7 @@ mod tests {
         let block_groups = Sample::get_block_groups(conn, collection, Sample::DEFAULT_NAME);
         let block_group = &block_groups[0];
 
-        let all_sequences = BlockGroup::get_all_sequences(conn, &block_group.id, false);
+        let all_sequences = BlockGroup::get_all_sequences(conn, &block_group.id, false).unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec![
@@ -266,7 +266,7 @@ mod tests {
                 expected_sequences.push(part1.to_string() + part2);
             }
         }
-        let all_sequences = BlockGroup::get_all_sequences(conn, &block_group.id, false);
+        let all_sequences = BlockGroup::get_all_sequences(conn, &block_group.id, false).unwrap();
         assert_eq!(
             all_sequences,
             expected_sequences

--- a/src/main.rs
+++ b/src/main.rs
@@ -182,7 +182,7 @@ fn call_cli() -> Result<(), Box<dyn std::error::Error>> {
 
                 match block_group {
                     Ok(bg) => {
-                        let block_graph = BlockGroup::get_graph(graph_conn, &bg.id);
+                        let block_graph = BlockGroup::get_graph(graph_conn, &bg.id)?;
                         let current_path = BlockGroup::get_current_path(graph_conn, &bg.id);
                         // Use a default height of 10 for now
                         match show_inline_gen_graph_widget(
@@ -643,7 +643,7 @@ fn call_cli() -> Result<(), Box<dyn std::error::Error>> {
                 .ensure_search_index()
                 .map_err(|_| "No .gen directory found. Run 'gen init' first.")?;
             for bg in block_groups {
-                let graph = BlockGroup::get_graph(graph_conn, &bg.id);
+                let graph = BlockGroup::get_graph(graph_conn, &bg.id)?;
                 let matcher = GenGraphMatcher::new(graph_conn, graph);
                 let index = SeedIndex::build(&matcher, kmer_size, true);
                 let path = index_dir.join(format!("{}.bin", bg.id));
@@ -695,7 +695,7 @@ fn call_cli() -> Result<(), Box<dyn std::error::Error>> {
             let query_bytes = query.as_bytes();
             println!("sample\tgraph\tblocks\toffset");
             for bg in block_groups {
-                let graph = BlockGroup::get_graph(graph_conn, &bg.id);
+                let graph = BlockGroup::get_graph(graph_conn, &bg.id)?;
                 let matcher = GenGraphMatcher::new(graph_conn, graph);
                 let matches = index_dir
                     .as_ref()

--- a/src/operation_management.rs
+++ b/src/operation_management.rs
@@ -1905,7 +1905,7 @@ mod tests {
             HashSet::from_iter(vec!["ATCATCGATCGATCGATCGGGAACACACAGAGA".to_string()]);
 
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &foo_bg_id, false),
+            BlockGroup::get_all_sequences(conn, &foo_bg_id, false).unwrap(),
             patch_1_seqs
         );
         assert_eq!(
@@ -1935,7 +1935,7 @@ mod tests {
         let foo_bg_id = BlockGroup::get_id(&collection, "foo", "m123", Some(&default_bg));
         let patch_2_seqs = HashSet::from_iter(vec!["ATCGATCGATCGAGATCGGGAACACACAGAGA".to_string()]);
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &foo_bg_id, false),
+            BlockGroup::get_all_sequences(conn, &foo_bg_id, false).unwrap(),
             patch_2_seqs
         );
         assert_ne!(patch_1_seqs, patch_2_seqs);
@@ -1953,7 +1953,7 @@ mod tests {
         let foo_bg_id = BlockGroup::get_id(&collection, "foo", "m123", Some(&default_bg));
         let patch_2_seqs = HashSet::from_iter(vec!["ATCATCGATCGAGATCGGGAACACACAGAGA".to_string()]);
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &foo_bg_id, false),
+            BlockGroup::get_all_sequences(conn, &foo_bg_id, false).unwrap(),
             patch_2_seqs
         );
         assert_eq!(
@@ -1973,7 +1973,7 @@ mod tests {
         let unknown_seqs =
             HashSet::from_iter(vec!["ATCATCGATAGACGATCGATCGGGAACACACAGAGA".to_string()]);
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &unknown_bg_id, false),
+            BlockGroup::get_all_sequences(conn, &unknown_bg_id, false).unwrap(),
             unknown_seqs
         );
         assert_ne!(unknown_seqs, patch_2_seqs);

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -531,11 +531,11 @@ mod tests {
 
         apply_patch_archive(&target_context, &mut write_stream).unwrap();
         for bg in BlockGroup::query(conn, "select * from block_groups;", params![]).iter() {
-            let seqs = BlockGroup::get_all_sequences(conn, &bg.id, false);
+            let seqs = BlockGroup::get_all_sequences(conn, &bg.id, false).unwrap();
             assert!(!seqs.is_empty());
             assert_eq!(
                 seqs,
-                BlockGroup::get_all_sequences(target_conn, &bg.id, false),
+                BlockGroup::get_all_sequences(target_conn, &bg.id, false).unwrap(),
             );
         }
     }

--- a/src/updates/fasta.rs
+++ b/src/updates/fasta.rs
@@ -294,7 +294,7 @@ mod tests {
         );
         assert_eq!(block_groups.len(), 1);
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &block_groups[0].id, false),
+            BlockGroup::get_all_sequences(conn, &block_groups[0].id, false).unwrap(),
             HashSet::from_iter(expected_sequences),
         );
     }
@@ -407,7 +407,7 @@ mod tests {
         );
         assert_eq!(block_groups.len(), 1);
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &block_groups[0].id, false),
+            BlockGroup::get_all_sequences(conn, &block_groups[0].id, false).unwrap(),
             HashSet::from_iter(expected_sequences),
         );
     }
@@ -476,7 +476,7 @@ mod tests {
         );
         assert_eq!(block_groups.len(), 1);
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &block_groups[0].id, false),
+            BlockGroup::get_all_sequences(conn, &block_groups[0].id, false).unwrap(),
             HashSet::from_iter(expected_sequences),
         );
     }
@@ -545,7 +545,7 @@ mod tests {
         );
         assert_eq!(block_groups.len(), 1);
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &block_groups[0].id, false),
+            BlockGroup::get_all_sequences(conn, &block_groups[0].id, false).unwrap(),
             HashSet::from_iter(expected_sequences),
         );
     }
@@ -620,7 +620,7 @@ mod tests {
         );
         assert_eq!(block_groups.len(), 1);
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &block_groups[0].id, false),
+            BlockGroup::get_all_sequences(conn, &block_groups[0].id, false).unwrap(),
             HashSet::from_iter(expected_sequences),
         );
     }
@@ -689,7 +689,7 @@ mod tests {
         );
         assert_eq!(block_groups.len(), 1);
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &block_groups[0].id, false),
+            BlockGroup::get_all_sequences(conn, &block_groups[0].id, false).unwrap(),
             HashSet::from_iter(expected_sequences),
         );
     }
@@ -756,7 +756,7 @@ mod tests {
         );
         assert_eq!(block_groups.len(), 1);
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &block_groups[0].id, false),
+            BlockGroup::get_all_sequences(conn, &block_groups[0].id, false).unwrap(),
             HashSet::from_iter(expected_sequences),
         );
     }
@@ -809,7 +809,7 @@ mod tests {
         );
         assert_eq!(block_groups.len(), 1);
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &block_groups[0].id, false),
+            BlockGroup::get_all_sequences(conn, &block_groups[0].id, false).unwrap(),
             HashSet::from_iter(expected_sequences),
         );
 
@@ -871,7 +871,7 @@ mod tests {
         );
         assert_eq!(block_groups.len(), 1);
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &block_groups[0].id, false),
+            BlockGroup::get_all_sequences(conn, &block_groups[0].id, false).unwrap(),
             HashSet::from_iter(expected_sequences),
         );
     }
@@ -927,7 +927,7 @@ mod tests {
         );
         assert_eq!(block_groups.len(), 1);
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &block_groups[0].id, false),
+            BlockGroup::get_all_sequences(conn, &block_groups[0].id, false).unwrap(),
             HashSet::from_iter(expected_sequences),
         );
     }

--- a/src/updates/gaf.rs
+++ b/src/updates/gaf.rs
@@ -512,7 +512,7 @@ mod tests {
         let _ = import_gfa(&context, &gfa_path, &collection, "");
         let gaf_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("fixtures/chr22_het.gaf");
         update_with_gaf(&context, gaf_path, csv_path, "test", "child", None).unwrap();
-        let graph = Sample::get_graph(conn, "test", "child");
+        let graph = Sample::get_graph(conn, "test", "child").unwrap();
 
         let query = Node::query(
             conn,
@@ -580,7 +580,7 @@ mod tests {
         let _ = import_gfa(&context, &gfa_path, &collection, "");
         let gaf_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("fixtures/chr22_het.gaf");
         update_with_gaf(&context, gaf_path, csv_path, "test", "child", None).unwrap();
-        let graph = Sample::get_graph(conn, "test", "child");
+        let graph = Sample::get_graph(conn, "test", "child").unwrap();
 
         // we should end up with a new edge putting our insert to the beginning of the graph, which is node 3.
         let query = Node::query(

--- a/src/updates/genbank.rs
+++ b/src/updates/genbank.rs
@@ -388,6 +388,7 @@ mod tests {
             let block_group_id = BlockGroup::get_id("", Sample::DEFAULT_NAME, "insertion", None);
             let sequences: HashSet<String> =
                 BlockGroup::get_all_sequences(conn, &block_group_id, false)
+                    .unwrap()
                     .iter()
                     .map(|s| s.to_lowercase())
                     .collect();
@@ -443,6 +444,7 @@ mod tests {
             let block_group_id = BlockGroup::get_id("", Sample::DEFAULT_NAME, "insertion", None);
             let sequences: HashSet<String> =
                 BlockGroup::get_all_sequences(conn, &block_group_id, false)
+                    .unwrap()
                     .iter()
                     .map(|s| s.to_lowercase())
                     .collect();
@@ -456,6 +458,7 @@ mod tests {
             let block_group_id = BlockGroup::get_id("", Sample::DEFAULT_NAME, "deletion", None);
             let sequences: HashSet<String> =
                 BlockGroup::get_all_sequences(conn, &block_group_id, false)
+                    .unwrap()
                     .iter()
                     .map(|s| s.to_lowercase())
                     .collect();

--- a/src/updates/gfa.rs
+++ b/src/updates/gfa.rs
@@ -550,7 +550,7 @@ mod tests {
         );
         assert_eq!(block_groups.len(), 1);
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &block_groups[0].id, false),
+            BlockGroup::get_all_sequences(conn, &block_groups[0].id, false).unwrap(),
             HashSet::from_iter(expected_sequences),
         );
     }
@@ -602,7 +602,7 @@ mod tests {
         );
         assert_eq!(block_groups.len(), 1);
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &block_groups[0].id, false),
+            BlockGroup::get_all_sequences(conn, &block_groups[0].id, false).unwrap(),
             HashSet::from_iter(expected_sequences),
         );
     }

--- a/src/updates/library.rs
+++ b/src/updates/library.rs
@@ -297,7 +297,7 @@ mod tests {
         let block_groups = Sample::get_block_groups(conn, "test", "new sample");
         let block_group = &block_groups[0];
 
-        let all_sequences = BlockGroup::get_all_sequences(conn, &block_group.id, false);
+        let all_sequences = BlockGroup::get_all_sequences(conn, &block_group.id, false).unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec![
@@ -357,7 +357,7 @@ mod tests {
         let block_groups = Sample::get_block_groups(conn, "test", "new sample");
         let block_group = &block_groups[0];
 
-        let all_sequences = BlockGroup::get_all_sequences(conn, &block_group.id, false);
+        let all_sequences = BlockGroup::get_all_sequences(conn, &block_group.id, false).unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec![
@@ -424,7 +424,7 @@ mod tests {
                 expected_sequences.push(seq);
             }
         }
-        let all_sequences = BlockGroup::get_all_sequences(conn, &block_group.id, false);
+        let all_sequences = BlockGroup::get_all_sequences(conn, &block_group.id, false).unwrap();
         assert_eq!(
             all_sequences,
             expected_sequences
@@ -476,7 +476,7 @@ mod tests {
         let block_groups = Sample::get_block_groups(conn, "test", "new sample");
         let block_group = &block_groups[0];
 
-        let all_sequences = BlockGroup::get_all_sequences(conn, &block_group.id, false);
+        let all_sequences = BlockGroup::get_all_sequences(conn, &block_group.id, false).unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec![
@@ -537,7 +537,7 @@ mod tests {
                 expected_sequences.push(seq);
             }
         }
-        let all_sequences = BlockGroup::get_all_sequences(conn, &block_group.id, false);
+        let all_sequences = BlockGroup::get_all_sequences(conn, &block_group.id, false).unwrap();
         assert_eq!(
             all_sequences,
             expected_sequences

--- a/src/updates/sequence.rs
+++ b/src/updates/sequence.rs
@@ -247,7 +247,7 @@ mod tests {
         );
         assert_eq!(block_groups.len(), 1);
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &block_groups[0].id, false),
+            BlockGroup::get_all_sequences(conn, &block_groups[0].id, false).unwrap(),
             HashSet::from_iter(expected_sequences),
         );
         assert_eq!(
@@ -364,7 +364,7 @@ mod tests {
         );
         assert_eq!(block_groups.len(), 1);
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &block_groups[0].id, false),
+            BlockGroup::get_all_sequences(conn, &block_groups[0].id, false).unwrap(),
             HashSet::from_iter(expected_sequences),
         );
     }
@@ -424,7 +424,7 @@ mod tests {
         );
         assert_eq!(block_groups.len(), 1);
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &block_groups[0].id, false),
+            BlockGroup::get_all_sequences(conn, &block_groups[0].id, false).unwrap(),
             HashSet::from_iter(expected_sequences),
         );
     }
@@ -490,7 +490,7 @@ mod tests {
         );
         assert_eq!(block_groups.len(), 1);
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &block_groups[0].id, false),
+            BlockGroup::get_all_sequences(conn, &block_groups[0].id, false).unwrap(),
             HashSet::from_iter(expected_sequences),
         );
     }
@@ -550,7 +550,7 @@ mod tests {
         );
         assert_eq!(block_groups.len(), 1);
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &block_groups[0].id, false),
+            BlockGroup::get_all_sequences(conn, &block_groups[0].id, false).unwrap(),
             HashSet::from_iter(expected_sequences),
         );
     }
@@ -610,7 +610,7 @@ mod tests {
         );
         assert_eq!(block_groups.len(), 1);
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &block_groups[0].id, false),
+            BlockGroup::get_all_sequences(conn, &block_groups[0].id, false).unwrap(),
             HashSet::from_iter(expected_sequences),
         );
     }
@@ -659,7 +659,7 @@ mod tests {
         );
         assert_eq!(block_groups.len(), 1);
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &block_groups[0].id, false),
+            BlockGroup::get_all_sequences(conn, &block_groups[0].id, false).unwrap(),
             HashSet::from_iter(expected_sequences),
         );
 

--- a/src/updates/vcf.rs
+++ b/src/updates/vcf.rs
@@ -735,17 +735,20 @@ mod tests {
                 conn,
                 &get_sample_bg(conn, &collection, Sample::DEFAULT_NAME).id,
                 false,
-            ),
+            )
+            .unwrap(),
             HashSet::from_iter(vec!["ATCGATCGATCGATCGATCGGGAACACACAGAGA".to_string()])
         );
         // `G1` genotype has no changes
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &get_sample_bg(conn, &collection, "G1").id, false),
+            BlockGroup::get_all_sequences(conn, &get_sample_bg(conn, &collection, "G1").id, false)
+                .unwrap(),
             HashSet::from_iter(vec!["ATCGATCGATCGATCGATCGGGAACACACAGAGA".to_string()])
         );
         // `foo` is homozygous for the first variant and does not contain the second
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &get_sample_bg(conn, &collection, "foo").id, false),
+            BlockGroup::get_all_sequences(conn, &get_sample_bg(conn, &collection, "foo").id, false)
+                .unwrap(),
             HashSet::from_iter(vec!["ATCATCGATCGATCGATCGGGAACACACAGAGA".to_string(),])
         );
 
@@ -787,12 +790,14 @@ mod tests {
                 conn,
                 &get_sample_bg(conn, &collection, Sample::DEFAULT_NAME).id,
                 false,
-            ),
+            )
+            .unwrap(),
             HashSet::from_iter(vec!["ATCGATCGATCGATCGATCGGGAACACACAGAGA".to_string()])
         );
         // `bar` sample has the refrence + a deletion of the C
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &get_sample_bg(conn, &collection, "bar").id, false),
+            BlockGroup::get_all_sequences(conn, &get_sample_bg(conn, &collection, "bar").id, false)
+                .unwrap(),
             HashSet::from_iter(vec![
                 "ATCGATCGATCGATCGATCGGGAACACACAGAGA".to_string(),
                 "ATCGATCGATGATCGATCGGGAACACACAGAGA".to_string()
@@ -800,7 +805,8 @@ mod tests {
         );
         // `baz` sample has a deletion of CG and an insertion of A
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &get_sample_bg(conn, &collection, "baz").id, false),
+            BlockGroup::get_all_sequences(conn, &get_sample_bg(conn, &collection, "baz").id, false)
+                .unwrap(),
             HashSet::from_iter(vec![
                 "ATCGATCGATATCGATCGGGAACACACAGAGA".to_string(),
                 "ATCGATCGATCAGATCGATCGGGAACACACAGAGA".to_string(),
@@ -844,7 +850,8 @@ mod tests {
                 conn,
                 &get_sample_bg(conn, &collection, Sample::DEFAULT_NAME).id,
                 false,
-            ),
+            )
+            .unwrap(),
             HashSet::from_iter(vec!["ATCGATCGATCGATCGATCGGGAACACACAGAGA".to_string()])
         );
         assert_eq!(
@@ -852,7 +859,8 @@ mod tests {
                 conn,
                 &get_sample_bg(conn, &collection, "sample 1").id,
                 false
-            ),
+            )
+            .unwrap(),
             HashSet::from_iter(
                 [
                     "ATCGATCGATAGAGATCGATCGGGAACACACAGAGA",
@@ -936,7 +944,8 @@ mod tests {
                 conn,
                 &get_sample_bg(conn, &collection, "unknown").id,
                 false
-            ),
+            )
+            .unwrap(),
             HashSet::from_iter(
                 ["ATCGATCGATAGACGATCGATCGGGAACACACAGAGA",]
                     .iter()
@@ -977,7 +986,8 @@ mod tests {
         )
         .unwrap();
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &get_sample_bg(conn, &collection, "foo").id, false),
+            BlockGroup::get_all_sequences(conn, &get_sample_bg(conn, &collection, "foo").id, false)
+                .unwrap(),
             HashSet::from_iter(
                 ["ATCATCGATCGATCGATCGGGAACACACAGAGA",]
                     .iter()
@@ -1019,7 +1029,8 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &get_sample_bg(conn, &collection, "foo").id, true),
+            BlockGroup::get_all_sequences(conn, &get_sample_bg(conn, &collection, "foo").id, true)
+                .unwrap(),
             HashSet::from_iter(vec![
                 "ATCGATCGATCGGATCGGGAACACACAGAGA".to_string(),
                 "ATCGATCGATCGATCATCATCGATCGGGAACACACAGAGA".to_string()
@@ -1364,19 +1375,23 @@ mod tests {
                 conn,
                 &get_sample_bg(conn, &collection, Sample::DEFAULT_NAME).id,
                 true,
-            ),
+            )
+            .unwrap(),
             HashSet::from_iter(vec!["ATCGATCGATCGATCGATCGGGAACACACAGAGA".to_string()])
         );
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &get_sample_bg(conn, &collection, "f1").id, true),
+            BlockGroup::get_all_sequences(conn, &get_sample_bg(conn, &collection, "f1").id, true)
+                .unwrap(),
             HashSet::from_iter(vec!["ATCTCGATCGATCGCGGGAACACACAGAGA".to_string()])
         );
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &get_sample_bg(conn, &collection, "f2").id, true),
+            BlockGroup::get_all_sequences(conn, &get_sample_bg(conn, &collection, "f2").id, true)
+                .unwrap(),
             HashSet::from_iter(vec!["ATCTGGATCGATCGCGGAATCAGAACACACAGGA".to_string()])
         );
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &get_sample_bg(conn, &collection, "f3").id, true),
+            BlockGroup::get_all_sequences(conn, &get_sample_bg(conn, &collection, "f3").id, true)
+                .unwrap(),
             HashSet::from_iter(vec!["ATCGGGATCGATCGCTCAGAACACACAGGA".to_string()])
         );
     }
@@ -1427,7 +1442,8 @@ mod tests {
             conn,
             &get_sample_bg(conn, &collection, "child").id,
             true,
-        );
+        )
+        .unwrap();
         assert_eq!(
             child_sequences,
             HashSet::from_iter(vec![
@@ -1485,7 +1501,8 @@ mod tests {
             conn,
             &get_sample_bg(conn, &collection, "child").id,
             true,
-        );
+        )
+        .unwrap();
         assert_eq!(
             child_sequences,
             HashSet::from_iter(vec![

--- a/src/views/block_group.rs
+++ b/src/views/block_group.rs
@@ -227,7 +227,7 @@ pub fn view_block_group(
 
         let block_group = block_group.unwrap();
         block_group_id = Some(block_group.id);
-        block_graph = BlockGroup::get_graph(conn, &block_group.id);
+        block_graph = BlockGroup::get_graph(conn, &block_group.id)?;
         explorer_state.selected_block_group_id = Some(block_group.id);
         focus_zone = FocusZone::Canvas;
     } else {
@@ -1111,7 +1111,7 @@ pub fn view_block_group(
         // for the full duration of the blocking DB work.
         if is_loading && let Some(ref new_block_group_id) = explorer_state.selected_block_group_id {
             // Create a new graph for the selected block group
-            block_graph = BlockGroup::get_graph(conn, new_block_group_id);
+            block_graph = BlockGroup::get_graph(conn, new_block_group_id)?;
             // Update the graph controller
             graph_controller = create_gen_graph_controller(block_graph.clone());
             let block_group = match BlockGroup::get_by_id(conn, new_block_group_id) {

--- a/src/views/gen_graph_widget.rs
+++ b/src/views/gen_graph_widget.rs
@@ -571,7 +571,7 @@ mod tests {
         )
         .unwrap();
 
-        let gen_graph = Sample::get_graph(conn, collection, "SAMPLE1");
+        let gen_graph = Sample::get_graph(conn, collection, "SAMPLE1").unwrap();
         let mut controller = create_gen_graph_controller(gen_graph);
 
         let mut terminal = create_test_terminal(120, 30);

--- a/src/views/testing/connectivity_test.rs
+++ b/src/views/testing/connectivity_test.rs
@@ -41,7 +41,7 @@ mod tests {
         import_gfa(&context, &gfa_path, collection_name, Sample::DEFAULT_NAME)
             .expect("GFA import failed");
 
-        let gen_graph = Sample::get_graph(conn, collection_name, Sample::DEFAULT_NAME);
+        let gen_graph = Sample::get_graph(conn, collection_name, Sample::DEFAULT_NAME).unwrap();
 
         // Test with small partitions to force inter-partition edges
         let config = GraphConfig {

--- a/src/views/testing/keyboard_navigation_test.rs
+++ b/src/views/testing/keyboard_navigation_test.rs
@@ -46,7 +46,7 @@ mod tests {
         import_gfa(&context, &gfa_path, collection_name, Sample::DEFAULT_NAME)
             .expect("GFA import failed");
 
-        let gen_graph = Sample::get_graph(conn, collection_name, Sample::DEFAULT_NAME);
+        let gen_graph = Sample::get_graph(conn, collection_name, Sample::DEFAULT_NAME).unwrap();
 
         let config = GraphConfig {
             partition: PartitionConfig {
@@ -318,7 +318,7 @@ mod tests {
         import_gfa(&context, &gfa_path, collection_name, Sample::DEFAULT_NAME)
             .expect("GFA import failed");
 
-        let gen_graph = Sample::get_graph(conn, collection_name, Sample::DEFAULT_NAME);
+        let gen_graph = Sample::get_graph(conn, collection_name, Sample::DEFAULT_NAME).unwrap();
 
         // Configure with large partition for stability
         let config = GraphConfig {
@@ -389,7 +389,7 @@ mod tests {
         import_gfa(&context, &gfa_path, collection_name, Sample::DEFAULT_NAME)
             .expect("GFA import failed");
 
-        let gen_graph = Sample::get_graph(conn, collection_name, Sample::DEFAULT_NAME);
+        let gen_graph = Sample::get_graph(conn, collection_name, Sample::DEFAULT_NAME).unwrap();
 
         // Configure with large partition for stability
         let config = GraphConfig {


### PR DESCRIPTION
There were a few cases where graph construction was failing. The root of it is `blocks_from_edges` assumes a pairwise set of edges, so if there were more source nodes than target nodes (2 upstream nodes going to the same point), it would fail.