### PR TITLE
fix(gen-r): validate breakpoints type in chunks/derive_chunks

### DIFF
--- a/gen-r/R/high_level.R
+++ b/gen-r/R/high_level.R
@@ -128,6 +128,9 @@ resolve_granges_columns <- function(parts_list, seq_containers) {
   }
 
   bg$chunks <- function(new_sample, breakpoints = NULL, chunk_size = NULL, backbone = NULL) {
+    if (!is.null(breakpoints) && !is.numeric(breakpoints) && !is.integer(breakpoints)) {
+      stop("breakpoints must be a numeric or integer vector, e.g. c(10L, 20L)", call. = FALSE)
+    }
     lapply(
       gen_bg$chunks(
         new_sample,
@@ -704,6 +707,9 @@ Repository <- function(path = NULL) {
   }
 
   repo$derive_chunks <- function(sample, new_sample, region, backbone = NULL, breakpoints = NULL, chunk_size = NULL, collection = NULL) {
+    if (!is.null(breakpoints) && !is.numeric(breakpoints) && !is.integer(breakpoints)) {
+      stop("breakpoints must be a numeric or integer vector, e.g. c(10L, 20L)", call. = FALSE)
+    }
     inner$derive_chunks(collection, sample, new_sample, region, backbone,
                         if (is.null(breakpoints)) integer(0) else as.integer(breakpoints),
                         if (is.null(chunk_size)) NULL else as.integer(chunk_size))

--- a/gen-r/tests/testthat/test-basic.R
+++ b/gen-r/tests/testthat/test-basic.R
@@ -37,6 +37,7 @@ expect_binding_result <- function(result) {
       is.list(result) ||
       is.logical(result) ||
       is.null(result) ||
+      inherits(result, "gen_block_group") ||
       inherits(result, "try-error")
   )
 }
@@ -223,7 +224,7 @@ test_that("graph operation bindings work", {
 
   expect_binding_result(try(repo$derive_chunks(
     sample = "sample-a", new_sample = "chunked",
-    region = "m123", breakpoints = "10,20"
+    region = "m123", breakpoints = c(10L, 20L)
   ), silent = TRUE))
 
   groups <- repo$get_block_groups()


### PR DESCRIPTION
## Summary

- Add early type validation for `breakpoints` arg in `bg$chunks()` and `repo$derive_chunks()` — errors with a clear message if non-numeric/integer passed
- Fix test: `breakpoints = "10,20"` → `c(10L, 20L)` (was silently passing a string)
- Add `gen_block_group` to allowed result types in `expect_binding_result()`

## Test plan

- [ ] `cd gen-r && make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)