### PR TITLE
CLI: rename "block group" → "sequence graph" etc.

### DIFF
--- a/src/commands/graph_operations/derive_chunks.rs
+++ b/src/commands/graph_operations/derive_chunks.rs
@@ -132,7 +132,7 @@ pub fn derive_chunks_operation(
     }
 
     let summary_str = format!(
-        " {}: {} new derived block group(s)",
+        " {}: {} new derived sequence graph(s)",
         new_sample_name, chunk_range_length,
     );
 

--- a/src/commands/graph_operations/derive_subgraph.rs
+++ b/src/commands/graph_operations/derive_subgraph.rs
@@ -77,7 +77,7 @@ pub fn derive_subgraph_operation(
         return Err(err.into());
     }
 
-    let summary_str = format!(" {}: new derived block group", new_sample_name,);
+    let summary_str = format!(" {}: new derived sequence graph", new_sample_name,);
 
     let _op = end_operation(
         db_context,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -281,7 +281,7 @@ pub enum Commands {
         #[arg(short, long)]
         sample: Option<String>,
     },
-    /// Search for an exact sequence across all block groups
+    /// Search for an exact sequence across all sequence graphs
     ///
     /// Each match is reported with a blocks column formatted as [hash:start-end, ...],
     /// where hash is a 12-character node hash prefix from the original node the block

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -28,7 +28,7 @@ pub enum SequenceUpdateError {
     NodeError(#[from] NodeError),
     #[error("Path creation error: {0}")]
     PathError(#[from] PathError),
-    #[error("Block group creation error: {0}")]
+    #[error("Sequence graph creation error: {0}")]
     BlockGroupError(#[from] BlockGroupError),
     #[error("Sample creation error: {0}")]
     SampleError(#[from] SampleError),
@@ -48,7 +48,9 @@ pub enum SequenceUpdateError {
     MissingCoordinates(String),
     #[error("Unsupported region type for sequence update: {0}")]
     UnsupportedRegionType(String),
-    #[error("Resolved path '{path_name}' was not found in target block group '{block_group_name}'")]
+    #[error(
+        "Resolved path '{path_name}' was not found in target sequence graph '{block_group_name}'"
+    )]
     MissingResolvedPath {
         path_name: String,
         block_group_name: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -211,7 +211,7 @@ fn call_cli() -> Result<(), Box<dyn std::error::Error>> {
                     }
                     Err(_) => {
                         eprintln!(
-                            "No block group found with name {:?} and sample {:?} in collection {}",
+                            "No sequence graph found with name {:?} and sample {:?} in collection {}",
                             name, sample_name, collection_name
                         );
                     }

--- a/src/views/block_group.rs
+++ b/src/views/block_group.rs
@@ -183,7 +183,7 @@ pub fn view_block_group(
 ) -> Result<(), Box<dyn Error>> {
     let progress_bar = get_handler();
     let bar = progress_bar.add(get_time_elapsed_bar());
-    let _ = progress_bar.println("Loading block group");
+    let _ = progress_bar.println("Loading sequence graph");
 
     // Get the node object corresponding to the position given by the user
     let origin = if let Some(position_str) = position {
@@ -218,7 +218,7 @@ pub fn view_block_group(
 
         if block_group.is_err() {
             panic!(
-                "No block group found with name {:?} and sample {:?} in collection {} ",
+                "No sequence graph found with name {:?} and sample {:?} in collection {} ",
                 name,
                 sample_name.clone(),
                 collection_name
@@ -250,7 +250,7 @@ pub fn view_block_group(
             Ok(bg) => bg,
             Err(err) => {
                 // TODO: Handle these with messages instead of panic'ing
-                panic!("Failed to load block group {bg_id}: {err}");
+                panic!("Failed to load sequence graph {bg_id}: {err}");
             }
         });
 
@@ -404,7 +404,7 @@ pub fn view_block_group(
                                         Ok(highlighting_enabled) => {
                                             if highlighting_enabled {
                                                 info!(
-                                                    "Path highlighting enabled for block group {}",
+                                                    "Path highlighting enabled for sequence graph {}",
                                                     block_group_id
                                                 );
                                             } else {
@@ -416,7 +416,7 @@ pub fn view_block_group(
                                         }
                                     }
                                 } else {
-                                    warn!("No block group selected for path highlighting");
+                                    warn!("No sequence graph selected for path highlighting");
                                 }
                             }
                             _ => {
@@ -1118,7 +1118,10 @@ pub fn view_block_group(
                 Ok(bg) => bg,
                 Err(err) => {
                     // TODO: Handle these with messages instead of panic'ing
-                    panic!("Failed to load block group {}: {err}", new_block_group_id);
+                    panic!(
+                        "Failed to load sequence graph {}: {err}",
+                        new_block_group_id
+                    );
                 }
             };
 


### PR DESCRIPTION
This follows the Python and R bindings rename PRs where there were more Rust internals that got exposed to users under confusing names. The CLI has a much smaller surface in this regard, but I need to go through it in more detail before taking this out of draft.