### PR TITLE
Fix bug where files weren't being manifested during pull

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,7 @@ Use the narrowest reliable validation for the change, then broaden when touching
   ```bash
   make r-test
   ```
+- Give each new unit test a name that starts with `test_`.
 
 Some builds and tests need the Cap'n Proto compiler (`capnp`) installed. Python packaging targets may need `maturin`, and R targets may need Docker, R, and npm depending on the path exercised.
 

--- a/gen-capnp-schemas/gen-models.capnp
+++ b/gen-capnp-schemas/gen-models.capnp
@@ -210,13 +210,9 @@ struct DatabaseChangeset {
 
 struct ManifestOperation {
   operation @0 :Operation;
-  # Legacy operation file additions without operation-specific filename/filePath
-  # metadata. Keep this field shape stable for compatibility with older
-  # manifest writers.
-  fileAdditions @1 :List(FileAddition);
+  operationFileAdditions @1 :List(ManifestOperationFileAddition);
   annotationFileAdditions @4 :List(FileAddition);
   annotationFileDetails @5 :List(ManifestAnnotationFileAddition);
-  operationFileAdditions @6 :List(ManifestOperationFileAddition);
   operationSummary :union {
     none @2 :Void;
     some @3 :OperationSummary;

--- a/gen-models/src/manifest.rs
+++ b/gen-models/src/manifest.rs
@@ -50,15 +50,6 @@ impl<'a> Capnp<'a> for ManifestOperationFileAddition {
 }
 
 impl ManifestOperationFileAddition {
-    fn from_legacy_file_addition(file_addition: FileAddition) -> Self {
-        let operation_file = OperationFile::new(file_addition.file_path());
-        Self {
-            file_addition,
-            filename: operation_file.filename,
-            file_path: operation_file.file_path,
-        }
-    }
-
     pub fn get_files_for_operation(
         conn: &OperationsConnection,
         operation_hash: &HashId,
@@ -66,15 +57,18 @@ impl ManifestOperationFileAddition {
         Ok(
             OperationFile::get_files_for_operation(conn, operation_hash)?
                 .into_iter()
-                .map(|file| Self {
-                    file_addition: FileAddition {
+                .map(|file| {
+                    let file_addition = FileAddition {
                         id: file.id,
                         asset_uri: file.asset_uri,
                         file_type: file.file_type,
                         checksum: file.checksum,
-                    },
-                    filename: file.filename,
-                    file_path: file.file_path,
+                    };
+                    Self {
+                        file_path: file_addition.file_path().to_string(),
+                        file_addition,
+                        filename: file.filename,
+                    }
                 })
                 .collect(),
         )
@@ -147,16 +141,6 @@ impl<'a> Capnp<'a> for ManifestOperation {
         let mut operation_builder = builder.reborrow().init_operation();
         self.operation.write_capnp(&mut operation_builder);
 
-        let mut legacy_file_additions_builder = builder
-            .reborrow()
-            .init_file_additions(self.file_additions.len() as u32);
-        for (i, file_addition) in self.file_additions.iter().enumerate() {
-            let mut file_addition_builder = legacy_file_additions_builder.reborrow().get(i as u32);
-            file_addition
-                .file_addition
-                .write_capnp(&mut file_addition_builder);
-        }
-
         let mut operation_file_additions_builder = builder
             .reborrow()
             .init_operation_file_additions(self.file_additions.len() as u32);
@@ -198,20 +182,11 @@ impl<'a> Capnp<'a> for ManifestOperation {
 
     fn read_capnp(reader: Self::Reader) -> Self {
         let operation = Operation::read_capnp(reader.get_operation().unwrap());
-        let file_additions = if reader.has_operation_file_additions() {
-            let file_additions_reader = reader.get_operation_file_additions().unwrap();
-            file_additions_reader
-                .iter()
-                .map(ManifestOperationFileAddition::read_capnp)
-                .collect()
-        } else {
-            let file_additions_reader = reader.get_file_additions().unwrap();
-            file_additions_reader
-                .iter()
-                .map(FileAddition::read_capnp)
-                .map(ManifestOperationFileAddition::from_legacy_file_addition)
-                .collect()
-        };
+        let file_additions_reader = reader.get_operation_file_additions().unwrap();
+        let file_additions = file_additions_reader
+            .iter()
+            .map(ManifestOperationFileAddition::read_capnp)
+            .collect();
 
         let annotation_file_additions = if reader.has_annotation_file_details() {
             let annotation_file_details_reader = reader.get_annotation_file_details().unwrap();
@@ -491,7 +466,7 @@ mod tests {
     use crate::{
         annotations::{AnnotationFile, AnnotationFileAdditionInput},
         file_types::FileTypes,
-        operations::OperationInfo,
+        operations::{OperationFile, OperationInfo},
         session_operations::{end_operation, start_operation},
         test_helpers::setup_gen,
     };
@@ -552,60 +527,6 @@ mod tests {
 
         let deserialized = ManifestOperation::read_capnp(root.into_reader());
         assert_eq!(manifest_operation, deserialized);
-    }
-
-    #[test]
-    fn test_manifest_operation_reads_legacy_file_additions() {
-        let context = setup_gen();
-        let conn = context.graph().conn();
-        let op_conn = context.operations().conn();
-
-        let db_uuid = crate::metadata::get_db_uuid(conn);
-        crate::files::GenDatabase::create(op_conn, &db_uuid, "test_db", "test_db_path").unwrap();
-
-        let mut session = start_operation(conn);
-        crate::sequence::Sequence::new()
-            .sequence("ACGT")
-            .sequence_type("DNA")
-            .save(conn)
-            .unwrap();
-        let operation = end_operation(
-            &context,
-            &mut session,
-            &OperationInfo {
-                files: vec![],
-                description: "test op".to_string(),
-            },
-            "test",
-            None,
-        )
-        .unwrap();
-
-        let legacy_file_addition = FileAddition {
-            id: HashId([1u8; 32]),
-            asset_uri: "s3://bucket/path/reference.fa".to_string(),
-            file_type: FileTypes::Fasta,
-            checksum: HashId([2u8; 32]),
-        };
-
-        let mut message = TypedBuilder::<manifest_operation::Owned>::new_default();
-        let mut root = message.init_root();
-        operation.write_capnp(&mut root.reborrow().init_operation());
-        let mut legacy_file_additions = root.reborrow().init_file_additions(1);
-        legacy_file_addition.write_capnp(&mut legacy_file_additions.reborrow().get(0));
-        root.reborrow().get_operation_summary().set_none(());
-
-        let deserialized = ManifestOperation::read_capnp(root.into_reader());
-        assert_eq!(deserialized.file_additions.len(), 1);
-        assert_eq!(
-            deserialized.file_additions[0].file_addition,
-            legacy_file_addition
-        );
-        assert_eq!(
-            deserialized.file_additions[0].file_path,
-            "s3://bucket/path/reference.fa"
-        );
-        assert_eq!(deserialized.file_additions[0].filename, "reference.fa");
     }
 
     #[test]
@@ -738,6 +659,49 @@ mod tests {
             .unwrap();
         assert_eq!(manifest.operations.len(), 1);
         assert_eq!(manifest.operations[0].operation.hash, op1.hash);
+    }
+
+    #[test]
+    fn test_manifest_generator_uses_asset_path_for_operation_files() {
+        let context = setup_gen();
+        let conn = context.graph().conn();
+        let op_conn = context.operations().conn();
+
+        let db_uuid = crate::metadata::get_db_uuid(conn);
+        crate::files::GenDatabase::create(op_conn, &db_uuid, "test_db", "test_db_path").unwrap();
+
+        let repo_root = context.workspace().repo_root().unwrap();
+        let input_path = repo_root.join("fastas").join("input.fa");
+        fs::create_dir_all(input_path.parent().unwrap()).unwrap();
+        fs::write(&input_path, ">seq\nACGT\n").unwrap();
+
+        let mut session = start_operation(conn);
+        crate::sequence::Sequence::new()
+            .sequence("ACGT")
+            .sequence_type("DNA")
+            .save(conn)
+            .unwrap();
+        let operation = end_operation(
+            &context,
+            &mut session,
+            &OperationInfo {
+                files: vec![OperationFile::new("fastas/input.fa")],
+                description: "file op".to_string(),
+            },
+            "test",
+            None,
+        )
+        .unwrap();
+
+        let generator = ManifestGenerator::new(op_conn);
+        let manifest = generator
+            .generate_manifest("main", Some(&operation.hash))
+            .unwrap();
+        let file = &manifest.operations[0].file_additions[0];
+
+        assert_eq!(file.filename, "input.fa");
+        assert_eq!(file.file_path, file.file_addition.file_path());
+        assert!(file.file_path.starts_with(".gen/assets/"));
     }
 
     #[test]

--- a/gen-models/src/manifest.rs
+++ b/gen-models/src/manifest.rs
@@ -65,7 +65,7 @@ impl ManifestOperationFileAddition {
                         checksum: file.checksum,
                     };
                     Self {
-                        file_path: file_addition.file_path().to_string(),
+                        file_path: file.file_path,
                         file_addition,
                         filename: file.filename,
                     }
@@ -662,7 +662,7 @@ mod tests {
     }
 
     #[test]
-    fn test_manifest_generator_uses_asset_path_for_operation_files() {
+    fn test_manifest_generator_preserves_operation_file_path() {
         let context = setup_gen();
         let conn = context.graph().conn();
         let op_conn = context.operations().conn();
@@ -700,8 +700,8 @@ mod tests {
         let file = &manifest.operations[0].file_additions[0];
 
         assert_eq!(file.filename, "input.fa");
-        assert_eq!(file.file_path, file.file_addition.file_path());
-        assert!(file.file_path.starts_with(".gen/assets/"));
+        assert_eq!(file.file_path, "fastas/input.fa");
+        assert!(file.file_addition.file_path().starts_with(".gen/assets/"));
     }
 
     #[test]

--- a/gen-models/src/operations.rs
+++ b/gen-models/src/operations.rs
@@ -157,13 +157,15 @@ impl Operation {
     }
 
     pub fn add_file(
-        _workspace: &Workspace,
+        workspace: &Workspace,
         conn: &OperationsConnection,
         operation_hash: &HashId,
         file_addition: &FileAddition,
         filename: &str,
         file_path: &str,
     ) -> Result<(), FileAdditionError> {
+        let file_path =
+            OperationFile::storage_file_path(workspace, file_path, &file_addition.checksum)?;
         let query = "INSERT INTO operation_files (operation_hash, file_addition_id, filename, file_path) VALUES (?1, ?2, ?3, ?4)";
         let mut stmt = conn.prepare(query)?;
         stmt.execute(params![

--- a/gen-models/src/operations.rs
+++ b/gen-models/src/operations.rs
@@ -157,15 +157,13 @@ impl Operation {
     }
 
     pub fn add_file(
-        workspace: &Workspace,
+        _workspace: &Workspace,
         conn: &OperationsConnection,
         operation_hash: &HashId,
         file_addition: &FileAddition,
         filename: &str,
         file_path: &str,
     ) -> Result<(), FileAdditionError> {
-        let file_path =
-            OperationFile::storage_file_path(workspace, file_path, &file_addition.checksum)?;
         let query = "INSERT INTO operation_files (operation_hash, file_addition_id, filename, file_path) VALUES (?1, ?2, ?3, ?4)";
         let mut stmt = conn.prepare(query)?;
         stmt.execute(params![

--- a/src/commands/clone.rs
+++ b/src/commands/clone.rs
@@ -19,13 +19,16 @@ use crate::{
 
 const ORIGIN: &str = "origin";
 
-pub fn execute(url: &str) -> Result<(), Box<dyn std::error::Error>> {
-    execute_in_parent(url, Path::new("."))
+pub fn execute(url: &str, workspace: &Workspace) -> Result<(), Box<dyn std::error::Error>> {
+    execute_in_parent(url, workspace)
 }
 
-fn execute_in_parent(url: &str, parent_path: &Path) -> Result<(), Box<dyn std::error::Error>> {
+fn execute_in_parent(
+    url: &str,
+    parent_workspace: &Workspace,
+) -> Result<(), Box<dyn std::error::Error>> {
     let repo_name = infer_repo_name(url)?;
-    let repo_path = parent_path.join(&repo_name);
+    let repo_path = parent_workspace.base_dir().join(&repo_name);
 
     create_clone_directory(&repo_path)?;
 
@@ -115,7 +118,7 @@ mod tests {
     use crate::test_helpers::{create_operation, setup_gen_on_disk};
 
     #[test]
-    fn infer_repo_name_from_genhub_url() {
+    fn test_infer_repo_name_from_genhub_url() {
         assert_eq!(
             infer_repo_name("https://www.genhub.bio/api/repos/foo/bar").unwrap(),
             "bar"
@@ -123,7 +126,7 @@ mod tests {
     }
 
     #[test]
-    fn infer_repo_name_ignores_trailing_slash() {
+    fn test_infer_repo_name_ignores_trailing_slash() {
         assert_eq!(
             infer_repo_name("https://www.genhub.bio/api/repos/foo/bar/").unwrap(),
             "bar"
@@ -131,7 +134,7 @@ mod tests {
     }
 
     #[test]
-    fn create_clone_directory_errors_when_directory_exists() {
+    fn test_create_clone_directory_errors_when_directory_exists() {
         let temp_dir = tempdir().unwrap();
         let repo_path = temp_dir.path().join("existing-repo");
         fs::create_dir(&repo_path).unwrap();
@@ -142,7 +145,7 @@ mod tests {
     }
 
     #[test]
-    fn create_clone_directory_creates_missing_directory() {
+    fn test_create_clone_directory_creates_missing_directory() {
         let temp_dir = tempdir().unwrap();
         let repo_path = temp_dir.path().join("new-repo");
 
@@ -152,7 +155,7 @@ mod tests {
     }
 
     #[test]
-    fn clone_from_file_remote_materializes_asset_files() {
+    fn test_clone_from_file_remote_materializes_asset_files() {
         let remote_context = setup_gen_on_disk();
         let remote_conn = remote_context.graph().conn();
         let remote_op_conn = remote_context.operations().conn();
@@ -193,7 +196,8 @@ mod tests {
             "file://{}",
             remote_context.workspace().base_dir().to_string_lossy()
         );
-        execute_in_parent(&remote_url, clone_parent.path()).unwrap();
+        let clone_parent_workspace = Workspace::new(clone_parent.path());
+        execute_in_parent(&remote_url, &clone_parent_workspace).unwrap();
 
         let cloned_repo_path = clone_parent
             .path()
@@ -212,7 +216,7 @@ mod tests {
     }
 
     #[test]
-    fn pull_without_login_when_initial_pull_succeeds() {
+    fn test_pull_without_login_when_initial_pull_succeeds() {
         let pull_count = Cell::new(0);
         let login_count = Cell::new(0);
 
@@ -233,7 +237,7 @@ mod tests {
     }
 
     #[test]
-    fn login_and_retry_pull_after_auth_error() {
+    fn test_login_and_retry_pull_after_auth_error() {
         let pull_count = Cell::new(0);
         let login_count = Cell::new(0);
 
@@ -258,7 +262,7 @@ mod tests {
     }
 
     #[test]
-    fn non_auth_pull_errors_do_not_login() {
+    fn test_non_auth_pull_errors_do_not_login() {
         let pull_count = Cell::new(0);
         let login_count = Cell::new(0);
 
@@ -281,7 +285,7 @@ mod tests {
     }
 
     #[test]
-    fn login_errors_stop_before_retrying_pull() {
+    fn test_login_errors_stop_before_retrying_pull() {
         let pull_count = Cell::new(0);
         let login_count = Cell::new(0);
 

--- a/src/commands/clone.rs
+++ b/src/commands/clone.rs
@@ -202,7 +202,7 @@ mod tests {
         let cloned_repo_path = clone_parent
             .path()
             .join(remote_context.workspace().base_dir().file_name().unwrap());
-        let cloned_file_path = cloned_repo_path.join("fastas/clone_file.fa");
+        let cloned_file_path = cloned_repo_path.join("clone_file.fa");
         assert!(cloned_file_path.exists());
         assert_eq!(
             fs::read(cloned_file_path).unwrap(),

--- a/src/commands/clone.rs
+++ b/src/commands/clone.rs
@@ -20,15 +20,8 @@ use crate::{
 const ORIGIN: &str = "origin";
 
 pub fn execute(url: &str, workspace: &Workspace) -> Result<(), Box<dyn std::error::Error>> {
-    execute_in_parent(url, workspace)
-}
-
-fn execute_in_parent(
-    url: &str,
-    parent_workspace: &Workspace,
-) -> Result<(), Box<dyn std::error::Error>> {
     let repo_name = infer_repo_name(url)?;
-    let repo_path = parent_workspace.base_dir().join(&repo_name);
+    let repo_path = workspace.base_dir().join(&repo_name);
 
     create_clone_directory(&repo_path)?;
 
@@ -197,12 +190,12 @@ mod tests {
             remote_context.workspace().base_dir().to_string_lossy()
         );
         let clone_parent_workspace = Workspace::new(clone_parent.path());
-        execute_in_parent(&remote_url, &clone_parent_workspace).unwrap();
+        execute(&remote_url, &clone_parent_workspace).unwrap();
 
         let cloned_repo_path = clone_parent
             .path()
             .join(remote_context.workspace().base_dir().file_name().unwrap());
-        let cloned_file_path = cloned_repo_path.join("clone_file.fa");
+        let cloned_file_path = cloned_repo_path.join("fastas/clone_file.fa");
         assert!(cloned_file_path.exists());
         assert_eq!(
             fs::read(cloned_file_path).unwrap(),

--- a/src/commands/clone.rs
+++ b/src/commands/clone.rs
@@ -1,7 +1,7 @@
 use std::{
     fs,
     io::{self, ErrorKind},
-    path::{Path, PathBuf},
+    path::Path,
 };
 
 use gen_core::config::Workspace;
@@ -20,8 +20,12 @@ use crate::{
 const ORIGIN: &str = "origin";
 
 pub fn execute(url: &str) -> Result<(), Box<dyn std::error::Error>> {
+    execute_in_parent(url, Path::new("."))
+}
+
+fn execute_in_parent(url: &str, parent_path: &Path) -> Result<(), Box<dyn std::error::Error>> {
     let repo_name = infer_repo_name(url)?;
-    let repo_path = PathBuf::from(&repo_name);
+    let repo_path = parent_path.join(&repo_name);
 
     create_clone_directory(&repo_path)?;
 
@@ -98,9 +102,17 @@ fn infer_repo_name(repo_url: &str) -> Result<String, Box<dyn std::error::Error>>
 mod tests {
     use std::{cell::Cell, io};
 
+    use gen_core::HashId;
+    use gen_models::{
+        file_types::FileTypes,
+        manifest::ManifestGenerator,
+        operations::{Branch, Operation},
+        traits::Query,
+    };
     use tempfile::tempdir;
 
     use super::*;
+    use crate::test_helpers::{create_operation, setup_gen_on_disk};
 
     #[test]
     fn infer_repo_name_from_genhub_url() {
@@ -137,6 +149,66 @@ mod tests {
         create_clone_directory(&repo_path).unwrap();
 
         assert!(repo_path.is_dir());
+    }
+
+    #[test]
+    fn clone_from_file_remote_materializes_asset_files() {
+        let remote_context = setup_gen_on_disk();
+        let remote_conn = remote_context.graph().conn();
+        let remote_op_conn = remote_context.operations().conn();
+        track_database(remote_conn, remote_op_conn).unwrap();
+
+        let remote_operation = create_operation(
+            &remote_context,
+            "fastas/clone_file.fa",
+            FileTypes::Fasta,
+            "remote operation",
+            HashId::random_str(),
+        );
+        let remote_branch = Branch::get_by_name(remote_op_conn, "main").unwrap();
+        let remote_manifest = ManifestGenerator::new(remote_op_conn)
+            .generate_manifest("main", remote_branch.current_operation_hash.as_ref())
+            .unwrap();
+        let manifest_operation = remote_manifest
+            .operations
+            .iter()
+            .find(|op| op.operation.hash == remote_operation.hash)
+            .unwrap();
+        let remote_asset_path = remote_context.workspace().repo_root().unwrap().join(
+            manifest_operation.file_additions[0]
+                .file_addition
+                .file_path(),
+        );
+        fs::remove_file(
+            remote_context
+                .workspace()
+                .repo_root()
+                .unwrap()
+                .join("fastas/clone_file.fa"),
+        )
+        .unwrap();
+
+        let clone_parent = tempdir().unwrap();
+        let remote_url = format!(
+            "file://{}",
+            remote_context.workspace().base_dir().to_string_lossy()
+        );
+        execute_in_parent(&remote_url, clone_parent.path()).unwrap();
+
+        let cloned_repo_path = clone_parent
+            .path()
+            .join(remote_context.workspace().base_dir().file_name().unwrap());
+        let cloned_file_path = cloned_repo_path.join("fastas/clone_file.fa");
+        assert!(cloned_file_path.exists());
+        assert_eq!(
+            fs::read(cloned_file_path).unwrap(),
+            fs::read(remote_asset_path).unwrap()
+        );
+
+        let operation_conn =
+            get_operation_connection(Some(cloned_repo_path.join(".gen/gen.db"))).unwrap();
+        let cloned_ops = Operation::all(&operation_conn);
+        assert!(cloned_ops.iter().any(|op| op.hash == remote_operation.hash));
     }
 
     #[test]

--- a/src/graphs/translation.rs
+++ b/src/graphs/translation.rs
@@ -1469,7 +1469,7 @@ fn translate_from(
 
 #[cfg(test)]
 mod tests {
-    use std::collections::{HashMap, HashSet};
+    use std::collections::HashSet;
 
     use gen_core::{HashId, PATH_END_NODE_ID, PATH_START_NODE_ID, Strand, range::Range};
     use gen_models::{

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,7 +73,7 @@ fn call_cli() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     if let Some(Commands::Clone { url }) = &cli.command {
-        return r#gen::commands::clone::execute(url);
+        return r#gen::commands::clone::execute(url, &workspace);
     }
 
     let operation_conn = get_operation_connection(Some(workspace.gen_db_path()?))?;

--- a/src/operation_management.rs
+++ b/src/operation_management.rs
@@ -1274,6 +1274,10 @@ fn copy_operation_from_remote_fs(
     Ok(())
 }
 
+/// This is materializing the file in the directory. The nested
+/// file_addition.file_path field will always be the asset_dir path, while the
+/// top level file_path field can be like fastas/hg19.fa. So if we are not in
+/// the asset_dir, we copy it out
 fn materialize_operation_file(
     workspace: &Workspace,
     file_addition: &ManifestOperationFileAddition,

--- a/src/operation_management.rs
+++ b/src/operation_management.rs
@@ -1397,12 +1397,10 @@ fn download_remote_operation_assets(
                 stored_asset_path,
             )?;
         }
-    }
 
-    for file_addition in &manifest_operation.file_additions {
-        let stored_asset_path = repo_root.join(file_addition.file_addition.file_path());
-        if stored_asset_path.exists() {
-            materialize_operation_file(&workspace, file_addition, &stored_asset_path)?;
+        let stored_asset_actual_path = repo_root.join(file_addition.file_addition.file_path());
+        if stored_asset_actual_path.exists() {
+            materialize_operation_file(&workspace, file_addition, &stored_asset_actual_path)?;
         }
     }
 

--- a/src/operation_management.rs
+++ b/src/operation_management.rs
@@ -1119,7 +1119,7 @@ fn ingest_manifest_operation(
                     &operation.hash,
                     &local_file_addition,
                     &file_addition.filename,
-                    &operation_file_destination(file_addition),
+                    &file_addition.file_path,
                 )?;
             }
             for annotation_file in &manifest_operation.annotation_file_additions {
@@ -1390,9 +1390,17 @@ fn download_remote_operation_assets(
         "dependencies",
     )?;
 
-    let asset_dir = workspace.asset_dir()?;
-    for file in asset_response.files {
-        let destination = remote_asset_destination(&asset_dir, &file.asset_path)?;
+    for file_addition in &manifest_operation.file_additions {
+        let stored_asset_path = file_addition.file_addition.file_path();
+        if !LocalAssetUri::is_asset_relative_path(&workspace, stored_asset_path)? {
+            continue;
+        }
+        let Some(file) = remote_asset_response_file(&asset_response.files, file_addition) else {
+            continue;
+        };
+        let destination =
+            LocalAssetUri::repo_relative_destination_path(&workspace, stored_asset_path)
+                .map_err(|err| RemoteOperationError::IOError(std::io::Error::other(err)))?;
         if !destination.exists() {
             if let Some(parent) = destination.parent() {
                 fs::create_dir_all(parent)?;
@@ -1402,7 +1410,7 @@ fn download_remote_operation_assets(
                 &file.url,
                 destination.as_path(),
                 Some(auth_token),
-                &file.asset_path,
+                stored_asset_path,
             )?;
         }
     }
@@ -1417,20 +1425,18 @@ fn download_remote_operation_assets(
     Ok(())
 }
 
-fn remote_asset_destination(
-    asset_dir: &FilePath,
-    asset_path: &str,
-) -> Result<PathBuf, RemoteOperationError> {
-    let filename = FilePath::new(asset_path)
-        .file_name()
-        .ok_or_else(|| {
-            RemoteOperationError::IOError(std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                format!("Remote asset path has no filename: {asset_path}"),
-            ))
-        })?
-        .to_os_string();
-    Ok(asset_dir.join(filename))
+fn remote_asset_response_file<'a>(
+    files: &'a [RemoteFileAsset],
+    file_addition: &ManifestOperationFileAddition,
+) -> Option<&'a RemoteFileAsset> {
+    let stored_asset_path = file_addition.file_addition.file_path();
+    let manifest_asset_path = file_addition.file_path.as_str();
+    let stored_asset_filename = FilePath::new(stored_asset_path).file_name();
+    files.iter().find(|file| {
+        file.asset_path == manifest_asset_path
+            || file.asset_path == stored_asset_path
+            || FilePath::new(&file.asset_path).file_name() == stored_asset_filename
+    })
 }
 
 fn download_binary(
@@ -2685,10 +2691,7 @@ mod tests {
             let branch = Branch::get_by_name(op_conn, "main").unwrap();
             pull_from_file_remote(&context, &remote_url, &branch).unwrap();
 
-            let local_file_path = local_workspace
-                .repo_root()
-                .unwrap()
-                .join("fastas/remote_file.fa");
+            let local_file_path = local_workspace.repo_root().unwrap().join("remote_file.fa");
             assert!(local_file_path.exists());
             assert_eq!(
                 fs::read(local_file_path).unwrap(),
@@ -2903,22 +2906,27 @@ mod tests {
         }
 
         #[test]
-        fn test_remote_asset_destination_uses_asset_filename() {
-            let context = setup_gen();
-            let asset_dir = context.workspace().asset_dir().unwrap();
+        fn test_remote_asset_response_file_matches_asset_filename() {
+            let checksum = HashId::convert_str("asset");
+            let asset_path = format!(".gen/assets/{checksum}.fa");
+            let file_addition = ManifestOperationFileAddition {
+                file_addition: FileAddition {
+                    id: HashId::random_str(),
+                    asset_uri: LocalAssetUri::asset_uri(&asset_path),
+                    file_type: FileTypes::Fasta,
+                    checksum,
+                },
+                filename: "reference.fa".to_string(),
+                file_path: asset_path,
+            };
+            let files = vec![RemoteFileAsset {
+                asset_path: format!("assets/{checksum}.fa"),
+                url: "https://example.com/asset".to_string(),
+            }];
 
-            assert_eq!(
-                remote_asset_destination(&asset_dir, "abc123.fa").unwrap(),
-                asset_dir.join("abc123.fa")
-            );
-            assert_eq!(
-                remote_asset_destination(&asset_dir, "assets/abc123.fa").unwrap(),
-                asset_dir.join("abc123.fa")
-            );
-            assert_eq!(
-                remote_asset_destination(&asset_dir, ".gen/assets/abc123.fa").unwrap(),
-                asset_dir.join("abc123.fa")
-            );
+            let matched = remote_asset_response_file(&files, &file_addition).unwrap();
+
+            assert_eq!(matched.url, "https://example.com/asset");
         }
 
         #[test]

--- a/src/operation_management.rs
+++ b/src/operation_management.rs
@@ -21,7 +21,7 @@ use gen_models::{
     file_types::FileTypes,
     manifest::{
         ManifestComparer, ManifestDiff, ManifestDiffError, ManifestError, ManifestGenerator,
-        ManifestOperation,
+        ManifestOperation, ManifestOperationFileAddition,
     },
     metadata::get_db_uuid,
     operations::{
@@ -572,39 +572,7 @@ fn apply_operations_to_remote(
                     )
                 })?;
 
-                // This is materializing the file in the directory. If file_addition file_path
-                // will always be the asset_dir path, while file_addition.file_path can be like
-                // fastas/hg19.fa. So if we are not in the asset_dir, we copy it out
-                if file_addition.file_path != file_addition.file_addition.file_path()
-                    && LocalAssetUri::is_asset_relative_path(
-                        remote_workspace,
-                        file_addition.file_addition.file_path(),
-                    )?
-                {
-                    let user_dst_path = LocalAssetUri::repo_relative_destination_path(
-                        remote_workspace,
-                        &file_addition.file_path,
-                    )
-                    .map_err(|err| RemoteOperationError::IOError(std::io::Error::other(err)))?;
-                    if user_dst_path.exists() {
-                        info!(
-                            "Skipping copy for existing file {}",
-                            user_dst_path.to_string_lossy()
-                        );
-                    } else {
-                        if let Some(parent) = user_dst_path.parent() {
-                            fs::create_dir_all(parent)?;
-                        }
-
-                        fs::copy(&dst_path, &user_dst_path).map_err(|_| {
-                            RemoteOperationError::FileTransferError(
-                                file_addition.file_path.clone(),
-                                dst_path.to_string_lossy().to_string(),
-                                user_dst_path.to_string_lossy().to_string(),
-                            )
-                        })?;
-                    }
-                }
+                materialize_operation_file(remote_workspace, file_addition, &dst_path)?;
             }
         }
 
@@ -1151,7 +1119,7 @@ fn ingest_manifest_operation(
                     &operation.hash,
                     &local_file_addition,
                     &file_addition.filename,
-                    &file_addition.file_path,
+                    &operation_file_destination(file_addition),
                 )?;
             }
             for annotation_file in &manifest_operation.annotation_file_additions {
@@ -1267,35 +1235,7 @@ fn copy_operation_from_remote_fs(
                 )
             })?;
 
-            if file_addition.file_path != file_addition.file_addition.file_path()
-                && LocalAssetUri::is_asset_relative_path(
-                    local_workspace,
-                    file_addition.file_addition.file_path(),
-                )?
-            {
-                let user_dst_path = LocalAssetUri::repo_relative_destination_path(
-                    local_workspace,
-                    &file_addition.file_path,
-                )
-                .map_err(|err| RemoteOperationError::IOError(std::io::Error::other(err)))?;
-                if user_dst_path.exists() {
-                    info!(
-                        "Skipping copy for existing file {}",
-                        user_dst_path.to_string_lossy()
-                    );
-                } else {
-                    if let Some(parent) = user_dst_path.parent() {
-                        fs::create_dir_all(parent)?;
-                    }
-                    fs::copy(&dst_path, &user_dst_path).map_err(|_| {
-                        RemoteOperationError::FileTransferError(
-                            file_addition.file_path.clone(),
-                            dst_path.to_string_lossy().to_string(),
-                            user_dst_path.to_string_lossy().to_string(),
-                        )
-                    })?;
-                }
-            }
+            materialize_operation_file(local_workspace, file_addition, &dst_path)?;
         }
     }
     for annotation_file in &manifest_operation.annotation_file_additions {
@@ -1334,6 +1274,62 @@ fn copy_operation_from_remote_fs(
     Ok(())
 }
 
+fn materialize_operation_file(
+    workspace: &Workspace,
+    file_addition: &ManifestOperationFileAddition,
+    stored_asset_path: &FilePath,
+) -> Result<(), RemoteOperationError> {
+    let operation_file_path = operation_file_destination(file_addition);
+    if operation_file_path == file_addition.file_addition.file_path()
+        || !LocalAssetUri::is_asset_relative_path(
+            workspace,
+            file_addition.file_addition.file_path(),
+        )?
+    {
+        return Ok(());
+    }
+
+    let user_dst_path =
+        LocalAssetUri::repo_relative_destination_path(workspace, &operation_file_path)
+            .map_err(|err| RemoteOperationError::IOError(std::io::Error::other(err)))?;
+    if user_dst_path.exists() {
+        info!(
+            "Skipping copy for existing file {}",
+            user_dst_path.to_string_lossy()
+        );
+        return Ok(());
+    }
+
+    if let Some(parent) = user_dst_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::copy(stored_asset_path, &user_dst_path).map_err(|_| {
+        RemoteOperationError::FileTransferError(
+            operation_file_path,
+            stored_asset_path.to_string_lossy().to_string(),
+            user_dst_path.to_string_lossy().to_string(),
+        )
+    })?;
+
+    Ok(())
+}
+
+fn operation_file_destination(file_addition: &ManifestOperationFileAddition) -> String {
+    if file_addition.file_path != file_addition.file_addition.file_path() {
+        return file_addition.file_path.clone();
+    }
+
+    let asset_filename = FilePath::new(file_addition.file_addition.file_path())
+        .file_name()
+        .and_then(|filename| filename.to_str());
+    if !file_addition.filename.is_empty() && Some(file_addition.filename.as_str()) != asset_filename
+    {
+        return file_addition.filename.clone();
+    }
+
+    file_addition.file_path.clone()
+}
+
 #[derive(Debug, Deserialize)]
 struct RemoteOperationAssetResponse {
     changeset: String,
@@ -1345,7 +1341,6 @@ struct RemoteOperationAssetResponse {
 #[derive(Debug, Deserialize)]
 struct RemoteFileAsset {
     asset_path: String,
-    file_path: String,
     url: String,
 }
 
@@ -1396,25 +1391,46 @@ fn download_remote_operation_assets(
     )?;
 
     let asset_dir = workspace.asset_dir()?;
-    let gen_path = FilePath::new(&asset_dir);
     for file in asset_response.files {
-        let destination = gen_path.join(&file.asset_path);
-        let user_destination = repo_root.join(&file.file_path);
+        let destination = remote_asset_destination(&asset_dir, &file.asset_path)?;
         if !destination.exists() {
+            if let Some(parent) = destination.parent() {
+                fs::create_dir_all(parent)?;
+            }
             download_binary(
                 client,
                 &file.url,
                 destination.as_path(),
                 Some(auth_token),
-                &file.file_path,
+                &file.asset_path,
             )?;
         }
-        if !user_destination.exists() {
-            std::fs::copy(destination.as_path(), user_destination.as_path())?;
+    }
+
+    for file_addition in &manifest_operation.file_additions {
+        let stored_asset_path = repo_root.join(file_addition.file_addition.file_path());
+        if stored_asset_path.exists() {
+            materialize_operation_file(&workspace, file_addition, &stored_asset_path)?;
         }
     }
 
     Ok(())
+}
+
+fn remote_asset_destination(
+    asset_dir: &FilePath,
+    asset_path: &str,
+) -> Result<PathBuf, RemoteOperationError> {
+    let filename = FilePath::new(asset_path)
+        .file_name()
+        .ok_or_else(|| {
+            RemoteOperationError::IOError(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("Remote asset path has no filename: {asset_path}"),
+            ))
+        })?
+        .to_os_string();
+    Ok(asset_dir.join(filename))
 }
 
 fn download_binary(
@@ -2620,6 +2636,67 @@ mod tests {
         }
 
         #[test]
+        fn test_pull_from_file_remote_materializes_asset_to_operation_path() {
+            let context = setup_gen();
+            let local_workspace = context.workspace();
+            let conn = context.graph().conn();
+            let op_conn = context.operations().conn();
+            track_database(conn, op_conn).unwrap();
+
+            let remote_context = setup_gen_on_disk();
+            let remote_conn = remote_context.graph().conn();
+            let remote_op_conn = remote_context.operations().conn();
+            track_database(remote_conn, remote_op_conn).unwrap();
+
+            let remote_operation = create_operation(
+                &remote_context,
+                "fastas/remote_file.fa",
+                FileTypes::Fasta,
+                "remote operation",
+                HashId::random_str(),
+            );
+            let remote_branch = Branch::get_by_name(remote_op_conn, "main").unwrap();
+            let remote_manifest = ManifestGenerator::new(remote_op_conn)
+                .generate_manifest("main", remote_branch.current_operation_hash.as_ref())
+                .unwrap();
+            let manifest_operation = remote_manifest
+                .operations
+                .iter()
+                .find(|op| op.operation.hash == remote_operation.hash)
+                .unwrap();
+            let remote_asset_path = remote_context.workspace().repo_root().unwrap().join(
+                manifest_operation.file_additions[0]
+                    .file_addition
+                    .file_path(),
+            );
+            fs::remove_file(
+                remote_context
+                    .workspace()
+                    .repo_root()
+                    .unwrap()
+                    .join("fastas/remote_file.fa"),
+            )
+            .unwrap();
+
+            let remote_url = format!(
+                "file://{}",
+                remote_context.workspace().base_dir().to_string_lossy()
+            );
+            let branch = Branch::get_by_name(op_conn, "main").unwrap();
+            pull_from_file_remote(&context, &remote_url, &branch).unwrap();
+
+            let local_file_path = local_workspace
+                .repo_root()
+                .unwrap()
+                .join("fastas/remote_file.fa");
+            assert!(local_file_path.exists());
+            assert_eq!(
+                fs::read(local_file_path).unwrap(),
+                fs::read(remote_asset_path).unwrap()
+            );
+        }
+
+        #[test]
         fn test_pull_from_file_remote_missing_branch_errors() {
             let context = setup_gen();
             let conn = context.graph().conn();
@@ -2823,6 +2900,57 @@ mod tests {
             );
 
             assert!(matches!(result, Err(RemoteOperationError::IOError(_))));
+        }
+
+        #[test]
+        fn test_remote_asset_destination_uses_asset_filename() {
+            let context = setup_gen();
+            let asset_dir = context.workspace().asset_dir().unwrap();
+
+            assert_eq!(
+                remote_asset_destination(&asset_dir, "abc123.fa").unwrap(),
+                asset_dir.join("abc123.fa")
+            );
+            assert_eq!(
+                remote_asset_destination(&asset_dir, "assets/abc123.fa").unwrap(),
+                asset_dir.join("abc123.fa")
+            );
+            assert_eq!(
+                remote_asset_destination(&asset_dir, ".gen/assets/abc123.fa").unwrap(),
+                asset_dir.join("abc123.fa")
+            );
+        }
+
+        #[test]
+        fn test_materialize_operation_file_uses_filename_for_legacy_asset_path() {
+            let context = setup_gen();
+            let workspace = context.workspace();
+            let checksum = HashId::convert_str("legacy-asset");
+            let asset_path = format!(".gen/assets/{checksum}.gbk");
+            let stored_asset_path = workspace.repo_root().unwrap().join(&asset_path);
+            fs::write(&stored_asset_path, b"legacy asset").unwrap();
+            let file_addition = ManifestOperationFileAddition {
+                file_addition: FileAddition {
+                    id: HashId::random_str(),
+                    asset_uri: LocalAssetUri::asset_uri(&asset_path),
+                    file_type: FileTypes::GenBank,
+                    checksum,
+                },
+                filename: "addgene-plasmid-122028-sequence-238860.gbk".to_string(),
+                file_path: asset_path,
+            };
+
+            materialize_operation_file(workspace, &file_addition, &stored_asset_path).unwrap();
+
+            let user_file_path = workspace
+                .repo_root()
+                .unwrap()
+                .join("addgene-plasmid-122028-sequence-238860.gbk");
+            assert_eq!(fs::read(user_file_path).unwrap(), b"legacy asset");
+            assert_eq!(
+                operation_file_destination(&file_addition),
+                "addgene-plasmid-122028-sequence-238860.gbk"
+            );
         }
     }
 }

--- a/src/operation_management.rs
+++ b/src/operation_management.rs
@@ -1279,7 +1279,7 @@ fn materialize_operation_file(
     file_addition: &ManifestOperationFileAddition,
     stored_asset_path: &FilePath,
 ) -> Result<(), RemoteOperationError> {
-    let operation_file_path = operation_file_destination(file_addition);
+    let operation_file_path = file_addition.file_path.clone();
     if operation_file_path == file_addition.file_addition.file_path()
         || !LocalAssetUri::is_asset_relative_path(
             workspace,
@@ -1312,22 +1312,6 @@ fn materialize_operation_file(
     })?;
 
     Ok(())
-}
-
-fn operation_file_destination(file_addition: &ManifestOperationFileAddition) -> String {
-    if file_addition.file_path != file_addition.file_addition.file_path() {
-        return file_addition.file_path.clone();
-    }
-
-    let asset_filename = FilePath::new(file_addition.file_addition.file_path())
-        .file_name()
-        .and_then(|filename| filename.to_str());
-    if !file_addition.filename.is_empty() && Some(file_addition.filename.as_str()) != asset_filename
-    {
-        return file_addition.filename.clone();
-    }
-
-    file_addition.file_path.clone()
 }
 
 #[derive(Debug, Deserialize)]
@@ -2691,7 +2675,10 @@ mod tests {
             let branch = Branch::get_by_name(op_conn, "main").unwrap();
             pull_from_file_remote(&context, &remote_url, &branch).unwrap();
 
-            let local_file_path = local_workspace.repo_root().unwrap().join("remote_file.fa");
+            let local_file_path = local_workspace
+                .repo_root()
+                .unwrap()
+                .join("fastas/remote_file.fa");
             assert!(local_file_path.exists());
             assert_eq!(
                 fs::read(local_file_path).unwrap(),
@@ -2927,38 +2914,6 @@ mod tests {
             let matched = remote_asset_response_file(&files, &file_addition).unwrap();
 
             assert_eq!(matched.url, "https://example.com/asset");
-        }
-
-        #[test]
-        fn test_materialize_operation_file_uses_filename_for_legacy_asset_path() {
-            let context = setup_gen();
-            let workspace = context.workspace();
-            let checksum = HashId::convert_str("legacy-asset");
-            let asset_path = format!(".gen/assets/{checksum}.gbk");
-            let stored_asset_path = workspace.repo_root().unwrap().join(&asset_path);
-            fs::write(&stored_asset_path, b"legacy asset").unwrap();
-            let file_addition = ManifestOperationFileAddition {
-                file_addition: FileAddition {
-                    id: HashId::random_str(),
-                    asset_uri: LocalAssetUri::asset_uri(&asset_path),
-                    file_type: FileTypes::GenBank,
-                    checksum,
-                },
-                filename: "addgene-plasmid-122028-sequence-238860.gbk".to_string(),
-                file_path: asset_path,
-            };
-
-            materialize_operation_file(workspace, &file_addition, &stored_asset_path).unwrap();
-
-            let user_file_path = workspace
-                .repo_root()
-                .unwrap()
-                .join("addgene-plasmid-122028-sequence-238860.gbk");
-            assert_eq!(fs::read(user_file_path).unwrap(), b"legacy asset");
-            assert_eq!(
-                operation_file_destination(&file_addition),
-                "addgene-plasmid-122028-sequence-238860.gbk"
-            );
         }
     }
 }


### PR DESCRIPTION
This fixes a bug I found where eg "foo.fa" was in the original repo but wasn't showing up when I did a gen clone of that repo from genhub