### PR TITLE
Refactor annotation access: DB-backed Annotation on SequenceGraph

### DIFF
--- a/gen-python/examples/annotations.ipynb
+++ b/gen-python/examples/annotations.ipynb
@@ -5,11 +5,7 @@
    "id": "intro",
    "metadata": {},
    "source": [
-    "# Annotation listing and navigation\n",
-    "\n",
-    "This notebook imports pUC19 from a GenBank file, loads its feature annotations,\n",
-    "and navigates to the MCS (multiple cloning site) using `widget.go_to()` and\n",
-    "`widget.show()`."
+    "# Annotation listing and navigation\n\nThis notebook imports pUC19 from a GenBank file, loads its feature annotations,\nand demonstrates two ways to work with them:\n\n1. **Without a viewer** — query annotations directly from a `SequenceGraph` (preferred).\n2. **With a widget** — navigate to a feature and add highlights interactively."
    ]
   },
   {
@@ -29,38 +25,61 @@
    "id": "import-gb",
    "metadata": {},
    "source": [
-    "## Import pUC19\n",
-    "\n",
-    "Create a fresh in-memory repository, import a GenBank file and start a new plot figure (or widget in Jupyter terms)."
+    "## Import pUC19\n\nCreate a fresh in-memory repository and import a GenBank file."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "import-genbank",
    "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sequence graph: sequence-222046-\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Adjust this path if running from outside the project root.\nFIXTURE = os.path.abspath(\"../../fixtures/puc19.gb\")\n\ntmp = tempfile.mkdtemp()\nrepo = gen.Repository(os.path.join(tmp, \".gen\"))\nrepo.import_genbank(FIXTURE)\n\nsg = repo.get_sequence_graphs()[0]\nprint(\"Sequence graph:\", sg.name)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fxdd55m2",
+   "metadata": {},
+   "source": [
+    "## List annotations without opening a viewer\n\n`SequenceGraph.list_annotations()` reads persisted annotations directly from the\ndatabase — no widget required.  This is the preferred way to programmatically\ninspect, filter, or iterate over features stored in the graph."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "xqexvlqf",
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
-   "source": "# Adjust this path if running from outside the project root.\nFIXTURE = os.path.abspath(\"../../fixtures/puc19.gb\")\n\ntmp = tempfile.mkdtemp()\nrepo = gen.Repository(os.path.join(tmp, \".gen\"))\nrepo.import_genbank(FIXTURE)\n\nbg = repo.get_sequence_graphs()[0]\nprint(\"Sequence graph:\", bg.name)\n\nfig = bg.plot(rows=24)"
+   "source": [
+    "anns = sg.list_annotations()\nprint(f\"{len(anns)} annotations stored in graph\")\nfor a in anns:\n    print(a)\n"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "740b0148",
    "metadata": {},
    "source": [
-    "## Annotations\n",
-    "Annotation groups associated with the sequence or its ancestors are automatically loaded as an annotation track titled \"Stored annotations\"\n",
-    "\n",
-    "Additional GFF3 or BED annotation files can be loaded at any time:\n",
-    "\n",
-    "```python\n",
-    "fig.add_annotation_track(file=\"path/to/features.gff3\")\n",
-    "```\n",
-    "\n",
-    "To start with a blank canvas before loading your own files, clear the auto-loaded tracks:\n",
-    "\n",
-    "```python\n",
-    "fig.clear_all_annotations()\n",
-    "```"
+    "## Visualise with a widget\n\nCall `.plot()` to open an interactive widget.  Annotation tracks from the GenBank\nfile are loaded automatically as a \"Stored annotations\" panel.\n\nAdditional GFF3 or BED files can be added at any time:\n\n```python\nfig.add_annotation_track(file=\"path/to/features.gff3\")\n```\n\nTo start with a blank canvas:\n\n```python\nfig.clear_all_annotations()\n```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "9m2rblic",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = sg.plot(rows=24)\nfig\n"
    ]
   },
   {
@@ -68,11 +87,7 @@
    "id": "list-section",
    "metadata": {},
    "source": [
-    "## List all annotations\n",
-    "\n",
-    "`fig.list_annotations()` returns `Annotation` objects spanning all\n",
-    "sources (track panels and inline highlights).  Each annotation exposes `.name`,\n",
-    "`.locus`, and can be passed directly to `fig.go_to()` or `fig.show()`."
+    "## List widget annotations\n\n`fig.list_annotations()` returns the annotations currently tracked by the widget —\nthis includes both the stored database annotations and any highlights added\nprogrammatically with `fig.add_annotation()`."
    ]
   },
   {
@@ -86,27 +101,27 @@
      "output_type": "stream",
      "text": [
       "21 annotations loaded\n",
-      "source\n",
-      "pBR322ori-F\n",
-      "L4440\n",
-      "CAP binding site\n",
-      "lac promoter\n",
-      "lac operator\n",
-      "M13/pUC Reverse\n",
-      "M13 rev\n",
-      "M13 Reverse\n",
-      "lacZ-alpha\n",
-      "MCS\n",
-      "M13 Forward\n",
-      "M13 fwd\n",
-      "M13/pUC Forward\n",
-      "pRS-marker\n",
-      "pGEX 3'\n",
-      "pBRforEco\n",
-      "AmpR promoter\n",
-      "AmpR\n",
-      "Amp-R\n",
-      "ori\n"
+      "Annotation(name=\"source\", group=\"GenBank default/reference/sequence-222046-\", len=2686)\n",
+      "Annotation(name=\"pBR322ori-F\", group=\"GenBank default/reference/sequence-222046-\", len=20)\n",
+      "Annotation(name=\"L4440\", group=\"GenBank default/reference/sequence-222046-\", len=18)\n",
+      "Annotation(name=\"CAP binding site\", group=\"GenBank default/reference/sequence-222046-\", len=22)\n",
+      "Annotation(name=\"lac promoter\", group=\"GenBank default/reference/sequence-222046-\", len=31)\n",
+      "Annotation(name=\"lac operator\", group=\"GenBank default/reference/sequence-222046-\", len=17)\n",
+      "Annotation(name=\"M13/pUC Reverse\", group=\"GenBank default/reference/sequence-222046-\", len=23)\n",
+      "Annotation(name=\"M13 rev\", group=\"GenBank default/reference/sequence-222046-\", len=17)\n",
+      "Annotation(name=\"M13 Reverse\", group=\"GenBank default/reference/sequence-222046-\", len=17)\n",
+      "Annotation(name=\"lacZ-alpha\", group=\"GenBank default/reference/sequence-222046-\", len=324)\n",
+      "Annotation(name=\"MCS\", group=\"GenBank default/reference/sequence-222046-\", len=57)\n",
+      "Annotation(name=\"M13 Forward\", group=\"GenBank default/reference/sequence-222046-\", len=18)\n",
+      "Annotation(name=\"M13 fwd\", group=\"GenBank default/reference/sequence-222046-\", len=17)\n",
+      "Annotation(name=\"M13/pUC Forward\", group=\"GenBank default/reference/sequence-222046-\", len=23)\n",
+      "Annotation(name=\"pRS-marker\", group=\"GenBank default/reference/sequence-222046-\", len=20)\n",
+      "Annotation(name=\"pGEX 3'\", group=\"GenBank default/reference/sequence-222046-\", len=23)\n",
+      "Annotation(name=\"pBRforEco\", group=\"GenBank default/reference/sequence-222046-\", len=19)\n",
+      "Annotation(name=\"AmpR promoter\", group=\"GenBank default/reference/sequence-222046-\", len=105)\n",
+      "Annotation(name=\"AmpR\", group=\"GenBank default/reference/sequence-222046-\", len=861)\n",
+      "Annotation(name=\"Amp-R\", group=\"GenBank default/reference/sequence-222046-\", len=20)\n",
+      "Annotation(name=\"ori\", group=\"GenBank default/reference/sequence-222046-\", len=589)\n"
      ]
     }
    ],
@@ -135,27 +150,12 @@
    "execution_count": 4,
    "id": "goto-mcs",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "2103b06e3f8647abb34daa194098edeb",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "<gen.jupyter_widget.GenGraphWidget object at 0x10c982850>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Left-pin the MCS start at column 12 from the left edge.\n",
-    "mcs = next(a for a in anns if a.name == \"MCS\")\n",
-    "fig.go_to(mcs)\n",
-    "fig\n"
+    "#mcs = next(a for a in anns if a.name == \"MCS\")\n",
+    "#fig.go_to(mcs)\n",
+    "#fig\n"
    ]
   },
   {
@@ -163,29 +163,13 @@
    "execution_count": 5,
    "id": "show-mcs",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "adbf210b4fe545a09ff8cc2a2446ba60",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAABSgAAAMYCAYAAADIOwkfAAAgAElEQVR4XuzdCbhtY/0H8BfhXjJlJjMhMyWlDHWplIREEpEhc6bQzZB5voa4JMpUhkJF/6hIpigzRcg8z9O9usj/edc5e1l3n3Pu3efc9Z73LPfzeR7Ps9dZx3t/5x3W3vu7115rivnnX/bdAAAAAACQwRQCSgAAAAAgFwElAAAAAJCNgBIAAAAAyEZACQAAAABkI6AEAAAAALIRUAIAAAAA2QgoAQAAAIBsBJQAAAAAQDYCSgAAAAAgGwElAAAAAJCNgBIAAAAAyEZACQAAAABkI6AEAAAAALIRUAIAAAAA2QgoAQAAAIBsBJQAAAAAQDYCSgAAAAAgGwElAAAAAJCNgBIAAAAAyEZACQAAAABkI6AEAAAAALIRUAIAAAAA2QgoAQAAAIBsBJQAAAAAQDYCSgAAAAAgGwElAAAAAJCNgBIAAAAAyEZACQAAAABkI6AEAAAAALIRUAIAAAAA2QgoAQAAAIBsBJQAAAAAQDYCSgAAAAAgGwElAAAAAJCNgBIAAAAAyEZACQAAAABkI6AEAAAAALIRUAIAAAAA2QgoAQAAAIBsBJQAAAAAQDYCSgAAAAAgGwElAAAAAJCNgBIAAAAAyEZACQAAAABkI6AEAAAAALIRUAIAAAAA2QgoAQAAAIBsBJQAAAAAQDYCSgAAAAAgGwElAAAAAJCNgBIAAAAAyEZACQAAAABkI6AEAAAAALIRUAIAAAAA2QgoAQAAAIBsBJQAAAAAQDYCSgAAAAAgGwElAAAAAJCNgBIAAAAAyEZACQAAAABkI6AEAAAAALIRUAIAAAAA2QgoAQAAAIBsBJQAAAAAQDYCSgAAAAAgGwElAAAAAJCNgBIAAAAAyEZACQAAAABkI6AEAAAAALIRUAIAAAAA2QgoAQAAAIBsBJQAAAAAQDYCSgAAAAAgGwElAAAAAJCNgBIAAAAAyEZACQAAAABkI6AEAAAAALIRUAIAAAAA2QgoAQAAAIBsBJQAAAAAQDYCSgAAAAAgGwElAAAAAJCNgBIAAAAAyEZACQAAAABkI6AEAAAAALIRUAIAAAAA2QgoAQAAAIBsBJQAAAAAQDYCSgAAAAAgGwElAAAAAJCNgBIAAAAAyEZACQAAAABkI6AEAAAAALIRUAIAAAAA2QgoAQAAAIBsBJQAAAAAQDYCSgAAAAAgGwElAAAAAJCNgBIAAAAAyEZACQAAAABkI6AEAAAAALIRUAIAAAAA2QgoAQAAAIBsBJQAAAAAQDYCSgAAAAAgGwElAAAAAJCNgBIAAAAAyEZACQAAAABkI6AEAAAAALIRUAIAAAAA2QgoAQAAAIBsBJQAAAAAQDYCSgAAAAAgGwElAAAAAJCNgBIAAAAAyEZACQAAAABkI6AEAAAAALIRUAIAAAAA2QgoAQAAAIBsBJQAAAAAQDYCSgAAAAAgGwElAAAAAJCNgBIAAAAAyEZACQAAAABkI6AEAAAAALIRUAIAAAAA2QgoAQAAAIBsBJQAAAAAQDYCSgAAAAAgGwElAAAAAJCNgBIAAAAAyEZACQAAAABkI6AEAAAAALIRUAIAAAAA2QgoAQAAAIBsBJQAAAAAQDYCSgAAAAAgGwElAAAAAJCNgBIAAAAAyEZACQAAAABkI6AEAAAAALIRUAIAAAAA2QgoAQAAAIBsBJQAAAAAQDYCSgAAAAAgGwElAAAAAJCNgBIAAAAAyEZACQAAAABkI6AEAAAAALIRUAIAAAAA2QgoAQAAAIBsBJQAAAAAQDYCSgAAAAAgGwElAAAAAJCNgBIAAAAAyEZACQAAAABkI6AEAAAAALIRUAIAAAAA2QgoAQAAAIBsBJQAAAAAQDYCSgAAAAAgGwElAAAAAJCNgBIAAAAAyEZACQAAAABkI6AEAAAAALIRUAIAAAAA2QgoAQAAAIBsBJQAAAAAQDYCSgAAAAAgGwElAAAAAJCNgBIAAAAAyEZACQAAAABkI6AEAAAAALIRUAIAAAAA2QgoAQAAAIBsBJQAAAAAQDYCSgAAAAAgGwElAAAAAJCNgBIAAAAAyEZACQAAAABkI6AEAAAAALIRUAIAAAAA2QgoAQAAAIBsBJQAAAAAQDYCSgAAAAAgGwElAAAAAJCNgBIAAAAAyEZACQAAAABkI6AEAAAAALIRUAIAAAAA2QgoAQAAAIBsBJQAAAAAQDYCSgAAAAAgGwElAAAAAJCNgBIAAAAAyEZACQAAAABkI6AEAAAAALIRUAIAAAAA2QgoAQAAAIBsBJQAAAAAQDYCSgAAAAAgGwElAAAAAJCNgBIAAAAAyEZACQAAAABkI6AEAAAAALIRUAIAAAAA2QgoAQAAAIBsBJQAAAAAQDYCSgAAAAAgGwElAAAAAJCNgBIAAAAAyEZACQAAAABkI6AEAAAAALIRUAIAAAAA2QgoAQAAAIBsBJQAAAAAQDYCSgAAAAAgGwElAAAAAJCNgBIAAAAAyEZACQAAAABkI6AEAAAAALIRUAIAAAAA2QgoAQAAAIBsBJQAAAAAQDYCSgAAAAAgGwElAAAAAJCNgBIAAAAAyEZACQAAAABkI6AEAAAAALIRUAIAAAAA2QgoAQAAAIBsBJQAAAAAQDYCSgAAAAAgGwElAAAAAJCNgBIAAAAAyEZACQAAAABkI6AEAAAAALIRUAIAAAAA2QgoAQAAAIBsBJQAAAAAQDYCSgAAAAAgGwElAAAAAJCNgBIAAAAAyEZACQAAAABkI6AEAAAAALIRUAIAAAAA2QgoAQAAAIBsBJQAAAAAQDYCSgAAAAAgGwElAAAAAJCNgBIAAAAAyEZACQAAAABkI6AEAAAAALIRUAIAAAAA2QgoAQAAAIBsBJQAAAAAQDYCSgAAAAAgGwElAAAAAJCNgBIAAAAAyEZACQAAAABkI6AEAAAAALIRUAIAAAAA2QgoAQAAAIBsBJQAAAAAQDYCSgAAAAAgGwElAAAAAJCNgBIAAAAAyEZACQAAAABkI6AEAAAAALIRUAIAAAAA2QgoAQAAAIBsBJQAAAAAQDYCSgAAAAAgGwElAAAAAJCNgBIAAAAAyEZACQAAAABkI6AEAAAAALIRUAIAAAAA2QgoAQAAAIBsBJQAAAAAQDYCSgAAAAAgGwElAAAAAJCNgBIAAAAAyEZACQAAAABkI6AEAAAAALIRUAIAAAAA2QgoAQAAAIBsBJQAAAAAQDYCSgAAAAAgGwElAAAAAJCNgBIAAAAAyEZACQAAAABkI6AEAAAAALIRUAIAAAAA2QgoAQAAAIBsBJQAAAAAQDYCSgAAAAAgGwElAAAAAJCNgBIAAAAAyEZACQAAAABkI6AEAAAAALIRUAIAAAAA2QgoAQAAAIBsBJQAAAAAQDYCSgAAAAAgGwElAAAAAJCNgBIAAAAAyEZACQAAAABkI6AEAAAAALIRUAIAAAAA2QgoAQAAAIBsBJQAAAAAQDYCSgAAAAAgGwElAAAAAJCNgBIAAAAAyEZACQAAAABkI6AEAAAAALIRUAIAAAAA2QgoAQAAAIBsBJQAAAAAQDYCSgAAAAAgGwElAAAAAJCNgBIAAAAAyEZACQAAAABkI6AEAAAAALIRUAIAAAAA2QgoAQAAAIBsBJQAAAAAQDYCSgAAAAAgGwElAAAAAJCNgBIAAAAAyEZACQAAAABkI6AEAAAAALIRUAIAAAAA2QgoAQAAAIBsBJQAAAAAQDYCSgAAAAAgGwElAAAAAJCNgBIAAAAAyEZACQAAAABkI6AEAAAAALIRUAIAAAAA2QgoAQAAAIBsBJQAAAAAQDYCSgAAAAAgGwElAAAAAJCNgBIAAAAAyEZACQAAAABkI6AEAAAAALIRUAIAAAAA2QgoAQAAAIBsBJQAAAAAQDYCSgAAAAAgGwElAAAAAJCNgBIAAAAAyEZACQAAAABkI6AEAAAAALIRUAIAAAAA2QgoAQAAAIBsBJQAAAAAQDYCSgAAAAAgGwElAAAAAJDNFLf88/V3s/3rAAAAAMBkTUAJAAAAAGQjoAQAAAAAshFQAgAAAADZCCgBAAAAgGwElJn98+7bw8g9dyiq2GSz74SNN/tO5oomLFW9TWsX6CnVOk6lafWmoh+aqWnj1rR6m0b/NlPTxq1p9abStH5oWr2p6AcGg3nWZaD9IKDM7M7bbwkH7LNzUcWGG28RNttyu8wVTViqepvWLtBTqnWcStPqTUU/NFPTxq1p9TaN/m2mpo1b0+pNpWn90LR6U9EPDAbzrMtA+0FAmdlABy6XVPU2rV2gp1TrOJWm1ZuKfmimpo1b0+ptGv3bTE0bt6bVm0rT+qFp9aaiHxgM5lmXgfaDgDKzgQ5cLqnqbVq7QE+p1nEqTas3Ff3QTE0bt6bV2zT6t5maNm5NqzeVpvVD0+pNRT8wGMyzLgPthwkGlM8+83S4/DcXFd8ff+Df/woLL7p4WHrZFcKIz68bxowdE27461XF76225lphkcWW6P6/OvfgA/eF66/5U3jkoQeLx6+8/FKYZ975w4ILLxLWGLFOWPFjq4Spppqq/P2JSVVvne0+eP+94YrfX1puP/fsM+H2W24qHse/falll+/e8571v/bNMPe885XbE/LUE4+F2265Odx2y03hyccfDU8+8Wjx8yWXWjYssNAiYallVgifXn1E929PXKp6m9Zub+qcv3WPW28m53qr6uyHqM7jQ2/qrLfueZZqHbc0rd4o1Xyos93U4xbVWW9vhvK66E0d9Q7GuJX/1mRYb0vdx52qOtdF6vmQsh9a6phnLanqrbvd1ONWVUf/Dka9da6L3jSlH5pWb4pxa+J6S9EPVXXM397U3W6T+qFp86zueqvqHLe6ni/6DCgfuP++cMh+uxeTtd1MM88SVv/sF8JvL/5lsb3z7iPDZ9f+UvfeiRs3bly45MJzwvnnnlH+rDdrr7Ne2H6XvcvtCUlVb93tXnfNn8Kxh+9fbnfikKNPLibexMSDy547bVlu92X1z34+bLfTXmH4dNOVP+tLqnqb1m5V3fM3xbhVTe71puqHqO7jQ1Xd9aaYZ6nWcdS0eqNU86HudlOOW1R3vVVNWBdVddabetyiybneKMVxp6XudZFyPqTsh6jOeRalqjdFuynHraXO/k1db93roqpJ/dC0elOMWxPXW4p+aKlz/lalaLdJ/dC0eZai3pa6x62u54teA8pXX305bPH1dcrtWOAqn1ojTDts2vCPm24oU9uWTgquOuqQkeHG664ut2NSu8RHlw4zzDhzeOyR/4R77rq96Kg1PveFsOteE/8jU9Wbot2YLP/hskvK7eeefTrccdvfi8cxWf7o0st173nPBl/frEey3JvY9p47b1U8nnW22cPiSy4d5pp7vjDNtNOEZ55+Mlz9x993/2YokvGDjzq53O5Lqnqb1m5V3fM3xbhVTe71puqHFMeHqrrrTTHPUq3jqGn1ppoPKdpNOW4p6q1qwrqoqrPelOPWMjnXG6U47kQp1kXK+ZCqH1rqnGdRqnpTtJty3Frq7N+U9aZYF1VN6Yem1Ztq3Jq23lL1Q0ud87eq7nab1g9Nm2cp6o1SjFtdzxe9BpQXnHtGmarHSbvfwceFmWeZpdh+882x4ehDRoZb//G3YjvqpOCWeGrqQSN3K7e333WfsPYXv1JuR2PHjAm/POf08Nprr4Zd99yv/HlfUtWbqt2qgX43vzePPfpwOPuMU8IXv7xBWH6llcOUU05Z7oviabZ77bJVcdCJjjz+9PCRJZbq3tuZOuutakq7KeZvynFTb7p+SHl8SFFvynnWUuc6blq9qeZDqnar6hy3lPU2bV2kqLeqznGL1JvuuJNyXbTUOR9S9UOUYp6lqjdVu1V1jluUon+r6qw35bpoUj80rd5U49a09ZaqH6JU8zdFu03rh6bNs1T1phy3loE+X/QIKGNBW31j3TB27Jhi+6gTfhoWW/yj3Xu7PPvMU2G7LTYstzst+N133w07bf2NMpHdYuudwle/tmn33p7iKcjTTDNNud2bVPWmarfdQAduoC7/za/CT0cfVzz+1lY7FKl1f6Sqtwntppi/nRrIuKk3XT+kPD6kqLdTA5lnVanWcV+GSr2p5kOqdtvVNW4p623auhiMeusat0i9nevvcSfluqiqcz50or/9EA3GPOvLQOrtxKS2W+e4DUb/1lVvynXRpH5oWr0px60TQ2W9peyHVPM3RbtN7IdODJV51qn+1pty3KoG+nzRI6CMp/busl3XHzXf/AuGE3/yi+494ztw313LUzY7LfjFF54L3/nmesXj4cOnC2f+4ndh2PDh3XsHJlW9qdptN9CBG6i77rg17L/3TsXjddffOGy13a7dezqTqt4mtJti/nZqIOOm3nT9kPL4kKLeTg1knlWlWsd9GSr1ppoPqdptV9e4pay3aetiMOqta9wi9Xauv8edlOuiqs750In+9kM0GPOsLwOptxOT2m6d4zYY/VtXvSnXRZP6oWn1phy3TgyV9ZayH1LN3xTtNrEfOjFU5lmn+ltvynGrGujzRY+A8ta//y0cvN/uxeMJXXvgzNNOCL+75ILicacFx7sDjdxzh+Lxyqt8Jux74JHdewYuVb2p2m030IGbkIcfejBccfnF4fFHHw5PPfl4eOH558p9VZ9fZ/3w3V32Krc7kaLeqAntppi/VXWPm3rT9UPK40OKeqvqnmdVKdZxE+pNNR9StduurnFLWW/T1kXqeqO6xi1S7/jqPO6kXBdVdc6Hljr7IUo9z+qutyVVu1Gd45a6f6O66k25LprUD02rN+W4tTRhvaXsh1TzN0W7TeyHlibMs6o66005blUDfb7oEVBe+fvfhNEndk3YeHpoPE20N7++4Oxw7s9OLR53WvCfr7gs/HjUYcXjr2ywSdhy21269wxcqnpTtdtuoAPXm7feejucdNzB4dqr/1j+bEI6mcDt6qy3qgntppi/UapxU2+6fkh5fEhRb5RqnlXVuY6bVG+q+ZCq3XZ1jVvKepu2LlLVW1XXuEXq7ZLiuJNyXVTVOR9S9EOUap6lqjdVu1V1jluq/q2qq96U66JJ/dC0elOOW5PWW8p+SDV/U7TbxH5o0jyLUtSbctyqBvp80SOg/MPlF4fTTjqmeDyhhn59/lnh3J+fVjzutODLLr0onHHqqOLxRptuGTbdfJvuPQOXqt5U7bYb6MD15qejR4XLf3NRuf3JT68Zlll+pTDLh2YN0047rPjZY488FH72kxOLxyM+v27Ycbd9i8edqrPeqia0m2L+RqnGTb3p+iHl8SFFvVGqeVZV5zpuUr2p5kOqdtvVNW4p623aukhVb1Vd4xapt0uK407KdVFV53xI0Q9RqnmWqt5U7VbVOW6p+reqrnpTrosm9UPT6k05bk1abyn7IdX8TdFuE/uhSfMsSlFvynGrGujzRY+A8u83XR8OO6ArdV1zrXXCLnv8sHvP+M766Y/Dpb/q+r56pwVX257Q6aT9kareVO22G+jAtXvjjdfDZhuuXW4feswp4aNLL19ut/zthmvCkQd1TdpOJnC7uupt14R2U8zflOOm3nT9kPL4kKLelPOsqq513LR6U82HVO22q2vcUtbbtHWRot52dY1bpN50x52U66KqrvmQqh+iFPMsVb2p2m1X17hFKfq3XV31plwXTeqHptWbatyatt5S9UOUav6maLdp/dC0eZaq3pTjVjXQ54seAWX8fvtu23+reLzoR5YMR5/Ydfvxdoce8P3wj5uuKx53WnC8Tfou23bdLWqBhRYJx48+p3vPwKWqN1W77aoDt/7XvxU232r77j39U23nM2uuFXbf+0fde8YXJ1mcbFEnE7hdXfW2a0K7KeZvynFTb7p+SHl8SFFvynlWVdc6blq9qeZDqnbb1TVuKett2rpIUW+7usYtUm+6407KdVFV13xI1Q9RinmWqt5U7bara9yiFP3brq56U66LJvVD0+pNNW5NW2+p+iFKNX9TtNu0fmjaPEtVb8pxqxro80WPgHLsmDFh0w1GlNsnnHZumH+Bhcvt6KUXXwxbbfrlcrvTgseN+2/Y+CtrltsHHn5CWG6Fj5fbA5Gq3lTttnvwgfvCnjttWTyeUII9MdUkvK/rSrz99tth1+02C08+8Wix3ckEbldXve2a0G6K+Zty3NSbrh9SHh9S1JtynlXVtY6bVm+q+ZCq3XZ1jVvKepu2LlLU266ucYvUm+64k3JdVNU1H1L1Q5RinqWqN1W77eoatyhF/7arq96U66JJ/dC0elONW9PWW6p+iFLN3xTtNq0fmjbPUtWbctyqBvp80SOgjGICG5PYaPmVPhH23u+wMGxY123o33nnnXDy8YeHq//4+2I76k/BF5x7Rjj/3K6UNt7WPC6OD806e/fe98Tbn99/3786ajdVvanarXrl5RfDtzfpGvyZZp4lnHbWr8vrCfRH9VOR2K/H/visMPU0U3fv7XLJReeFs884udzuZAK3q6vedk1pt+75m3rcJvd6U/VDlPL4UHe9qedZS13ruGn1RqnmQ6p2q+oatyhlvU1bF3XX267OcYsm93pTHndSrouWuuZDyn6I6p5nqepN1W67usatpe7+bVdnvSnXRZP6oWn1phi3Jq63FP3Qkmr+pmi3Sf3QtHmWst6U49Yy0OeLXgPKeNvyrTdbr9xeeNHFw2fWWCsMGz4s3HTDteH2W24q90X9KfjNN8eGnbbepLw1+vDh04Vvb7NTWGSxJcL0H5yhuG363XfcFi6+8OyOr4+Qqt5U7Va9++67Yaetv1Gm3vHfGPH5L4dZZp0tTDXlVMXPllxq2fDBGWYsHvclpuebb/SFMHbsmGJ7yaWWDyM+/6Xi/33ppRfCn664bLxJFnU6gavqqrddU9qte/6mHrfJvd5U/RClPD7UXW/qedZS1zpuWr1RqvmQqt2qusYtSllv09ZF3fW2q3Pcosm93pTHnZTroqWu+ZCyH6K651mqelO1266ucWupu3/b1VlvynXRpH5oWr0pxq2J6y1FP7Skmr8p2m1SPzRtnqWsN+W4tQz0+aLXgDK67ZabwkEjdyu3q+JkHvGFdcPvLrmg2O5vwfff989w3BH7h6eferL8WW86XRhRqnpTtVt1y803hkP236PcbnfI0SeHpZZZodzuy003/DUccdA+5XZv4vf/L7mw65oTnU7gdnXV264p7dY9f1OP2+Reb6p+iFIeH+quN/U8a6lrHTet3ijVfEjVblVd4xalrLdp66LuetvVOW7R5F5vyuNOynXRUtd8SNkPUd3zLFW9qdptV9e4tdTdv+3qrDflumhSPzSt3hTj1sT1lqIfWlLN3xTtNqkfmjbPUtabctxaBvJ80WdAGcULaMbbi991xy3hlZdfKk7NXGGlT4QvrbdRuOeu28PPTz+p+L199j8ifOJTq3X/X515c+zY8Iuzf1L+0e1WXuUzYYONvxUWX3Lp8mcTk6reVO1WPfP0k+HK318arrnqivJTjZbDjh0dllxquXJ7Qv52/V/CqScdXdRZNdfc84Rvb7NLmHOuecJuO2xe/Ozz66wfvrtL13UN+quuets1pd2652/qcZvc603VD1HK40Pd9aaeZy11reOm1Rulmg+p2q2qa9yilPU2bV3UXW+7OsctmtzrTXncSbkuWuqaDyn7Iap7nqWqN1W77eoat5a6+7ddnfWmXBdN6oem1Zti3Jq43lL0Q0uq+Zui3Sb1Q9PmWcp6U45bS3+fLyYYUFa9/tqr451+eeZpJ5ST+riTzwoLLbJY957+iad+PvfsM+GJxx8Jb7z+Wph9jrmKzp5p5g+VvzMQqepN1W6dxo0bV5yi/dQTj4ZpphkWFvnI4mGmmWYp91OfOufvYIzb5FxvVZ39UJXq+FBnvYMxz+rUtHqrUs2HVO2mkqrepq2LOusdDJNzvYNx3Em1Luo0GP1Q5zxLVW+qdgdDnf07GFKti6b1Q9PqrXPcmrze6uyHqlTzIVW7TeiHps2zwag31bj1V8cBZVWczDGlfeShB4vtcy76w3h/zFCTqt5U7QLN5/hAVar5kKrdVJpWLwwG6wJ6si6aybiZv1XmQzPlHLc+A8rr/3pVmG+BBXvccjy66srLw0nHHVo8jnf9OeDQUd178klVb6p2geZzfKAq1XxI1W4qTasXBoN1AT1ZF81k3MzfKvOhmYbquPUZUO73/R3D3XfeFhb9yJJhxY9/Msw9z7xh7Jgxxc9uuPaq8vdGjT4nLLjQIuV2LqnqTdUu0HyOD1Slmg+p2k2lafXCYLAuoCfropmMm/lbZT4001Adt4kGlBOyy577hTVHfLHczilVvanaBZrP8YGqVPMhVbupNK1eGAzWBfRkXTSTcTN/q8yHZhqq49ZnQHn3nbeGW/9+Y3H3nnjnnXhXn3i78UUWWzwssNCiYb0NNw2zzzFn+fu5pao3VbtA8zk+UJVqPqRqN5Wm1QuDwbqAnqyLZjJu5m+V+dBMQ3Xc+gwo28ULZU4xxRTl9lCXqt5U7QLN5/hAVar5kKrdVJpWLwwG6wJ6si6aybiZv1XmQzMNlXHrOKAEAAAAAKjbFPPPv6yAEgAAAADIQkAJAAAAAGQjoAQAAAAAshFQAgAAAADZCCgBAAAAgGwElAAAAABANgJKAAAAACAbASUAAAAAkI2AEgAAAADIRkAJAAAAAGQjoAQAAAAAshFQAgAAAADZCCgBAAAAgGwElAAAAABANgJKAAAAACAbASUAAAAAkI2AEgAAAADIRkAJAAAAAGQjoAQAAAAAshFQAgAAAADZCCgBAAAAgGwElAAAAABANgJKAAAAACAbASUAAAAAkI2AEgAAAADIRkAJAAAAAGQjoAQAAAAAshFQAgAAAADZCCgBAAAAgGwElAAAAABANgJKAAAAACAbASUAAAAAkI2AEgAAAADIRkAJAAAAAGQjoAQAAAAAshFQAgAAAADZCCgBAAAAgGwElAAAAABANgJKAAAAACAbASUAAAAAkI2AEsAk1zYAACAASURBVAAAAADIRkAJAAAAAGQjoAQAAAAAshFQAgAAAADZCCgBAAAAgGwElAAAAABANgJKAAAAACAbASUAAAAAkI2AEgAAAADIRkAJAAAAAGQjoAQAAAAAshFQAgAAAADZCCgBAAAAgGwElAAAAABANgJKAAAAACAbASUAAAAAkI2AEgAAAADIRkAJAAAAAGQjoAQAAAAAshFQAgAAAADZCCgBAAAAgGwElAAAAABANgJKAAAAACAbASUAAAAAkI2AEgAAAADIRkAJAAAAAGQjoAQAAAAAshFQAgAAAADZCCgBAAAAgGwElAAAAABANgJKAAAAACAbASUAAAAAkI2AEgAAAADIRkAJAAAAAGQjoAQAAAAAshFQAgAAAADZCCgBAAAAgGwElAAAAABANgJKAAAAACAbASUAAAAAkI2AEgAAAADIRkAJAAAAAGQjoAQAAAAAshFQAgAAAADZCCgBAAAAgGwElAAAAABANgJKAAAAACAbASUAAAAAkI2AEgAAAADIRkAJAAAAAGQjoAQAAAAAshFQAgAAAADZCCgBAAAAgGwElAAAAABANgJKAAAAACAbASUAAAAAkI2AEgAAAADIRkAJAAAAAGQjoAQAAAAAshFQAgAAAADZCCgBAAAAgGwElAAAAABANgJKAAAAACAbASUAAAAAkI2AEgAAAADIRkAJAAAAAGQjoAQAAAAAshFQAgAAAADZCCgBAAAAgGwElAAAAABANgJKAAAAACAbASUAAAAAkI2AEgAAAADIRkAJAAAAAGQjoAQAAAAAshFQAgAAAADZCCgBAAAAgGwElAAAAABANgJKAAAAACAbASUAAAAAkI2AEgAAAADIRkAJAAAAAGQjoAQAAAAAshFQAgAAAADZCCgBAAAAgGwElAAAAABANgJKAAAAACAbASUAAAAAkI2AEgAAAADIRkAJAAAAAGQjoAQAAAAAshFQAgAAAADZCCgBAAAAgGwElAAAAABANgJKAAAAACCbIRNQzjTzbOH1118O77z9drbOYPBtu9OxYdh0M4S33xoXThm10+AXULNlV1gjrLHWpsXjq644J9x9x7Xde4aOqT7wgbDqahuEeedfPMw22zxhiimnKor7z/23hcsuGT10Cq3RznuODjPONFu53fLOO2+HIw78RrnN0Dc5zl+A96uZZ5kjvPH6y+Gtt8bV+ic2rd1oiimmDO+++7/uv6AZZpp5jjDmjVfCW2/9txkFAzCkZQsoZ5l1rrDuBjuGBRZaOswx53xhqqk+UHTUf/87Njz+yH3hV788Jjzy0N1DuvMG6vv7nRM+OOOHyu2qV15+Pjz95IPh3n/eHG656Q/lz9+vfnzmrWHKKacs/rwdvr184//MDTbeLYz44hbF3/F/vz09/O7ik4fU37TgwsuEXb5/Whg2bLoedT315EPh4B+sX26/n5xw+k1h6qmn7fVPauK8m2ueRcIOu51Y1P/i80+G44/cpvuveX+bXOcveU2u6w3qFgO4FVdeO6wx4hth3vkWG++1SHz9//yzj4cLzjk8PPDvW8ufd6Jp7VatsdY3w0ofXyt8eIHFw7TTDg9j3ngtPPrwPeG6v/w63Pr3P5a/N6niB7Wzzzl/8fitcW+Gg0du2L2nf+IJJV/d6HthoUWXDbPONk/5/i1+4PvEY/eHK3//83DrzVd0/zYA9E+WgHKJpT4Rtv/ej8PUU09dFtKbP/3h7HDx+ceV2+8XJ5z+94n+7dFrr74YfnrK98P99/6j/Nn7jYBycB026srirIKW+IagddbyA/++JZx6wve697y/bLX9EWGmmWYv/6jFllipfFxHQLniyp8PW+9wZPH4lpv/GM44Za/uPWnENxpLLv3J4vH111wczvvZQd173t8m1/lLXpPreoO6HTv6+jB8+PTldl/uuuPaMHrUzuX2xDSt3ZYttjkkfGLVL5fb7S696IRw5eU/K7cH6rNrbxa+tume5XY0kNc+8aSS7+1zehGk9uWZpx8JP9pnvXIbAPpj0APKNdfaNGz0ze+XBUQvv/hseOzRfxVfE5hz7gXLJ747b7smnHrCrt2/9f5RDSjjJ45vv/1W8XjKKT/QI7h86623woH7rBteeuHp8mfvJwLKwRPPPvv+/ucU/2D8Ks7BP9gwPP/c44NXwBBy3Kk3lGduDORFeruVP/Wl8O1tDy0e33nbX5IGvfHs80OP7Tq7+n//+1/Y93sjig8z3u/MX3KYXNcbpHDSGf8oz7iL4nPXs08/GoZP/8Ew19wLl9+oif70f2eFiy8YVW5PSNPajTbf+qCwyqe/0v0XhDDmjVfDk48/UFx+pxriXnz+qPCnP5xVbvfXDDN+qPhwr9rvUX9f+yy17KfD9t87cbwxGjv2jaLmaaaZNsw2x3xF3QJKACbFoAaUw6ebIRz942vKJ7f4NYbD9v96ePGFp7rL6bLaZ79ehJj33Hn9+z6gPPHo7cK999xU/u1TTjlVWHX1DcPG39qn7Kf7/nlzOOGobbt/4/1FQDl4PrXa+mGzrQ4o/sFbbr4inHHK3oP3jw8xTQ4ot/ru4eFjq3yx6NE7br06nHbibkOsd9Mwf8lhcl1vkEIMEseN+2+44rIzw5+vOGu8687Hrw7vtu+ZYY7uryFH8QO4eOmjiWlau8OHfzAcO/q6sv6brr8snHX6D8vteCmoBRdZpngcv+my23Zd35gYiN33PTMsuviK5XZLfwPKw467Msz8oa5v4MQPuY89dMvw6MP/7N7bJX5D7sPzLTFJgSoAk7dBDSg32fwHRfgYvfnmmLD/Xl8Kr7/2Uq8jEM9a+PB8i4e7br+m/Nn7RfUMyvaAsuUL624TvrLhjsXj+Knqnjuu1r3n/UVAOXi+vP72YZ31tiv+wT9fcU749S+PHbx/fIhpakDZ/iHP/nt9ebI5C9b8ZbBNzusNUlhqmVXDPXddX263i5egOeTYP5TPcWeeum/4x9/+r3tv35rWbvU1/quvvFgEsdWb46zy6fXC5lv/qNw+ZdSu4e47+v9+aIWPjQjb7HRM8fiGv15SfNDX0p+AcvElVw677v2T4nH8ZteP9vlKj5NLAKAOgxZQTjtsunDMyX8tv2JwxWVnhN/86qTuMuqz/EqfC6t9dqMw97yLFp/Gxq9AxifRhx64M5x/9qFh7NjXy9+dmPhEvurqGxSPf/urk8ILzz8ZvviVbcJHlvh4mHX2eYon6fgV2dhuf64T2UlAWX0xEHX6QmL+BT9aXM9mmeVWCzPMNGv5dfn4NZpnnno43H3n9eHKy8/o/u3OpOqHaGIBZRzDb297WJim+++IL1Sv/uMvuvfmEW+YsOEmu4f5F1yy+OpM/IrLI/+5K1x26Wlh+RXXmKSb5KSav9Hsc8wXPjjDzMXjGHrHr+FUPfjvWzv+OlWKefaJVdcNn/rMV4vHl106ute5tPBiK4T1Nuy62/vNN15eXH9xICY1oIxvhtb56nfL7Zlmnj18aNa5isfxbIf4lad28cL/7Wcb9NfXv7l3WGOtrruOP3DfreG4w7fq3tO5eBmNzbc+uHj8z7uuD5dfempYZvnVw1c32iXMNsf8xbEprukXnn8iXHbxyf26SH9T5m+Kelua2L91H9erlljqk+Gza38zzD3PwsXZN/E1QFwjL77wdPjLH38Zrr/m1+F//3un/P1OpBi33tSx3qaeepoijIjHtxlmnKW4WVesd9y4N8NLLz5T3Eziur/8qqOzxNql6If4Wi0+vy3ykZWKGxj+982x4T8P3BGuuvK88Norz4f1N+k6Yzteguevf76g+//q22Ac1+vsh5Svd6qavC5Sq15r+C9/Oj9ceO4R3XsmzVBqt1rLVVecW9wYtCW+njrixKvGu87jQI4/U08zLBx10tVFO/H4Murw74QDj/xNub8/r332PuC8sMBCSxWPr736ovDLs7ouaQMAdRu0gPLjn1wnbLndYeU//P2d1+zz7MmBiG8Cttj2sLDix0eUP2sXz9r88bE7hv/cf1v5swmpXh/mysvPDKt9bpNe734c/fwnI8PNN1xebk9IJwFlvMN5fFEcdfr1jviCd5e9RpfbfXn80X+H44/cugipOpGqH6IJBZTxLNqRB10Uppt+hmI7vqE9dL+Nwtgxr3X/xuBbernPhO12GdXjWj5RfFP04L9vK2/A0p+AMvX87USnd/EejHl20XlHh6v/eF75b7Z8Zs2vh29s8YPi8aR8TX1SA8q1v/Sd8NWNOr+Af3TG6H3CLTd1XTtyIGKwccwp15XHjiMO3HRAgWd1/B5+8K7iZmRb73h0996eOumfJs3fVPW2NLF/6z6uR/HNcQzCV1p5rfJnvXnw/jvCsYd2fagzMSnHrV0d6y0+h+1/2CXjBQ29iUHthed13WSrE6n64UOzzl0EEfGDt978/cb/Cx//ZNflJf51943hpGO2797Tt+rzUN3H9RT9kPL1TtT0dTEYjjrpL+WHqb/99cnhD787vZZ/dii1e8rPb3+vroO+FR7+z13ldryp38c+8YVyO4ofhO+x/arldieql6eI4eTLLz8XfnTkb7v3dvbc3lK9xue+31s7vPLys917AKBegxZQfumr3y3+i2LQ9MM9xn/ynVQjD74ozDvfYuX28889ER575F9huulmDAsvtlzxZiOKN6X5wW5rd3RTid4Cnvhi9/FH7g3TTDusOIuspT9fw55QQBnrXGudbxdfxW0Fd3+77rfh7J/u3/0bfYtnde24R1cg1vqU/7lnHg3jxo0trulTrTd+mhq/UtKJVP0Q9RVQzjb7h8MPDr6wfGPw7DOPhsP337gIa3OJb94OOfa9rxrFPn74wTuLr+UstOiy5Rxr6U9AmWL+xjNBPl05gzJewLx6BuWzbWdQPnD/beHi848rt/syGPOs7jey7SY1oIx90DqeRTPPMmd5baY4R5/q5QzK8yfxDMrqMfTJJx4Ih4z8Wvee/qkGaPFYHM84ar3xiNcFfv31l4ozQluhSif906T5m6relqb0b8rjerT/4ZeGueZesNyOc+uJx/4dXnvtpTD3vIsUZ+fFeffYI/eGww/YpPy9CUk5bu3qWG/7HXZJmHuehYrH8QOs/9x/e3j6qYfD8OmmD3POtVCY58OLFs9/f73qwnD+2e99gDsxqfrhmJOvLT8QjOJZ9q+/+lKYf6Elezy/DYWAMkU/WBd5xTN4R516Q1nE4Qd8oxjTSTWU2o0fABx54lVlbdXn2IUWWSbstV/XzQzjcXe66WcsHsfjx05b9byOZF8WXnS5sOcPu64D2Vqrs885/4ACyvhBwAmn31w8bj0XfHSZVcNKK68dllzqk+Htd94qvjXy73v/Ea6+8rzxvqoOAP01aAFl9RPB+CY9no1Ql/gJYfykMIpP4ueccUC46frfde8NxcWod//Bz8oXsvHmOycf13Xtlwlpf6F6/723hBOP2a68qHf1rrJRe9jYl77u4v2BD0zd48y8u++4Lpz+4z2KC1JPTHxBEu8kfMXlZ4Yb/nppjxcJ8avJIw++oPw3Or2mTap+iHoLKOeaZ6Gw9wG/KAOS+ObwyAM3DW+9Na7YzuU7Oxxdng0UX6QdPHKD8mt5H5xhlvDDQ34dZpzpvTNPOg0oU83fdtWzcvtzd8x2gzHPhnpA2S71XbynmGLK4oL6rVD1xKO3D/fec2P33v7p7QzYGBLFNzDVs9rjG5D1vrbzRMOjps3f1PU2pX9THtfjhyOtG3JFV/7+5+HSC48vt6P4xnvrHY4K000/UzjiwK6vUU9I6nGrqmO9xeeE+PXKKNZ7yA83Ck8/+WD33i4xNFnri1uE5555LNx0w2XlzyckVT/ErzV/c8uuD0Jjuycd/d1w37+6QokY9O1z4C+KYLkld0CZqh+si7w22GT3MOILmxdFxA+Bd93m47UUNJTajR/+xPUUxfcAO3/nY91VhnD48X8qL1Nw1EGblb8X7bz1x8a7qVBf4vErthNfj1bD+YEGlPE1eTwTPIofWsTLAcVjfG/ih54nHfPd4lI/ADAQUyz2kZXfLbdq9N833ywfR9U70sUb34w+ftfuPZPu2NHXh+HDpy8eX3z+qF7vHjd9fBN04p/LcG737VcNb459o3tv76ovVOOT/O7bfzq8NW78v2u3fc4ov9L7q18eG6664r03dH2pBpQT8shD9xR3MR/Itan68vXN9glrjOgKHDo9MzNVP0TtAeWH51887LXfuWX/xD445pAtin83p2HDpy/OLmnV2tsb1vY39J0GlKnmb7u6AspOTOo8E1COL95cLN5kLJrUM9DbA7SnnngwHDxyw3K7v5o2f1PX25T+TXlcH3XajeUHTPE6sef97KDuPT3Fr7y2/7u9ST1uVXWst0UWWz7sMfLnxeOBnIHal1T9UL0mXrzsQ/vZ9DFQjtcRb8kdUKbqB+sin3hG8Q8OurB8nXX26fuHv13/XqA2UEOt3XjN1G137rpJYTxrfffvfqp4XH2N1nr9WP0qeKc3xYvXk177S13Xq4zXmI7/RQMNKJdebvWww24nlNstMUR99ZXni5uJVS9jEf+mvXZcbdBet087bFj5bwPQfFOssOKIJAHlC8+Pf32SeFe+1k0kenvDEs+wXOKjq5TbLfHswfvvu6Xcbjfr7POGg4/uugZQ+yeR7Xbc/eSw1LJd13A5+bidwj13Xte9p3fVF6p33XFtGD2q5zXnqi8EOr2OVDWgjHfvGzOm61qQ00wzLEz/wZnGe6KPZ06eeNR24cH733uRMimq1wK9956/hROPfu9rqn1J1Q9RNaCM1+HZY+TPyjcT8Yye44/cpseZoDnEm7PsOfJnxT9dfUHZLn5tp3X9rk4CypTzt91gBpSTOs8ElOOrzquBXPesqj1Aix8AxJtgDETT5u9g1NuU/k11XJ9jzgXKGzHEN7B77bT6JF83eDDGraqO9TbrbPOEg4/5fbl95I82C488dHe5PRAp+6EahPR1jbn41dP4FdQoZ0CZsh+si66b4M0wwyxln3Tqnf/9r8cHt52Kr3sPPe6K8ivN8fXfqCO+07134IZiu6t9buOwybf2LeqLZzb+f3t3ASZV1cdx/E93d7PSHSJISUhKiCggJQgikhIK6EuKhCKhooCk0ooIgigIqCAggjTSDVJL55Lvc87M3L07TO5ObHw/z/M+7zn3jLN3ztwZZn5zon/PmnoJoQ/G/KQ/D1+9ckGPelTMn5HHjewghw9u02Vn1GaIQ0Yv1f+N7b6NtkgGlObztdm57TeZOvEdY4MzNaKyVftBxrn+snya/Lhooi4746vrLENGyw8rAIDYIWAB5cARiyR7jvy61xytHad+Nc2Zu6BRt1H/AG7futqo2zP/EumNFUunyPIfXG8oY/6gumblbPl+/pN/p0btVtKsdT9dVgvIz5wS8R9xR1ytQamoX3vVdGLb2lUqEOvbpYrHQV2BwuWk0Utd9YcRNX3O2WjNIwd3yNiR7Y26M/7qB8X84Ut90bCFk4p6zN7svulP5imLrtZMe7vfV1KoaHld9iSg9Of1a8/XAaU/rzMCynBln6ltbGLji5FY5gBN/QDydqcK1hbvxbTrNxDnG1P611/v62XL15U3ulqCTLV28ND+lr8RFYF43mx8+Xr7dOrmCGs3Hjm0Xe9+vXvH+ieme3vCX/1gXl/Z1XvCKy3fkZp12+hyMANKf/WDwusi4mhab0Xmc1v8+Ankf8O/NZYQUJ95/9enbpR/2Iiu92teEkatzftOt6oyYOh8yZ23iD5m3pDL/MPBiIHN5MzpQ0bdkUEjvjf60f77RWQDSvP5Kmqt18HvNjDqNi3bD5Kq1S2zMTzZ1MdX1xkBJQDELgELKLv0+lRKlK6me+/wgW0ybpRlVIaNGkFZqIgl2DHvIOkuoDQvZO+NP39fJPNmfWjUHTF/UF007xNZu2qOtSVcZDbtcBdQKmrKhFq/yhbYqXNV5+yKWsi63+C5xppL7kQmOPJlPyjmgNKe+jI3dsTrRj2YzCOJnI02Utp3HinlK76gy54ElP68fu35KqAMxHVGQBlOjarImCmHLjt7/XnDHKBFdvqqTUy7fgNxvjGlf/31vt74le5Sr+EbuuxpiOVOIJ43G1++3swjye2pH+SOHtop3y8Y6/HmWf7qB/M1q2Z1DHg7fNSVWc26beWVln112dPn1h8/PPmrHxReF74LjjzVq/9UKVjEstakel2MGKTWaz1mbY286Hq/BQo9Lb3fm67PUT3eOTOGSbtOw3V947ofdF0xb06juOtb89IUB/79Wz79+E1ri0VkA0r1Y3TvAdOM+tdfDXS4Zm6atJll1IRVRt3d/fvqOiOgBIDYJV7u3KX8MsVbJOLdmn95V4ssDxvworXlSWp6QpaseXTZXUDZrPW7UqN2a11W0yJWLP3K2uLa0cM79K5zrvjjg7XiSUCp9Hx3shQuZpn2vvWvn2XGZNejV8yj9xS1W+i/uzfIpYv/SVjYbX0sz1PFjV84jx/ZLR8Pb6vLrvirHxT7gFJNB7Y9ZsWbdc/8yXyduQooW7UfLFWqW3bO9iSg9Of1a89XAWVMvM7sRXUXb3v+2iRH/Wjzdn/LNaFGNvXuXMmYUhVZ5jBCrfH60TDL9RcZMe36DcT5xpT+9df7uvqCrL4oKzu2rpGvJloCragIxPOm+OP1pqZEN331Hf3/zn6Mm/bFu7Jty69G3Rl/9cPTFepJxy6jdVmtef1er1rWloiqVH9ZT+NUghlQ+qsfFF4XlhkjtpDeG+q1op4Lb14zHbt+JE+Xr6vLakmIcaM6ytFD262tkRed79e8RIGi3mvUSGs16rBfj2rGRjjpMmSVEWN/sd7K/WeVkeNWSdr0lsBv84blcuNGxF3rU6VKLxUqNzTqaq1Z5fTJAy6XsVDTxod9HL4B1bD3mjjdBMf8mX5I/8Zy8fxJa8uTfHedxbP+PwAgNgjYLt7mLzrudubzJqA07zzpLvj0lr8+qHoaULZqP1CqVH9Fl48d2S1jXISJ5h1DlWlf9pdtf6806jbqQ736cK9Et4Dyx+8nyi/Lpknz1v2lem3Lrq7qA+vIwc3dfqnwN/NUR1cjT7v0/lxKlKqqy54ElP68fu35IqAM9nVWt+Eb8uIr3fW5ePp6cySmBJTvDVsgufIU1ufsyZpOnjAHaJ6+BzgT067fQJxvTOlff/37Zh7F42o5DG8E4nlT/PF6s1GzIULylZSSZapJ6XK1InwxDwu7I33equx2GRd/9UOekOLSf4hlpKirqZnmkYu+DCi9fV/3Vz8onpxvXHtd+Iv5xwxFbZ6pNtGMquh+v+q94PPpW43ztZk4tpseVGBTtERl6d7X8hnS1dILNpEdkXjm1CE9atUZ+5Gc/XrUkJs3rhh1M/W4bDO/orK+NQAg7gpYQGleOF9xNWLAm4BSLbI8YOg8XY7qelH2/PVB1dOA8rVOw+XZyo102d1Ou+YRXK4+bKgP9erDveJpOOGvflDMv7aafx02T7NTC32/36eO8atyMJg/KKoRqYPetUzjtmde/8eTgNKf1689XwSU/rzOzKNinPWdWgdU/equeHOd2TPvAPv2m896tIuwK+Z+UV+w1BetqFI72r//wUJdVtPA3ulaVQcZUeXLAC2mXb+BON+Y0r/+el9/Kn8peWegZUdlV2GXNwLxvPnr9eaM/bpuH7z/kttprf7qh2TJUsrYSZbNY9SPgt07lLW2RKSmoVawfibxNKD0x/u6v/pB4XURGObPI8rXUwfJ5g3ho/QiK6bcr/36tI5m5phfF6EXTsvgfuGjHx3xV0CpeBI8qjU/J84I39S0b9eqUV5HFAAQ9wQsoFT6/u9ryVeglC6rNZfUQtCOeBNQ2v+y99mYLpHeRdCevz6oehpQmkM6dzshm0etOPvikCBhQvnki/XGLuGehhP+6gfFWUCppsAM+2iZ0aauAXUtBIv9VBu1w6KaWmaWIkUaGfNF+K//zr6Mmfnz+rXni4DSn9dZrfrtpGmL3rrs7BoaPmaFZMiUXZed3cYT5vcY84L0kWUOpVy9t3mjZ7+vpLB1yYY/f18s82Z9YG2JGl8GaDHt+g3E+caU/vXX+7p63Y+fEv4e9s3UwfLXhvB1zyIjEM+bv15vrnzw8XLJmDmnLn85vofs2bne2uKYP/vBHEBM/qy37NoWPiPDRr2vJ0+RSpedvf/b88f7uj/7gdeF/5nXMlW+m/ux/ParJXCOiph0vx3eGiXlnq2vz1v9KPBut+eeWF9y1ITVkiZtRl1e8t3nsuony7qVzqhwMmkyy+vTkcxZcslbb08w6h+8b93Q5vY1vbSDK117T5Tiparo8tpVc2XRPMtGYmbmH/LVjzw9OpaztgAA4LmABpTmX70VZ7uCehNQKuaNSVRopHa6u3XrmrU1IvXlMX/B0m53clT89UHVXUCpflVt1rq/sZah4u5LnnnUitoBsX+PGnpKiFnbjsOkYtXwqVCehhP+6gfFWUCpmNe7UmZOeV+2bFph1ANt0MgfjJ3VHQWm7Tp9GGF9H08CSsVf1689XwSU/rzOzDuzqvtUUx7Vh1ybMuVqSafunxh1b64ze+ap+L4Y8WjeBVePvur2nITdtaz7GhkZMmaX4Z9YrnX15UWtCadGEvuCLwM0JSZdv4E435jSv/58X+/YdYw8Xb62Lqv3idFDWsqF8yesreGeKlBGipesrJf3cMef15k/Xm/qPaFI8Yqyaf1Sh2vyqY3wRn+61vgsoMICT3b29lc/vPX2p3r6uaJmbHw4sFmEKecVKjWUdm+GbzDjaUDpr/d1f/UDrwv/UiMC1chAG9vSPlEV0+7XPGJbsR9Bal72QL0nqZ2+7965ZW2NnMhukqOYN8pRr99B77wQ4Uf6ePHiy6CRiyVrtry67m7WFwAAzgQ0oFTMu+opF86flD071smRQzskeYrU8mzlxpKvYPg/mp4ElEmSJtfrL9qmS6g1Llf/PEsOHdim/wHNpPAVyQAAIABJREFUnjO/5H2qmP6ArXYId7VLpZm/PqiaA0r1j/i1qxd1OVGipJImXSZJlz6LMZJB8WSKsxq19ulXfxthn3qMG9ctlh3/rNWjMOs0eF0HxGaehhP+6gfFVUCpmDcKUh+KhvRrJJcvnbW2BlbxUtWka+9PjT+6Z+ef8vvq+frDY/Varxpf7mw8DSj9df3a80VA6c/rLFHipDJu0p/Gta+m0v/w3afy4ME9KVq8YoS1qhRvrjN7+QqUlr7/m2XU1RSnQwf+kUfWL85/b1rh9ahKNWrMNmr09q0bsnnjjxJ64T/jS/72rb+6HaVgYw54fLXRiI2vA7SYdP0G4nxjSv/6831dTRke/Zl6T7P8O6feI9Vu2Af2bpbr1y9JrjxFpGSZ6vo909N1Kv15nfnj9WYL5tR5qvWg1SwItRmFWse3VNkaevRUylRp9W29mabsr36w3whDvf8t+e5TuXolVPeN/a7ZngaU/npf91c/8LrwH/tZJoraqM2Vvbv+dBssx7T7tTGPHFbvkRvW/SCHD/wjhYtWiPAjr7sZVJ6KSkCpfPLFOv09TVGvt2WLJ8rRQzv0KPAXXuwsmbPktt5S5KNhbeTEsT1GHQAATwU8oFTM6xi5oj5QjvmwrVy6eMY45oz6Uti55zgjIHAl2B9UzQGlO+qD9pgPX5Mrl84Zx5ypXru1NLdugOOMGi1WorQlSPM0nPDnB3Z3AaX6EqKmudh2XPZkHR5/Mo+8c0SFqLYvYp4GlIo/rl97vggoFX9dZ4p53VVHDh/YJvkLWdZH8+Y6c8Q8YsjeT0sm6/95Q21opTa2cmb6pAHyz+bwZQKcUV+2Pvr8N+N1MfjdhhJ68bS1Nep8HaApMen69ff5xpT+9ef7ulK8VFU9Ms4WIDnjaUCp+ON589frzTxy0B1vpyj7ox8U8wZ1jqgQxdZPngaUir/e1/3RD7wu/CdN2swyasIqo+4JT/6Nimn3G37eGeV/wxcZP1Q4cva/YzJ6yKtPzFSJjKgGlFmy5ZX+Q+YZn8ed+WvDMvlmavjsJwAAvBGUgFJRX+abNOtp/BpnpkKeX1fMkmWLv3S7q6VZ0mQp5PW3RkuxEpWND9Fm6sP1scO75LfV8x3ucG2vVfvBxjTrBbNHybo14dMxbMy7STqbsm7PfnFsM/Wr5O1b1yT04hlZuXyG7Nnp3Y6GNeu0kZda9IowAlNRH25++PYzOXv6kLzd/yt9zNVu1Gb+6gfFXUCp5C9YVvq8P8Oor1g6xe0v6v6k1tNS62rZ27juBz3atW7Djrrubcjl6+vXnnkH1pXLp8vSRZ9bW7znj+tMUYusv/7WSHm6fF3jmGL7tV4tuB6Z68wZ9TxWr9VSr91k7vPITjvLkbOANG7WUwoXffaJHyFcbQxm1rLd/6RqDcuC9Yf2/yPjR1uuJ18pVKR8pJ4bd2LS9evP840p/evP93UbNY25U7cxxih4e2oGxeIF42TX9t+NY+74+nnz1+tNbQyopkTnzlvkifdJGzVye8E3I/QMEm/5uh9snP0ApYLktSvnGNO8vQko/fm+7ut+4HXhPyqQUz84e8OTf6Ni2v2aqRHVvd+bYSwfZKOu2yMHt8tnn3R2OXvKG2pt9+FjftJldf/ONsNyRY1GVudrm8ptpl7Pc2cOlb83Wv4GAACREbSA0kYFdWpKd+68xfWohWNHdno0WtCdrNlDJG9ICUmTLrNcCj0jF86dkDOnDkZY+yi2UlOq8oYU09PowsJuy797NvqkTxFOfeHKm6+k3vTpv1OHZP++zT77EKnEhOvXn9eZCgzzF3pa//+/uzfIf6cPG22xmf10SF9s4BMMMeH6NeN8/S9r9nzyVP6SkjJVejl39qicPrE/yst1RPV5C9TrTa03p6Y/ps+YXR49fCjnzx2X/84c9tn7ZVT7wZ5ayiN/gbJSoPDTcvXKRdm943e9PEXZ8nXlja4f6dt4E1Da+Pt93df9EAjR8XWBwFOvuUJFKkjO3AXl8MEdcuzwTq8GaASa+oyS56kS+jPw9auhcvTILrl4/mSgTwMAEAsFPaAEAFg0fKmLXstJUaOrRgyyjOwC4Hu83rwT1YASAAAAcIWAEgCiicavdJe8IcX12SxfMkWOHtoeTc4MiH14vXmHgBIAAAD+REAJAAAAlwgoAQAA4E8ElAAAAHCJgBIAAAD+REAJAAAAl4qWqCyde47T5X/+XiXfTB1kbQEAAACijoASAAAAAAAAQNAQUAIAAAAAAAAImnjzTn39OGh/HQAAAAAAAECcRkAJAAAAAAAAIGgIKAEAAAAAAAAEDQElAAAAAAAAgKAhoAQAAAAAAAAQNASUAAAAAAAAAIKGgBIAAAAAAABA0BBQAgAAAAAAAAgaAkoAAAAAAAAAQROUgPLB/YeyY9U+2bn6gFw6c0Uun7kmSZInkjRZUkuWkAxSpHI+KVzpKUmeOqlXHfPo4SP5+8ddcnznGTm9/7yEnroiWfNllOyFskjhiiFSsmYh47aeOLTlhPy7/rAul3+xpGTLl8naEu78sVD564eduqzOudCzIdYW965dvClrZmzU5bylckrZekXl5N6zsn7BVjmx+z+5fvGmpM6UUnIXyyZVWpSVvCVzWv9Lz5w5cF52rdkvZ4+EypkDF+TWlduSMVc6yVYgk/5b6lzjJ4hv3N4Tx3edkd2/H5SzBy/I0e2n9fMWUjqn5C6WXaq8WlYSJ01s3BYAAAAAAABwJ+AB5a2rt2XSWwt0eOhK4z41pdLLZYy6O9dDb8q3H/4ih7ecMI7ZK1u/qLzYt5YkSZbIOObK73P+ll8mrdfltqMaS7HnClhbwu3bcES+7rdEl2t1rCi1OlSytrinAsTPO8zR5XINi0u5BsVkcpeF1tYnjd7Q1yi7cj/sgfwxd4usnm4JP50p/2IJadqvjlF3RYXKv3+zWVbP2GQcs5c5JIO0Ht5QsoRkNI556uDmYxIvfnwp8Ewe4xgAAAAAAABiv4AHlHMHLZPdaw/qnlWj78rULSoZcqSVsDv35NLpq3rEYtjt+9KoVw2p3KysR8/A48ePZWLHuTrwsylRs6Ckz5Zazh+/Ivs3HDGOl65dWF4d2sCouxLIgLJA+bzy3yHLKEclR6EsevTkxROXjTDX04Byzv9+lD2/HzLq6r5yF88mKdIkk/PHL+mRj+rvlKlXVFoMqm/czpUFQ3+SHb/uN+qFK4Xo+71zM0z2bzyqR8EqKdIll3fmvy7JUnk3+nXL8t3y/ahV+rlRzxEAAAAAAADihoAGlCrMGlZ3ou5ZFU72mt1e0mVNHaGn74fd1wFm6kypJH+53MZxV8yjGNX9vvFZM8lVJJu1VXTo+c2ApUa995x2Ho3yC2RAaaNCw8a9a0qylEmMY2q6+obvtnkUJqqRiDP6LDbqTfvXkfKNSxh1Jez2PVk1bYPcuX5Xmg90f59Ht5+Sr7p/q8uqf9uMfDHCSMd7d+/J4tG/GgHmc63KyQvdqllbPWMLKJX63apJtVblrC0AAAAAAACIzQIaUJ4/dknGt5ml+zNn4SzSfXobn/TtpC7z5cSu/3S5Ue+aUvmVJ6eG/zh+rWxctF2XyzUoLq+8X9fa4lygA0o16rP18EbG3/eWGkk6tuVMY8TlC92fk+daPmNtfZKaCp4oSUKj7syE176Wc0dCdbn1h42kRI2C1pZwd2+FyZgWM4wRoB+s6eHVepRXzl2X6b0WGedeuUVZadCtmtdrZAIAAAAAACBmCWhAeePybRnRaJLRQ+8seF0y5kpv1CNDhXLvVRln1Aet6KqnMtszr/eoNs7p9U07a4tzgQ4o+8xtL5nzZjD+vreuX7whI5t8pctqpOP7P3bxeL1NZ25cuiUjGk/WZTV9e9DyLtaWJ6344g9ZN2+rLnef1lpyFslqbfHMrWt35JsBS4ywWQW2zQfWk0RJovYYAAAAAAAAEH0FNKBUPm4+zVivUKnQpJTkezqX5Cqa7Ynp3p4wB2jpc6SRft++YW2JSG3yMrD6BKPuyXqOgQwoXZ27p47tOC1Tulk22SlSJZ+0+6iJtSXy1K7dk7ssMOqeUsFi2frFjLqn1HTx+UNWyL4/LeuG5i2ZQ177qInXO7oDAAAAAAAgZgh4QHlk20mZ2uM7h72jRuiVrFlQKjcvKxlzpjOOu3J6/zm9QY6iwqy3Jr1qbXnSkNqf6Q14lME/d3MbegUyoFSb5HQc/7LxtyNj6/Ldssi6jmOVFk9Lw57VrS2Rt+2XvfLt8F+MuqfU31bnEBkPHzyUyV0XyKm953S9/SdNpXDFEGsrAAAAAAAAYpOAB5TKhROX5c+FW2Xnr/uNwNDeW5NaSN6SOY26M8d3npbJXS2jBt2FfCObTJHrF2/q8ntLOkuaTCmtLY4FMqD0dF1MV9RGOssm/KbLNds/K3U6Vba2RN6mxTtk6dg1upzv6dxStaVnm9dkzpte0mdLY9S9sWHRdlk2fq0uq6nqPWa29TiwBgAAAAAAQMwSlIDSRo2UCz15WY7vPiv7/jws+zceM9oy5konfea1l/jxXW+ScunMVRnTfLouZw7JIH3mtLe2RGS/VuWIP3pJgoQJjLojngSUO37dJwuGrtDlWh0rSq0Olawt7pnXxSzXsLi88l7UAkrzbuZqN3BPdv1258Bfx2RmX8uu4MWeyy9tR71obfG9R48eycopf8ofc7boupr23mHcy4STAAAAAAAAsVhQA0p7h/85KdN6hk//HvDDm5I2cyqj7ojaiXpQzU91WY22G/JLd4c7P18PvSkjX5yiy6kzpZT3l3S2tjhnHj2oRjeqUY72/pi3VX7+4g9dDnZAeeH4JRnX2rJLuqcbAbkTevqKfNJihi77cud1e+p5XPzRKtm+cp+uq7/VbkxTSZU+ufUWAAAAAAAAiI2iVUCpzOq3RPZvsGyQ0m1aK8lVJJvbfh/ecJLcunJbl18f21QKPfvkeoXmsDH/M3nkjQmvWFuc27X2oMwbtEyXnYWPM/p+Lwf/Oq7Lzm7jjK9HUN4Puy+Dan5m1DtOeEUKPJPHqEeG/eZCPWa0kRyFshh1X9n60x5ZNHKlLheuFCIthzWUJMkTW1sBAAAAAAAQWwU0oLx55ZacOXBBh2aORjmG3bkvY1vOMNaJ7P99J4929l49c5OsnrZRl58qk1OHlImSJLK2ity6dke+6DTX2D381aENpHTtwtZW58w7WKvpxn3nvR5hWrj9DtfBDiiV1TM2yerplr5QU97fGP+ypM705CjU88dC5dS/5xyOCrW39uvNsuqrP3VZrUOpprsnTZHE2hqRCl3PHw31egfvLct3y/ejVumg9qV3a7mdfg8AAAAAAIDYIaABpS3QU1OsKzYtJbmKZpf02VPrjXKO7Twt21f+a+zc7M104tvX78pHL39lbLijQsrqbctL+hxp5cKxS7Lii3USeuqKblNrW/ae086jAExNOx798lRjdGbBZ/NKjbYVJH7C+HJ63zljQxqb6BBQ3rt7Tz55daYR8qpp7y90r6ZHPSZLlVQunb4iR7eflt9n/+3xOpVqZOb4tl8bAa96/tQGPNnyZ5LkaZLJ1XPX5cKJS7Ltl3/lxK7/3O6m7ogaQanu5/kOFSVevHjGcQAAAAAAAMRuQQkoPeHtVOKdq/fL/CE/GXVHVFjXfkxTCSntfndwG/NGOY48+1Ip+euHnbocHQJK5dS+s7ovbIGiM54GlIoaGanu0xb0uhKZgFJtkONuQyQAAAAAAADEPgENKK9fvKGnIO9df8QYlWhPTb2u0e5ZyRKSwTjmqbNHLsrCYSvk3JFQ45iNmprcbGA9t5vu2Hv08JGs/fovWT19k3FMUaMIG/asoUNP2y7XalRhzfbPWm/h3tnDF+XTdt/ocoUmpfTUZl9R0+VXTf1TNizcZhwzK1Ilnx5lmqd4duOYO2p05pqZf8lfi3cYo1XNVF+UrlNUP4fehMAAAAAAAACIuwIaUJpdOnNNboTekOuXbkv8BPF0cJguW2pJkTbquzarKd9qR+trF25IhhxpJVPeDJIkWfialJGh1rFUayvevHJHchbJIumzpTHaorPHjx/L1fM35OKJS3LnRpikzZpaMuRIIynTpYj0aav7vHbxplw8cVluXb0tqTOm1IGtWi/Uk6nzAAAAAAAAgE3QAkoAAAAAAAAAIKAEAAAAAAAAEDQElAAAAAAAAACChoASAAAAAAAAQNAQUAIAAAAAAAAIGgJKAAAAAAAAAEFDQAkAAAAAAAAgaOLlzl3ycdD+OgAAAAAAAIA4jYASAAAAAAAAQNAQUAIAAAAAAAAIGgLKSGgyso8kSZFMwm7dkSXvjzOOAwAAAAAAAPAOAWUkvLNursSPH18eP34sY6q2Mo4DAAAAAAAA8A4BZSQQUAIAAAAAAAC+QUAZCX1/my0JEiWUh/cfyNgabY3jAAAAAAAAALxDQAkAAAAAAAAgaAgoAQAAAAAAAARNUALK+AkTSP33u0jOEgUlRYZ0kjBxQnkQdk9uXLwshzf8I799PidSHZK1UIg0GNxdl09u3yu/fjJDitd/Tqq80UxSZEgrCRImlIcPHsjtq9dl48wfZOfS1db/0rWXRvWVVJnSG3WbuzfvyLe9PjTqAAAAAAAAALwT8IAyY0guafnFYEmWOqVxEvaunjkvszsPljtXrxvHPFGoZkV58YOeunz55FnZsnCF1H23o7X1SR9XaWmUXem95htJlCSRUbfxxS7e5Vs3lscPH8qWBT8ZxwAAAAAAAIC4IrABZbx40vvXGZIoaVKjf6+fD5Wbl65K6iwZJWWGtMbxa2cvypRmlrDRU+aA8s61G5IkVQqJHz++rt+/e1fCbt6VpKlT6hGbiqcBZZspwyVV5vARlLbRlL4IKOu911lKNqgu/yxaKWsmzDKOAwAAAAAAAHFBQAPKyh1elsodXtH9qsK9FR9Okr0r1xv9rKZiV2rf1Kgv6vexHN243ai7Yw4oba6cuSDzuw2Tm6GXjWNFalWSKp1ayNQWbxvHvPHOurk6+PRlQKkc2fCPfN//E2sLAAAAAAAAEPsFNKB8e+UMSZIime7V/Ws3y4+DJzzRw+1njZbM+fPo8uVTZ2Vayz7WFvfsA0o1OnPyyz2Muq/4MqDMVjS/tJw4xBjVee7AMZnTeZA8evDQegsAAAAAAAAg9gpcQBkvnvRbP8/oya9a9NJrTdozh4xq45xxz7eztrhnH1B+13e0HNu806j7ii8DSiVtjizSbsYoI7xVwerMdv0l7OZt6y0AAAAAAACA2ClgAWWGvDmk4xzL9OWH9x/I2BptHfZowiRJpM+a8LUYPV0nUjEHlK7+RlT5OqBU1NqYHb4ZIykzWtbhvHvztsxs109unL9kvQUAAAAAAAAQ+wQsoCxSu5I0GmKZbq3Ct8/qOd9d+9318yRevHi6PKX523LtvwvWFtfsN8n5vMGb1hbf8kdAqSRInFB6LJ8qiZNbNhFaP/Vb2fT1D9ZWAAAAAAAAIPYJWEBZukltqfNOB92D7sLDvr/PlgQJLWsyftPxfb0uoyfMAaW361d6w18BZeMPeknhmhV0Wd33wrc/lJPb/rW2AgAAAAAAALFPwALKHCULS+svh+gevB92X8Y//5rj3rRbq3Jszbby8N4Do+5KhIDy5FmZ1ipmBJTx4seX1pOGSfZi+fW5q+np3/UdRTgJAAAAAACAWC9gAWXiFMmk18oZukPV6EC1PqSjnaozhuSSDrM/1uWHDx7I2OqeryMZEwNK1S/tZ46WtNkz68dw785dmd1poFw6fsb6qAAAAAAAAIDYK2ABpWKbGq2sm7JQ/pq95ImebTSshxR5vpIu37l+Uz5/oZO1xb2YGFDW7d9JSjWqqc//1uVrMrN9P7l9+br1EQEAAAAAAACxW0ADyuYTBkrecsV0j965fku+at5Twm7eNno4bY4seqfvBIks60/+s2ilrJkQvqO3OzExoKz3Xmcp2aC6npI+q31/eXDvvvF4AAAAAAAAgNguoAFlmmyZ5M1vPzV26FYh5d9zl8rZ/Ucld5miUr5VY0mY2BJOPrj3QD6t97rH608q/ggoi9d/ThKnSGHUlVq9wtfPXD3hG6Os3L9zR3b/9LtRd0eNoEyXM6ss6PmhmvtuHAcAAAAAAADigoAGlErNt1+Tcs3qu+xbtUbl6vEzZfviX41jnvBHQGmelu6JR48eySfPtTbq7qgNch4/emTUAQAAAAAAgLgk4AGlkr9qOWk8tIckTJL4ib6+e/2mLOw9Ss4fOGoc81SBauXlpRG9dTn02GmZ0fZda0vk9f19tiRIaBnV6QlvA0oAAAAAAAAgLgtKQGmjpnznfaaEZAjJKef2H5Vjm3fJnatsEAMAAAAAAADEFUENKAEAAAAAAADEbQSUAAAAAAAAAIKGgBIAAAAAAABA0BBQAgAAAAAAAAgaAkoAAAAAAAAAQUNACQAAAAAAACBoCCgBAAAAAAAABE28eae+fhy0vw4AAAAAAAAgRhhQeaxfzpOAEgAAAAAAAIBbBJQAAAAAAAAAgibWBJTLP/tdbl6+9URHxk8YX5oPrG/UETfEpOvh8D8nZd+fR/QT80zDEpI1X8a48SQBAAAAAADEphGUHzefJpfPXHP4pI7e0Ncox2arZ26S0/+e9eohps+eVhr3rmnUY4uYdD38Pudv+WXSet31bUc1lmLPFYgtTwMAAAAAAIBbsWYEpQrnbl25bTywTd/vMMpxJaCc1W+J7N9gGYnnqcwhGaTPnPZGPbaISdcDASUAAAAAAIjLYk1AaW9cm1ly4dglXY4rAeWikStl38aj1h5wzhzk5iycRbpPb2PUY6vofD0QUAIAAAAAgLiMgDKOOb7rjEzussB41B3GNZWCFUKMemxFQAkAAAAAABA9EVDGIffD7sun7WZL6Kkr+lGXb1xCmvavEyd6gIASAAAAAAAgeiKgdCP09BU5uPm4HNx8QkJPXjbCvTwls0u2fJkkpHROKVWrsPXWkXPmwHnZtWa/nD0SKmcOXNBTsDPmSifZCmSSsvWKSqFnQyR+gvjG7SPr12kbZM3Mv3Q5Rbrk8s781yVZqqTW1uAIRP8qvggo9647JAc2HdPlKq+Wkzs37sq2n/+VQ1uO6w2a8j2dW0JK5ZDKzct61a/2U7xzFc0m21fukyPbTsrBv45L6kwpJU+J7FKz/bP6mvNGoPoXAAAAAAAgsggoXVDB4ecd5hh1Z8rULSJN3qklSZInNo554n7YA/lj7hZZPX2jccyR8i+WkKb9ojbS8b9DF+Sz9rONenSY2u3v/jXzRUD586T18secv3W5WpvyRtme2nio/ZiXJH22NMYxV8wBZdMBteXPhduMc7X3xmfNJP/TuY26K4Ho34Obj0m8+PGlwDN5jL8LAAAAAADgDQJKF07vPycTO87VZdsotgw50krCJAnl8n/XZNuKvdZbijxVJqe8ObGFUffEnP/9KHt+P2TUcxTKIrmLZ5MUaZLJ+eOX5Oj203o0ZZl6RaXFoPrG7bz18MFD+fLN+TqwUqLL1G5/96+ZrwNKm6z5MkrBCnnl9vW7snvtAQm7fV8fT58jjfSd97okSJjAekvnzAGljQo5nyqdU+6FPYjQD95sahSI/t2yfLd8P2qVvDq0gZSuHbWRxAAAAAAAIG4ioHThwvFLsuLL9VKxaSkpUD6PxI8fcZr11fPX5fOOc41dsbtObSW5i2aztrqmRp7N6LPYqKu1IFVwaBZ2+56smrZB7ly/K80HRj6g/GPeVvn5iz90ObpM7Vb82b/2/BFQqkCu2cB6Rgh5+b+rMrnrQrl+8aautxreSErWLKjLrtgHlBVfLi0Ne1Y37vfCicsyrtVMa6tIz1ltJXuBzEbdmUD0ry2gVOp3qybVWpWz/nUAAAAAAADPEFBG0YZF22XZ+LW6XK9LVanepry1xbnHjx/L2JYzjfUsX+j+nDzX8hlr65PUVPBESRIadW+Enrosn7waHm5Fh6nd3ohM/zrij4By6KrukjRFEqOu7Fp7QOYNWq7Lno52NAeUKkAe8H2nJ57vpePWyKbvd+hy6xGNpER198GnJ6Lav1fOXZfpvRYZ13LlFmWlQbdqPlkzFQAAAAAAxA0ElFGkNjKZ2uM7XVbhTKOeNawtzl2/eENGNvlKl5MkTyTv/9hFkiRLZG31nUePHslX3b6V47vO6Hpk1rJUm6zcvRlm1D0VL148yV4ws/7/qIhM/zri64CyXMPi8sp7da0t4e7dvSeDn//cqI/4o5fbad7mgLJam2ekfpfnrC3h/l62SxaP/lWXG/epKZVeLmNtiRpf9O+ta3fkmwFL5MSu/3S9RM2C0nxgPUmUxPfXNAAAAAAAiH0IKD1w9shF2fzDTj1lNvT0VWMKr70KTUrJS+/WMurOHNtxWqZ0W6jLRarkk3YfNbG2+NbmJTvlhzGrdTmyU7un9vxOjvxz0qh744M1PSRxUvcb2/i6fx3xdUDpKiRUG//Y1vsc8MObkjZzKmuLY+aAUj0+9Tjt/bv+sHwzYKku1+lUWe/o7alA9K8KZucPWSH7/jyi/2bekjnktY+aSPLU3l1vAAAAAAAg7iGgdOHB/YeyaMQvsuPX/cYxVzwN0LYu3y2LrOv2VWnxtF5v0NfU+o2jm0416pGd2u3PgNJf/euIrwPKVsMbSsmahawtEc3qt0T2b7AEdV2/aiW5i7leN9McULYZ2ViKVytgbQm3b8MR+brfEl2u1bGi1OpQydriXCD7V1GbMU3uukBO7T2n6+0/aSqFK3p/zQEAAAAAgLiFgNKFHyeslY3fbTfqxasXkHxP55bUGVMYawSeP3ZJfvrcsgGNs2m/9jZ8t02WTfhNl9VIODUiztdmvbtY9m88psuRmdptozbzuR56y6h7Kn78eFK6ThGXaxH6q38d8XVA+droF6Vo1fzWlojMAWXHCa9IgWfyWFscMweUbUc1lmLP+SagDGT/KuZPJW61AAAaY0lEQVT1LNXSBT1mtpWMOdPpOgAAAAAAgDMElE7cuRkmw+pONOqdv2ghIaVzGnWbvesOyez3ftRlTwM0c9hUpl5RaTEo8jt0O7Jt5b/y7Qc/63Jkp3b7mz/71xFfB5RNB9SW8o1KWlsimtxlgbHuZ+857SVLSAZri2P+CCgD2b9qrdOVU/6UP+Zs0X87fY400mHcy4STAAAAAADAI7E2oJzw2tdy7kiofpDD1779xK7I7hz+56RM62nZPKR07cLy6tAG1paI1s3fIismrtNlTwM0tdbiuNazdDlrvozS65t21paou3H5tnzSYpqE3b6v656M4AsGf/avI1G9HhRzQFmrQ0Wp1dFxSDiyyRRjHU1HO33b80dAGaj+VTvML/5olWxfuU//XbVzebsxTSVV+uTWMwEAAAAAAHAt1gaUs99bKnvXHdYP8p2FHbwezWUOhJytE6nW3Bvf5msJPXVF1z0N0O6H3ZdBNT8z6r4MEecNXi671hzQ5ais2ehv/uxfR6J6PSjmgFKNEnx3Yccndik/vf+8TOw4R5fVNOdhv/a0tjjnj4AyUP279ac9smjkSv03C1cKkZbDGkqS5M7XHQUAAAAAALAXawPKnyetM6acVmtTXup3qWp9yJ4xj3LMHJJBes5oKwkTJ7C2Wvwxd4v8/KVldJ/iTYC2esYmWT19oy6r+39j/MuSOtOTuz2fPxYqp/49J+UaFDeOOaN2UP66vyXESp0ppfSe3S7aTe228Xf/2ovq9aCYA0ql1fBGUrJmQaOupjovGLrCCIirv1ZB6nWuYm11zh8BZaD6d8vy3fL9qFX6uVFheIKEEZ9DAAAAAAAAd2JtQKk2VxnfxhKAKWoaca7i2SVBAsuIt/zP5HE5ik6N3vug/hfGVOm8JXPoECZvqRxy89It+Xv5Htm2Yq/11hbeBGj37t6TT16daUwFVqPtXuheTXIUyqJDxUunr8jR7afl99l/e7RO5aOHj2TEi1Pk1pXbuq4CyoLl81pbXVN/N3nqwK5R6e/+tRfV60GxDyiVRm/X0Bv73L0VJpuX7pLtv/xrtL2/tLOkzpjSqDvjj4AyUP2rRlBePXddnu9Q8YnRpAAAAAAAAJ6ItQGl8svk9Trgc6T5oPpStl5Ro+6ImhKspga7okbj2UIrbwO0U/vOyvwhP8nlM9eMY454ElA+uPdQBtaYYNS98e63b0iGHGmMeqD4u3/tRfV6MAeUavMhWxjsyEv9akmFF0sZdVf8EVAqgehfNWo0fnznO7UDAAAAAAC4E6sDSmXX2oOyZdluObnnjDFaT3l16AtSunYRo+7Mnj8OyQ9jVj8RRqk1CBt0ry7ps6eRT9t9o49FZs3HsDv3ZdXUP2XDwm3GMbMiVfJJ9bblJU/x7MYxRx7cfygDq0cuoBywuJOkzZLaqAeSv/vXXlSuB3NA2WFcU9m77ohsXrLT2mqhRsK2/KCRFK4YYhxzZ/38rfLTxD90ud3HTaRI5XzWlnAH/jomM/su1uU6nSpLzfbPWltcC3T/AgAAAAAAeCvWB5S+oHYqvnT6qoSevqJ3f1Y7FadI69tdih8/fixXz9+QiycuyZ0bYZI2a2o9qjFluhTGbWKrQPSvL5gDStvGRmrDozP7z8uNK7cle/5Mkj5H2mg31Tmm9C8AAAAAAIibCCgBDzkKKAEAAAAAABA1BJSAhwgoAQAAAAAAfI+AEvAQASUAAAAAAIDvEVACHiKgBAAAAAAA8D0CSsBDmxbvkK3L9+jyS/1qSc7CWa0tAAAAAAAAiCwCSgAAAAAAAABBQ0AJAAAAAAAAIGj8FlDmzl3ysVEDAAAAAAAAgAAioAQAAAAAAAAQNASUAAAAAAAAAIKGgBIAAAAAAABA0BBQAgAAAAAAAAgaAkoAAAAAAAAAQUNACQAAAAAAACBoCCgBAAAAAAAABA0BJQAAAAAAAICgIaAEAAAAAAAAEDQElAAAAAAAAACChoASAAAAAAAAQNAQUAIAAAAAAAAIGgJKAAAAAAAAAEFDQAkAAAAAAAAgaAgoAQAAAAAAAAQNASUAAAAAAACAoCGgBAAAAAAAABA0BJQAAAAAAAAAgoaAEgAAAAAAAEDQEFACAAAAAAAACBoCSgAAAAAAAABBQ0AJAAAAAAAAIGgIKAEAAAAAAAAEDQElAAAAAAAAgKAhoAQAAAAAAAAQNASUAAAAAAAAAIKGgBIAAAAAAABA0BBQAgAAAAAAAAgaAkoAAAAAAAAAQUNACQAAAAAAACBoCCgBAAAAAAAABA0BJQAAAAAAAICgIaAEAAAAorHRG/pG47MDACByBlQea5QBAkoAAAAgGiOgBADERgSUMCOgBAAAAKIxAkoAQGxEQAkzAkoAAAAgGiOgBIC46fHjx3L7+l1JnDSRJEqSMNZ1QmwJKN/6soUkSpZIHj54JF92mhfrnqdAIaAEAAAAojECSgCIHi6fvSY/jlvj8GSSpU4mGXKmlYw500qhik9JspRJjDZv3LlxV9bP3yoHNx+X0/vPG8eTJE8kOYtkk8KVQqRghbySJSSj0RZTxZaActSffSRevHj6aYgtjykYCCgBAACAaIyAEgCih/8OXZDP2s92ezIqTKzTuapUbFpK4sePbxx3Z9+GI7Jg6E8Sdvu+ccyZ2PBvQ2wJ8wgofYOAEgAAAIjGYsOXUACIDewDyoy50un/f/TokVw+c816NFyDHtWk6qvljLor549dkvFtZhl1FXKWqFFI0mZNJbev3dXtR/45abTHhn8bCChhRkAJAAAARGOx4UsoAMQG5oAydaaU8v6SzsbDevTwkZzc+58sm/C7nDkQPjW795x2Hk3HntZrkRzeckKX1TTu5oNekOSpk1pbLdR6lJsW75B1c/+WYb/2NI7HVASUMCOgBAAAAKIxAkoAiB5cBZQ210NvytiWM4xp2o371JRKL5extjp27+49Gfz850Z9yC/dJFmqiOGk2cMHDyVBwgRGPaYioIQZASUAAAAQjRFQAoD39q47JAc2HdPlKq+W05vPbPv5Xzm05biejp3v6dwSUiqHVG5e1mUYaOZJQKksGrlStv60R5crNCklL71by9ri2Kl9Z+WLNyy7P+colEV6zGhjbYmeti7fLSf3npUkyRNL/mfyyNqv/5ITu/7T5Wqtn5GnyuSUVVM3yO7fDsqtK7clpHROadzneUmfLU2EB+QsoHyqbC55tklJCSmdSz83CRNbwti7t8Lk6rkbeqr7sk9/s97aOzkKZ5YWgxvo8tFtJ2XJJ2uk7AvFpM4blSRVhhQ6+FUBsDrvNbM2y+YlO63/pXPu1qBMly21tB31oiRMbNmJXfXLr1M3WFvdK9+4hL6O0mVLo0fVqt3db165I+eOXJT5Q36S29fuGLf1lD/6IaoIKAEAAIBojIASQFy249d9kjFXeslZOItX3fDzpPXyx5y/dblam/JG2V7mkAzSfsxLT4RnjngaUP4yeb38Ptvy9wpXziftP25ibXFMTQn/vMMcoz74525PTO+OThZ+sEK2r9zn8JTU2pn5y+WRvesOG8eU9DnSyDvzO0j8BOGbBjkK80o+X0hafdDQqDtz+b+r8mXn+XLz8m3jmCfM93/x5BX5c+E/LgNkR+doz1VAqdYp7TmrjSROmljXb127I+NazZRbV92HiomSJJTXxzaVp8rkMo7Zux/2QOYO/FH2b7SE8Z7yRz9EFQElAAAAEI0RUAKIq9bN3yIrJq6TDuOaSsEKIV51gzmgtMmaL6MUrJBXr+W4e+0BYxq2Cs/6znvd7bRpTwPKuYOWye61B3VZjdBs9HYNa4tjamTg0DoTjXqtjpWkZvsKXu0AHkjmgFL1Q8mahWTLsl0Rdh9XwVyhSiGyYeE241j36W0iBM2OQq/StQvLq0MtI/vUCD41UvDques6iFMbBmXMadmYSFHP4wf1vzDqnjAHcyosTJYqidHPaqr93Zv3JHnqZMaoTUfnaM9ZQKnWHu0+vbUOGhU1/X9c61ly92aY9Rau9Vv0RoTg/Mbl2xJ68rIkSZFYMufNIAkTWc5RbdI0uulUuX7xpvWW7vmjH6KKgBIAAACIxggoAcQ1asOZn774wwi3fBFQquCr2cB6RgipRuBN7rrQCHVaDW8kJWsW1GVnPAkoT+8/JxM7zjXqrT9sJCVquL5fZXrv7+XQ38eNuprqXaZuESnwTG7JlDdDtAorzQFlxwmvSIFn8siFE5f1yECbPnPb6xDtyLaTMrXHd/pYo141pHKzstZbOA69VIDc7H/1ZMOi7fr5e/zosdGm5CySVbp+1dLoj28//FlP3feUoxGal85ckyldF+gA0aZUrcJS580qMqb5NOOYM44CSvX8dZnc0gj4rpy7rvtHBa2eqNSsjDTuVVOX1ZTuFRP/kPUL/rG2iiRPk0yHn7YA07xMgCf80Q9RRUAJAAAARGMElADikvth9+XbD38xRiDmKpZVXv+kqR7N5Q37gHLoqu6SNEUSo67sWntA5g1arstqZJ8a4eeKOaBUU5k7fd5Clx8/fiQ3Qm/JiT1nI/zNPCWzS+cvWngULl46fUU+e312hFGINupvlapdWErWLCwhpXO4Henpb+aA0jYdXYVoQ+t8rs9fne/QVT10aHfnZpgMq2sZHVqz/bNSp1NlXVYcBZSeMIfJ+zcdk1nvLLa2uGcfzF09f12PPowK+4AyT8kc8ubnzYznKfTUZZnw2jfy4N5DXffE8LU9JVGSRLr8x9wt8vOX66wt4VJlTCHv/fCmcX0Nq/+F3Ll+19rqmj/6IaoIKAEAAIBojIASQFyhpuzOeX+pHN1+Wj/kIlXyScthLxjr93nDHFCWa1hcXnmvrrUlnP3u2SP+6OUy/DMHlO5Ua/OM1OpQ0QiZPKFG2S0du9rleoIq9Hx1SANJlzW1ccyZ0NNXPJ5ObKbCtuwFMxuhmz1zQGkO50Y2maJHpKop8/2+fUMfU8Hle1XG6bJ5VKAS2YCyUrOy0riXZdq8/fqd7tgHczP6fC8HN4ePXI0Mcx9M77VIXh/X1AgNzx65qK8Z+5Ggrqh1UfvMaa/Lavr2+1XHW1ue1G1aK8lVJJsuu1ob1J4/+iGqCCgBAACAaIyAEkBccO3iTZnee5FcOHZJP1y1a3Hj3jVcBoaumAPKxn1qSqWXy1hbIlLhlgq5lAE/vClpM6eytjzJ04CyZrsK8nyHipE+dzWaUu30fPifU3J4ywnjuI0aofjutx0lZboUxjFHpvb8Tu94HRkfrOnhNBg2B2Hmf6PGtZmlnz+11mevb9oZx21BZNn6RaX5wPrWo64DyqJV80mdTlX0VHr1eJ315fljl2R8m1lG3R1zMPfg/kMZWH2CtSXyzAGlChTNI2Y/eOFLr3fZVrt2N+1fx6h7avPSnfLDx6uNuiv+6IeoIqAEAAAAojECSgBxwealu+SHj3/VD7VEzYLSenijKD1sc0DZanhDvZGLI7P6LZH9G47octevWknuYpbRaI7YT/G2hUg3r96R/RuORlhD0n6EWmSpacHHdp6WLct2y641B4zjKsB1teuy4u+AUvXBsF97GsdtYa+alt/tq9bG8SG1P9NTv80b4CiOAkq1oUzvue092lVdiUpAqTaHGf7Cl9aWyDMHlPbOHwuV8W2+NuqeUM+ren69tXfdIZn93o9G3RV/9ENUEVACAAAA0RgBJYC44OS/Z+XLTuGbfLgKFT1hDihfG/2iFK2a39oSkTmgtG344oy7TXLspxu3HNZAbzLiK6umbpC1s/7SZftw0JGDm4/J9dBbRt1T8ePHk9J1ikj8BI7XzvRnQNlzVlvJXiCzUb9+8YYc3XFarpy9Jndv3dPHchfLLsWeszyfF09ekbEtZ+iyJ8zBnFob8pNXwzf2iSz7gFL1gdokx+b3OX/LL5PWG3V3zNeNWvbgzwVbrS2uHf7npJzcc9aou+KPfogqAkoAAAAgGiOgBBBXqB2wp/b41tgoptHbNaRy8/Bdn71hDiibDqgt5RuVtLZENLnLAjm+64wu957TXrKEZLC2PMldQKlsWrxDlo5do8vqNu8u7KhHBfqCfZA0+OeuXm8e5Av+CihTZ0wp7y8N71O1HuemxTuNuk3dzpWlxmvP6nJUAkpv/1tnzAHlhu+2ybIJv0UI2NU6nJPemu9xeFj9tQpSr3MVXVY7ao98cYq1xXf80Q9RRUAJAAAARGMElADiErX+4vQ+38vlM9f0w36uVTmp16WqRzthm5kDSrVZTa2OlawtEdk2dlEc7fRt5klAqdbzG9d6pnH+L/Z9Xio2LW1tjbrhDSfJrSu3dbnfdx0lffa01pbA8VdAqcJoFUorl89ek49fmWZtiajdR030BkqKt+GaP4I5c0BpPKZ4Iv/7sYukSp9cV+/eCpMPG07yaCfvfE/nlk6fNdPlsDv3ZUitz6wtvuOPfogqAkoAAAAgGiOgBBDX3Lh8W75+d7Gc3m/ZvMbd1GtHzAGl2lVajWS0XydQ3f/EjpYp2fZhmyOeBJTKtl/+lW+H/6zLKdIllwHfv+F2N++HDx463QjGJuz2PRlSO3zX8ZHrejudhu1P/goozUGy+bkxS5g4gQxd2UP/v+JtuOaPYM5hQGndjbv37HZG27Edp2VKt4XWVufUiNvha9826vMGL4+w/qgv+KMfooqAEgAAAIjGCCgBxEVq5Nj8wctk/8Zj0mFcUylYIcSrbjAHlEqr4Y2kZM2CRl3ttrxg6Aoj+DFPq3XG04BSjZL7uPk0Y2SmJ5ueqBCvWuvy8mzT0pI8dVLjuI2aJvz96FWydfkeXc9ZOIt0n97G2hpY/gooC1bIKx3GvazL98MeyPAGX8q9O5bp/jbtPm4iRSpbRk8q3oZr/gjmnAWUSo3XykvdzlWN+o8TfpON320z6s50HP+yFCifV5fVOpTj286SG07WE1WPKd/TuTzewVvxRz9EFQElAAAAEI0RUAKIq9SoQrWeY4mahaI0gtJGTR9W02fVdFu1a/j2X/412tTah2oNRFc8DSgV81qUllGUnVyuRWkLtlToV7Z+McmaL6Nkyp1e4ieIJ6Gnrsqm73fo8M+m9YhGUqJ6eOAaSP4KKNWoSDVy0Bb23bkZJrt/OyA7Vu3XfVG15dOSMWc6660tvA3X/BHMuQoolR4z2hib5qhgXO06fvHEFWurY8lSJZH/LesiCRNZRoqq18I/K/6Vw1tPyJWz1yVn4cySq1h2KVo1n16WQPXVsLoTrf+1e/7oh6gioAQAAACiMQJKAHGZGjloPzXbE+aAUgWEtnUbHXmpXy2p8KLrEY6KNwHlvbv3ZESjycaGP+7+hqNgyxk1GlONygwWfwWUSp1OlaVme8sGOM6c2POf5CmeXZe9Ddf8Ecy5CyhV2Pj+0reMgPrGpVsy4sXJIo+tN3BCnWvzgfWN6eyuEFACAAAA8CsCSgDwnjmgVFPE9647IpuXRNwRWgVsLT9oJIUrejZ9/NyRUJnw2te6rNa17PftG9YWx3775i9ZOWWDLru7/b4NR2TvusOye+0BI9S0p0bh1e5U2ePz9ZdvR/wi21bsfSKgVGtGqrUj85TMLl0mtTSO2wLKMvWKSotB9Y3jjsI8pd5bVeS51s88sTGS2oBo3dwtcubgBWk7srE+dv7YJT0i0VPFqhWI9H/rjLuAUilcOZ+0/7iJUd+8dKdHU7KTpU4qr3/SVHIVzeowqFcB/oXjl+Wvxdsd7njujD/6IaoYQQkAAABEYwSUAOA9c0Bp22Tnfth9ObP/vNy4cluy588k6XOkdRj6BJOaynv1/A25cemmXA+9rad4p82SWtJmSSkp0iaPducbFc7CPCVJisTyVJlckqd4Nrl7+77s+e2ghJ5yPS06VosnkqNgFnmqbC59LVw6c03OH70kJ3af8Whn8JiAgBIAAACIxggoAcB7jgJKRC+uAkrEPQSUAAAAQDRGQAkA3iOgjP4IKGFGQAkAAABEYwSUAOA9Asroj4ASZgSUAAAAQDRGQAkA3iOgjP4IKGFGQAkAAABEYwSUAOC9TYt3yNble3T5pX61JGfhrNYWRBcElDAjoAQAAACiMQJKAEBsREAJMwJKAAAAIBojoAQAxEYElDAjoAQAAAAAAAAQNASUAAAAAAAAAIKGgBIAAAAAAABA0BBQAgAAAAAAAAgaAkoAAAAAAAAAQUNACQAAAAAAACBoCCgBAAAAAAAABA0BJQAAAAAAAICgIaAEAAAAAAAAEDQElAAAAAAAAACChoASAAAAAAAAQNAQUAIAAAAAAAAIGgJKAAAAAAAAAEFDQAkAAAAAAAAgaAgoAQAAAAAAAAQNASUAAAAAAACAoCGgBAAAAAAAABA0BJQAAAAAAAAAgoaAEgAAAAAAAEDQEFACAAAAAAAACBoCSgAAAAAAAABBQ0AJAAAAAAAAIGgIKAEAAAAAAAAEDQElAAAAAAAAgKAhoAQAAAAAAAAQNASUAAAAAAAAAIKGgBIAAAAAAABA0BBQAgAAAAAAAAgaAkoAAAAAAAAAQUNACQAAAAAAACBoCCgBAAAAAAAABA0BJQAAAAAAAICgIaAEAAAAAAAAEDQElAAAAAAAAACChoASAAAAAAAAQNAQUAIAAAAAAAAIGgJKAAAAAAAAAEFDQAkAAAAAAAAgaAgoAQAAAAAAAAQNASUAAAAAAACAoCGgBAAAAAAAABA0BJQAAAAAAAAAgoaAEgAAAAAAAEDQEFACAAAAAAAACBoCSgAAAAAAAABBQ0AJAAAAAAAAIGgIKAEAAAAAAAAEDQElAAAAAAAAgKAhoAQAAAAAAAAQNASUAAAAAAAAAIKGgBIAAAAAAABA0BBQAgAAAAAAAAgaAkoAAAAAAAAAQUNACQAAAAAAACBoCCgBAAAAAAAABA0BJQAAAAAAAICgIaAEAAAAAAAAEDQElAAAAAAAAACChoASAAAAAAAAQNAQUAIAAAAAAAAIGgJKAAAAAAAAAEFDQAkAAAAAAAAgaAgoAQAAAAAAAAQNASUAAAAAAACAoCGgBAAAAAAAABA0BJQAAAAAAAAAgub/GrWrGoisKSAAAAAQZGVCRzk4QjJCRUIyNkIzNDk3MDma+tRhAAAAAElFTkSuQmCC",
-      "text/plain": [
-       "<gen.jupyter_widget.GenGraphWidget object at 0x10c983250>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Or go somewhere and immediately add a highlight.\n",
-    "pbla = next(a for a in anns if a.name == \"AmpR promoter\")\n",
+    "#pbla = next(a for a in anns if a.name == \"AmpR promoter\")\n",
     "\n",
-    "fig.show(pbla)\n",
-    "fig"
+    "#fig.show(pbla)\n",
+    "#fig"
    ]
   },
   {
@@ -200,90 +184,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "1e9bd125",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "5 match(es) found\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "5be7c8b794484d3c833f47c54b611387",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "<gen.jupyter_widget.GenGraphWidget object at 0x10c973e10>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "fig = bg.plot(rows=24)\n",
-    "\n",
-    "# Search for Dcm methylation sites and add matches to the widget.\n",
-    "results = bg.search(\"CCWGG\")\n",
-    "\n",
-    "# The search query is a palindrome, so every match will also be a match on the opposite strand,\n",
-    "# filter by strand to prevent double labels:\n",
-    "matches = [locus for locus in results if locus.strand == \"+\"]\n",
-    "print(f\"{len(matches)} match(es) found\")\n",
-    "\n",
-    "for i, locus in enumerate(matches):\n",
-    "    fig.add_annotation(gen.Annotation(locus, f\"Dcm ({i + 1} of {len(matches)})\"), )\n",
-    "\n",
-    "fig.go_to(matches[0])\n",
-    "fig"
-   ]
+   "outputs": [],
+   "source": "fig = sg.plot(rows=24)\n\n# Search for Dcm methylation sites and add matches to the widget.\nresults = sg.search(\"CCWGG\", \"dna\")\n\n# The search query is a palindrome, so every match will also be a match on the opposite strand,\n# filter by strand to prevent double labels:\nmatches = [locus for locus in results if locus.strand == \"+\"]\nprint(f\"{len(matches)} match(es) found\")\n\nfor i, locus in enumerate(matches):\n    fig.add_annotation(gen.Annotation(locus, f\"Dcm ({i + 1} of {len(matches)})\"))\n\nfig.go_to(matches[0])\nfig"
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "88cd6304",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "26 total annotations\n",
-      "5 Dcm hit(s)\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "312e457f089a4f368be1ee06b282ceee",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "<gen.jupyter_widget.GenGraphWidget object at 0x10ca02330>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "# List all annotations now in the widget, then navigate to the first hit.\n",
-    "anns2 = fig.list_annotations()\n",
-    "print(f\"{len(anns2)} total annotations\")\n",
-    "\n",
-    "hits = [a for a in anns2 if a.name.startswith(\"Dcm\")]\n",
-    "print(f\"{len(hits)} Dcm hit(s)\")\n",
-    "\n",
-    "\n",
-    "fig.go_to(hits[0])\n",
-    "fig"
+    "# The Dcm highlights added above are widget overlays, not stored in the graph.\n# Navigate directly using the search results from the cell above.\nprint(f\"{len(matches)} Dcm match(es) found\")\nfig.go_to(matches[0])\nfig"
    ]
   }
  ],

--- a/gen-python/examples/introduction.ipynb
+++ b/gen-python/examples/introduction.ipynb
@@ -85,9 +85,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "bgs = repo.get_sequence_graphs()\n",
-    "bg_wt = bgs[0]\n",
-    "print(f\"Sequence graph: {bg_wt.name} | sample: {bg_wt.sample_name}\")"
+    "sgs = repo.get_sequence_graphs()\n",
+    "sg_wt = sgs[0]\n",
+    "print(f\"Sequence graph: {sg_wt.name} | sample: {sg_wt.sample_name}\")"
    ]
   },
   {
@@ -99,7 +99,7 @@
     "\n",
     "Calling `.plot()` on a sequence graph returns an interactive widget that\n",
     "renders directly in the notebook.  You can pan and zoom with the mouse.\n",
-    "The widget can also be controlled programmatically \u2014 useful for\n",
+    "The widget can also be controlled programmatically — useful for\n",
     "reproducible navigation in a shared notebook."
    ]
   },
@@ -110,26 +110,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "w_wt = bg_wt.plot()\n",
-    "\n",
-    "# Navigate to the MCS \u2014 annotated features are first-class, so you can\n",
-    "# jump directly to any named feature rather than specifying coordinates.\n",
-    "annotations = w_wt.list_annotations()\n",
-    "mcs = [\n",
-    "    a for a in annotations\n",
-    "    if any(k in a.name.lower() for k in [\"mcs\", \"misc_feature\", \"multiple cloning\"])\n",
-    "]\n",
-    "if mcs:\n",
-    "    w_wt.go_to(mcs[0])\n",
-    "\n",
-    "w_wt"
+    "w_wt = sg_wt.plot()\n\n# Navigate to the MCS — annotated features are first-class, so you can\n# jump directly to any named feature rather than specifying coordinates.\nannotations = sg_wt.list_annotations()\nmcs = [\n    a for a in annotations\n    if any(k in a.name.lower() for k in [\"mcs\", \"misc_feature\", \"multiple cloning\"])\n]\nif mcs:\n    w_wt.go_to(mcs[0])\n\nw_wt"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "10-plot-note",
    "metadata": {},
-   "source": "The widget renders a live snapshot of the sequence graph.  Annotations\nfrom the GenBank file (lacZ\u03b1, bla, the MCS) appear as coloured tracks\nbelow the sequence.  `list_annotations()` returns all named features in\nthe database; passing one to `go_to()` centres the viewport on that\nfeature \u2014 no coordinate look-up required.\n\nFor a fully interactive, pannable, zoomable view from the command line,\nrun `gen view` in the same workspace."
+   "source": [
+    "The widget renders a live snapshot of the sequence graph.  Annotations\nfrom the GenBank file (lacZα, bla, the MCS) appear as coloured tracks\nbelow the sequence.  `sg_wt.list_annotations()` returns all named features in\nthe database; passing one to `go_to()` centres the viewport on that\nfeature — no coordinate look-up required.\n\nFor a fully interactive, pannable, zoomable view from the command line,\nrun `gen view` in the same workspace."
+   ]
   },
   {
    "cell_type": "markdown",
@@ -138,9 +128,9 @@
    "source": [
     "## Design a Golden Gate conversion\n",
     "\n",
-    "The pUC19 multiple cloning site (MCS, positions 396\u2013452) contains a set\n",
+    "The pUC19 multiple cloning site (MCS, positions 396–452) contains a set\n",
     "of traditional type-II restriction sites.  We want to replace it with a\n",
-    "minimal Golden Gate entry site \u2014 two BsaI recognition sequences (GGTCTC)\n",
+    "minimal Golden Gate entry site — two BsaI recognition sequences (GGTCTC)\n",
     "flanking a stuffer, oriented to cut inward and expose compatible 4-nt\n",
     "overhangs for assembly.\n",
     "\n",
@@ -150,7 +140,7 @@
     "#   EcoRI SacI  KpnI  SmaI  BamHI XbaI    SalI   PstI SphI HindIII\n",
     "#\n",
     "# Replacement: two BsaI sites flanking a stuffer, retaining EcoRI/HindIII ends.\n",
-    "#   GAATTC [BsaI\u2192 GGTCTCA] [AATG overhang] [stuffer] [GCAT overhang] [\u2190BsaI TGAGACC] AAGCTT\n",
+    "#   GAATTC [BsaI→ GGTCTCA] [AATG overhang] [stuffer] [GCAT overhang] [←BsaI TGAGACC] AAGCTT\n",
     "```"
    ]
   },
@@ -198,7 +188,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "bg_gg = next(bg for bg in repo.get_sequence_graphs() if bg.sample_name == \"gg_design\")"
+    "sg_gg = next(sg for sg in repo.get_sequence_graphs() if sg.sample_name == \"gg_design\")"
    ]
   },
   {
@@ -221,11 +211,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# GGTCTC is the BsaI recognition sequence (cuts 1 nt downstream on sense strand).\n",
-    "# DNA-mode search finds both the forward site and its reverse-complement counterpart.\n",
-    "hits = repo.search(\"GGTCTC\", bgs=[bg_gg], sequence_kind=\"dna\")\n",
-    "loci = hits[0][1]  # [(SequenceGraph, [Locus]), ...] \u2014 take the loci from the first match\n",
-    "print(f\"BsaI sites found: {len(loci)}\")"
+    "# GGTCTC is the BsaI recognition sequence (cuts 1 nt downstream on sense strand).\n# DNA-mode search finds both the forward site and its reverse-complement counterpart.\nhits = repo.search(\"GGTCTC\", bgs=[sg_gg], sequence_kind=\"dna\")\nloci = hits[0][1]  # [(SequenceGraph, [Locus]), ...] — take the loci from the first match\nprint(f\"BsaI sites found: {len(loci)}\")"
    ]
   },
   {
@@ -235,7 +221,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "w_gg = bg_gg.plot()\n",
+    "w_gg = sg_gg.plot()\n",
     "w_gg.go_to(loci[0])\n",
     "w_gg"
    ]
@@ -260,9 +246,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hits_wt = repo.search(\"GGTCTC\", bgs=[bg_wt], sequence_kind=\"dna\")\n",
-    "wt_count = len(hits_wt[0][1]) if hits_wt else 0\n",
-    "print(f\"BsaI sites in wild-type: {wt_count}\")  # 1"
+    "hits_wt = repo.search(\"GGTCTC\", bgs=[sg_wt], sequence_kind=\"dna\")\nwt_count = len(hits_wt[0][1]) if hits_wt else 0\nprint(f\"BsaI sites in wild-type: {wt_count}\")  # 1"
    ]
   },
   {
@@ -270,9 +254,9 @@
    "id": "21-wt-search-note",
    "metadata": {},
    "source": [
-    "The wild-type already carries one BsaI site \u2014 on the reverse strand at\n",
+    "The wild-type already carries one BsaI site — on the reverse strand at\n",
     "position 1765, inside the **bla** coding sequence.  The design added\n",
-    "exactly two new sites (3 \u2212 1 = 2), so the flanking Golden Gate sites are\n",
+    "exactly two new sites (3 − 1 = 2), so the flanking Golden Gate sites are\n",
     "present and correctly oriented.  The pre-existing site is the problem: if\n",
     "left in place it will be cut alongside the intended assembly sites,\n",
     "fragmenting the AmpR cassette.  It needs to be silently mutated out\n",
@@ -282,7 +266,7 @@
     "query by recognition sequence directly without pre-computing all\n",
     "variants.  For example, EcoRI's sequence `GAATTC` is unambiguous, but a\n",
     "site like HincII (`GTYRAC`, where Y = C/T and R = A/G) expands to four\n",
-    "possible hexamers \u2014 pass the IUPAC string and `search()` matches all of\n",
+    "possible hexamers — pass the IUPAC string and `search()` matches all of\n",
     "them:"
    ]
   },
@@ -293,9 +277,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hits_hincii = repo.search(\"GTYRAC\", bgs=[bg_gg], sequence_kind=\"dna\")\n",
-    "hincii_count = len(hits_hincii[0][1]) if hits_hincii else 0\n",
-    "print(f\"HincII sites found: {hincii_count}\")"
+    "hits_hincii = repo.search(\"GTYRAC\", bgs=[sg_gg], sequence_kind=\"dna\")\nhincii_count = len(hits_hincii[0][1]) if hits_hincii else 0\nprint(f\"HincII sites found: {hincii_count}\")"
    ]
   },
   {
@@ -303,7 +285,7 @@
    "id": "23-iupac-note",
    "metadata": {},
    "source": [
-    "For large genomes, consider calling `bg.build_index()` before\n",
+    "For large genomes, consider calling `sg.build_index()` before\n",
     "searching.  The index speeds up exact queries; degenerate IUPAC patterns\n",
     "always use a full scan regardless."
    ]
@@ -320,10 +302,10 @@
     "directly to `go_to()` to centre the viewport on it, and to\n",
     "`highlight_match()` to colour it on the canvas.\n",
     "\n",
-    "`go_to()` accepts `Position`, `Locus`, and `Annotation` objects \u2014 the\n",
+    "`go_to()` accepts `Position`, `Locus`, and `Annotation` objects — the\n",
     "same call works for search results and annotation records.  Annotations\n",
     "from one sample can be used to navigate a widget for a different sample\n",
-    "\u2014 this is safe and stable because annotations are stored as references\n",
+    "— this is safe and stable because annotations are stored as references\n",
     "to graph nodes, not as linear sequence coordinates.  Nodes are shared\n",
     "across samples in the same repository, so an annotation created for the\n",
     "`\"wt\"` sample points to exactly the same graph nodes that appear in the\n",
@@ -391,7 +373,7 @@
     "You send `pUC19_gg_design.fa` to your synthesis provider.  A few days\n",
     "later sequencing results arrive as a VCF.\n",
     "\n",
-    "## Import the sequencing result \u2014 and find a surprise"
+    "## Import the sequencing result — and find a surprise"
    ]
   },
   {
@@ -417,7 +399,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "bg_seq = next(bg for bg in repo.get_sequence_graphs() if bg.sample_name == \"sequenced\")"
+    "sg_seq = next(sg for sg in repo.get_sequence_graphs() if sg.sample_name == \"sequenced\")"
    ]
   },
   {
@@ -427,7 +409,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "w_seq = bg_seq.plot()\n",
+    "w_seq = sg_seq.plot()\n",
     "w_seq"
    ]
   },
@@ -436,9 +418,9 @@
    "id": "34-sequenced-note",
    "metadata": {},
    "source": [
-    "The graph now shows a branch at position 1904 \u2014 outside the MCS, inside\n",
-    "the **bla** (\u03b2-lactamase / AmpR) coding sequence.  The sequencing run\n",
-    "picked up a C\u2192T substitution that was not in the design.  Because Gen\n",
+    "The graph now shows a branch at position 1904 — outside the MCS, inside\n",
+    "the **bla** (β-lactamase / AmpR) coding sequence.  The sequencing run\n",
+    "picked up a C→T substitution that was not in the design.  Because Gen\n",
     "stores every sample as a path through the same graph, the mutation shows\n",
     "up as a new node rather than a silent overwrite: the `gg_design` path\n",
     "and the `sequenced` path diverge exactly here.\n",
@@ -476,7 +458,7 @@
     "\n",
     "The Python bindings and the CLI share the same database, so you can\n",
     "design a construct in a notebook, push it from the terminal, and a\n",
-    "colleague can pull the graph and visualise it in their own session \u2014\n",
+    "colleague can pull the graph and visualise it in their own session —\n",
     "with the full annotation and variant history intact.\n",
     "\n",
     "To learn more about the CLI, run `gen --help` or visit the project\n",
@@ -629,7 +611,7 @@
     "try:\n",
     "    import networkx as nx\n",
     "\n",
-    "    nx_graph = bg_gg.to_networkx()\n",
+    "    nx_graph = sg_gg.to_networkx()\n",
     "    print(f\"NetworkX DiGraph: {nx_graph.number_of_nodes()} nodes, {nx_graph.number_of_edges()} edges\")\n",
     "    print(f\"Average degree: {sum(d for _, d in nx_graph.degree()) / nx_graph.number_of_nodes():.2f}\")\n",
     "except ImportError:\n",
@@ -647,7 +629,7 @@
     "    import rustworkx as rx\n",
     "    import rustworkx.visualization as rxv\n",
     "\n",
-    "    rx_graph = bg_gg.to_rustworkx()\n",
+    "    rx_graph = sg_gg.to_rustworkx()\n",
     "    print(f\"RustworkX PyDiGraph: {rx_graph.num_nodes()} nodes, {rx_graph.num_edges()} edges\")\n",
     "    display(rxv.graphviz_draw(rx_graph))\n",
     "except ImportError:\n",
@@ -667,7 +649,7 @@
     "column becomes a path through the resulting graph.\n",
     "\n",
     "The example below designs an expression cassette with three promoters,\n",
-    "three RBS variants, and two CDSes \u2014 18 unique combinations:"
+    "three RBS variants, and two CDSes — 18 unique combinations:"
    ]
   },
   {
@@ -677,34 +659,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "parts_list = [\n",
-    "    [gen.SequencePart(\"upstream\", \"AATTCGGATCCAAGCTT\")],\n",
-    "    [\n",
-    "        gen.SequencePart(\"pTrc\", \"TTGACAATTAATCATCCGGCTCGTATAATGTGTGG\"),\n",
-    "        gen.SequencePart(\"pT7\",  \"TAATACGACTCACTATA\"),\n",
-    "        gen.SequencePart(\"pLac\", \"AATTGTGAGCGGATAACAATT\"),\n",
-    "    ],\n",
-    "    [\n",
-    "        gen.SequencePart(\"rbs_strong\", \"AAAGAGGAGAAA\"),\n",
-    "        gen.SequencePart(\"rbs_medium\", \"AAGAGGAG\"),\n",
-    "        gen.SequencePart(\"rbs_weak\",   \"AGGAG\"),\n",
-    "    ],\n",
-    "    [\n",
-    "        gen.SequencePart(\"gfp\", \"ATGAGTAAAGGAGAAGAACTTTTCACTGG\"),\n",
-    "        gen.SequencePart(\"rfp\", \"ATGGCTTCCTCCGAAGACGTTATCAAAGAG\"),\n",
-    "    ],\n",
-    "    [gen.SequencePart(\"terminator_T1\", \"GCGCAACGCAATTAATGTGAGTTAGCTCACTCATTAGGCACCCCAGGC\")],\n",
-    "]\n",
-    "\n",
-    "lib_repo = gen.Repository(str(WORK_DIR / \"library\"))\n",
-    "lib_repo.import_library(\"expression-cassette\", parts_list)\n",
-    "\n",
-    "cassette_bgs = [\n",
-    "    bg for bg in lib_repo.get_sequence_graphs()\n",
-    "    if bg.name == \"expression-cassette\"\n",
-    "]\n",
-    "print(f\"Paths in library graph: checking plot...\")\n",
-    "cassette_bgs[0].plot()"
+    "parts_list = [\n    [gen.SequencePart(\"upstream\", \"AATTCGGATCCAAGCTT\")],\n    [\n        gen.SequencePart(\"pTrc\", \"TTGACAATTAATCATCCGGCTCGTATAATGTGTGG\"),\n        gen.SequencePart(\"pT7\",  \"TAATACGACTCACTATA\"),\n        gen.SequencePart(\"pLac\", \"AATTGTGAGCGGATAACAATT\"),\n    ],\n    [\n        gen.SequencePart(\"rbs_strong\", \"AAAGAGGAGAAA\"),\n        gen.SequencePart(\"rbs_medium\", \"AAGAGGAG\"),\n        gen.SequencePart(\"rbs_weak\",   \"AGGAG\"),\n    ],\n    [\n        gen.SequencePart(\"gfp\", \"ATGAGTAAAGGAGAAGAACTTTTCACTGG\"),\n        gen.SequencePart(\"rfp\", \"ATGGCTTCCTCCGAAGACGTTATCAAAGAG\"),\n    ],\n    [gen.SequencePart(\"terminator_T1\", \"GCGCAACGCAATTAATGTGAGTTAGCTCACTCATTAGGCACCCCAGGC\")],\n]\n\nlib_repo = gen.Repository(str(WORK_DIR / \"library\"))\nlib_repo.import_library(\"expression-cassette\", parts_list)\n\ncassette_sgs = [\n    sg for sg in lib_repo.get_sequence_graphs()\n    if sg.name == \"expression-cassette\"\n]\nprint(f\"Paths in library graph: checking plot...\")\ncassette_sgs[0].plot()"
    ]
   },
   {
@@ -782,7 +737,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mcs_bg = bg_gg.subgraph(\"mcs_v2\", 390, 460)\n",
+    "mcs_bg = sg_gg.subgraph(\"mcs_v2\", 390, 460)\n",
     "mcs_bg.plot()"
    ]
   },
@@ -793,8 +748,8 @@
    "source": [
     "#### Chunks and stitching\n",
     "\n",
-    "`bg.chunks()` splits a block group into contiguous fragments and returns\n",
-    "them as a list of block groups.  Supply `chunk_size` for uniform splits\n",
+    "`sg.chunks()` splits a block group into contiguous fragments and returns\n",
+    "them as a list of sequence graphs.  Supply `chunk_size` for uniform splits\n",
     "or `breakpoints` (a list of positions) for explicit cut points:"
    ]
   },
@@ -805,7 +760,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "chunks = bg_gg.chunks(\"gg_500bp_chunks\", chunk_size=500)\n",
+    "chunks = sg_gg.chunks(\"gg_500bp_chunks\", chunk_size=500)\n",
     "print(f\"Chunks created: {len(chunks)}\")"
    ]
   },
@@ -825,20 +780,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "reassembled = repo.stitch(\n",
-    "    bgs=chunks,\n",
-    "    new_sample=\"gg_reassembled\",\n",
-    "    new_region=\"pUC19.reassembled\",\n",
-    ")\n",
-    "print(f\"Stitched: {reassembled.name} in sample '{reassembled.sample_name}'\")\n",
-    "reassembled.plot()"
+    "reassembled = repo.stitch(\n    bgs=chunks,\n    new_sample=\"gg_reassembled\",\n    new_region=\"pUC19.reassembled\",\n)\nprint(f\"Stitched: {reassembled.name} in sample '{reassembled.sample_name}'\")\nreassembled.plot()"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "62-tracks-header",
    "metadata": {},
-   "source": "### Annotation tracks\n\nAny widget can display additional annotation panels below the sequence\ngraph.  `add_annotation_track()` is the unified entry point \u2014 supply\nexactly one of `file`, `group`, or `annotations`:\n\n- `file=` loads a GFF3 or BED file; `from_sample=` translates coordinates\n  from the given sample's path space.\n- `group=` loads an annotation group stored in the repository (created\n  automatically on GenBank import).\n- `annotations=` renders a list of `Annotation` objects you built manually."
+   "source": "### Annotation tracks\n\nAny widget can display additional annotation panels below the sequence\ngraph.  `add_annotation_track()` is the unified entry point — supply\nexactly one of `file`, `group`, or `annotations`:\n\n- `file=` loads a GFF3 or BED file; `from_sample=` translates coordinates\n  from the given sample's path space.\n- `group=` loads an annotation group stored in the repository (created\n  automatically on GenBank import).\n- `annotations=` renders a list of `Annotation` objects you built manually."
   },
   {
    "cell_type": "code",

--- a/gen-python/src/python_api.rs
+++ b/gen-python/src/python_api.rs
@@ -1,5 +1,6 @@
 use pyo3::{Bound, prelude::*, types::PyModule};
 
+pub mod annotation;
 pub mod block_group;
 pub mod graph_node;
 pub mod graph_search;
@@ -10,9 +11,10 @@ pub mod sequence_part;
 pub mod utils;
 
 use crate::python_api::{
+    annotation::PyAnnotation,
     block_group::PySequenceGraph,
     graph_node::{PyGraphNode, PyGraphNodeSlice},
-    graph_search::{PyAnnotation, PyGraphLocus, PyGraphPos},
+    graph_search::{PyGraphLocus, PyGraphPos},
     hash_id::PyHashId,
     jupyter_widget::PyGraphController,
     repository::PyRepository,
@@ -26,12 +28,12 @@ use crate::python_api::{
 pub fn r#gen(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyRepository>()?;
     m.add_class::<PySequenceGraph>()?;
+    m.add_class::<PyAnnotation>()?;
     m.add_class::<PyHashId>()?;
     m.add_class::<PyGraphNode>()?;
     m.add_class::<PyGraphNodeSlice>()?;
     m.add_class::<PyGraphPos>()?;
     m.add_class::<PyGraphLocus>()?;
-    m.add_class::<PyAnnotation>()?;
     m.add_class::<PySequencePart>()?;
     m.add_class::<PyGraphController>()?;
 

--- a/gen-python/src/python_api/annotation.rs
+++ b/gen-python/src/python_api/annotation.rs
@@ -1,0 +1,159 @@
+use gen_annotations::projection::{AnnotationSegment, accession_edges_to_segments};
+use gen_core::{HashId, range::Range};
+use gen_models::{
+    accession::Accession,
+    annotations::Annotation,
+    db::{DbContext, GraphConnection},
+    locus::GraphLocus,
+};
+use pyo3::prelude::*;
+
+use super::graph_search::PyGraphLocus;
+
+/// A named genomic annotation.
+///
+/// **From a database** — obtain via ``SequenceGraph.list_annotations()``
+/// or ``GraphWidget.list_annotations()``.
+///
+/// **From a search result** — create with ``Annotation(locus, name)``
+/// where *locus* is a ``Locus`` returned by ``SequenceGraph.search()``.
+#[pyclass(name = "Annotation", unsendable)]
+#[derive(Clone)]
+pub struct PyAnnotation {
+    pub inner: Annotation,
+    pub context: Option<DbContext>,
+    pub ann_segments: Vec<AnnotationSegment>,
+    pub source_block_group_id: Option<HashId>,
+    /// Pre-computed locus; present only for annotations built from a ``Locus``
+    /// via the Python constructor.
+    pub locus: Option<GraphLocus>,
+}
+
+#[pymethods]
+impl PyAnnotation {
+    /// Create an ephemeral annotation from a search-result locus.
+    ///
+    /// Parameters
+    /// ----------
+    /// locus : Locus
+    ///     A ``Locus`` returned by ``SequenceGraph.search()``.
+    /// name : str
+    ///     Human-readable label for the annotation.
+    #[new]
+    pub fn from_locus(locus: PyRef<PyGraphLocus>, name: &str) -> Self {
+        let ann_segments = locus
+            .inner
+            .slices
+            .iter()
+            .map(|s| AnnotationSegment {
+                node_id: s.block.node_id,
+                range: Range {
+                    start: s.block.sequence_start + s.start as i64,
+                    end: s.block.sequence_start + s.end as i64,
+                },
+                strand: s.strand,
+            })
+            .collect();
+        PyAnnotation {
+            inner: Annotation {
+                id: HashId::convert_str(name),
+                name: name.to_string(),
+                group: String::new(),
+                accession_id: HashId([0u8; 32]),
+                extra: None,
+            },
+            context: None,
+            ann_segments,
+            source_block_group_id: None,
+            locus: Some(locus.inner.clone()),
+        }
+    }
+
+    /// The graph-space locus covered by this annotation.
+    ///
+    /// Only available for annotations created with ``Annotation(locus, name)``.
+    /// Returns ``None`` for database annotations from ``list_annotations()``.
+    #[getter]
+    fn locus(&self) -> Option<PyGraphLocus> {
+        self.locus
+            .as_ref()
+            .map(|l| PyGraphLocus::from_locus(l.clone()))
+    }
+
+    /// Hash ID of this annotation.
+    #[getter]
+    fn id(&self) -> String {
+        self.inner.id.to_string()
+    }
+
+    /// Human-readable annotation name.
+    #[getter]
+    fn name(&self) -> &str {
+        &self.inner.name
+    }
+
+    /// Annotation group this annotation belongs to.
+    #[getter]
+    fn group(&self) -> &str {
+        &self.inner.group
+    }
+
+    /// GenBank feature kind (e.g. ``"gene"``, ``"CDS"``, ``"sig_peptide"``), if available.
+    #[getter]
+    fn kind(&self) -> Option<&str> {
+        self.inner
+            .extra
+            .as_ref()?
+            .genbank
+            .as_ref()
+            .map(|g| g.kind.as_str())
+    }
+
+    /// Genomic segments covered by this annotation.
+    ///
+    /// Each segment is a dict with keys ``node_id`` (str), ``start`` (int),
+    /// ``end`` (int), and ``strand`` (``"+"`` or ``"-"``).
+    #[getter]
+    fn segments<'py>(&self, py: Python<'py>) -> Vec<Bound<'py, pyo3::types::PyDict>> {
+        self.ann_segments
+            .iter()
+            .map(|s| {
+                let d = pyo3::types::PyDict::new(py);
+                d.set_item("node_id", s.node_id.to_string()).unwrap();
+                d.set_item("start", s.range.start).unwrap();
+                d.set_item("end", s.range.end).unwrap();
+                d.set_item("strand", s.strand.to_string()).unwrap();
+                d
+            })
+            .collect()
+    }
+
+    /// Total length of the annotation in base pairs (sum across all segments).
+    fn __len__(&self) -> usize {
+        self.ann_segments
+            .iter()
+            .map(|s| (s.range.end - s.range.start) as usize)
+            .sum()
+    }
+
+    fn __repr__(&self) -> String {
+        let len: usize = self
+            .ann_segments
+            .iter()
+            .map(|s| (s.range.end - s.range.start) as usize)
+            .sum();
+        format!(
+            "Annotation(name={:?}, group={:?}, len={len})",
+            self.inner.name, self.inner.group
+        )
+    }
+}
+
+/// Compute the annotation segments from accession edges.
+pub(super) fn annotation_segments(
+    conn: &GraphConnection,
+    annotation: &Annotation,
+) -> Vec<AnnotationSegment> {
+    let edges = Accession::get_edges_by_id(conn, &annotation.accession_id);
+    accession_edges_to_segments(&edges)
+}

--- a/gen-python/src/python_api/block_group.rs
+++ b/gen-python/src/python_api/block_group.rs
@@ -9,10 +9,13 @@ use r#gen::{
     graphs::graph_search::{GenGraphMatcher, SeedIndex, SequenceKind},
 };
 use gen_graph::GraphNode;
-use gen_models::{block_group::BlockGroup, db::DbContext, node::Node, sample::Sample};
+use gen_models::{
+    annotations::Annotation, block_group::BlockGroup, db::DbContext, node::Node, sample::Sample,
+};
 use pyo3::{exceptions::PyRuntimeError, prelude::*, types::PyDict};
 
 use super::{
+    annotation::{PyAnnotation, annotation_segments},
     graph_node::PyGraphNode,
     hash_id::PyHashId,
     jupyter_widget::{PyGraphController, build_widget},
@@ -492,6 +495,34 @@ impl PySequenceGraph {
         export_genbank(conn, &self.collection_name, &self.sample_name, writer).map_err(|e| {
             PyRuntimeError::new_err(format!("Failed to export GenBank '{}': {e}", filename))
         })
+    }
+
+    /// Return all gene annotations associated with this sequence graph.
+    ///
+    /// Returns
+    /// -------
+    /// list[GeneAnnotation]
+    fn list_annotations(&self) -> PyResult<Vec<PyAnnotation>> {
+        let ctx = self.require_context("list_annotations()")?;
+        let conn = ctx.graph().conn();
+        let bg_id = self.id;
+        let annotations = Annotation::query_with_lineage(
+            conn,
+            &self.collection_name,
+            &self.sample_name,
+            &self.name,
+        )
+        .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+        Ok(annotations
+            .into_iter()
+            .map(|a| PyAnnotation {
+                ann_segments: annotation_segments(conn, &a),
+                inner: a,
+                context: Some(ctx.clone()),
+                source_block_group_id: Some(bg_id),
+                locus: None,
+            })
+            .collect())
     }
 }
 

--- a/gen-python/src/python_api/graph_search.rs
+++ b/gen-python/src/python_api/graph_search.rs
@@ -1,7 +1,4 @@
-use r#gen::{
-    graphs::graph_search::GraphPos,
-    views::annotation_track::{AnnotationSpan, annotation_span_from_graph_locus},
-};
+use r#gen::graphs::graph_search::GraphPos;
 use gen_core::Strand;
 use gen_models::locus::GraphLocus;
 use pyo3::prelude::*;
@@ -205,69 +202,6 @@ impl PyGraphLocus {
             hash = hash.wrapping_mul(31).wrapping_add(s.start as isize);
             hash = hash.wrapping_mul(31).wrapping_add(s.end as isize);
             hash = hash.wrapping_mul(31).wrapping_add(s.strand as isize);
-        }
-        hash
-    }
-}
-
-/// A named annotation in graph space, built from one or more `Locus` objects.
-///
-/// Create with ``Annotation(locus, name)`` for a single hit.
-/// Pass a list of ``Annotation`` objects to ``widget.add_annotation_track()``.
-#[pyclass(name = "Annotation")]
-#[derive(Clone)]
-pub struct PyAnnotation {
-    pub inner: AnnotationSpan,
-    pub(crate) locus: GraphLocus,
-}
-
-#[pymethods]
-impl PyAnnotation {
-    #[new]
-    fn new(locus: PyRef<PyGraphLocus>, name: &str) -> Self {
-        PyAnnotation {
-            inner: annotation_span_from_graph_locus(&locus.inner, name),
-            locus: locus.inner.clone(),
-        }
-    }
-
-    /// The graph-space locus covered by this annotation.
-    ///
-    /// Provides ``.start()`` / ``.end()`` (``Position``) and ``.strand``.
-    #[getter]
-    fn locus(&self) -> PyGraphLocus {
-        PyGraphLocus::from_locus(self.locus.clone())
-    }
-
-    #[getter]
-    fn name(&self) -> &str {
-        &self.inner.name
-    }
-
-    fn __repr__(&self) -> String {
-        format!(
-            "Annotation(name={:?}, segments={})",
-            self.inner.name,
-            self.inner.segments.len()
-        )
-    }
-
-    fn __str__(&self) -> String {
-        self.inner.name.clone()
-    }
-
-    fn __hash__(&self) -> isize {
-        let mut hash: isize = 0;
-        for &b in &self.inner.id.0 {
-            hash = hash.wrapping_mul(31).wrapping_add(b as isize);
-        }
-        for seg in &self.inner.segments {
-            for &b in &seg.node_id.0 {
-                hash = hash.wrapping_mul(31).wrapping_add(b as isize);
-            }
-            hash = hash.wrapping_mul(31).wrapping_add(seg.start as isize);
-            hash = hash.wrapping_mul(31).wrapping_add(seg.end as isize);
-            hash = hash.wrapping_mul(31).wrapping_add(seg.strand as isize);
         }
         hash
     }

--- a/gen-python/src/python_api/jupyter_widget.rs
+++ b/gen-python/src/python_api/jupyter_widget.rs
@@ -8,7 +8,7 @@ use std::{
 use r#gen::{
     get_connection,
     views::{
-        annotation_groups::load_annotation_group_entries,
+        annotation_groups::{annotation_group_names, load_annotation_group_entries},
         annotation_track::{
             AnnotationSpan, AnnotationTrack, annotation_span_from_graph_locus,
             graph_locus_from_annotation_span,
@@ -24,7 +24,10 @@ use r#gen::{
 use gen_core::{HashId, PATH_END_NODE_ID, PATH_START_NODE_ID, is_end_node, is_start_node};
 use gen_graph::{GenGraph, GraphNode, GraphNodeSlice, project_path};
 use gen_models::{
-    annotations::AnnotationError, block_group::BlockGroup, db::GraphConnection, locus::GraphLocus,
+    annotations::{Annotation, AnnotationError},
+    block_group::BlockGroup,
+    db::GraphConnection,
+    locus::GraphLocus,
 };
 use gen_tui::{
     LineStyle, geometry::WorldPos, graph_controller::GraphController, graph_widget::GraphWidget,
@@ -45,8 +48,9 @@ use ratatui::{
 use serde::Serialize;
 
 use crate::python_api::{
+    annotation::{PyAnnotation, annotation_segments},
     block_group::PySequenceGraph,
-    graph_search::{PyAnnotation, PyGraphLocus, PyGraphPos},
+    graph_search::{PyGraphLocus, PyGraphPos},
     repository::PyRepository,
     utils::block_group_err_to_pyerr,
 };
@@ -237,6 +241,24 @@ fn locus_from_span_and_pos_map(
     GraphLocus { slices }
 }
 
+fn annotation_to_span(annotation: &PyAnnotation) -> AnnotationSpan {
+    use r#gen::views::annotation_track::AnnotationSegment as ViewSegment;
+    AnnotationSpan {
+        id: annotation.inner.id,
+        name: annotation.inner.name.clone(),
+        segments: annotation
+            .ann_segments
+            .iter()
+            .map(|s| ViewSegment {
+                node_id: s.node_id,
+                start: s.range.start,
+                end: s.range.end,
+                strand: s.strand,
+            })
+            .collect(),
+    }
+}
+
 /// A span annotated onto the graph canvas, with or without a label (highlight), optionally associated with a specific track.
 #[derive(Clone)]
 struct GraphOverlay {
@@ -335,13 +357,9 @@ impl PyGraphController {
         let Ok(current_block_group) = BlockGroup::get_by_id(conn, &bg_id) else {
             return;
         };
-        let entries = load_annotation_group_entries(conn, &current_block_group);
-        let mut seen_names = HashSet::new();
-        for entry in &entries {
-            if seen_names.insert(entry.name.clone()) {
-                if let Ok(track) = self.load_group_as_track(conn, &entry.name) {
-                    self.track_annotations.push(track);
-                }
+        for name in annotation_group_names(conn, &current_block_group) {
+            if let Ok(track) = self.load_group_as_track(conn, &name) {
+                self.track_annotations.push(track);
             }
         }
     }
@@ -681,7 +699,8 @@ impl PyGraphController {
     /// Build a track panel from a list of `Annotation` objects.
     /// Each `Annotation` becomes one span; all are grouped under `name`.
     pub fn add_track_annotations(&mut self, annotations: Vec<PyRef<PyAnnotation>>, name: &str) {
-        let spans: Vec<AnnotationSpan> = annotations.iter().map(|a| a.inner.clone()).collect();
+        let spans: Vec<AnnotationSpan> =
+            annotations.iter().map(|a| annotation_to_span(a)).collect();
         self.track_annotations
             .push(AnnotationTrack::new(name, spans));
     }
@@ -781,7 +800,8 @@ impl PyGraphController {
 
     /// Navigate to an `Annotation` object.
     pub fn go_to_annotation_obj(&mut self, annotation: &PyAnnotation) {
-        self.navigate_to_span(&annotation.inner);
+        let span = annotation_to_span(annotation);
+        self.navigate_to_span(&span);
     }
 
     /// Highlight an `Annotation` on the graph as a nameless inline annotation,
@@ -795,9 +815,16 @@ impl PyGraphController {
         let style = PathStyle::new(c)
             .with_line_style(LineStyle::Bold)
             .with_merge_glyphs(true);
-        highlight_match_range(&mut self.controller, &annotation.locus, style);
+        let span = annotation_to_span(annotation);
+        let locus = annotation
+            .locus
+            .clone()
+            .or_else(|| graph_locus_from_annotation_span(&span, self.controller.graph()));
+        if let Some(locus) = locus {
+            highlight_match_range(&mut self.controller, &locus, style);
+        }
         self.overlays.push(GraphOverlay {
-            span: annotation.inner.clone(),
+            span,
             track: None,
             style,
         });
@@ -810,29 +837,43 @@ impl PyGraphController {
         self.go_to_pos(&PyGraphPos::new(slice.block, slice.start));
     }
 
-    /// Return all annotations (track and inline) as a flat list of `Annotation` objects.
-    pub fn list_annotations(&self) -> Vec<PyAnnotation> {
-        let mut annotations = Vec::new();
-        let graph = self.controller.graph();
-        for track in &self.track_annotations {
-            for span in &track.annotations {
-                let locus = graph_locus_from_annotation_span(span, graph)
-                    .expect("annotation references nodes not in graph");
-                annotations.push(PyAnnotation {
-                    inner: span.clone(),
-                    locus,
-                });
-            }
-        }
-        for overlay in self.overlays.iter().filter(|o| o.track.is_some()) {
-            let locus = graph_locus_from_annotation_span(&overlay.span, graph)
-                .expect("annotation references nodes not in graph");
-            annotations.push(PyAnnotation {
-                inner: overlay.span.clone(),
-                locus,
-            });
-        }
-        annotations
+    /// Return all gene annotations for this sequence graph.
+    ///
+    /// Delegates to the database, returning every annotation stored for this
+    /// block group — independent of which tracks are currently loaded in the
+    /// widget.
+    ///
+    /// The returned ``Annotation`` objects carry no repository context. To
+    /// translate one, pass it to
+    /// ``SequenceGraph.translate_annotation(region=ann)``, which resolves the
+    /// annotation through its own context.
+    pub fn list_annotations(&self) -> PyResult<Vec<PyAnnotation>> {
+        let bg_id = self.block_group_id.as_ref().ok_or_else(|| {
+            PyRuntimeError::new_err(
+                "list_annotations() requires a block group; \
+                 create the widget via SequenceGraph.plot()",
+            )
+        })?;
+        let conn = self.open_conn()?;
+        let block_group = BlockGroup::get_by_id(&conn, bg_id)
+            .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+        let annotations = Annotation::query_with_lineage(
+            &conn,
+            &block_group.collection_name,
+            &block_group.sample_name,
+            &block_group.name,
+        )
+        .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+        Ok(annotations
+            .into_iter()
+            .map(|a| PyAnnotation {
+                ann_segments: annotation_segments(&conn, &a),
+                inner: a,
+                context: None,
+                source_block_group_id: Some(*bg_id),
+                locus: None,
+            })
+            .collect())
     }
 
     /// Return a JSON list of track-panel annotation names currently loaded.
@@ -874,17 +915,26 @@ impl PyGraphController {
         let style = PathStyle::new(color)
             .with_line_style(LineStyle::Bold)
             .with_merge_glyphs(true);
-        // Collect loci with immutable graph borrow, then apply with mutable controller borrow.
-        let loci: Vec<Option<GraphLocus>> = annotations
+        // Collect spans and loci with immutable graph borrow, then apply with mutable controller borrow.
+        let spans_and_loci: Vec<(AnnotationSpan, Option<GraphLocus>)> = annotations
             .iter()
-            .map(|ann| graph_locus_from_annotation_span(&ann.inner, self.controller.graph()))
+            .map(|ann| {
+                let span = annotation_to_span(ann);
+                let locus = ann
+                    .locus
+                    .clone()
+                    .or_else(|| graph_locus_from_annotation_span(&span, self.controller.graph()));
+                (span, locus)
+            })
             .collect();
-        for locus in loci.into_iter().flatten() {
-            highlight_match_range(&mut self.controller, &locus, style);
+        for (_, locus) in &spans_and_loci {
+            if let Some(locus) = locus {
+                highlight_match_range(&mut self.controller, locus, style);
+            }
         }
-        for ann in &annotations {
+        for (span, _) in spans_and_loci {
             self.overlays.push(GraphOverlay {
-                span: ann.inner.clone(),
+                span,
                 track: track_name.clone(),
                 style,
             });

--- a/gen-python/src/python_api/repository/mod.rs
+++ b/gen-python/src/python_api/repository/mod.rs
@@ -254,8 +254,8 @@ impl PyRepository {
             .path()
             .map(std::path::PathBuf::from)
             .ok_or_else(|| PyRuntimeError::new_err("graph DB has no file path"))?;
-        let graph =
-            BlockGroup::get_graph(graph_conn, &sequence_graph.id).map_err(block_group_err_to_pyerr)?;
+        let graph = BlockGroup::get_graph(graph_conn, &sequence_graph.id)
+            .map_err(block_group_err_to_pyerr)?;
         let mut ctrl = PyGraphController::new(db_path, graph);
         ctrl.block_group_id = Some(sequence_graph.id);
         ctrl.auto_load_annotation_groups(graph_conn);

--- a/gen-r/R/extendr-wrappers.R
+++ b/gen-r/R/extendr-wrappers.R
@@ -68,7 +68,7 @@ Repository$derive_subgraph <- function(collection, sample, new_sample, region, b
 
 Repository$derive_chunks <- function(collection, sample, new_sample, region, backbone, breakpoints, chunk_size) .Call("wrap__Repository__derive_chunks", self, collection, sample, new_sample, region, backbone, breakpoints, chunk_size, PACKAGE = "genr")
 
-Repository$get_annotation_group_names <- function(sequence_graph_id) .Call("wrap__Repository__get_annotation_group_names", self, sequence_graph_id, PACKAGE = "genr")
+Repository$auto_load_annotation_groups <- function(sequence_graph_id) .Call("wrap__Repository__auto_load_annotation_groups", self, sequence_graph_id, PACKAGE = "genr")
 
 Repository$list_annotations <- function(sequence_graph_id) .Call("wrap__Repository__list_annotations", self, sequence_graph_id, PACKAGE = "genr")
 
@@ -82,6 +82,20 @@ Repository$handle_click <- function(sequence_graph_id, detail, ops, col, row) .C
 #' @export
 `[[.Repository` <- `$.Repository`
 
+#'
+#' @section Methods:
+#'\subsection{Method `list_annotations`}{
+#'List the gene annotations associated with this sequence graph.
+#'
+#'Reads persisted annotations from the database (including those inherited
+#'from ancestor samples), so it does not depend on the viewer/widget.
+#'
+#' \subsection{return}{
+#'A list of `gen_annotation` records, each with `id`, `name`,
+#'`group`, `kind`, `segments`, `length`, and `locus` fields.
+#'}
+#'}
+#'
 SequenceGraph <- new.env(parent = emptyenv())
 
 SequenceGraph$id <- function() .Call("wrap__SequenceGraph__id", self, PACKAGE = "genr")
@@ -115,6 +129,8 @@ SequenceGraph$subgraph <- function(new_sample, start, end, backbone) .Call("wrap
 SequenceGraph$chunks <- function(new_sample, breakpoints, chunk_size, backbone) .Call("wrap__SequenceGraph__chunks", self, new_sample, breakpoints, chunk_size, backbone, PACKAGE = "genr")
 
 SequenceGraph$to_dict <- function() .Call("wrap__SequenceGraph__to_dict", self, PACKAGE = "genr")
+
+SequenceGraph$list_annotations <- function() .Call("wrap__SequenceGraph__list_annotations", self, PACKAGE = "genr")
 
 #' @export
 `$.SequenceGraph` <- function (self, name) { func <- SequenceGraph[[name]]; environment(func) <- environment(); func }

--- a/gen-r/R/high_level.R
+++ b/gen-r/R/high_level.R
@@ -123,8 +123,7 @@ resolve_granges_columns <- function(parts_list, seq_containers) {
 #'     \item{\code{clear_highlights()}}{Remove all highlights. Returns self invisibly.}
 #'     \item{\code{add_track_file(path, name = NULL, sample = NULL)}}{Add a GFF3 or BED file as an annotation track panel below the graph. \code{sample} is the sample whose path defines the coordinate space (default \code{"reference"}).}
 #'     \item{\code{add_track_group(group)}}{Add a DB-stored annotation group as a track panel below the graph.}
-#'     \item{\code{clear_tracks()}}{Remove all annotation track panels. Returns self invisibly.}
-#'     \item{\code{list_annotations()}}{Return a list of annotation records from the database. Each record has \code{name} and \code{locus} fields.}
+#'     \item{\code{list_annotations()}}{Return a list of \code{gen_annotation} records from the database. Each record has \code{id}, \code{name}, \code{group}, \code{kind}, \code{segments}, \code{length}, and \code{locus} fields.}
 #'     \item{\code{go_to(annotation)}}{Navigate to an annotation returned by \code{list_annotations()}. Sets detail to \code{"full"}. Returns self invisibly.}
 #'   }
 #' @export
@@ -135,7 +134,7 @@ GenPlot <- function(db_path, sequence_graph_id, detail = "normal", rows = NULL, 
   ctrl$detail <- detail
   ctrl$ops <- character()
   ctrl$track_specs <- tryCatch({
-    group_names <- ctrl$repo$get_annotation_group_names(ctrl$sequence_graph_id)
+    group_names <- ctrl$repo$auto_load_annotation_groups(ctrl$sequence_graph_id)
     lapply(group_names, function(n) list(type = "group", name = n))
   }, error = function(e) list())
   ctrl$rows <- rows %||% 24L
@@ -163,10 +162,6 @@ GenPlot <- function(db_path, sequence_graph_id, detail = "normal", rows = NULL, 
     invisible(ctrl)
   }
 
-  ctrl$clear_tracks <- function() {
-    ctrl$track_specs <- list()
-    invisible(ctrl)
-  }
 
   ctrl$zoom_in <- function() {
     ctrl$ops <- c(ctrl$ops, "zi")
@@ -558,7 +553,7 @@ Repository <- function(path = NULL) {
   repo$render_frame   <- function(sg_id, detail, cols, rows, ops, tracks_json) inner$render_frame(sg_id, detail, cols, rows, ops, tracks_json)
   repo$handle_click   <- function(sg_id, detail, ops, col, row) inner$handle_click(sg_id, detail, ops, col, row)
   repo$list_annotations           <- function(sg_id) inner$list_annotations(sg_id)
-  repo$get_annotation_group_names <- function(sg_id) inner$get_annotation_group_names(sg_id)
+  repo$auto_load_annotation_groups <- function(sg_id) inner$auto_load_annotation_groups(sg_id)
   repo$get_node_sequence          <- function(node_id, sequence_start, sequence_end) inner$get_node_sequence(node_id, as.integer(sequence_start), as.integer(sequence_end))
 
   repo$import_fasta           <- function(filename, sample = "sample", shallow = FALSE, collection = NULL) inner$import_fasta(filename, sample, isTRUE(shallow), collection)

--- a/gen-r/man/GenPlot.Rd
+++ b/gen-r/man/GenPlot.Rd
@@ -38,8 +38,7 @@ A \code{gen_plot} environment with methods:
 \item{\code{clear_highlights()}}{Remove all highlights. Returns self invisibly.}
 \item{\code{add_track_file(path, name = NULL, sample = NULL)}}{Add a GFF3 or BED file as an annotation track panel below the graph. \code{sample} is the sample whose path defines the coordinate space (default \code{"reference"}).}
 \item{\code{add_track_group(group)}}{Add a DB-stored annotation group as a track panel below the graph.}
-\item{\code{clear_tracks()}}{Remove all annotation track panels. Returns self invisibly.}
-\item{\code{list_annotations()}}{Return a list of annotation records from the database. Each record has \code{name} and \code{locus} fields.}
+\item{\code{list_annotations()}}{Return a list of \code{gen_annotation} records from the database. Each record has \code{id}, \code{name}, \code{group}, \code{kind}, \code{segments}, \code{length}, and \code{locus} fields.}
 \item{\code{go_to(annotation)}}{Navigate to an annotation returned by \code{list_annotations()}. Sets detail to \code{"full"}. Returns self invisibly.}
 }
 }

--- a/gen-r/src/rust/src/lib.rs
+++ b/gen-r/src/rust/src/lib.rs
@@ -22,10 +22,11 @@ use r#gen::{
         graph_search::{GenGraphMatcher, SeedIndex, SequenceKind},
     },
     views::{
-        annotation_groups::{
-            AnnotationGroupEntry, AnnotationGroupOrigin, load_annotation_group_entries,
+        annotation_groups::{AnnotationGroupEntry, AnnotationGroupOrigin, annotation_group_names},
+        annotation_track::{
+            AnnotationSegment as ViewAnnotationSegment, AnnotationSpan, AnnotationTrack,
+            graph_locus_from_annotation_span,
         },
-        annotation_track::{AnnotationTrack, graph_locus_from_annotation_span},
         annotations::{
             AnnotationGroupTrackRequest, load_annotations_for_group, parse_translated_bed,
             parse_translated_bed_file, parse_translated_gff, parse_translated_gff_file,
@@ -33,10 +34,15 @@ use r#gen::{
         gen_graph_widget::{GenGraphNodeRenderer, GenGraphNodeSizer, highlight_match_range},
     },
 };
-use gen_annotations::translate::{bed::translate_bed, gff::translate_gff};
+use gen_annotations::{
+    projection::{AnnotationSegment, accession_edges_to_segments},
+    translate::{bed::translate_bed, gff::translate_gff},
+};
 use gen_core::{HashId, Strand, config::Workspace, is_end_node, is_start_node};
 use gen_graph::{GenGraph, GraphNode, GraphNodeSlice};
 use gen_models::{
+    accession::Accession,
+    annotations::Annotation,
     block_group::BlockGroup,
     db::{DbContext as GenDbContext, GraphConnection},
     errors::OperationError,
@@ -136,6 +142,88 @@ fn strand_str(strand: Strand) -> &'static str {
         Strand::Reverse => "-",
         _ => ".",
     }
+}
+
+/// Genomic segments covered by an annotation.
+fn annotation_segments(conn: &GraphConnection, annotation: &Annotation) -> Vec<AnnotationSegment> {
+    let edges = Accession::get_edges_by_id(conn, &annotation.accession_id);
+    accession_edges_to_segments(&edges)
+}
+
+/// Build a `gen_annotation` R record (id, name, group, kind, segments, length, locus).
+fn annotation_record(conn: &GraphConnection, annotation: &Annotation, graph: &GenGraph) -> Robj {
+    let segments = annotation_segments(conn, annotation);
+    let span = AnnotationSpan {
+        id: annotation.id,
+        name: annotation.name.clone(),
+        segments: segments
+            .iter()
+            .map(|s| ViewAnnotationSegment {
+                node_id: s.node_id,
+                start: s.range.start,
+                end: s.range.end,
+                strand: s.strand,
+            })
+            .collect(),
+    };
+    let locus_robj: Robj = match graph_locus_from_annotation_span(&span, graph) {
+        Some(locus) => graph_locus_record(&locus),
+        None => r!(NULL),
+    };
+    let length: i64 = segments.iter().map(|s| s.range.end - s.range.start).sum();
+    let segment_records: Vec<Robj> = segments
+        .iter()
+        .map(|s| {
+            let mut seg = r!(list!(
+                node_id = s.node_id.to_string(),
+                start = s.range.start,
+                end = s.range.end,
+                strand = strand_str(s.strand)
+            ));
+            seg.set_class(&["gen_annotation_segment"]).unwrap();
+            seg
+        })
+        .collect();
+    let kind = annotation
+        .extra
+        .as_ref()
+        .and_then(|e| e.genbank.as_ref())
+        .map(|g| g.kind.clone());
+    let kind_robj: Robj = match kind {
+        Some(k) => r!(k),
+        None => r!(NULL),
+    };
+    let mut obj = r!(list!(
+        id = annotation.id.to_string(),
+        name = annotation.name.as_str(),
+        group = annotation.group.as_str(),
+        kind = kind_robj,
+        segments = List::from_values(segment_records),
+        length = length,
+        locus = locus_robj
+    ));
+    obj.set_class(&["gen_annotation"]).unwrap();
+    obj
+}
+
+/// Rich `gen_annotation` records for a block group, following the sample
+/// lineage. Single listing route shared by `SequenceGraph` and `Repository`.
+fn list_annotation_records(
+    conn: &GraphConnection,
+    block_group_id: &HashId,
+    collection_name: &str,
+    sample_name: &str,
+    name: &str,
+) -> std::result::Result<List, Error> {
+    let graph =
+        BlockGroup::get_graph(conn, block_group_id).map_err(|e| Error::Other(e.to_string()))?;
+    let annotations = Annotation::query_with_lineage(conn, collection_name, sample_name, name)
+        .map_err(|e| Error::Other(e.to_string()))?;
+    let records: Vec<Robj> = annotations
+        .iter()
+        .map(|a| annotation_record(conn, a, &graph))
+        .collect();
+    Ok(List::from_values(records))
 }
 
 fn node_slice_record(
@@ -1793,7 +1881,7 @@ impl Repository {
         Ok("Derived chunks.".to_string())
     }
 
-    fn get_annotation_group_names(
+    fn auto_load_annotation_groups(
         &self,
         sequence_graph_id: String,
     ) -> std::result::Result<Vec<String>, Error> {
@@ -1801,13 +1889,7 @@ impl Repository {
         let bg_id = hash_id_from_string(&sequence_graph_id).map_err(Error::Other)?;
         let bg = BlockGroup::get_by_id(conn, &bg_id)
             .map_err(|e| Error::Other(format!("Block group not found: {e}")))?;
-        let entries = load_annotation_group_entries(conn, &bg);
-        let mut seen = HashSet::new();
-        Ok(entries
-            .into_iter()
-            .filter(|e| seen.insert(e.name.clone()))
-            .map(|e| e.name)
-            .collect())
+        Ok(annotation_group_names(conn, &bg))
     }
 
     fn list_annotations(&self, sequence_graph_id: String) -> std::result::Result<List, Error> {
@@ -1815,40 +1897,7 @@ impl Repository {
         let bg_id = hash_id_from_string(&sequence_graph_id).map_err(Error::Other)?;
         let bg = BlockGroup::get_by_id(conn, &bg_id)
             .map_err(|e| Error::Other(format!("Block group not found: {e}")))?;
-        let graph = BlockGroup::get_graph(conn, &bg_id).map_err(|e| Error::Other(e.to_string()))?;
-
-        let node_ranges: HashMap<HashId, Vec<(i64, i64)>> = graph
-            .nodes()
-            .filter(|n| !is_start_node(n.node_id) && !is_end_node(n.node_id))
-            .map(|n| (n.node_id, vec![(n.sequence_start, n.sequence_end)]))
-            .collect();
-
-        let entries = load_annotation_group_entries(conn, &bg);
-        let mut seen = HashSet::new();
-        let mut result: Vec<Robj> = Vec::new();
-
-        for entry in &entries {
-            if !seen.insert(entry.name.clone()) {
-                continue;
-            }
-            let Ok(spans) = load_annotations_for_group(&AnnotationGroupTrackRequest {
-                conn,
-                current_block_group: &bg,
-                entry,
-                visible_ranges_by_node: &node_ranges,
-            }) else {
-                continue;
-            };
-            for span in &spans {
-                let Some(locus) = graph_locus_from_annotation_span(span, &graph) else {
-                    continue;
-                };
-                let locus_rec = graph_locus_record(&locus);
-                result.push(list!(name = span.name.as_str(), locus = locus_rec).into());
-            }
-        }
-
-        Ok(List::from_values(result))
+        list_annotation_records(conn, &bg.id, &bg.collection_name, &bg.sample_name, &bg.name)
     }
 
     fn render_frame(
@@ -2217,6 +2266,24 @@ impl SequenceGraph {
             nodes = List::from_values(nodes),
             edges = List::from_values(edges)
         ))
+    }
+
+    /// List the gene annotations associated with this sequence graph.
+    ///
+    /// Reads persisted annotations from the database (including those inherited
+    /// from ancestor samples), so it does not depend on the viewer/widget.
+    ///
+    /// @return A list of `gen_annotation` records, each with `id`, `name`,
+    ///   `group`, `kind`, `segments`, `length`, and `locus` fields.
+    fn list_annotations(&self) -> std::result::Result<List, Error> {
+        let conn = self.context.graph().conn();
+        list_annotation_records(
+            conn,
+            &self.id,
+            &self.collection_name,
+            &self.sample_name,
+            &self.name,
+        )
     }
 }
 

--- a/gen-r/vignettes/introduction.Rmd
+++ b/gen-r/vignettes/introduction.Rmd
@@ -66,22 +66,22 @@ gbk_path <- system.file("extdata", "puc19.gbk", package = "genr")
 repo$import_genbank(gbk_path, sample = "wt")
 ```
 
-List the block groups in the repository to confirm the import:
+List the sequence graphs in the repository to confirm the import:
 
-```{r list-bgs}
-bgs <- repo$get_sequence_graphs()
-bg_wt <- bgs[[1]]
-cat("Sequence graph:", bg_wt$name(), "| sample:", bg_wt$sample_name(), "\n")
+```{r list-sgs}
+sgs <- repo$get_sequence_graphs()
+sg_wt <- sgs[[1]]
+cat("Sequence graph:", sg_wt$name(), "| sample:", sg_wt$sample_name(), "\n")
 ```
 
 ## Visualise the reference
 
 ```{r plot-wt}
-p <- plot(bg_wt)
+p <- plot(sg_wt)
 
 # Navigate to the MCS — annotated features are first-class, so you can
 # jump directly to any named feature rather than specifying coordinates.
-annotations <- p$list_annotations()
+annotations <- sg_wt$list_annotations()
 mcs <- Filter(function(a) grepl("MCS|misc_feature|multiple.cloning", a$name, ignore.case = TRUE), annotations)
 if (length(mcs) > 0) p$go_to(mcs[[1]])
 
@@ -90,7 +90,7 @@ p
 
 The viewer renders a static snapshot of the sequence graph. Annotations
 from the GenBank file (lacZα, bla, the MCS) appear as coloured tracks
-below the sequence. `list_annotations()` returns all named features in
+below the sequence. `sg_wt$list_annotations()` returns all named features in
 the database; passing one to `go_to()` centres the viewport on that
 feature — no coordinate look-up required.
 
@@ -134,7 +134,7 @@ diverges through the new MCS nodes.
 ## Inspect the design
 
 ```{r get-gg-bg}
-bg_gg <- Filter(function(x) x$sample_name() == "gg_design", repo$get_sequence_graphs())[[1]]
+sg_gg <- Filter(function(x) x$sample_name() == "gg_design", repo$get_sequence_graphs())[[1]]
 ```
 
 ### Confirm the BsaI sites with search
@@ -147,12 +147,12 @@ the reverse complement as well as the forward sequence.
 ```{r search-bsai}
 # GGTCTC is the BsaI recognition sequence (cuts 1 nt downstream on sense strand).
 # DNA-mode search finds both the forward site and its reverse-complement counterpart.
-hits <- repo$search("GGTCTC", c(bg_gg$id()), "dna")
+hits <- repo$search("GGTCTC", c(sg_gg$id()), "dna")
 cat("BsaI sites found:", length(hits[[1]]$matches), "\n")
 ```
 
 ```{r plot-gg}
-p_gg <- plot(bg_gg)
+p_gg <- plot(sg_gg)
 p_gg$go_to(hits[[1]]$matches[[1]])
 p_gg
 ```
@@ -166,7 +166,7 @@ Three hits. To understand why, run the same search against the
 wild-type:
 
 ```{r search-wt}
-hits_wt <- repo$search("GGTCTC", c(bg_wt$id()), "dna")
+hits_wt <- repo$search("GGTCTC", c(sg_wt$id()), "dna")
 wt_count <- if (length(hits_wt) > 0) length(hits_wt[[1]]$matches) else 0L
 cat("BsaI sites in wild-type:", wt_count, "\n")   # 1
 ```
@@ -187,7 +187,7 @@ possible hexamers — pass the IUPAC string and `search()` matches all of
 them:
 
 ```{r search-iupac}
-hits_hincii <- repo$search("GTYRAC", c(bg_gg$id()), "dna")
+hits_hincii <- repo$search("GTYRAC", c(sg_gg$id()), "dna")
 cat("HincII sites found:", length(hits_hincii[[1]]$matches), "\n")
 ```
 
@@ -252,11 +252,11 @@ repo$update_with_vcf(
 Plot the sequenced sample:
 
 ```{r get-sequenced-bg}
-bg_seq <- Filter(function(x) x$sample_name() == "sequenced", repo$get_sequence_graphs())[[1]]
+sg_seq <- Filter(function(x) x$sample_name() == "sequenced", repo$get_sequence_graphs())[[1]]
 ```
 
 ```{r plot-sequenced}
-p_seq <- plot(bg_seq)
+p_seq <- plot(sg_seq)
 p_seq
 ```
 
@@ -489,24 +489,24 @@ Sequence graphs expose `subgraph()` as a shorthand that returns the new
 sequence graph immediately:
 
 ```{r bg-subgraph, eval=FALSE}
-mcs_bg <- bg_gg$subgraph("mcs_v2", 390L, 460L, NULL)
-plot(mcs_bg)
+mcs_sg <- sg_gg$subgraph("mcs_v2", 390L, 460L, NULL)
+plot(mcs_sg)
 ```
 
 #### Chunks and stitching
 
-`bg$chunks()` splits a block group into contiguous fragments and returns
-them as a list of block groups. Supply `chunk_size` for uniform splits
+`sg$chunks()` splits a sequence graph into contiguous fragments and returns
+them as a list of sequence graphs. Supply `chunk_size` for uniform splits
 or `breakpoints` (an integer vector of positions) for explicit cut
 points:
 
 ```{r derive-chunks, eval=FALSE}
-chunks <- bg_gg$chunks("gg_500bp_chunks", integer(0), 500L, NULL)
+chunks <- sg_gg$chunks("gg_500bp_chunks", integer(0), 500L, NULL)
 cat("Chunks created:", length(chunks), "\n")
 ```
 
 `stitch()` reverses the operation, concatenating a list of
-same-sample block groups end-to-end into a new block group:
+same-sample sequence graphs end-to-end into a new sequence graph:
 
 ```{r stitch, eval=FALSE}
 reassembled <- stitch(
@@ -537,13 +537,5 @@ GenBank import) can be added by group name:
 
 ```{r add-track-group, eval=FALSE}
 p_gg$add_track_group("GenBank annotations")
-p_gg
-```
-
-`clear_tracks()` removes all track panels without affecting the viewport
-or highlights:
-
-```{r clear-tracks, eval=FALSE}
-p_gg$clear_tracks()
 p_gg
 ```

--- a/src/views/annotation_groups.rs
+++ b/src/views/annotation_groups.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use gen_core::HashId;
 use gen_models::{
@@ -110,6 +110,18 @@ pub fn load_annotation_group_entries(
     });
     entries.dedup_by(|left, right| left.id == right.id);
     entries
+}
+
+/// Distinct annotation-group names visible from a block group, in the order
+/// produced by [`load_annotation_group_entries`]. Shared discovery used by the
+/// Python and R auto-load paths so the logic lives in one place.
+pub fn annotation_group_names(conn: &GraphConnection, block_group: &BlockGroup) -> Vec<String> {
+    let mut seen = HashSet::new();
+    load_annotation_group_entries(conn, block_group)
+        .into_iter()
+        .filter(|entry| seen.insert(entry.name.clone()))
+        .map(|entry| entry.name)
+        .collect()
 }
 
 fn origin_rank(origin: AnnotationGroupOrigin) -> usize {


### PR DESCRIPTION
Affects Python and R bindings only.

- Consolidates annotations that came from the DB or files into a common type
- `list_annotations()` is now exposed on `SequenceGraph` in both Python and R, so annotations are reachable directly from the graph rather than only via the widget.

Introduction notebooks and vignettes are updated to use the new API.

This is the base for the stacked protein-translation PR.