### PR TITLE
Use nodes for accessions instead of edges

### DIFF
--- a/gen-annotations/src/projection.rs
+++ b/gen-annotations/src/projection.rs
@@ -27,19 +27,17 @@ impl OrderedMerge for AnnotationSegment {
     }
 }
 
-pub fn accession_nodes_to_segments(nodes: &[AccessionNode]) -> Vec<AnnotationSegment> {
-    nodes
-        .iter()
-        .filter(|node| node.sequence_end > node.sequence_start)
-        .map(|node| AnnotationSegment {
+impl From<&AccessionNode> for AnnotationSegment {
+    fn from(node: &AccessionNode) -> Self {
+        AnnotationSegment {
             node_id: node.node_id,
             range: Range {
                 start: node.sequence_start,
                 end: node.sequence_end,
             },
             strand: node.strand,
-        })
-        .collect()
+        }
+    }
 }
 
 pub fn project_annotation_segments(

--- a/gen-annotations/src/projection.rs
+++ b/gen-annotations/src/projection.rs
@@ -5,7 +5,7 @@ use gen_core::{
     path::PathBlock,
     range::{OrderedMerge, Range, merge_ordered_items},
 };
-use gen_models::accession::AccessionEdge;
+use gen_models::accession::AccessionNode;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct AnnotationSegment {
@@ -27,50 +27,19 @@ impl OrderedMerge for AnnotationSegment {
     }
 }
 
-pub fn accession_edges_to_segments(edges: &[AccessionEdge]) -> Vec<AnnotationSegment> {
-    let mut segments = Vec::new();
-    let mut current_node = None;
-    let mut current_start = None;
-    let mut current_strand = None;
-
-    for edge in edges {
-        if edge.source_coordinate < 0 {
-            current_node = Some(edge.target_node_id);
-            current_start = Some(edge.target_coordinate);
-            current_strand = Some(edge.target_strand);
-            continue;
-        }
-
-        if let (Some(node_id), Some(start), Some(strand)) =
-            (current_node, current_start, current_strand)
-        {
-            let (segment_start, segment_end) = if start <= edge.source_coordinate {
-                (start, edge.source_coordinate)
-            } else {
-                (edge.source_coordinate, start)
-            };
-            if segment_end > segment_start {
-                segments.push(AnnotationSegment {
-                    node_id,
-                    range: Range {
-                        start: segment_start,
-                        end: segment_end,
-                    },
-                    strand,
-                });
-            }
-        }
-
-        if edge.target_coordinate < 0 {
-            break;
-        }
-
-        current_node = Some(edge.target_node_id);
-        current_start = Some(edge.target_coordinate);
-        current_strand = Some(edge.target_strand);
-    }
-
-    segments
+pub fn accession_nodes_to_segments(nodes: &[AccessionNode]) -> Vec<AnnotationSegment> {
+    nodes
+        .iter()
+        .filter(|node| node.sequence_end > node.sequence_start)
+        .map(|node| AnnotationSegment {
+            node_id: node.node_id,
+            range: Range {
+                start: node.sequence_start,
+                end: node.sequence_end,
+            },
+            strand: node.strand,
+        })
+        .collect()
 }
 
 pub fn project_annotation_segments(

--- a/gen-capnp-schemas/gen-models.capnp
+++ b/gen-capnp-schemas/gen-models.capnp
@@ -112,22 +112,14 @@ struct Accession {
   }
 }
 
-struct AccessionEdge {
-  id @0 :List(UInt8);
-  sourceNodeId @1 :List(UInt8);
-  sourceCoordinate @2 :Int64;
-  sourceStrand @3 :Core.Strand;
-  targetNodeId @4 :List(UInt8);
-  targetCoordinate @5 :Int64;
-  targetStrand @6 :Core.Strand;
-  chromosomeIndex @7 :Int64;
-}
-
-struct AccessionPath {
+struct AccessionNode {
   id @0 :List(UInt8);
   accessionId @1 :List(UInt8);
-  indexInPath @2 :Int64;
-  edgeId @3 :List(UInt8);
+  nodeId @2 :List(UInt8);
+  sequenceStart @3 :Int64;
+  sequenceEnd @4 :Int64;
+  strand @5 :Core.Strand;
+  indexInPath @6 :Int64;
 }
 
 # Operation and version control models
@@ -298,12 +290,11 @@ struct ChangesetModels {
   paths @7 :List(Path);
   pathEdges @8 :List(PathEdge);
   accessions @9 :List(Accession);
-  accessionEdges @10 :List(AccessionEdge);
-  accessionPaths @11 :List(AccessionPath);
-  annotationGroups @12 :List(AnnotationGroup);
-  annotations @13 :List(Annotation);
-  annotationGroupSamples @14 :List(AnnotationGroupSample);
-  sampleLineages @15 :List(SampleLineage);
+  accessionNodes @10 :List(AccessionNode);
+  annotationGroups @11 :List(AnnotationGroup);
+  annotations @12 :List(Annotation);
+  annotationGroupSamples @13 :List(AnnotationGroupSample);
+  sampleLineages @14 :List(SampleLineage);
 }
 
 struct DependencyModels {
@@ -315,5 +306,5 @@ struct DependencyModels {
   edges @5 :List(Edge);
   paths @6 :List(Path);
   accessions @7 :List(Accession);
-  accessionEdges @8 :List(AccessionEdge);
+  accessionNodes @8 :List(AccessionNode);
 }

--- a/gen-diff/src/graph.rs
+++ b/gen-diff/src/graph.rs
@@ -279,7 +279,7 @@ mod tests {
             edges: vec![],
             paths: vec![],
             accessions: vec![],
-            accession_edges: vec![],
+            accession_nodes: vec![],
         }
     }
 
@@ -443,8 +443,7 @@ mod tests {
             paths: vec![],
             path_edges: vec![],
             accessions: vec![],
-            accession_edges: vec![],
-            accession_paths: vec![],
+            accession_nodes: vec![],
             annotation_groups: vec![],
             annotations: vec![],
             annotation_group_samples: vec![],

--- a/gen-diff/src/operations.rs
+++ b/gen-diff/src/operations.rs
@@ -315,7 +315,7 @@ mod tests {
             edges: vec![],
             paths: vec![],
             accessions: vec![],
-            accession_edges: vec![],
+            accession_nodes: vec![],
         }
     }
 
@@ -376,8 +376,7 @@ mod tests {
             paths: vec![],
             path_edges: vec![],
             accessions: vec![],
-            accession_edges: vec![],
-            accession_paths: vec![],
+            accession_nodes: vec![],
             annotation_groups: vec![],
             annotations: vec![],
             annotation_group_samples: vec![],

--- a/gen-models/migrations/core/01-initial/up.sql
+++ b/gen-models/migrations/core/01-initial/up.sql
@@ -70,29 +70,19 @@ CREATE TABLE accessions (
 CREATE UNIQUE INDEX accession_uidx ON accessions(block_group_id, parent_accession_id, name) WHERE parent_accession_id is not null;
 CREATE UNIQUE INDEX accession_null_aid_uidx ON accessions(block_group_id, name) WHERE parent_accession_id is null;
 
-CREATE TABLE accession_edges (
-  id BLOB PRIMARY KEY NOT NULL,
-  source_node_id BLOB NOT NULL,
-  source_coordinate INTEGER NOT NULL,
-  source_strand TEXT NOT NULL,
-  target_node_id BLOB NOT NULL,
-  target_coordinate INTEGER NOT NULL,
-  target_strand TEXT NOT NULL,
-  chromosome_index INTEGER NOT NULL,
-  FOREIGN KEY(source_node_id) REFERENCES nodes(id),
-  FOREIGN KEY(target_node_id) REFERENCES nodes(id)
-) STRICT;
-CREATE UNIQUE INDEX accession_edge_uidx ON accession_edges(source_node_id, source_coordinate, source_strand, target_node_id, target_coordinate, target_strand, chromosome_index);
-
-CREATE TABLE accession_paths (
+CREATE TABLE accession_nodes (
   id BLOB PRIMARY KEY NOT NULL,
   accession_id BLOB NOT NULL,
+  node_id BLOB NOT NULL,
+  sequence_start INTEGER NOT NULL,
+  sequence_end INTEGER NOT NULL,
+  strand TEXT NOT NULL,
   index_in_path INTEGER NOT NULL,
-  edge_id BLOB NOT NULL,
-  FOREIGN KEY(edge_id) REFERENCES accession_edges(id),
+  FOREIGN KEY(node_id) REFERENCES nodes(id),
   FOREIGN KEY(accession_id) REFERENCES accessions(id)
 ) STRICT;
-CREATE UNIQUE INDEX accession_path_uidx ON accession_paths(accession_id, edge_id, index_in_path);
+CREATE UNIQUE INDEX accession_nodes_path_uidx ON accession_nodes(accession_id, index_in_path);
+CREATE UNIQUE INDEX accession_nodes_slice_uidx ON accession_nodes(accession_id, node_id, sequence_start, sequence_end, strand, index_in_path);
 
 CREATE TABLE edges (
   id BLOB PRIMARY KEY NOT NULL,

--- a/gen-models/src/accession.rs
+++ b/gen-models/src/accession.rs
@@ -163,6 +163,8 @@ impl<'a> Capnp<'a> for AccessionNode {
     }
 }
 
+/// AccessionNodeData is a non-database form of AccessionNode. It allows callers to construct
+/// an AccessionNode without having to calculate the id.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct AccessionNodeData {
     pub accession_id: HashId,
@@ -773,7 +775,7 @@ mod tests {
     }
 
     #[test]
-    fn test_accession_blocks_are_direct_node_slices() {
+    fn test_accession_node_to_accession_blocks_conversion() {
         let conn = &get_connection(None).unwrap();
         let (block_group_id, _path) = setup_block_group(conn);
         let accession = Accession::create(conn, "test", &block_group_id, None).unwrap();
@@ -841,7 +843,7 @@ mod tests {
     }
 
     #[test]
-    fn test_query_accessions_groups_nodes_by_accession() {
+    fn test_query_accessions() {
         let conn = &get_connection(None).unwrap();
         let (block_group_id, _path) = setup_block_group(conn);
         let accession_1 = Accession::create(conn, "test-1", &block_group_id, None).unwrap();
@@ -895,7 +897,7 @@ mod tests {
     }
 
     #[test]
-    fn test_create_from_edges_persists_accession_nodes() {
+    fn test_create_from_edges() {
         let conn = &get_connection(None).unwrap();
         let (block_group_id, _path) = setup_block_group(conn);
         let path_edges = vec![

--- a/gen-models/src/accession.rs
+++ b/gen-models/src/accession.rs
@@ -1,20 +1,16 @@
-use std::collections::HashSet;
-
 use gen_core::{
     HashId, NodeIntervalBlock, PATH_END_NODE_ID, PATH_START_NODE_ID, Strand, calculate_hash,
     region::{Region, RegionResolutionError, RegionResolver},
     traits::Capnp,
 };
 use intervaltree::IntervalTree;
-use itertools::Itertools;
 use rusqlite::{Row, params};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::{
-    block_group_edge::AugmentedEdgeData,
     db::GraphConnection,
-    gen_models_capnp::{accession, accession_edge, accession_path},
+    gen_models_capnp::{accession, accession_node},
     traits::*,
 };
 
@@ -32,7 +28,7 @@ pub enum AccessionError {
     DatabaseError(#[from] rusqlite::Error),
     #[error("Duplicate entry with uuid: {0}")]
     Duplicate(String),
-    #[error("Accession {0} has no edges in accession_paths")]
+    #[error("Accession {0} has no nodes in accession_nodes")]
     MissingPath(HashId),
 }
 
@@ -92,102 +88,34 @@ impl<'a> Capnp<'a> for Accession {
 }
 
 #[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Hash)]
-pub struct AccessionEdge {
-    pub id: HashId,
-    pub source_node_id: HashId,
-    pub source_coordinate: i64,
-    pub source_strand: Strand,
-    pub target_node_id: HashId,
-    pub target_coordinate: i64,
-    pub target_strand: Strand,
-    pub chromosome_index: i64,
-}
-
-#[derive(Debug, Error, PartialEq)]
-pub enum AccessionEdgeError {
-    #[error("Database error: {0}")]
-    DatabaseError(#[from] rusqlite::Error),
-}
-
-impl<'a> Capnp<'a> for AccessionEdge {
-    type Builder = accession_edge::Builder<'a>;
-    type Reader = accession_edge::Reader<'a>;
-
-    fn write_capnp(&self, builder: &mut Self::Builder) {
-        builder.set_id(&self.id.0).unwrap();
-        builder.set_source_node_id(&self.source_node_id.0).unwrap();
-        builder.set_source_coordinate(self.source_coordinate);
-        builder.set_source_strand(self.source_strand.into());
-        builder.set_target_node_id(&self.target_node_id.0).unwrap();
-        builder.set_target_coordinate(self.target_coordinate);
-        builder.set_target_strand(self.target_strand.into());
-        builder.set_chromosome_index(self.chromosome_index);
-    }
-
-    fn read_capnp(reader: Self::Reader) -> Self {
-        let id = reader
-            .get_id()
-            .unwrap()
-            .as_slice()
-            .unwrap()
-            .try_into()
-            .unwrap();
-        let source_node_id = reader
-            .get_source_node_id()
-            .unwrap()
-            .as_slice()
-            .unwrap()
-            .try_into()
-            .unwrap();
-        let source_coordinate = reader.get_source_coordinate();
-        let source_strand = reader.get_source_strand().unwrap().into();
-        let target_node_id = reader
-            .get_target_node_id()
-            .unwrap()
-            .as_slice()
-            .unwrap()
-            .try_into()
-            .unwrap();
-        let target_coordinate = reader.get_target_coordinate();
-        let target_strand = reader.get_target_strand().unwrap().into();
-        let chromosome_index = reader.get_chromosome_index();
-
-        AccessionEdge {
-            id,
-            source_node_id,
-            source_coordinate,
-            source_strand,
-            target_node_id,
-            target_coordinate,
-            target_strand,
-            chromosome_index,
-        }
-    }
-}
-
-#[derive(Deserialize, Serialize, Debug, PartialEq)]
-pub struct AccessionPath {
+pub struct AccessionNode {
     pub id: HashId,
     pub accession_id: HashId,
+    pub node_id: HashId,
+    pub sequence_start: i64,
+    pub sequence_end: i64,
+    pub strand: Strand,
     pub index_in_path: i64,
-    pub edge_id: HashId,
 }
 
 #[derive(Debug, Error, PartialEq)]
-pub enum AccessionPathError {
+pub enum AccessionNodeError {
     #[error("Database error: {0}")]
     DatabaseError(#[from] rusqlite::Error),
 }
 
-impl<'a> Capnp<'a> for AccessionPath {
-    type Builder = accession_path::Builder<'a>;
-    type Reader = accession_path::Reader<'a>;
+impl<'a> Capnp<'a> for AccessionNode {
+    type Builder = accession_node::Builder<'a>;
+    type Reader = accession_node::Reader<'a>;
 
     fn write_capnp(&self, builder: &mut Self::Builder) {
         builder.set_id(&self.id.0).unwrap();
         builder.set_accession_id(&self.accession_id.0).unwrap();
+        builder.set_node_id(&self.node_id.0).unwrap();
+        builder.set_sequence_start(self.sequence_start);
+        builder.set_sequence_end(self.sequence_end);
+        builder.set_strand(self.strand.into());
         builder.set_index_in_path(self.index_in_path);
-        builder.set_edge_id(&self.edge_id.0).unwrap();
     }
 
     fn read_capnp(reader: Self::Reader) -> Self {
@@ -205,74 +133,63 @@ impl<'a> Capnp<'a> for AccessionPath {
             .unwrap()
             .try_into()
             .unwrap();
-        let index_in_path = reader.get_index_in_path();
-        let edge_id = reader
-            .get_edge_id()
+        let node_id = reader
+            .get_node_id()
             .unwrap()
             .as_slice()
             .unwrap()
             .try_into()
             .unwrap();
+        let sequence_start = reader.get_sequence_start();
+        let sequence_end = reader.get_sequence_end();
+        let strand = reader.get_strand().unwrap().into();
+        let index_in_path = reader.get_index_in_path();
 
-        AccessionPath {
+        AccessionNode {
             id,
             accession_id,
+            node_id,
+            sequence_start,
+            sequence_end,
+            strand,
             index_in_path,
-            edge_id,
         }
     }
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct AccessionEdgeData {
-    pub source_node_id: HashId,
-    pub source_coordinate: i64,
-    pub source_strand: Strand,
-    pub target_node_id: HashId,
-    pub target_coordinate: i64,
-    pub target_strand: Strand,
-    pub chromosome_index: i64,
+pub struct AccessionNodeData {
+    pub accession_id: HashId,
+    pub node_id: HashId,
+    pub sequence_start: i64,
+    pub sequence_end: i64,
+    pub strand: Strand,
+    pub index_in_path: i64,
 }
 
-impl AccessionEdgeData {
+impl AccessionNodeData {
     pub fn id_hash(&self) -> HashId {
         HashId(calculate_hash(&format!(
-            "{}:{}:{}:{}:{}:{}:{}",
-            self.source_node_id,
-            self.source_coordinate,
-            self.source_strand,
-            self.target_node_id,
-            self.target_coordinate,
-            self.target_strand,
-            self.chromosome_index
+            "{}:{}:{}:{}:{}:{}",
+            self.accession_id,
+            self.node_id,
+            self.sequence_start,
+            self.sequence_end,
+            self.strand,
+            self.index_in_path
         )))
     }
 }
 
-impl From<&AccessionEdge> for AccessionEdgeData {
-    fn from(item: &AccessionEdge) -> Self {
-        AccessionEdgeData {
-            source_node_id: item.source_node_id,
-            source_coordinate: item.source_coordinate,
-            source_strand: item.source_strand,
-            target_node_id: item.target_node_id,
-            target_coordinate: item.target_coordinate,
-            target_strand: item.target_strand,
-            chromosome_index: item.chromosome_index,
-        }
-    }
-}
-
-impl From<&AugmentedEdgeData> for AccessionEdgeData {
-    fn from(item: &AugmentedEdgeData) -> Self {
-        AccessionEdgeData {
-            source_node_id: item.edge_data.source_node_id,
-            source_coordinate: item.edge_data.source_coordinate,
-            source_strand: item.edge_data.source_strand,
-            target_node_id: item.edge_data.target_node_id,
-            target_coordinate: item.edge_data.target_coordinate,
-            target_strand: item.edge_data.target_strand,
-            chromosome_index: item.chromosome_index,
+impl From<&AccessionNode> for AccessionNodeData {
+    fn from(item: &AccessionNode) -> Self {
+        AccessionNodeData {
+            accession_id: item.accession_id,
+            node_id: item.node_id,
+            sequence_start: item.sequence_start,
+            sequence_end: item.sequence_end,
+            strand: item.strand,
+            index_in_path: item.index_in_path,
         }
     }
 }
@@ -340,19 +257,17 @@ impl Accession {
         }
     }
 
-    pub fn get_edges_by_id(conn: &GraphConnection, accession_id: &HashId) -> Vec<AccessionEdge> {
-        let query = "\
-            select ae.* \
-            from accession_edges ae \
-            join accession_paths ap on ap.edge_id = ae.id \
-            where ap.accession_id = ?1 \
-            order by ap.index_in_path;";
-        AccessionEdge::query(conn, query, params![accession_id])
+    pub fn get_nodes_by_id(conn: &GraphConnection, accession_id: &HashId) -> Vec<AccessionNode> {
+        AccessionNode::query(
+            conn,
+            "select * from accession_nodes where accession_id = ?1 order by index_in_path;",
+            params![accession_id],
+        )
     }
 
     pub fn blocks(&self, conn: &GraphConnection) -> Result<Vec<NodeIntervalBlock>, AccessionError> {
-        let edges = Self::get_edges_by_id(conn, &self.id);
-        if edges.is_empty() {
+        let nodes = Self::get_nodes_by_id(conn, &self.id);
+        if nodes.is_empty() {
             return Err(AccessionError::MissingPath(self.id));
         }
 
@@ -366,15 +281,15 @@ impl Accession {
             strand: Strand::Forward,
         }];
 
-        for (into, out_of) in edges.iter().tuple_windows() {
-            let block_len = out_of.source_coordinate - into.target_coordinate;
+        for node in nodes {
+            let block_len = node.sequence_end - node.sequence_start;
             blocks.push(NodeIntervalBlock {
-                node_id: into.target_node_id,
+                node_id: node.node_id,
                 start: offset,
                 end: offset + block_len,
-                sequence_start: into.target_coordinate,
-                sequence_end: out_of.source_coordinate,
-                strand: into.target_strand,
+                sequence_start: node.sequence_start,
+                sequence_end: node.sequence_end,
+                strand: node.strand,
             });
             offset += block_len;
         }
@@ -455,180 +370,97 @@ impl Query for Accession {
     }
 }
 
-impl AccessionEdge {
+impl AccessionNode {
     pub fn create(
         conn: &GraphConnection,
-        edge: AccessionEdgeData,
-    ) -> Result<AccessionEdge, AccessionEdgeError> {
-        let hash = HashId(calculate_hash(&format!(
-            "{}:{}:{}:{}:{}:{}:{}",
-            edge.source_node_id,
-            edge.source_coordinate,
-            edge.source_strand,
-            edge.target_node_id,
-            edge.target_coordinate,
-            edge.target_strand,
-            edge.chromosome_index
-        )));
-        // TODO: handle get-or-create
-        let insert_statement = "INSERT INTO accession_edges (id, source_node_id, source_coordinate, source_strand, target_node_id, target_coordinate, target_strand, chromosome_index) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8);";
+        node: AccessionNodeData,
+    ) -> Result<AccessionNode, AccessionNodeError> {
+        let hash = node.id_hash();
+        let insert_statement = "INSERT INTO accession_nodes (id, accession_id, node_id, sequence_start, sequence_end, strand, index_in_path) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7);";
         let mut stmt = conn.prepare(insert_statement).unwrap();
         match stmt.execute(params![
             hash,
-            edge.source_node_id,
-            edge.source_coordinate,
-            edge.source_strand,
-            edge.target_node_id,
-            edge.target_coordinate,
-            edge.target_strand,
-            edge.chromosome_index
+            node.accession_id,
+            node.node_id,
+            node.sequence_start,
+            node.sequence_end,
+            node.strand,
+            node.index_in_path
         ]) {
             Ok(_) => {}
             Err(rusqlite::Error::SqliteFailure(err, _details)) => {
                 if err.code == rusqlite::ErrorCode::ConstraintViolation {}
             }
-            Err(err) => return Err(AccessionEdgeError::DatabaseError(err)),
+            Err(err) => return Err(AccessionNodeError::DatabaseError(err)),
         };
-        Ok(AccessionEdge {
+        Ok(AccessionNode {
             id: hash,
-            source_node_id: edge.source_node_id,
-            source_coordinate: edge.source_coordinate,
-            source_strand: edge.source_strand,
-            target_node_id: edge.target_node_id,
-            target_coordinate: edge.target_coordinate,
-            target_strand: edge.target_strand,
-            chromosome_index: edge.chromosome_index,
+            accession_id: node.accession_id,
+            node_id: node.node_id,
+            sequence_start: node.sequence_start,
+            sequence_end: node.sequence_end,
+            strand: node.strand,
+            index_in_path: node.index_in_path,
         })
     }
 
-    pub fn bulk_create(conn: &GraphConnection, edges: &[AccessionEdgeData]) -> Vec<HashId> {
-        let edge_ids = edges.iter().map(|edge| edge.id_hash()).collect::<Vec<_>>();
-        let query = AccessionEdge::query_by_ids(conn, &edge_ids);
-        let existing_edges = query.iter().map(|edge| &edge.id).collect::<HashSet<_>>();
+    pub fn bulk_create(conn: &GraphConnection, nodes: &[AccessionNodeData]) -> Vec<HashId> {
+        let node_ids = nodes
+            .iter()
+            .map(AccessionNodeData::id_hash)
+            .collect::<Vec<_>>();
+        let batch_size = max_rows_per_batch(conn, 7);
 
-        let mut edges_to_insert = HashSet::new();
-        for (index, edge) in edge_ids.iter().enumerate() {
-            if !existing_edges.contains(edge) {
-                edges_to_insert.insert(&edges[index]);
-            }
-        }
-
-        let batch_size = max_rows_per_batch(conn, 8);
-
-        for chunk in &edges_to_insert.iter().chunks(batch_size) {
+        for chunk in nodes.chunks(batch_size) {
             let mut rows = vec![];
             let mut params: Vec<Box<dyn rusqlite::ToSql>> = Vec::new();
-            for edge in chunk {
-                params.push(Box::new(edge.id_hash()));
-                params.push(Box::new(edge.source_node_id));
-                params.push(Box::new(edge.source_coordinate));
-                params.push(Box::new(edge.source_strand));
-                params.push(Box::new(edge.target_node_id));
-                params.push(Box::new(edge.target_coordinate));
-                params.push(Box::new(edge.target_strand));
-                params.push(Box::new(edge.chromosome_index));
-                rows.push("(?, ?, ?, ?, ?, ?, ?, ?)");
+            for node in chunk {
+                params.push(Box::new(node.id_hash()));
+                params.push(Box::new(node.accession_id));
+                params.push(Box::new(node.node_id));
+                params.push(Box::new(node.sequence_start));
+                params.push(Box::new(node.sequence_end));
+                params.push(Box::new(node.strand));
+                params.push(Box::new(node.index_in_path));
+                rows.push("(?, ?, ?, ?, ?, ?, ?)");
             }
             let sql = format!(
-                "INSERT INTO accession_edges (id, source_node_id, source_coordinate, source_strand, target_node_id, target_coordinate, target_strand, chromosome_index) VALUES {};",
+                "INSERT OR IGNORE INTO accession_nodes (id, accession_id, node_id, sequence_start, sequence_end, strand, index_in_path) VALUES {};",
                 rows.join(",")
             );
             conn.execute(&sql, rusqlite::params_from_iter(params))
                 .unwrap();
         }
-        edge_ids
+        node_ids
     }
 
-    pub fn bulk_delete(conn: &GraphConnection, edges: &[AccessionEdgeData]) {
-        let ids = edges.iter().map(|e| e.id_hash()).collect::<Vec<_>>();
-        AccessionEdge::delete_by_ids(conn, &ids);
+    pub fn bulk_delete(conn: &GraphConnection, nodes: &[AccessionNodeData]) {
+        let ids = nodes
+            .iter()
+            .map(AccessionNodeData::id_hash)
+            .collect::<Vec<_>>();
+        AccessionNode::delete_by_ids(conn, &ids);
     }
 
-    pub fn to_data(edge: AccessionEdge) -> AccessionEdgeData {
-        AccessionEdgeData {
-            source_node_id: edge.source_node_id,
-            source_coordinate: edge.source_coordinate,
-            source_strand: edge.source_strand,
-            target_node_id: edge.target_node_id,
-            target_coordinate: edge.target_coordinate,
-            target_strand: edge.target_strand,
-            chromosome_index: edge.chromosome_index,
-        }
+    pub fn to_data(node: AccessionNode) -> AccessionNodeData {
+        AccessionNodeData::from(&node)
     }
 }
 
-impl Query for AccessionEdge {
-    type Model = AccessionEdge;
+impl Query for AccessionNode {
+    type Model = AccessionNode;
 
-    const TABLE_NAME: &'static str = "accession_edges";
+    const TABLE_NAME: &'static str = "accession_nodes";
 
     fn process_row(row: &Row) -> Self::Model {
-        AccessionEdge {
-            id: row.get(0).unwrap(),
-            source_node_id: row.get(1).unwrap(),
-            source_coordinate: row.get(2).unwrap(),
-            source_strand: row.get(3).unwrap(),
-            target_node_id: row.get(4).unwrap(),
-            target_coordinate: row.get(5).unwrap(),
-            target_strand: row.get(6).unwrap(),
-            chromosome_index: row.get(7).unwrap(),
-        }
-    }
-}
-
-impl AccessionPath {
-    pub fn create(
-        conn: &GraphConnection,
-        accession_id: &HashId,
-        edge_ids: &[HashId],
-    ) -> Result<(), AccessionPathError> {
-        let batch_size = max_rows_per_batch(conn, 4);
-
-        for (index1, chunk) in edge_ids.chunks(batch_size).enumerate() {
-            let mut rows_to_insert = vec![];
-            let mut params: Vec<Box<dyn rusqlite::ToSql>> = Vec::new();
-            for (index2, edge_id) in chunk.iter().enumerate() {
-                rows_to_insert.push("(?, ?, ?, ?)".to_string());
-                let index_of = index1 * 100000 + index2;
-                let hash = HashId(calculate_hash(&format!(
-                    "{accession_id}:{edge_ids:?}:{index_of}",
-                )));
-                params.push(Box::new(hash));
-                params.push(Box::new(accession_id));
-                params.push(Box::new(edge_id));
-                params.push(Box::new(index_of));
-            }
-
-            let sql = format!(
-                "INSERT OR IGNORE INTO accession_paths (id, accession_id, edge_id, index_in_path) VALUES {};",
-                rows_to_insert.join(", ")
-            );
-
-            let mut stmt = match conn.prepare(&sql) {
-                Ok(s) => s,
-                Err(e) => return Err(AccessionPathError::DatabaseError(e)),
-            };
-            match stmt.execute(rusqlite::params_from_iter(params)) {
-                Ok(_) => {}
-                Err(e) => return Err(AccessionPathError::DatabaseError(e)),
-            }
-        }
-
-        Ok(())
-    }
-}
-
-impl Query for AccessionPath {
-    type Model = AccessionPath;
-
-    const TABLE_NAME: &'static str = "accession_paths";
-
-    fn process_row(row: &Row) -> AccessionPath {
-        AccessionPath {
+        AccessionNode {
             id: row.get(0).unwrap(),
             accession_id: row.get(1).unwrap(),
-            index_in_path: row.get(2).unwrap(),
-            edge_id: row.get(3).unwrap(),
+            node_id: row.get(2).unwrap(),
+            sequence_start: row.get(3).unwrap(),
+            sequence_end: row.get(4).unwrap(),
+            strand: row.get(5).unwrap(),
+            index_in_path: row.get(6).unwrap(),
         }
     }
 }
@@ -759,26 +591,25 @@ mod tests {
     }
 
     #[test]
-    fn test_accession_edge_capnp_serialization() {
-        let accession_edge = AccessionEdge {
+    fn test_accession_node_capnp_serialization() {
+        let accession_node = AccessionNode {
             id: "0000000000000000000000000000030000000000000000000000000000000000"
                 .try_into()
                 .unwrap(),
-            source_node_id: HashId::convert_str("10"),
-            source_coordinate: 100,
-            source_strand: Strand::Forward,
-            target_node_id: HashId::convert_str("20"),
-            target_coordinate: 200,
-            target_strand: Strand::Reverse,
-            chromosome_index: 1,
+            accession_id: HashId::convert_str("accession"),
+            node_id: HashId::convert_str("20"),
+            sequence_start: 2,
+            sequence_end: 4,
+            strand: Strand::Reverse,
+            index_in_path: 1,
         };
 
-        let mut message = TypedBuilder::<accession_edge::Owned>::new_default();
+        let mut message = TypedBuilder::<accession_node::Owned>::new_default();
         let mut root = message.init_root();
-        accession_edge.write_capnp(&mut root);
+        accession_node.write_capnp(&mut root);
 
-        let deserialized = AccessionEdge::read_capnp(root.into_reader());
-        assert_eq!(accession_edge, deserialized);
+        let deserialized = AccessionNode::read_capnp(root.into_reader());
+        assert_eq!(accession_node, deserialized);
     }
 
     #[test]
@@ -858,6 +689,73 @@ mod tests {
                 sequence_end: 5,
                 strand: Strand::Forward,
             }],
+        );
+    }
+
+    #[test]
+    fn accession_blocks_are_direct_node_slices() {
+        let conn = &get_connection(None).unwrap();
+        let (block_group_id, _path) = setup_block_group(conn);
+        let accession = Accession::create(conn, "test", &block_group_id, None).unwrap();
+
+        AccessionNode::bulk_create(
+            conn,
+            &[
+                AccessionNodeData {
+                    accession_id: accession.id,
+                    node_id: HashId::convert_str("test-a-node"),
+                    sequence_start: 2,
+                    sequence_end: 4,
+                    strand: Strand::Forward,
+                    index_in_path: 0,
+                },
+                AccessionNodeData {
+                    accession_id: accession.id,
+                    node_id: HashId::convert_str("test-t-node"),
+                    sequence_start: 0,
+                    sequence_end: 2,
+                    strand: Strand::Forward,
+                    index_in_path: 1,
+                },
+            ],
+        );
+
+        assert_eq!(
+            accession.blocks(conn).unwrap(),
+            vec![
+                NodeIntervalBlock {
+                    node_id: PATH_START_NODE_ID,
+                    start: i64::MIN + 1,
+                    end: 0,
+                    sequence_start: 0,
+                    sequence_end: 0,
+                    strand: Strand::Forward,
+                },
+                NodeIntervalBlock {
+                    node_id: HashId::convert_str("test-a-node"),
+                    start: 0,
+                    end: 2,
+                    sequence_start: 2,
+                    sequence_end: 4,
+                    strand: Strand::Forward,
+                },
+                NodeIntervalBlock {
+                    node_id: HashId::convert_str("test-t-node"),
+                    start: 2,
+                    end: 4,
+                    sequence_start: 0,
+                    sequence_end: 2,
+                    strand: Strand::Forward,
+                },
+                NodeIntervalBlock {
+                    node_id: PATH_END_NODE_ID,
+                    start: 4,
+                    end: i64::MAX - 1,
+                    sequence_start: 0,
+                    sequence_end: 0,
+                    strand: Strand::Forward,
+                },
+            ],
         );
     }
 

--- a/gen-models/src/accession.rs
+++ b/gen-models/src/accession.rs
@@ -217,6 +217,36 @@ impl From<AccessionNodeData> for AccessionNode {
 }
 
 impl Accession {
+    /// An accession is an ordered array of slices of nodes. The purpose
+    /// of an accession is to provide additional layers of information to
+    /// a graph. These extra pieces of information can be features such
+    /// as gene annotations, epigenetic markers, translocations, and so on.
+    ///
+    /// From a modeling stance, there is a table AccessionNodes, which holds
+    /// the positions within a Node the accession covers, its strand, and what
+    /// position it is in the array. Accessions are not meant to be restricted
+    /// to a graph topology. Take the following example of a spliced gene:
+    ///
+    /// AAAAAAAAAAAAAAAATTTTTTTTTTTTCCCCCCCCCCCCCCCCCCCGGGGGGGGGGGGGGGG
+    ///     [part-a]--->[part-b]---->[part-c]-->[part-d]
+    ///
+    /// There are no edges in the primary sequence, but there are 4 accession nodes
+    /// linked together. There is similarly no guarantee that nodes are on the same
+    /// blockgroup, which enables modeling of events such as translocations.
+    ///
+    /// Similarly, we do not model an accession on the edges of the graph
+    /// because the variation in the graph does not impact the accession. Take an example
+    /// where a variant is introduced in the intronic region of a gene:
+    ///
+    ///             A
+    ///            / \
+    /// AAAAAAAAAA-TTT-TTTTTTCCCCCCCCCCC
+    /// [part-1]----------->[part-2]
+    ///
+    /// If we annotated according to edges, the introduction of the A variant questions
+    /// if we should store part-1/part-2 also on the new edge between them. Storing it
+    /// on nodes means it is up to the context the graph is being used to determine how to
+    /// treat the graph topology.
     fn id_hash(
         block_group_id: &HashId,
         parent_accession_id: Option<&HashId>,

--- a/gen-models/src/accession.rs
+++ b/gen-models/src/accession.rs
@@ -1,15 +1,19 @@
+use std::{collections::HashMap, rc::Rc};
+
 use gen_core::{
     HashId, NodeIntervalBlock, PATH_END_NODE_ID, PATH_START_NODE_ID, Strand, calculate_hash,
     region::{Region, RegionResolutionError, RegionResolver},
     traits::Capnp,
 };
 use intervaltree::IntervalTree;
-use rusqlite::{Row, params};
+use rusqlite::{Row, params, types::Value as SQLValue};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::{
+    block_group_edge::AugmentedEdgeData,
     db::GraphConnection,
+    errors::QueryError,
     gen_models_capnp::{accession, accession_node},
     traits::*,
 };
@@ -26,6 +30,8 @@ pub struct Accession {
 pub enum AccessionError {
     #[error("Database error: {0}")]
     DatabaseError(#[from] rusqlite::Error),
+    #[error("Accession node creation error: {0}")]
+    AccessionNodeError(#[from] AccessionNodeError),
     #[error("Duplicate entry with uuid: {0}")]
     Duplicate(String),
     #[error("Accession {0} has no nodes in accession_nodes")]
@@ -194,6 +200,20 @@ impl From<&AccessionNode> for AccessionNodeData {
     }
 }
 
+impl From<AccessionNodeData> for AccessionNode {
+    fn from(item: AccessionNodeData) -> Self {
+        AccessionNode {
+            id: item.id_hash(),
+            accession_id: item.accession_id,
+            node_id: item.node_id,
+            sequence_start: item.sequence_start,
+            sequence_end: item.sequence_end,
+            strand: item.strand,
+            index_in_path: item.index_in_path,
+        }
+    }
+}
+
 impl Accession {
     fn id_hash(
         block_group_id: &HashId,
@@ -234,6 +254,34 @@ impl Accession {
             }
             Err(e) => Err(AccessionError::DatabaseError(e)),
         }
+    }
+
+    pub fn create_from_edges(
+        conn: &GraphConnection,
+        name: &str,
+        block_group_id: &HashId,
+        parent_accession_id: Option<&HashId>,
+        edges: &[AugmentedEdgeData],
+    ) -> Result<Accession, AccessionError> {
+        let accession = Self::create(conn, name, block_group_id, parent_accession_id)?;
+        let accession_nodes = edges
+            .windows(2)
+            .enumerate()
+            .map(|(index, edge_pair)| {
+                let into = &edge_pair[0].edge_data;
+                let out_of = &edge_pair[1].edge_data;
+                AccessionNodeData {
+                    accession_id: accession.id,
+                    node_id: into.target_node_id,
+                    sequence_start: into.target_coordinate,
+                    sequence_end: out_of.source_coordinate,
+                    strand: into.target_strand,
+                    index_in_path: index as i64,
+                }
+            })
+            .collect::<Vec<_>>();
+        AccessionNode::bulk_create(conn, &accession_nodes)?;
+        Ok(accession)
     }
 
     pub fn get_or_create(
@@ -307,8 +355,15 @@ impl Accession {
     }
 
     pub fn length(&self, conn: &GraphConnection) -> Result<i64, AccessionError> {
-        let blocks = self.blocks(conn)?;
-        Ok(blocks.last().unwrap().start)
+        let nodes = Self::get_nodes_by_id(conn, &self.id);
+        if nodes.is_empty() {
+            return Err(AccessionError::MissingPath(self.id));
+        }
+
+        Ok(nodes
+            .iter()
+            .map(|node| node.sequence_end - node.sequence_start)
+            .sum())
     }
 
     pub fn intervaltree(
@@ -346,7 +401,13 @@ impl RegionResolver for Accession {
 
         match matches.len() {
             0 => Err(RegionResolutionError::NotFound(region.name.clone())),
-            1 => Ok(matches.into_iter().next().unwrap()),
+            1 => {
+                if let Some(accession) = matches.into_iter().next() {
+                    Ok(accession)
+                } else {
+                    Err(RegionResolutionError::NotFound(region.name.clone()))
+                }
+            }
             _ => Err(RegionResolutionError::Ambiguous(format!(
                 "multiple accessions named {}",
                 region.name
@@ -371,13 +432,41 @@ impl Query for Accession {
 }
 
 impl AccessionNode {
+    pub fn query_accessions(
+        conn: &GraphConnection,
+        accession_ids: &[HashId],
+    ) -> Result<HashMap<HashId, Vec<AccessionNode>>, QueryError> {
+        if accession_ids.is_empty() {
+            return Ok(HashMap::new());
+        }
+
+        let accession_values = accession_ids
+            .iter()
+            .copied()
+            .map(SQLValue::from)
+            .collect::<Vec<_>>();
+        let nodes = AccessionNode::try_query(
+            conn,
+            "select * from accession_nodes where accession_id in rarray(?1) order by accession_id, index_in_path;",
+            params![Rc::new(accession_values)],
+        )?;
+        let mut nodes_by_accession = HashMap::new();
+        for node in nodes {
+            nodes_by_accession
+                .entry(node.accession_id)
+                .or_insert_with(Vec::new)
+                .push(node);
+        }
+        Ok(nodes_by_accession)
+    }
+
     pub fn create(
         conn: &GraphConnection,
         node: AccessionNodeData,
     ) -> Result<AccessionNode, AccessionNodeError> {
         let hash = node.id_hash();
         let insert_statement = "INSERT INTO accession_nodes (id, accession_id, node_id, sequence_start, sequence_end, strand, index_in_path) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7);";
-        let mut stmt = conn.prepare(insert_statement).unwrap();
+        let mut stmt = conn.prepare(insert_statement)?;
         match stmt.execute(params![
             hash,
             node.accession_id,
@@ -393,18 +482,13 @@ impl AccessionNode {
             }
             Err(err) => return Err(AccessionNodeError::DatabaseError(err)),
         };
-        Ok(AccessionNode {
-            id: hash,
-            accession_id: node.accession_id,
-            node_id: node.node_id,
-            sequence_start: node.sequence_start,
-            sequence_end: node.sequence_end,
-            strand: node.strand,
-            index_in_path: node.index_in_path,
-        })
+        Ok(AccessionNode::from(node))
     }
 
-    pub fn bulk_create(conn: &GraphConnection, nodes: &[AccessionNodeData]) -> Vec<HashId> {
+    pub fn bulk_create(
+        conn: &GraphConnection,
+        nodes: &[AccessionNodeData],
+    ) -> Result<Vec<HashId>, AccessionNodeError> {
         let node_ids = nodes
             .iter()
             .map(AccessionNodeData::id_hash)
@@ -428,10 +512,9 @@ impl AccessionNode {
                 "INSERT OR IGNORE INTO accession_nodes (id, accession_id, node_id, sequence_start, sequence_end, strand, index_in_path) VALUES {};",
                 rows.join(",")
             );
-            conn.execute(&sql, rusqlite::params_from_iter(params))
-                .unwrap();
+            conn.execute(&sql, rusqlite::params_from_iter(params))?;
         }
-        node_ids
+        Ok(node_ids)
     }
 
     pub fn bulk_delete(conn: &GraphConnection, nodes: &[AccessionNodeData]) {
@@ -440,10 +523,6 @@ impl AccessionNode {
             .map(AccessionNodeData::id_hash)
             .collect::<Vec<_>>();
         AccessionNode::delete_by_ids(conn, &ids);
-    }
-
-    pub fn to_data(node: AccessionNode) -> AccessionNodeData {
-        AccessionNodeData::from(&node)
     }
 }
 
@@ -473,7 +552,8 @@ mod tests {
     use super::*;
     use crate::{
         block_group::{BlockGroup, PathCache},
-        block_group_edge::BlockGroupEdgeData,
+        block_group_edge::{AugmentedEdgeData, BlockGroupEdgeData},
+        edge::EdgeData,
         path::Path,
         path_edge::PathEdge,
         test_helpers::{create_bg, get_connection, interval_tree_verify, setup_block_group},
@@ -693,7 +773,7 @@ mod tests {
     }
 
     #[test]
-    fn accession_blocks_are_direct_node_slices() {
+    fn test_accession_blocks_are_direct_node_slices() {
         let conn = &get_connection(None).unwrap();
         let (block_group_id, _path) = setup_block_group(conn);
         let accession = Accession::create(conn, "test", &block_group_id, None).unwrap();
@@ -718,7 +798,8 @@ mod tests {
                     index_in_path: 1,
                 },
             ],
-        );
+        )
+        .unwrap();
 
         assert_eq!(
             accession.blocks(conn).unwrap(),
@@ -756,6 +837,133 @@ mod tests {
                     strand: Strand::Forward,
                 },
             ],
+        );
+    }
+
+    #[test]
+    fn test_query_accessions_groups_nodes_by_accession() {
+        let conn = &get_connection(None).unwrap();
+        let (block_group_id, _path) = setup_block_group(conn);
+        let accession_1 = Accession::create(conn, "test-1", &block_group_id, None).unwrap();
+        let accession_2 = Accession::create(conn, "test-2", &block_group_id, None).unwrap();
+        let accession_1_nodes = vec![
+            AccessionNodeData {
+                accession_id: accession_1.id,
+                node_id: HashId::convert_str("test-a-node"),
+                sequence_start: 2,
+                sequence_end: 4,
+                strand: Strand::Forward,
+                index_in_path: 0,
+            },
+            AccessionNodeData {
+                accession_id: accession_1.id,
+                node_id: HashId::convert_str("test-t-node"),
+                sequence_start: 0,
+                sequence_end: 2,
+                strand: Strand::Reverse,
+                index_in_path: 1,
+            },
+        ];
+        let accession_2_nodes = vec![AccessionNodeData {
+            accession_id: accession_2.id,
+            node_id: HashId::convert_str("test-c-node"),
+            sequence_start: 1,
+            sequence_end: 3,
+            strand: Strand::Forward,
+            index_in_path: 0,
+        }];
+        AccessionNode::bulk_create(conn, &accession_1_nodes).unwrap();
+        AccessionNode::bulk_create(conn, &accession_2_nodes).unwrap();
+
+        let grouped =
+            AccessionNode::query_accessions(conn, &[accession_2.id, accession_1.id]).unwrap();
+
+        assert_eq!(
+            grouped.get(&accession_1.id).unwrap(),
+            &accession_1_nodes
+                .into_iter()
+                .map(AccessionNode::from)
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(
+            grouped.get(&accession_2.id).unwrap(),
+            &accession_2_nodes
+                .into_iter()
+                .map(AccessionNode::from)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_create_from_edges_persists_accession_nodes() {
+        let conn = &get_connection(None).unwrap();
+        let (block_group_id, _path) = setup_block_group(conn);
+        let path_edges = vec![
+            AugmentedEdgeData {
+                edge_data: EdgeData {
+                    source_node_id: PATH_START_NODE_ID,
+                    source_coordinate: -1,
+                    source_strand: Strand::Forward,
+                    target_node_id: HashId::convert_str("test-a-node"),
+                    target_coordinate: 2,
+                    target_strand: Strand::Forward,
+                },
+                chromosome_index: 0,
+                phased: 0,
+            },
+            AugmentedEdgeData {
+                edge_data: EdgeData {
+                    source_node_id: HashId::convert_str("test-a-node"),
+                    source_coordinate: 4,
+                    source_strand: Strand::Forward,
+                    target_node_id: HashId::convert_str("test-t-node"),
+                    target_coordinate: 0,
+                    target_strand: Strand::Reverse,
+                },
+                chromosome_index: 0,
+                phased: 0,
+            },
+            AugmentedEdgeData {
+                edge_data: EdgeData {
+                    source_node_id: HashId::convert_str("test-t-node"),
+                    source_coordinate: 2,
+                    source_strand: Strand::Reverse,
+                    target_node_id: PATH_END_NODE_ID,
+                    target_coordinate: -1,
+                    target_strand: Strand::Forward,
+                },
+                chromosome_index: 0,
+                phased: 0,
+            },
+        ];
+
+        let accession =
+            Accession::create_from_edges(conn, "test", &block_group_id, None, &path_edges).unwrap();
+        let expected_nodes = vec![
+            AccessionNodeData {
+                accession_id: accession.id,
+                node_id: HashId::convert_str("test-a-node"),
+                sequence_start: 2,
+                sequence_end: 4,
+                strand: Strand::Forward,
+                index_in_path: 0,
+            },
+            AccessionNodeData {
+                accession_id: accession.id,
+                node_id: HashId::convert_str("test-t-node"),
+                sequence_start: 0,
+                sequence_end: 2,
+                strand: Strand::Reverse,
+                index_in_path: 1,
+            },
+        ];
+
+        assert_eq!(
+            Accession::get_nodes_by_id(conn, &accession.id),
+            expected_nodes
+                .into_iter()
+                .map(AccessionNode::from)
+                .collect::<Vec<_>>(),
         );
     }
 

--- a/gen-models/src/block_group.rs
+++ b/gen-models/src/block_group.rs
@@ -648,8 +648,7 @@ impl BlockGroup {
         let end_blocks: Vec<&NodeIntervalBlock> =
             tree.query_point(end - 1).map(|x| &x.value).collect();
         assert_eq!(end_blocks.len(), 1);
-        let accession = Accession::create(conn, name, &path.block_group_id, None)
-            .expect("Unable to create accession.");
+        let accession = Accession::create(conn, name, &path.block_group_id, None)?;
         let accession_nodes = tree
             .iter_sorted()
             .map(|entry| &entry.value)
@@ -668,7 +667,7 @@ impl BlockGroup {
                 }
             })
             .collect::<Vec<_>>();
-        AccessionNode::bulk_create(conn, &accession_nodes);
+        AccessionNode::bulk_create(conn, &accession_nodes)?;
         Ok(accession)
     }
 
@@ -783,37 +782,17 @@ impl BlockGroup {
                     );
                 }
                 Err(_) => {
-                    let acc = Accession::create(conn, &accession_name, &block_group_id, None)
-                        .expect("Accession could not be created.");
-                    let accession_nodes =
-                        Self::accession_nodes_from_augmented_edges(&acc.id, &path_edges);
-                    AccessionNode::bulk_create(conn, &accession_nodes);
+                    Accession::create_from_edges(
+                        conn,
+                        &accession_name,
+                        &block_group_id,
+                        None,
+                        &path_edges,
+                    )?;
                 }
             }
         }
         Ok(())
-    }
-
-    fn accession_nodes_from_augmented_edges(
-        accession_id: &HashId,
-        edges: &[AugmentedEdgeData],
-    ) -> Vec<AccessionNodeData> {
-        edges
-            .windows(2)
-            .enumerate()
-            .map(|(index, edge_pair)| {
-                let into = &edge_pair[0].edge_data;
-                let out_of = &edge_pair[1].edge_data;
-                AccessionNodeData {
-                    accession_id: *accession_id,
-                    node_id: into.target_node_id,
-                    sequence_start: into.target_coordinate,
-                    sequence_end: out_of.source_coordinate,
-                    strand: into.target_strand,
-                    index_in_path: index as i64,
-                }
-            })
-            .collect()
     }
 
     pub fn set_up_new_edges(
@@ -2286,7 +2265,7 @@ mod tests {
     }
 
     #[test]
-    fn accession_end_coordinate_is_not_included() {
+    fn test_accession_end_coordinate_is_not_included() {
         let conn = &get_connection(None).unwrap();
         let (_block_group_id, path) = setup_block_group(conn);
         let mut path_cache = PathCache::new(conn);

--- a/gen-models/src/block_group.rs
+++ b/gen-models/src/block_group.rs
@@ -678,8 +678,7 @@ impl BlockGroup {
     ) -> Result<(), BlockGroupError> {
         let mut new_augmented_edges_by_block_group =
             HashMap::<HashId, Vec<AugmentedEdgeData>>::new();
-        let mut new_accession_path_edges =
-            HashMap::<(HashId, String), Vec<AugmentedEdgeData>>::new();
+        let mut new_accession_edges = HashMap::<(HashId, String), Vec<AugmentedEdgeData>>::new();
         let mut local_tree_map = HashMap::new();
         let tree_map = match tree_map {
             Some(tree_map) => tree_map,
@@ -704,7 +703,7 @@ impl BlockGroup {
                 .and_modify(|new_edge_data| new_edge_data.extend(new_augmented_edges.clone()))
                 .or_insert_with(|| new_augmented_edges.clone());
             if let Some(accession) = &change.path_accession {
-                new_accession_path_edges
+                new_accession_edges
                     .entry((change.region.block_group.id, accession.clone()))
                     .and_modify(|new_edge_data: &mut Vec<AugmentedEdgeData>| {
                         new_edge_data.extend(new_augmented_edges.clone())
@@ -715,7 +714,7 @@ impl BlockGroup {
         Self::persist_insert_changes(
             conn,
             new_augmented_edges_by_block_group,
-            new_accession_path_edges,
+            new_accession_edges,
         )
     }
 
@@ -727,9 +726,9 @@ impl BlockGroup {
         let mut new_augmented_edges_by_block_group = HashMap::new();
         new_augmented_edges_by_block_group
             .insert(change.region.block_group.id, new_augmented_edges.clone());
-        let mut new_accession_path_edges = HashMap::new();
+        let mut new_accession_edges = HashMap::new();
         if let Some(accession) = &change.path_accession {
-            new_accession_path_edges.insert(
+            new_accession_edges.insert(
                 (change.region.block_group.id, accession.clone()),
                 new_augmented_edges,
             );
@@ -737,14 +736,14 @@ impl BlockGroup {
         Self::persist_insert_changes(
             conn,
             new_augmented_edges_by_block_group,
-            new_accession_path_edges,
+            new_accession_edges,
         )
     }
 
     fn persist_insert_changes(
         conn: &GraphConnection,
         new_augmented_edges_by_block_group: HashMap<HashId, Vec<AugmentedEdgeData>>,
-        new_accession_path_edges: HashMap<(HashId, String), Vec<AugmentedEdgeData>>,
+        new_accession_edges: HashMap<(HashId, String), Vec<AugmentedEdgeData>>,
     ) -> Result<(), BlockGroupError> {
         let mut edge_data_map = HashMap::new();
 
@@ -770,7 +769,7 @@ impl BlockGroup {
             BlockGroupEdge::bulk_create(conn, &new_block_group_edges);
         }
 
-        for ((block_group_id, accession_name), path_edges) in new_accession_path_edges {
+        for ((block_group_id, accession_name), path_edges) in new_accession_edges {
             match Accession::get(
                 conn,
                 "select * from accessions where name = ?1 AND block_group_id = ?2",

--- a/gen-models/src/block_group.rs
+++ b/gen-models/src/block_group.rs
@@ -21,13 +21,13 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::{
-    accession::{Accession, AccessionEdge, AccessionEdgeData, AccessionPath},
+    accession::{Accession, AccessionNode, AccessionNodeData},
     annotations::AnnotationError,
     block_group_edge::{AugmentedEdge, AugmentedEdgeData, BlockGroupEdge, BlockGroupEdgeData},
     db::GraphConnection,
     edge::{Edge, EdgeData, GroupBlock},
     errors::{
-        AccessionError, AccessionPathError, EdgeError, NodeError, PathError, QueryError,
+        AccessionError, AccessionNodeError, EdgeError, NodeError, PathError, QueryError,
         SequenceError,
     },
     gen_models_capnp::block_group,
@@ -62,8 +62,8 @@ pub enum BlockGroupError {
     NodeError(#[from] NodeError),
     #[error("Accession creation error: {0}")]
     AccessionError(#[from] AccessionError),
-    #[error("Accession path creation error: {0}")]
-    AccessionPathError(#[from] AccessionPathError),
+    #[error("Accession node creation error: {0}")]
+    AccessionNodeError(#[from] AccessionNodeError),
     #[error("Annotation error: {0}")]
     AnnotationError(#[from] AnnotationError),
     #[error("Query error: {0}")]
@@ -645,67 +645,30 @@ impl BlockGroup {
         let start_blocks: Vec<&NodeIntervalBlock> =
             tree.query_point(start).map(|x| &x.value).collect();
         assert_eq!(start_blocks.len(), 1);
-        let start_block = start_blocks[0];
         let end_blocks: Vec<&NodeIntervalBlock> =
             tree.query_point(end - 1).map(|x| &x.value).collect();
         assert_eq!(end_blocks.len(), 1);
-        let end_block = end_blocks[0];
-        let start_edge = AccessionEdgeData {
-            source_node_id: PATH_START_NODE_ID,
-            source_coordinate: -1,
-            source_strand: Strand::Forward,
-            target_node_id: start_block.node_id,
-            target_coordinate: start - start_block.start + start_block.sequence_start,
-            target_strand: Strand::Forward,
-            chromosome_index: 0,
-        };
-        let end_edge = AccessionEdgeData {
-            source_node_id: end_block.node_id,
-            source_coordinate: end - end_block.start + end_block.sequence_start,
-            source_strand: Strand::Forward,
-            target_node_id: PATH_END_NODE_ID,
-            target_coordinate: -1,
-            target_strand: Strand::Forward,
-            chromosome_index: 0,
-        };
         let accession = Accession::create(conn, name, &path.block_group_id, None)
             .expect("Unable to create accession.");
-        let mut path_edges = vec![start_edge];
-        if start_block == end_block {
-            path_edges.push(end_edge);
-        } else {
-            let mut in_range = false;
-            let path_blocks: Vec<&NodeIntervalBlock> = tree
-                .iter_sorted()
-                .map(|x| &x.value)
-                .filter(|block| {
-                    if *block == start_block {
-                        in_range = true;
-                    } else if *block == end_block {
-                        in_range = false;
-                        return true;
-                    }
-                    in_range
-                })
-                .collect::<Vec<_>>();
-            for (block, next_block) in path_blocks.iter().zip(path_blocks[1..].iter()) {
-                path_edges.push(AccessionEdgeData {
-                    source_node_id: block.node_id,
-                    source_coordinate: block.sequence_end,
-                    source_strand: block.strand,
-                    target_node_id: next_block.node_id,
-                    target_coordinate: next_block.sequence_start,
-                    target_strand: next_block.strand,
-                    chromosome_index: 0,
-                })
-            }
-            path_edges.push(end_edge);
-        }
-        AccessionPath::create(
-            conn,
-            &accession.id,
-            &AccessionEdge::bulk_create(conn, &path_edges),
-        )?;
+        let accession_nodes = tree
+            .iter_sorted()
+            .map(|entry| &entry.value)
+            .filter(|block| !is_terminal(block.node_id) && block.start < end && block.end > start)
+            .enumerate()
+            .map(|(index, block)| {
+                let clipped_start = start.max(block.start);
+                let clipped_end = end.min(block.end);
+                AccessionNodeData {
+                    accession_id: accession.id,
+                    node_id: block.node_id,
+                    sequence_start: clipped_start - block.start + block.sequence_start,
+                    sequence_end: clipped_end - block.start + block.sequence_start,
+                    strand: block.strand,
+                    index_in_path: index as i64,
+                }
+            })
+            .collect::<Vec<_>>();
+        AccessionNode::bulk_create(conn, &accession_nodes);
         Ok(accession)
     }
 
@@ -716,7 +679,8 @@ impl BlockGroup {
     ) -> Result<(), BlockGroupError> {
         let mut new_augmented_edges_by_block_group =
             HashMap::<HashId, Vec<AugmentedEdgeData>>::new();
-        let mut new_accession_edges = HashMap::<(HashId, String), Vec<AugmentedEdgeData>>::new();
+        let mut new_accession_path_edges =
+            HashMap::<(HashId, String), Vec<AugmentedEdgeData>>::new();
         let mut local_tree_map = HashMap::new();
         let tree_map = match tree_map {
             Some(tree_map) => tree_map,
@@ -741,7 +705,7 @@ impl BlockGroup {
                 .and_modify(|new_edge_data| new_edge_data.extend(new_augmented_edges.clone()))
                 .or_insert_with(|| new_augmented_edges.clone());
             if let Some(accession) = &change.path_accession {
-                new_accession_edges
+                new_accession_path_edges
                     .entry((change.region.block_group.id, accession.clone()))
                     .and_modify(|new_edge_data: &mut Vec<AugmentedEdgeData>| {
                         new_edge_data.extend(new_augmented_edges.clone())
@@ -752,7 +716,7 @@ impl BlockGroup {
         Self::persist_insert_changes(
             conn,
             new_augmented_edges_by_block_group,
-            new_accession_edges,
+            new_accession_path_edges,
         )
     }
 
@@ -764,9 +728,9 @@ impl BlockGroup {
         let mut new_augmented_edges_by_block_group = HashMap::new();
         new_augmented_edges_by_block_group
             .insert(change.region.block_group.id, new_augmented_edges.clone());
-        let mut new_accession_edges = HashMap::new();
+        let mut new_accession_path_edges = HashMap::new();
         if let Some(accession) = &change.path_accession {
-            new_accession_edges.insert(
+            new_accession_path_edges.insert(
                 (change.region.block_group.id, accession.clone()),
                 new_augmented_edges,
             );
@@ -774,14 +738,14 @@ impl BlockGroup {
         Self::persist_insert_changes(
             conn,
             new_augmented_edges_by_block_group,
-            new_accession_edges,
+            new_accession_path_edges,
         )
     }
 
     fn persist_insert_changes(
         conn: &GraphConnection,
         new_augmented_edges_by_block_group: HashMap<HashId, Vec<AugmentedEdgeData>>,
-        new_accession_edges: HashMap<(HashId, String), Vec<AugmentedEdgeData>>,
+        new_accession_path_edges: HashMap<(HashId, String), Vec<AugmentedEdgeData>>,
     ) -> Result<(), BlockGroupError> {
         let mut edge_data_map = HashMap::new();
 
@@ -807,7 +771,7 @@ impl BlockGroup {
             BlockGroupEdge::bulk_create(conn, &new_block_group_edges);
         }
 
-        for ((block_group_id, accession_name), path_edges) in new_accession_edges {
+        for ((block_group_id, accession_name), path_edges) in new_accession_path_edges {
             match Accession::get(
                 conn,
                 "select * from accessions where name = ?1 AND block_group_id = ?2",
@@ -819,20 +783,37 @@ impl BlockGroup {
                     );
                 }
                 Err(_) => {
-                    let acc_edges = AccessionEdge::bulk_create(
-                        conn,
-                        &path_edges
-                            .iter()
-                            .map(AccessionEdgeData::from)
-                            .collect::<Vec<_>>(),
-                    );
                     let acc = Accession::create(conn, &accession_name, &block_group_id, None)
                         .expect("Accession could not be created.");
-                    AccessionPath::create(conn, &acc.id, &acc_edges)?;
+                    let accession_nodes =
+                        Self::accession_nodes_from_augmented_edges(&acc.id, &path_edges);
+                    AccessionNode::bulk_create(conn, &accession_nodes);
                 }
             }
         }
         Ok(())
+    }
+
+    fn accession_nodes_from_augmented_edges(
+        accession_id: &HashId,
+        edges: &[AugmentedEdgeData],
+    ) -> Vec<AccessionNodeData> {
+        edges
+            .windows(2)
+            .enumerate()
+            .map(|(index, edge_pair)| {
+                let into = &edge_pair[0].edge_data;
+                let out_of = &edge_pair[1].edge_data;
+                AccessionNodeData {
+                    accession_id: *accession_id,
+                    node_id: into.target_node_id,
+                    sequence_start: into.target_coordinate,
+                    sequence_end: out_of.source_coordinate,
+                    strand: into.target_strand,
+                    index_in_path: index as i64,
+                }
+            })
+            .collect()
     }
 
     pub fn set_up_new_edges(
@@ -2312,13 +2293,13 @@ mod tests {
 
         let accession =
             BlockGroup::add_accession(conn, &path, "test", 3, 10, &mut path_cache).unwrap();
-        let edges = Accession::get_edges_by_id(conn, &accession.id);
+        let nodes = Accession::get_nodes_by_id(conn, &accession.id);
 
         assert_eq!(accession.length(conn).unwrap(), 7);
-        assert_eq!(edges.len(), 2);
-        assert_eq!(edges[1].source_node_id, HashId::convert_str("test-a-node"));
-        assert_eq!(edges[1].source_coordinate, 10);
-        assert_eq!(edges[1].target_node_id, PATH_END_NODE_ID);
+        assert_eq!(nodes.len(), 1);
+        assert_eq!(nodes[0].node_id, HashId::convert_str("test-a-node"));
+        assert_eq!(nodes[0].sequence_start, 3);
+        assert_eq!(nodes[0].sequence_end, 10);
     }
 
     #[test]

--- a/gen-models/src/changesets.rs
+++ b/gen-models/src/changesets.rs
@@ -1587,10 +1587,9 @@ mod tests {
         assert_eq!(dependencies.samples[0].name, "sample-1");
         assert_eq!(dependencies.accessions.len(), 1);
         assert_eq!(dependencies.accessions[0].id, accession.id);
-        assert_eq!(
-            dependencies.accession_nodes,
-            Accession::get_nodes_by_id(conn, &accession.id)
-        );
+        let dep_accession_nodes = Accession::get_nodes_by_id(conn, &accession.id);
+        assert!(!dep_accession_nodes.is_empty());
+        assert_eq!(dependencies.accession_nodes, dep_accession_nodes);
     }
 
     #[test]

--- a/gen-models/src/changesets.rs
+++ b/gen-models/src/changesets.rs
@@ -16,7 +16,7 @@ use rusqlite::{
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    accession::{Accession, AccessionEdge, AccessionEdgeData, AccessionPath},
+    accession::{Accession, AccessionNode, AccessionNodeData},
     annotations::{Annotation, AnnotationGroup, AnnotationGroupSample},
     block_group::{BlockGroup, NewBlockGroup},
     block_group_edge::{BlockGroupEdge, BlockGroupEdgeData},
@@ -90,8 +90,7 @@ pub struct ChangesetModels {
     pub paths: Vec<Path>,
     pub path_edges: Vec<PathEdge>,
     pub accessions: Vec<Accession>,
-    pub accession_edges: Vec<AccessionEdge>,
-    pub accession_paths: Vec<AccessionPath>,
+    pub accession_nodes: Vec<AccessionNode>,
     pub annotation_groups: Vec<AnnotationGroup>,
     pub annotations: Vec<Annotation>,
     pub annotation_group_samples: Vec<AnnotationGroupSample>,
@@ -192,22 +191,12 @@ impl<'a> Capnp<'a> for ChangesetModels {
             accession.write_capnp(&mut accession_builder);
         }
 
-        // Write accession edges
-        let mut accession_edges_builder = builder
+        let mut accession_nodes_builder = builder
             .reborrow()
-            .init_accession_edges(self.accession_edges.len() as u32);
-        for (i, accession_edge) in self.accession_edges.iter().enumerate() {
-            let mut accession_edge_builder = accession_edges_builder.reborrow().get(i as u32);
-            accession_edge.write_capnp(&mut accession_edge_builder);
-        }
-
-        // Write accession paths
-        let mut accession_paths_builder = builder
-            .reborrow()
-            .init_accession_paths(self.accession_paths.len() as u32);
-        for (i, accession_path) in self.accession_paths.iter().enumerate() {
-            let mut accession_path_builder = accession_paths_builder.reborrow().get(i as u32);
-            accession_path.write_capnp(&mut accession_path_builder);
+            .init_accession_nodes(self.accession_nodes.len() as u32);
+        for (i, accession_node) in self.accession_nodes.iter().enumerate() {
+            let mut accession_node_builder = accession_nodes_builder.reborrow().get(i as u32);
+            accession_node.write_capnp(&mut accession_node_builder);
         }
 
         // Write annotation groups
@@ -318,18 +307,10 @@ impl<'a> Capnp<'a> for ChangesetModels {
             accessions.push(Accession::read_capnp(accession_reader));
         }
 
-        // Read accession edges
-        let accession_edges_reader = reader.get_accession_edges().unwrap();
-        let mut accession_edges = Vec::new();
-        for accession_edge_reader in accession_edges_reader.iter() {
-            accession_edges.push(AccessionEdge::read_capnp(accession_edge_reader));
-        }
-
-        // Read accession paths
-        let accession_paths_reader = reader.get_accession_paths().unwrap();
-        let mut accession_paths = Vec::new();
-        for accession_path_reader in accession_paths_reader.iter() {
-            accession_paths.push(AccessionPath::read_capnp(accession_path_reader));
+        let accession_nodes_reader = reader.get_accession_nodes().unwrap();
+        let mut accession_nodes = Vec::new();
+        for accession_node_reader in accession_nodes_reader.iter() {
+            accession_nodes.push(AccessionNode::read_capnp(accession_node_reader));
         }
 
         // Read annotation groups
@@ -367,8 +348,7 @@ impl<'a> Capnp<'a> for ChangesetModels {
             paths,
             path_edges,
             accessions,
-            accession_edges,
-            accession_paths,
+            accession_nodes,
             annotation_groups,
             annotations,
             annotation_group_samples,
@@ -430,7 +410,7 @@ pub fn process_changesetiter(
     use itertools::Itertools;
 
     use crate::{
-        accession::{Accession, AccessionEdge},
+        accession::{Accession, AccessionNode},
         block_group::BlockGroup,
         edge::Edge,
         node::Node,
@@ -451,8 +431,7 @@ pub fn process_changesetiter(
     let mut created_paths = vec![];
     let mut created_path_edges = vec![];
     let mut created_accessions = vec![];
-    let mut created_accession_edges = vec![];
-    let mut created_accession_paths = vec![];
+    let mut created_accession_nodes = vec![];
     let mut created_annotation_groups = vec![];
     let mut created_annotations = vec![];
     let mut created_annotation_group_samples = vec![];
@@ -466,12 +445,10 @@ pub fn process_changesetiter(
     let mut previous_accessions = HashSet::new();
     let mut previous_nodes = HashSet::new();
     let mut previous_sequences = HashSet::new();
-    let mut previous_accession_edges = HashSet::new();
     let mut created_block_groups_set = HashSet::new();
     let mut created_paths_set = HashSet::new();
     let mut created_accessions_set = HashSet::new();
     let mut created_edges_set = HashSet::new();
-    let mut created_accession_edges_set = HashSet::new();
     let mut created_nodes_set = HashSet::new();
     let mut created_sequences_set = HashSet::new();
     let mut created_samples_set: HashSet<String> = HashSet::new();
@@ -680,49 +657,29 @@ pub fn process_changesetiter(
                         previous_accessions.insert(id);
                     }
                 }
-                "accession_edges" => {
-                    let edge_id = parse_hashid(item, pk_column);
-                    let source_node_id = parse_hashid(item, 1);
-                    let target_node_id = parse_hashid(item, 4);
-
-                    created_accession_edges.push(AccessionEdge {
-                        id: edge_id,
-                        source_node_id,
-                        source_coordinate: parse_number(item, 2),
-                        source_strand: Strand::column_result(item.new_value(3).unwrap()).unwrap(),
-                        target_node_id,
-                        target_coordinate: parse_number(item, 5),
-                        target_strand: Strand::column_result(item.new_value(6).unwrap()).unwrap(),
-                        chromosome_index: parse_number(item, 7),
-                    });
-
-                    created_accession_edges_set.insert(edge_id);
-                    let nodes = Node::query_by_ids(conn, &[source_node_id, target_node_id]);
-                    if !created_nodes_set.contains(&source_node_id) {
-                        previous_sequences.insert(nodes[0].sequence_hash);
-                    }
-                    if source_node_id != target_node_id
-                        && !created_nodes_set.contains(&target_node_id)
-                    {
-                        previous_sequences.insert(nodes[1].sequence_hash);
-                    }
-                }
-                "accession_paths" => {
+                "accession_nodes" => {
                     let accession_id = parse_hashid(item, 1);
-                    let edge_id = parse_hashid(item, 3);
+                    let node_id = parse_hashid(item, 2);
 
-                    created_accession_paths.push(AccessionPath {
+                    created_accession_nodes.push(AccessionNode {
                         id: parse_hashid(item, pk_column),
                         accession_id,
-                        index_in_path: parse_number(item, 2),
-                        edge_id,
+                        node_id,
+                        sequence_start: parse_number(item, 3),
+                        sequence_end: parse_number(item, 4),
+                        strand: Strand::column_result(item.new_value(5).unwrap()).unwrap(),
+                        index_in_path: parse_number(item, 6),
                     });
 
                     if !created_accessions_set.contains(&accession_id) {
                         previous_accessions.insert(accession_id);
                     }
-                    if !created_accession_edges_set.contains(&edge_id) {
-                        previous_accession_edges.insert(edge_id);
+                    if !created_nodes_set.contains(&node_id) && !is_terminal(node_id) {
+                        previous_nodes.insert(node_id);
+                        let nodes = Node::query_by_ids(conn, &[node_id]);
+                        if let Some(node) = nodes.first() {
+                            previous_sequences.insert(node.sequence_hash);
+                        }
                     }
                 }
                 "annotations" => {
@@ -805,8 +762,7 @@ pub fn process_changesetiter(
         paths: created_paths,
         path_edges: created_path_edges,
         accessions: created_accessions,
-        accession_edges: created_accession_edges,
-        accession_paths: created_accession_paths,
+        accession_nodes: created_accession_nodes,
         annotation_groups: created_annotation_groups,
         annotations: created_annotations,
         annotation_group_samples: created_annotation_group_samples,
@@ -821,7 +777,7 @@ pub fn process_changesetiter(
         edges: Edge::query_by_ids(conn, &previous_edges),
         paths: Path::query_by_ids(conn, &previous_paths),
         accessions: Accession::query_by_ids(conn, &previous_accessions),
-        accession_edges: AccessionEdge::query_by_ids(conn, &previous_accession_edges),
+        accession_nodes: vec![],
     };
 
     (changeset_models, dependency_models)
@@ -888,15 +844,6 @@ pub fn apply_changeset(
     for path in dependencies.paths.iter() {
         Path::create(conn, &path.name, &path.block_group_id, &[])?;
     }
-
-    AccessionEdge::bulk_create(
-        conn,
-        &dependencies
-            .accession_edges
-            .iter()
-            .map(AccessionEdgeData::from)
-            .collect::<Vec<AccessionEdgeData>>(),
-    );
 
     for accession in dependencies.accessions.iter() {
         Accession::get_or_create(
@@ -973,15 +920,6 @@ pub fn apply_changeset(
         let _ = PathEdge::bulk_create(conn, &path.id, &edges.collect::<Vec<_>>());
     }
 
-    AccessionEdge::bulk_create(
-        conn,
-        &changeset
-            .accession_edges
-            .iter()
-            .map(AccessionEdgeData::from)
-            .collect::<Vec<_>>(),
-    );
-
     for accession in &changeset.accessions {
         Accession::get_or_create(
             conn,
@@ -989,14 +927,15 @@ pub fn apply_changeset(
             &accession.block_group_id,
             accession.parent_accession_id.as_ref(),
         )?;
-        let edges = changeset
-            .accession_paths
-            .iter()
-            .filter(|ap| ap.accession_id == accession.id)
-            .sorted_by(|e1, e2| Ord::cmp(&e1.index_in_path, &e2.index_in_path))
-            .map(|ap| ap.edge_id);
-        AccessionPath::create(conn, &accession.id, &edges.collect::<Vec<_>>())?;
     }
+    AccessionNode::bulk_create(
+        conn,
+        &changeset
+            .accession_nodes
+            .iter()
+            .map(AccessionNodeData::from)
+            .collect::<Vec<_>>(),
+    );
 
     for annotation_group in &changeset.annotation_groups {
         AnnotationGroup::get_or_create(conn, &annotation_group.name).map_err(|err| match err {
@@ -1103,21 +1042,12 @@ pub fn revert_changeset(
             .map(|group| group.name.clone())
             .collect::<Vec<_>>(),
     );
-    AccessionPath::delete_by_ids(
+    AccessionNode::delete_by_ids(
         conn,
         &changeset
-            .accession_paths
+            .accession_nodes
             .iter()
             .map(|obj| obj.id)
-            .collect::<Vec<_>>(),
-    );
-    // TODO: edges can be made by other operations in other dbs earlier and reused, so we likely want to allow FK failures delete for deletions
-    AccessionEdge::delete_by_ids(
-        conn,
-        &changeset
-            .accession_edges
-            .iter()
-            .map(|pe| pe.id)
             .collect::<Vec<_>>(),
     );
     Accession::delete_by_ids(
@@ -1387,21 +1317,14 @@ mod tests {
                 block_group_id: HashId::pad_str(1),
                 parent_accession_id: None,
             }],
-            accession_edges: vec![AccessionEdge {
-                id: HashId::pad_str(1),
-                source_node_id: HashId::convert_str("1"),
-                source_coordinate: 0,
-                source_strand: Strand::Forward,
-                target_node_id: HashId::convert_str("2"),
-                target_coordinate: 0,
-                target_strand: Strand::Forward,
-                chromosome_index: 0,
-            }],
-            accession_paths: vec![AccessionPath {
+            accession_nodes: vec![AccessionNode {
                 id: HashId::pad_str(1),
                 accession_id: HashId::pad_str(1),
+                node_id: HashId::convert_str("1"),
+                sequence_start: 0,
+                sequence_end: 2,
+                strand: Strand::Forward,
                 index_in_path: 0,
-                edge_id: HashId::pad_str(1),
             }],
             annotation_groups: vec![AnnotationGroup {
                 name: "gff3".to_string(),
@@ -1454,8 +1377,7 @@ mod tests {
                 paths: vec![],
                 path_edges: vec![],
                 accessions: vec![],
-                accession_edges: vec![],
-                accession_paths: vec![],
+                accession_nodes: vec![],
                 annotation_groups: vec![],
                 annotations: vec![],
                 annotation_group_samples: vec![],
@@ -1554,21 +1476,14 @@ mod tests {
                 block_group_id: HashId::pad_str(1),
                 parent_accession_id: None,
             }],
-            accession_edges: vec![AccessionEdge {
-                id: HashId::pad_str(1),
-                source_node_id: HashId::convert_str("1"),
-                source_coordinate: 0,
-                source_strand: Strand::Forward,
-                target_node_id: HashId::convert_str("2"),
-                target_coordinate: 0,
-                target_strand: Strand::Forward,
-                chromosome_index: 0,
-            }],
-            accession_paths: vec![AccessionPath {
+            accession_nodes: vec![AccessionNode {
                 id: HashId::pad_str(1),
                 accession_id: HashId::pad_str(1),
+                node_id: HashId::convert_str("1"),
+                sequence_start: 0,
+                sequence_end: 2,
+                strand: Strand::Forward,
                 index_in_path: 0,
-                edge_id: HashId::pad_str(1),
             }],
             annotation_groups: vec![AnnotationGroup {
                 name: "gff3".to_string(),

--- a/gen-models/src/changesets.rs
+++ b/gen-models/src/changesets.rs
@@ -404,7 +404,7 @@ pub fn parse_maybe_number(item: &ChangesetItem, col: usize) -> Option<i64> {
 pub fn process_changesetiter(
     conn: &GraphConnection,
     mut changes: &[u8],
-) -> (ChangesetModels, DependencyModels) {
+) -> Result<(ChangesetModels, DependencyModels), ChangesetError> {
     use fallible_streaming_iterator::FallibleStreamingIterator;
     use gen_core::is_terminal;
     use itertools::Itertools;
@@ -768,6 +768,12 @@ pub fn process_changesetiter(
         annotation_group_samples: created_annotation_group_samples,
     };
 
+    let previous_accession_ids = previous_accessions.iter().copied().collect::<Vec<_>>();
+    let previous_accession_nodes = AccessionNode::query_accessions(conn, &previous_accession_ids)?
+        .into_values()
+        .flatten()
+        .collect::<Vec<_>>();
+
     let dependency_models = DependencyModels {
         collections: Collection::query_by_ids(conn, &previous_collections),
         samples: Sample::query_by_ids(conn, &previous_samples),
@@ -777,10 +783,10 @@ pub fn process_changesetiter(
         edges: Edge::query_by_ids(conn, &previous_edges),
         paths: Path::query_by_ids(conn, &previous_paths),
         accessions: Accession::query_by_ids(conn, &previous_accessions),
-        accession_nodes: vec![],
+        accession_nodes: previous_accession_nodes,
     };
 
-    (changeset_models, dependency_models)
+    Ok((changeset_models, dependency_models))
 }
 
 pub fn apply_changeset(
@@ -853,6 +859,14 @@ pub fn apply_changeset(
             accession.parent_accession_id.as_ref(),
         )?;
     }
+    AccessionNode::bulk_create(
+        conn,
+        &dependencies
+            .accession_nodes
+            .iter()
+            .map(AccessionNodeData::from)
+            .collect::<Vec<_>>(),
+    )?;
 
     for collection in &changeset.collections {
         Collection::create(conn, &collection.name)?;
@@ -935,7 +949,7 @@ pub fn apply_changeset(
             .iter()
             .map(AccessionNodeData::from)
             .collect::<Vec<_>>(),
-    );
+    )?;
 
     for annotation_group in &changeset.annotation_groups {
         AnnotationGroup::get_or_create(conn, &annotation_group.name).map_err(|err| match err {
@@ -1573,6 +1587,10 @@ mod tests {
         assert_eq!(dependencies.samples[0].name, "sample-1");
         assert_eq!(dependencies.accessions.len(), 1);
         assert_eq!(dependencies.accessions[0].id, accession.id);
+        assert_eq!(
+            dependencies.accession_nodes,
+            Accession::get_nodes_by_id(conn, &accession.id)
+        );
     }
 
     #[test]

--- a/gen-models/src/errors.rs
+++ b/gen-models/src/errors.rs
@@ -2,7 +2,7 @@ use gen_core::errors::{ConfigError, ConnectionError, StrandError};
 use thiserror::Error;
 
 pub use crate::{
-    accession::{AccessionError, AccessionPathError},
+    accession::{AccessionError, AccessionNodeError},
     annotations::{AnnotationError, AnnotationGroupError},
     block_group::BlockGroupError,
     collection::CollectionError,
@@ -43,8 +43,8 @@ pub enum ChangesetError {
     PathError(#[from] PathError),
     #[error("Accession creation error: {0}")]
     AccessionError(#[from] AccessionError),
-    #[error("Accession path creation error: {0}")]
-    AccessionPathError(#[from] AccessionPathError),
+    #[error("Accession node creation error: {0}")]
+    AccessionNodeError(#[from] AccessionNodeError),
     #[error("Sequence save error: {0}")]
     SequenceError(#[from] SequenceError),
     #[error("Block group creation error: {0}")]

--- a/gen-models/src/errors.rs
+++ b/gen-models/src/errors.rs
@@ -29,6 +29,8 @@ pub enum ChangesetError {
     StrandError(#[from] StrandError),
     #[error("Missing Model: {0}")]
     MissingModel(String),
+    #[error("Query error: {0}")]
+    QueryError(#[from] QueryError),
     #[error("Serialization Error: {0}")]
     SerializationError(String),
     #[error("SQLite Error: {0}")]

--- a/gen-models/src/metadata.rs
+++ b/gen-models/src/metadata.rs
@@ -82,7 +82,7 @@ mod tests {
     #[test]
     fn test_table_name_constants() {
         use crate::{
-            accession::{Accession, AccessionEdge, AccessionPath},
+            accession::{Accession, AccessionNode},
             annotations::Annotation,
             block_group::BlockGroup,
             block_group_edge::BlockGroupEdge,
@@ -111,8 +111,7 @@ mod tests {
 
         // Test accession models
         assert_eq!(Accession::table_name(), "accessions");
-        assert_eq!(AccessionEdge::table_name(), "accession_edges");
-        assert_eq!(AccessionPath::table_name(), "accession_paths");
+        assert_eq!(AccessionNode::table_name(), "accession_nodes");
         assert_eq!(Annotation::table_name(), "annotations");
 
         // Test operation models

--- a/gen-models/src/session_operations.rs
+++ b/gen-models/src/session_operations.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use crate::{
-    accession::{Accession, AccessionEdge},
+    accession::{Accession, AccessionNode},
     block_group::BlockGroup,
     changesets::{DatabaseChangeset, process_changesetiter, write_changeset},
     collection::Collection,
@@ -150,8 +150,7 @@ pub fn attach_session(session: &mut session::Session) {
         "path_edges",
         "block_group_edges",
         "accessions",
-        "accession_edges",
-        "accession_paths",
+        "accession_nodes",
         "annotation_groups",
         "annotations",
         "annotation_group_samples",
@@ -171,7 +170,7 @@ pub struct DependencyModels {
     pub edges: Vec<Edge>,
     pub paths: Vec<Path>,
     pub accessions: Vec<Accession>,
-    pub accession_edges: Vec<AccessionEdge>,
+    pub accession_nodes: Vec<AccessionNode>,
 }
 
 impl<'a> Capnp<'a> for DependencyModels {
@@ -243,13 +242,12 @@ impl<'a> Capnp<'a> for DependencyModels {
             accession.write_capnp(&mut accession_builder);
         }
 
-        // Write accession edges (note: field name is accessionEdges in capnp schema)
-        let mut accession_edges_builder = builder
+        let mut accession_nodes_builder = builder
             .reborrow()
-            .init_accession_edges(self.accession_edges.len() as u32);
-        for (i, accession_edge) in self.accession_edges.iter().enumerate() {
-            let mut accession_edge_builder = accession_edges_builder.reborrow().get(i as u32);
-            accession_edge.write_capnp(&mut accession_edge_builder);
+            .init_accession_nodes(self.accession_nodes.len() as u32);
+        for (i, accession_node) in self.accession_nodes.iter().enumerate() {
+            let mut accession_node_builder = accession_nodes_builder.reborrow().get(i as u32);
+            accession_node.write_capnp(&mut accession_node_builder);
         }
     }
 
@@ -310,11 +308,10 @@ impl<'a> Capnp<'a> for DependencyModels {
             accessions.push(Accession::read_capnp(accession_reader));
         }
 
-        // Read accession edges
-        let accession_edges_reader = reader.get_accession_edges().unwrap();
-        let mut accession_edges = Vec::new();
-        for accession_edge_reader in accession_edges_reader.iter() {
-            accession_edges.push(AccessionEdge::read_capnp(accession_edge_reader));
+        let accession_nodes_reader = reader.get_accession_nodes().unwrap();
+        let mut accession_nodes = Vec::new();
+        for accession_node_reader in accession_nodes_reader.iter() {
+            accession_nodes.push(AccessionNode::read_capnp(accession_node_reader));
         }
 
         DependencyModels {
@@ -326,7 +323,7 @@ impl<'a> Capnp<'a> for DependencyModels {
             edges,
             paths,
             accessions,
-            accession_edges,
+            accession_nodes,
         }
     }
 }
@@ -397,15 +394,14 @@ mod tests {
                 block_group_id: HashId::pad_str(1),
                 parent_accession_id: None,
             }],
-            accession_edges: vec![AccessionEdge {
+            accession_nodes: vec![AccessionNode {
                 id: HashId::pad_str(1),
-                source_node_id: HashId::convert_str("1"),
-                source_coordinate: 0,
-                source_strand: Strand::Forward,
-                target_node_id: HashId::convert_str("2"),
-                target_coordinate: 0,
-                target_strand: Strand::Forward,
-                chromosome_index: 0,
+                accession_id: HashId::pad_str(1),
+                node_id: HashId::convert_str("1"),
+                sequence_start: 0,
+                sequence_end: 2,
+                strand: Strand::Forward,
+                index_in_path: 0,
             }],
         };
 

--- a/gen-models/src/session_operations.rs
+++ b/gen-models/src/session_operations.rs
@@ -45,7 +45,7 @@ pub fn end_operation(
     let mut output = Vec::new();
     session.changeset_strm(&mut output).unwrap();
 
-    let (changeset_models, dependencies) = process_changesetiter(conn, &output);
+    let (changeset_models, dependencies) = process_changesetiter(conn, &output)?;
 
     let hash = if let Some(hash) = force_hash.into() {
         hash

--- a/src/exports/genbank.rs
+++ b/src/exports/genbank.rs
@@ -10,9 +10,7 @@ use std::{
 };
 
 use gb_io::{self, seq::Location};
-use gen_annotations::projection::{
-    AnnotationSegment, accession_nodes_to_segments, project_annotation_segments,
-};
+use gen_annotations::projection::{AnnotationSegment, project_annotation_segments};
 use gen_core::{Strand, is_terminal, path::PathBlock, range::Range};
 use gen_graph::{GenGraph, GraphEdge, GraphNode, all_simple_paths};
 use gen_models::{
@@ -101,10 +99,10 @@ fn export_annotations(
             continue;
         }
 
-        let accession_segments = accession_nodes_to_segments(&Accession::get_nodes_by_id(
-            conn,
-            &annotation.accession_id,
-        ));
+        let accession_segments = Accession::get_nodes_by_id(conn, &annotation.accession_id)
+            .iter()
+            .map(AnnotationSegment::from)
+            .collect::<Vec<_>>();
         let genbank_extra = annotation
             .extra
             .as_ref()
@@ -553,7 +551,7 @@ mod tests {
                 index_in_path: index as i64,
             })
             .collect::<Vec<_>>();
-        AccessionNode::bulk_create(conn, &nodes);
+        AccessionNode::bulk_create(conn, &nodes).unwrap();
         Annotation::create_with_samples(
             conn,
             name,

--- a/src/exports/genbank.rs
+++ b/src/exports/genbank.rs
@@ -11,7 +11,7 @@ use std::{
 
 use gb_io::{self, seq::Location};
 use gen_annotations::projection::{
-    AnnotationSegment, accession_edges_to_segments, project_annotation_segments,
+    AnnotationSegment, accession_nodes_to_segments, project_annotation_segments,
 };
 use gen_core::{Strand, is_terminal, path::PathBlock, range::Range};
 use gen_graph::{GenGraph, GraphEdge, GraphNode, all_simple_paths};
@@ -101,7 +101,7 @@ fn export_annotations(
             continue;
         }
 
-        let accession_segments = accession_edges_to_segments(&Accession::get_edges_by_id(
+        let accession_segments = accession_nodes_to_segments(&Accession::get_nodes_by_id(
             conn,
             &annotation.accession_id,
         ));
@@ -437,11 +437,9 @@ mod tests {
     use std::{fs::File, io, io::BufReader, path::PathBuf, str};
 
     use gb_io::reader;
-    use gen_core::{
-        HashId, PATH_END_NODE_ID, PATH_START_NODE_ID, Strand, is_terminal, strand::Strand::Forward,
-    };
+    use gen_core::{HashId, Strand, is_terminal, strand::Strand::Forward};
     use gen_models::{
-        accession::{Accession, AccessionEdge, AccessionEdgeData, AccessionPath},
+        accession::{Accession, AccessionNode, AccessionNodeData},
         annotations::{Annotation, AnnotationExtra, GenBankExtra, GenBankLocationOperator},
         block_group::BlockGroup,
         file_types::FileTypes,
@@ -542,47 +540,20 @@ mod tests {
             .into_iter()
             .filter(|block| !is_terminal(block.node_id))
             .collect::<Vec<_>>();
-        let first = segments
-            .first()
-            .expect("should contain at least one annotation segment");
-        let mut edges = vec![AccessionEdgeData {
-            source_node_id: PATH_START_NODE_ID,
-            source_coordinate: -1,
-            source_strand: Strand::Forward,
-            target_node_id: blocks[first.0].node_id,
-            target_coordinate: first.1,
-            target_strand: first.3,
-            chromosome_index: 0,
-        }];
-        for window in segments.windows(2) {
-            let current = window[0];
-            let next = window[1];
-            edges.push(AccessionEdgeData {
-                source_node_id: blocks[current.0].node_id,
-                source_coordinate: current.2,
-                source_strand: current.3,
-                target_node_id: blocks[next.0].node_id,
-                target_coordinate: next.1,
-                target_strand: next.3,
-                chromosome_index: 0,
-            });
-        }
-        let last = segments
-            .last()
-            .expect("should contain at least one annotation segment");
-        edges.push(AccessionEdgeData {
-            source_node_id: blocks[last.0].node_id,
-            source_coordinate: last.2,
-            source_strand: last.3,
-            target_node_id: PATH_END_NODE_ID,
-            target_coordinate: -1,
-            target_strand: Strand::Forward,
-            chromosome_index: 0,
-        });
-
         let accession = Accession::get_or_create(conn, name, &path.block_group_id, None).unwrap();
-        let edge_ids = AccessionEdge::bulk_create(conn, &edges);
-        AccessionPath::create(conn, &accession.id, &edge_ids);
+        let nodes = segments
+            .iter()
+            .enumerate()
+            .map(|(index, segment)| AccessionNodeData {
+                accession_id: accession.id,
+                node_id: blocks[segment.0].node_id,
+                sequence_start: segment.1,
+                sequence_end: segment.2,
+                strand: segment.3,
+                index_in_path: index as i64,
+            })
+            .collect::<Vec<_>>();
+        AccessionNode::bulk_create(conn, &nodes);
         Annotation::create_with_samples(
             conn,
             name,

--- a/src/genbank.rs
+++ b/src/genbank.rs
@@ -8,7 +8,7 @@ use gen_core::Strand;
 use gen_models::{
     annotations::{AnnotationExtra, GenBankExtra, GenBankLocationOperator, GenBankQualifier},
     errors::{
-        AccessionError, AccessionPathError, AnnotationError, BlockGroupError, CollectionError,
+        AccessionError, AccessionNodeError, AnnotationError, BlockGroupError, CollectionError,
         EdgeError, NodeError, OperationError, PathError, SampleError, SequenceError,
     },
 };
@@ -47,8 +47,8 @@ pub enum GenBankError {
     PathError(#[from] PathError),
     #[error("Accession creation error: {0}")]
     AccessionError(#[from] AccessionError),
-    #[error("Accession path creation error: {0}")]
-    AccessionPathError(#[from] AccessionPathError),
+    #[error("Accession node creation error: {0}")]
+    AccessionNodeError(#[from] AccessionNodeError),
     #[error("Sequence save error: {0}")]
     SequenceError(#[from] SequenceError),
 }

--- a/src/imports/genbank.rs
+++ b/src/imports/genbank.rs
@@ -12,7 +12,7 @@ use gen_core::{
     range::{Range, merge_ordered_items},
 };
 use gen_models::{
-    accession::{Accession, AccessionEdge, AccessionEdgeData, AccessionPath},
+    accession::{Accession, AccessionNode, AccessionNodeData},
     annotations::Annotation,
     block_group::{BlockGroup, BlockGroupChange, NewBlockGroup},
     block_group_edge::{BlockGroupEdge, BlockGroupEdgeData},
@@ -338,48 +338,24 @@ fn create_accession_for_segments(
         Ok(accession) => accession,
         Err(err) => return Err(GenBankError::AccessionError(err)),
     };
-    let mut edges = Vec::with_capacity(segments.len() + 1);
-
-    let first = segments.first().ok_or_else(|| {
-        GenBankError::ParseError("Annotation has no mappable segments".to_string())
-    })?;
-    edges.push(AccessionEdgeData {
-        source_node_id: PATH_START_NODE_ID,
-        source_coordinate: -1,
-        source_strand: Strand::Forward,
-        target_node_id: first.node_id,
-        target_coordinate: first.range.start,
-        target_strand: first.strand,
-        chromosome_index: 0,
-    });
-
-    for window in segments.windows(2) {
-        let current = &window[0];
-        let next = &window[1];
-        edges.push(AccessionEdgeData {
-            source_node_id: current.node_id,
-            source_coordinate: current.range.end,
-            source_strand: current.strand,
-            target_node_id: next.node_id,
-            target_coordinate: next.range.start,
-            target_strand: next.strand,
-            chromosome_index: 0,
-        });
+    if segments.is_empty() {
+        return Err(GenBankError::ParseError(
+            "Annotation has no mappable segments".to_string(),
+        ));
     }
-
-    let last = segments.last().unwrap();
-    edges.push(AccessionEdgeData {
-        source_node_id: last.node_id,
-        source_coordinate: last.range.end,
-        source_strand: last.strand,
-        target_node_id: PATH_END_NODE_ID,
-        target_coordinate: -1,
-        target_strand: Strand::Forward,
-        chromosome_index: 0,
-    });
-
-    let edge_ids = AccessionEdge::bulk_create(conn, &edges);
-    AccessionPath::create(conn, &accession.id, &edge_ids)?;
+    let nodes = segments
+        .iter()
+        .enumerate()
+        .map(|(index, segment)| AccessionNodeData {
+            accession_id: accession.id,
+            node_id: segment.node_id,
+            sequence_start: segment.range.start,
+            sequence_end: segment.range.end,
+            strand: segment.strand,
+            index_in_path: index as i64,
+        })
+        .collect::<Vec<_>>();
+    AccessionNode::bulk_create(conn, &nodes);
     Ok(accession.id)
 }
 
@@ -703,7 +679,7 @@ where
 mod tests {
     use std::{collections::HashSet, fs::File, io::BufReader, path::PathBuf};
 
-    use gen_annotations::projection::accession_edges_to_segments;
+    use gen_annotations::projection::accession_nodes_to_segments;
     use gen_models::{
         annotations::{Annotation, AnnotationGroup, GenBankLocationOperator},
         file_types::FileTypes,
@@ -1152,7 +1128,7 @@ mod tests {
             .iter()
             .find(|annotation| annotation.name == "M13 Forward")
             .unwrap();
-        let m13_forward_segments = accession_edges_to_segments(&Accession::get_edges_by_id(
+        let m13_forward_segments = accession_nodes_to_segments(&Accession::get_nodes_by_id(
             conn,
             &m13_forward.accession_id,
         ));
@@ -1161,7 +1137,7 @@ mod tests {
         assert_eq!(m13_forward_segments[0].range.end, 706);
         assert_eq!(m13_forward_segments[0].strand, Strand::Reverse);
 
-        let ori_segments = accession_edges_to_segments(&Accession::get_edges_by_id(
+        let ori_segments = accession_nodes_to_segments(&Accession::get_nodes_by_id(
             conn,
             &ori_annotation.accession_id,
         ));

--- a/src/imports/genbank.rs
+++ b/src/imports/genbank.rs
@@ -355,7 +355,7 @@ fn create_accession_for_segments(
             index_in_path: index as i64,
         })
         .collect::<Vec<_>>();
-    AccessionNode::bulk_create(conn, &nodes);
+    AccessionNode::bulk_create(conn, &nodes)?;
     Ok(accession.id)
 }
 
@@ -679,7 +679,6 @@ where
 mod tests {
     use std::{collections::HashSet, fs::File, io::BufReader, path::PathBuf};
 
-    use gen_annotations::projection::accession_nodes_to_segments;
     use gen_models::{
         annotations::{Annotation, AnnotationGroup, GenBankLocationOperator},
         file_types::FileTypes,
@@ -1128,19 +1127,19 @@ mod tests {
             .iter()
             .find(|annotation| annotation.name == "M13 Forward")
             .unwrap();
-        let m13_forward_segments = accession_nodes_to_segments(&Accession::get_nodes_by_id(
-            conn,
-            &m13_forward.accession_id,
-        ));
+        let m13_forward_segments = Accession::get_nodes_by_id(conn, &m13_forward.accession_id)
+            .iter()
+            .map(AnnotationSegment::from)
+            .collect::<Vec<_>>();
         assert_eq!(m13_forward_segments.len(), 1);
         assert_eq!(m13_forward_segments[0].range.start, 688);
         assert_eq!(m13_forward_segments[0].range.end, 706);
         assert_eq!(m13_forward_segments[0].strand, Strand::Reverse);
 
-        let ori_segments = accession_nodes_to_segments(&Accession::get_nodes_by_id(
-            conn,
-            &ori_annotation.accession_id,
-        ));
+        let ori_segments = Accession::get_nodes_by_id(conn, &ori_annotation.accession_id)
+            .iter()
+            .map(AnnotationSegment::from)
+            .collect::<Vec<_>>();
         assert_eq!(ori_segments.len(), 2);
         assert!(
             ori_segments

--- a/src/imports/genbank.rs
+++ b/src/imports/genbank.rs
@@ -572,8 +572,7 @@ where
                     let end = edit.end;
                     let region =
                         ResolvedGenRegion::from_path(conn, block_group.id, &path, start, end)?;
-                    let change_node_id = None;
-                    let change = match edit.edit_type {
+                    let (change, change_node_id) = match edit.edit_type {
                         EditType::Insertion | EditType::Replacement => {
                             let change_seq = Sequence::new()
                                 .sequence(&edit.new_sequence)
@@ -592,39 +591,45 @@ where
                                     new_hash = &change_seq.hash,
                                 )),
                             )?;
+                            (
+                                BlockGroupChange {
+                                    region: region.clone(),
+                                    path_accession: None,
+                                    block: PathBlock {
+                                        node_id: change_node_id,
+                                        block_sequence: edit.new_sequence.clone(),
+                                        sequence_start: 0,
+                                        sequence_end: change_seq.length,
+                                        path_start: start,
+                                        path_end: end + change_seq.length,
+                                        strand: Strand::Forward,
+                                    },
+                                    chromosome_index: 1,
+                                    phased: 0,
+                                    preserve_edge: true,
+                                },
+                                Some(change_node_id),
+                            )
+                        }
+                        EditType::Deletion => (
                             BlockGroupChange {
-                                region: region.clone(),
+                                region,
                                 path_accession: None,
                                 block: PathBlock {
-                                    node_id: change_node_id,
-                                    block_sequence: edit.new_sequence.clone(),
+                                    node_id: wt_node_id,
+                                    block_sequence: "".to_string(),
                                     sequence_start: 0,
-                                    sequence_end: change_seq.length,
+                                    sequence_end: 0,
                                     path_start: start,
-                                    path_end: end + change_seq.length,
+                                    path_end: end,
                                     strand: Strand::Forward,
                                 },
                                 chromosome_index: 1,
                                 phased: 0,
                                 preserve_edge: true,
-                            }
-                        }
-                        EditType::Deletion => BlockGroupChange {
-                            region,
-                            path_accession: None,
-                            block: PathBlock {
-                                node_id: wt_node_id,
-                                block_sequence: "".to_string(),
-                                sequence_start: 0,
-                                sequence_end: 0,
-                                path_start: start,
-                                path_end: end,
-                                strand: Strand::Forward,
                             },
-                            chromosome_index: 1,
-                            phased: 0,
-                            preserve_edge: true,
-                        },
+                            None,
+                        ),
                     };
                     BlockGroup::insert_change(conn, &change).unwrap();
                     applied_changes.push((edit, change_node_id));

--- a/src/updates/vcf.rs
+++ b/src/updates/vcf.rs
@@ -715,7 +715,7 @@ mod tests {
             false,
         )
         .unwrap();
-        update_with_vcf(
+        let _operation = update_with_vcf(
             &context,
             &vcf_path.to_str().unwrap().to_string(),
             &collection,
@@ -769,7 +769,7 @@ mod tests {
             false,
         )
         .unwrap();
-        update_with_vcf(
+        let _operation = update_with_vcf(
             &context,
             &vcf_path.to_str().unwrap().to_string(),
             &collection,
@@ -829,7 +829,7 @@ mod tests {
             false,
         )
         .unwrap();
-        update_with_vcf(
+        let _operation = update_with_vcf(
             &context,
             &vcf_path.to_str().unwrap().to_string(),
             &collection,
@@ -922,7 +922,7 @@ mod tests {
             false,
         )
         .unwrap();
-        update_with_vcf(
+        let _operation = update_with_vcf(
             &context,
             &vcf_path.to_str().unwrap().to_string(),
             &collection,
@@ -1245,7 +1245,6 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Unable to create accession")]
     fn test_disallows_creating_accession_nodes_that_exist() {
         let mut vcf_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         vcf_path.push("fixtures/accession.vcf");
@@ -1268,7 +1267,7 @@ mod tests {
         )
         .unwrap();
 
-        update_with_vcf(
+        let _operation = update_with_vcf(
             &context,
             &vcf_path.to_str().unwrap().to_string(),
             &collection,
@@ -1293,7 +1292,7 @@ mod tests {
         // This is invalid because lp1 already exists from accession.vcf
         vcf_path.push("fixtures/accession_2_invalid.vcf");
 
-        update_with_vcf(
+        let err = update_with_vcf(
             &context,
             &vcf_path.to_str().unwrap().to_string(),
             &collection,
@@ -1302,7 +1301,13 @@ mod tests {
             vec![Sample::DEFAULT_NAME.to_string()],
             false,
         )
-        .unwrap();
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            VcfError::BlockGroupError(BlockGroupError::AccessionError(
+                gen_models::accession::AccessionError::Duplicate(_)
+            ))
+        ));
     }
 
     #[test]

--- a/src/updates/vcf.rs
+++ b/src/updates/vcf.rs
@@ -1191,7 +1191,7 @@ mod tests {
     }
 
     #[test]
-    fn test_creates_accession_paths() {
+    fn test_creates_accession_nodes() {
         let context = setup_gen();
         let mut vcf_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         vcf_path.push("fixtures/accession.vcf");
@@ -1246,7 +1246,7 @@ mod tests {
 
     #[test]
     #[should_panic(expected = "Unable to create accession")]
-    fn test_disallows_creating_accession_paths_that_exist() {
+    fn test_disallows_creating_accession_nodes_that_exist() {
         let mut vcf_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         vcf_path.push("fixtures/accession.vcf");
         let mut fasta_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));

--- a/src/views/annotations.rs
+++ b/src/views/annotations.rs
@@ -7,12 +7,12 @@ use std::{
 };
 
 use gen_annotations::{
-    projection::accession_nodes_to_segments as projection_accession_nodes_to_segments,
+    projection as annotation_projection,
     translate::{bed::translate_bed, gff::translate_gff},
 };
 use gen_core::{HashId, Strand, Workspace};
 use gen_models::{
-    accession::{Accession, AccessionNode},
+    accession::Accession,
     annotations::{Annotation, AnnotationError},
     block_group::BlockGroup,
     db::GraphConnection,
@@ -28,18 +28,6 @@ use crate::views::{
     annotation_groups::AnnotationGroupEntry,
     annotation_track::{AnnotationSegment, AnnotationSpan, AnnotationTrack},
 };
-
-fn accession_nodes_to_segments(nodes: &[AccessionNode]) -> Vec<AnnotationSegment> {
-    projection_accession_nodes_to_segments(nodes)
-        .into_iter()
-        .map(|segment| AnnotationSegment {
-            node_id: segment.node_id,
-            start: segment.range.start,
-            end: segment.range.end,
-            strand: segment.strand,
-        })
-        .collect()
-}
 
 pub struct AnnotationGroupTrackRequest<'a> {
     pub conn: &'a GraphConnection,
@@ -67,8 +55,15 @@ fn load_group_annotations(
         .filter_map(|annotation| {
             let _ = Accession::get_by_id(conn, &annotation.accession_id)?;
             let nodes = Accession::get_nodes_by_id(conn, &annotation.accession_id);
-            let segments = accession_nodes_to_segments(&nodes)
-                .into_iter()
+            let segments = nodes
+                .iter()
+                .map(annotation_projection::AnnotationSegment::from)
+                .map(|segment| AnnotationSegment {
+                    node_id: segment.node_id,
+                    start: segment.range.start,
+                    end: segment.range.end,
+                    strand: segment.strand,
+                })
                 .filter(|segment| {
                     visible_ranges_by_node
                         .get(&segment.node_id)

--- a/src/views/annotations.rs
+++ b/src/views/annotations.rs
@@ -7,12 +7,12 @@ use std::{
 };
 
 use gen_annotations::{
-    projection::accession_edges_to_segments as projection_accession_edges_to_segments,
+    projection::accession_nodes_to_segments as projection_accession_nodes_to_segments,
     translate::{bed::translate_bed, gff::translate_gff},
 };
 use gen_core::{HashId, Strand, Workspace};
 use gen_models::{
-    accession::{Accession, AccessionEdge},
+    accession::{Accession, AccessionNode},
     annotations::{Annotation, AnnotationError},
     block_group::BlockGroup,
     db::GraphConnection,
@@ -29,8 +29,8 @@ use crate::views::{
     annotation_track::{AnnotationSegment, AnnotationSpan, AnnotationTrack},
 };
 
-fn accession_edges_to_segments(edges: &[AccessionEdge]) -> Vec<AnnotationSegment> {
-    projection_accession_edges_to_segments(edges)
+fn accession_nodes_to_segments(nodes: &[AccessionNode]) -> Vec<AnnotationSegment> {
+    projection_accession_nodes_to_segments(nodes)
         .into_iter()
         .map(|segment| AnnotationSegment {
             node_id: segment.node_id,
@@ -66,8 +66,8 @@ fn load_group_annotations(
         .into_iter()
         .filter_map(|annotation| {
             let _ = Accession::get_by_id(conn, &annotation.accession_id)?;
-            let edges = Accession::get_edges_by_id(conn, &annotation.accession_id);
-            let segments = accession_edges_to_segments(&edges)
+            let nodes = Accession::get_nodes_by_id(conn, &annotation.accession_id);
+            let segments = accession_nodes_to_segments(&nodes)
                 .into_iter()
                 .filter(|segment| {
                     visible_ranges_by_node


### PR DESCRIPTION
Replaces #175 

Refactors the accession model to store data on nodes instead of using an edge table. This makes accessions an ordered array of node slices. The strand information is stored on the accession node, as this was formerly on the edges. I think at some point we may have to do some more strand work to track it when we convert a region/accession into an intervaltree