### PR TITLE
fix(transaction): rollback if tx_commit fails in run_write and __exit__

### DIFF
--- a/gen-python/src/python_api/repository/mod.rs
+++ b/gen-python/src/python_api/repository/mod.rs
@@ -65,7 +65,10 @@ where
     match op(context) {
         Ok(val) => {
             if managed {
-                tx_commit(context)?;
+                if let Err(e) = tx_commit(context) {
+                    tx_rollback(context);
+                    return Err(e);
+                }
             }
             Ok(val)
         }
@@ -221,8 +224,9 @@ impl PyRepository {
         slf.in_transaction = false;
         if exc_type.is_some() {
             tx_rollback(&slf.context);
-        } else {
-            tx_commit(&slf.context)?;
+        } else if let Err(e) = tx_commit(&slf.context) {
+            tx_rollback(&slf.context);
+            return Err(e);
         }
         Ok(false)
     }


### PR DESCRIPTION
## Summary
- A commit failure (e.g. constraint violation at flush time) left the SQLite connection mid-transaction, so the next write failed with "cannot start a transaction within a transaction" instead of a clear error.
- `run_write` and `Repository.__exit__` now roll back before propagating the commit error.