### PR TITLE
Don't commit cargo.lock for R

### DIFF
--- a/.github/workflows/versioned-release.yml
+++ b/.github/workflows/versioned-release.yml
@@ -76,7 +76,7 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
           git add Cargo.toml gen-models/Cargo.toml gen-diff/Cargo.toml gen-python/Cargo.toml gen-r/src/rust/Cargo.toml gen-r/DESCRIPTION gen-sugiyama/Cargo.toml gen-tui/Cargo.toml gen-annotations/Cargo.toml gen-core/Cargo.toml gen-capnp-schemas/Cargo.toml gen-graph/Cargo.toml pyproject.toml
-          git add Cargo.lock gen-python/Cargo.lock gen-r/src/rust/Cargo.lock
+          git add Cargo.lock gen-python/Cargo.lock
           git commit -m "Release v${VERSION}"
           git tag -a "v${VERSION}" -m "Release v${VERSION}"
           git push origin HEAD


### PR DESCRIPTION
The Cargo.lock file for R is in the gitignore file: https://github.com/genhub-bio/gen/blob/main/.gitignore#L38

Unless we want to change that (I don't think we do), we shouldn't add it as part of the version bump