### PR TITLE
Add profiling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -38,6 +47,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "aligned-vec"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
+dependencies = [
+ "equator",
 ]
 
 [[package]]
@@ -202,6 +220,21 @@ dependencies = [
  "fastrand",
  "gloo-timers",
  "tokio",
+]
+
+[[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link",
 ]
 
 [[package]]
@@ -854,6 +887,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpp_demangle"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2bb79cb74d735044c972aae58ed0aaa9a837e85b01106a54c39e42e97f62253"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1120,6 +1162,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "uuid",
+]
+
+[[package]]
 name = "deflate64"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1352,6 +1403,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "equator"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
+dependencies = [
+ "equator-macro",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1440,6 +1511,18 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "findshlibs"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64"
+dependencies = [
+ "cc",
+ "lazy_static",
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "finl_unicode"
@@ -1686,6 +1769,7 @@ dependencies = [
  "once_cell",
  "petgraph 0.6.5",
  "postcard",
+ "pprof",
  "rand 0.10.1",
  "rat-cursor",
  "rat-text",
@@ -1699,6 +1783,8 @@ dependencies = [
  "sha2",
  "tempfile",
  "thiserror 2.0.18",
+ "tracing",
+ "tracing-subscriber",
  "tui-widget-list",
  "url",
  "url-parse",
@@ -1793,6 +1879,7 @@ dependencies = [
  "noodles",
  "opendal",
  "petgraph 0.6.5",
+ "postcard",
  "rand 0.10.1",
  "rusqlite",
  "rusqlite_migration",
@@ -1802,6 +1889,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
  "url",
 ]
 
@@ -1888,6 +1976,12 @@ dependencies = [
  "wasip2",
  "wasip3",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "glob"
@@ -2609,7 +2703,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -2835,7 +2929,7 @@ version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
 dependencies = [
- "nix",
+ "nix 0.29.0",
  "winapi",
 ]
 
@@ -2949,6 +3043,17 @@ name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+]
 
 [[package]]
 name = "nix"
@@ -3347,6 +3452,15 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.1",
  "objc2",
+]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -3875,6 +3989,27 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "pprof"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38a01da47675efa7673b032bf8efd8214f1917d89685e07e395ab125ea42b187"
+dependencies = [
+ "aligned-vec",
+ "backtrace",
+ "cfg-if",
+ "findshlibs",
+ "libc",
+ "log",
+ "nix 0.26.4",
+ "once_cell",
+ "smallvec",
+ "spin 0.10.0",
+ "symbolic-demangle",
+ "tempfile",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -5040,6 +5175,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shared_child"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5206,6 +5350,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
+name = "spin"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5286,6 +5439,29 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "symbolic-common"
+version = "12.18.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "332615d90111d8eeaf86a84dc9bbe9f65d0d8c5cf11b4caccedc37754eb0dcfd"
+dependencies = [
+ "debugid",
+ "memmap2",
+ "stable_deref_trait",
+ "uuid",
+]
+
+[[package]]
+name = "symbolic-demangle"
+version = "12.18.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "912017718eb4d21930546245af9a3475c9dccf15675a5c215664e76621afc471"
+dependencies = [
+ "cpp_demangle",
+ "rustc-demangle",
+ "symbolic-common",
+]
 
 [[package]]
 name = "syn"
@@ -5450,7 +5626,7 @@ dependencies = [
  "libc",
  "log",
  "memmem",
- "nix",
+ "nix 0.29.0",
  "num-derive",
  "num-traits",
  "ordered-float",
@@ -5512,6 +5688,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -5723,7 +5908,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5733,6 +5930,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -5903,6 +6126,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ default = ["models", "cli", "diff"]
 diff = []
 models = []
 cli = []
+profiling = ["gen-models/profiling", "dep:tracing", "dep:tracing-subscriber", "dep:pprof"]
 
 [dependencies]
 gen-core = { path = "gen-core", version = "0.2.0" }
@@ -84,6 +85,9 @@ indexmap = "2.11.3"
 anyhow = { version = "1.0.100", features = ["backtrace"] }
 postcard = { version = "1.1.3", default-features = false, features = ["alloc"] }
 zip = "2.4.2"
+tracing = { version = "0.1.41", optional = true }
+tracing-subscriber = { version = "0.3.19", features = ["registry"], optional = true }
+pprof = { version = "0.15.0", optional = true }
 
 [dev-dependencies]
 cargo-llvm-cov = "0.8.5"

--- a/bin/benchmark.sh
+++ b/bin/benchmark.sh
@@ -1,10 +1,16 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -e
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 BASE_DIR="$(dirname "${SCRIPT_DIR}")"
 GEN_DIR="${BASE_DIR}/.gen"
 GEN_BIN="${BASE_DIR}/target/release/gen"
+PROFILE_BIN="${BASE_DIR}/target/debug/gen"
+PYTHON_BIN="${PYTHON_BIN:-$(command -v python3 || command -v python)}"
+RESULTS=""
+PROFILE_DIR="${BASE_DIR}/.benchmark-profiles"
+PROFILE_RESULTS=""
+PROFILE_BENCHMARKS="${PROFILE_BENCHMARKS:-1}"
 
 init_test() {
   cd ${BASE_DIR}
@@ -13,51 +19,250 @@ init_test() {
 }
 
 get_size () {
-  local filesize_mb=$(python -c "import os;size=os.path.getsize('${GEN_DIR}/default.db') / (1024 * 1024);print(f'{size:.4f}')")
-  echo $filesize_mb
+  GEN_DIR="${GEN_DIR}" GEN_DB_PATH="${GEN_DIR}/gen.db" DEFAULT_DB_PATH="${GEN_DIR}/default.db" ${PYTHON_BIN} -c "import os
+from pathlib import Path
+
+def size_mb(path):
+    p = Path(path)
+    if not p.exists():
+        return '0.0000'
+    return f'{p.stat().st_size / (1024 * 1024):.4f}'
+
+gen_dir = os.environ['GEN_DIR']
+gen_db_path = os.environ['GEN_DB_PATH']
+default_db_path = os.environ['DEFAULT_DB_PATH']
+
+total = 0
+for root, _, files in os.walk(gen_dir):
+    for name in files:
+        total += os.path.getsize(os.path.join(root, name))
+
+print(f'{total / (1024 * 1024):.4f} {size_mb(gen_db_path)} {size_mb(default_db_path)}')"
 }
 
 time_taken() {
-  local start_time=$(python -c "import time;print(round(time.time()*1000))")
+  local start_time=$(${PYTHON_BIN} -c "import time;print(round(time.time()*1000))")
   "$@" > /dev/null 2> /dev/null
-  local end_time=$(python -c "import time;print(round(time.time()*1000))")
+  local end_time=$(${PYTHON_BIN} -c "import time;print(round(time.time()*1000))")
   local duration=$((end_time - start_time))
   echo $duration
 }
 
+record_result() {
+  local task="$1"
+  local duration="$2"
+  local total_size="$3"
+  local gen_db_size="$4"
+  local default_db_size="$5"
+  RESULTS+=$(printf "%-35s %-10s %-10s %-10s %-10s\n" "${task}" "${duration}" "${total_size}" "${gen_db_size}" "${default_db_size}")
+  RESULTS+=$'\n'
+}
+
+record_profile_result() {
+  local task="$1"
+  local profile_file="$2"
+  PROFILE_RESULTS+=$(printf "%-35s %s\n" "${task}" "${profile_file}")
+  PROFILE_RESULTS+=$'\n'
+}
+
+profile_taken() {
+  local output_file="$1"
+  shift
+  local start_time=$(${PYTHON_BIN} -c "import time;print(round(time.time()*1000))")
+  "$@" > "${output_file}" 2> /dev/null
+  local end_time=$(${PYTHON_BIN} -c "import time;print(round(time.time()*1000))")
+  local duration=$((end_time - start_time))
+  echo $duration
+}
+
+run_benchmark() {
+  local task="$1"
+  shift
+  local record_profile=1
+
+  if [[ "${1:-}" == "--no-profile-record" ]]; then
+    record_profile=0
+    shift
+  fi
+
+  if [[ "${PROFILE_BENCHMARKS}" == "1" ]]; then
+    local profile_file
+    profile_file="$(profile_path "${task}")"
+    local duration
+    duration=$(profile_taken "${profile_file}" "$@")
+    if [[ "${record_profile}" == "1" ]]; then
+      record_profile_result "${task}" "${profile_file}"
+    fi
+    printf '%s' "${duration}"
+  else
+    time_taken "$@"
+  fi
+}
+
+latest_operation_hash() {
+  ${GEN_BIN} operations | awk 'NR > 1 { if ($1 == ">") hash=$2; else hash=$1 } END { print hash }'
+}
+
+first_operation_hash() {
+  ${GEN_BIN} operations | awk 'NR > 1 { if ($1 == ">") print $2; else print $1; exit }'
+}
+
+setup_simple_fasta_repo() {
+  init_test
+  ${GEN_BIN} import fasta ${BASE_DIR}/fixtures/simple.fa --reference reference > /dev/null 2> /dev/null
+}
+
+setup_hg_branch_apply_repo() {
+  init_test
+  ${GEN_BIN} import fasta ${BASE_DIR}/fixtures/chr22.fa.gz --reference reference --shallow > /dev/null 2> /dev/null
+  ${GEN_BIN} checkout -b branch-a > /dev/null 2> /dev/null
+  ${GEN_BIN} update vcf ${BASE_DIR}/fixtures/HG00096.vcf.gz --parent-samples reference > /dev/null 2> /dev/null
+  BRANCH_A_HASH=$(latest_operation_hash)
+  ${GEN_BIN} checkout main > /dev/null 2> /dev/null
+}
+
+setup_hg_branch_switch_repo() {
+  setup_hg_branch_apply_repo
+  ${GEN_BIN} checkout -b branch-b > /dev/null 2> /dev/null
+  ${GEN_BIN} update vcf ${BASE_DIR}/fixtures/HG00097.vcf.gz --parent-samples reference > /dev/null 2> /dev/null
+}
+
+setup_hg_reset_repo() {
+  init_test
+  ${GEN_BIN} import fasta ${BASE_DIR}/fixtures/chr22.fa.gz --reference reference --shallow > /dev/null 2> /dev/null
+  RESET_HASH=$(first_operation_hash)
+  ${GEN_BIN} update vcf ${BASE_DIR}/fixtures/HG00096.vcf.gz --parent-samples reference > /dev/null 2> /dev/null
+}
+
+setup_library_update_repo() {
+  setup_simple_fasta_repo
+}
+
+setup_gfa_update_repo() {
+  init_test
+  ${GEN_BIN} import gfa ${BASE_DIR}/fixtures/simple.gfa --reference reference > /dev/null 2> /dev/null
+}
+
+print_results() {
+  echo "Benchmark results"
+  printf "%-35s %-10s %-10s %-10s %-10s\n" "Task" "Time (ms)" "Total (MB)" "gen.db (MB)" "default.db (MB)"
+  printf "%-35s %-10s %-10s %-10s %-10s\n" "---------------" "--------" "----------" "-----------" "--------------"
+  printf "%s" "${RESULTS}"
+}
+
+
+rm -rf "${PROFILE_DIR}"
+mkdir -p "${PROFILE_DIR}"
 
 cargo build --release
+cargo build --features profiling
+
+profile_path() {
+  local task="$1"
+  local slug
+  slug=$(printf '%s' "${task}" | tr '[:upper:]' '[:lower:]' | tr -cs '[:alnum:]' '_')
+  echo "${PROFILE_DIR}/${slug}.txt"
+}
+
 echo "full import benchmark"
 init_test
-FULL_IMPORT=$(time_taken ${GEN_BIN} import -f ${BASE_DIR}/fixtures/chr22.fa.gz)
-FULL_SIZE=$(get_size)
+FULL_IMPORT=$(run_benchmark "Full import" ${PROFILE_BIN} profile import fasta ${BASE_DIR}/fixtures/chr22.fa.gz --reference reference)
+read -r FULL_SIZE FULL_GEN_DB_SIZE FULL_DEFAULT_DB_SIZE <<< "$(get_size)"
+record_result "Full import" "${FULL_IMPORT}" "${FULL_SIZE}" "${FULL_GEN_DB_SIZE}" "${FULL_DEFAULT_DB_SIZE}"
+
 echo "shallow import benchmark"
 init_test
-SHALLOW_IMPORT=$(time_taken ${BASE_DIR}/target/release/gen import -f ${BASE_DIR}/fixtures/chr22.fa.gz --shallow)
-SHALLOW_SIZE=$(get_size)
+SHALLOW_IMPORT=$(run_benchmark "Shallow import" ${PROFILE_BIN} profile import fasta ${BASE_DIR}/fixtures/chr22.fa.gz --reference reference --shallow)
+read -r SHALLOW_SIZE SHALLOW_GEN_DB_SIZE SHALLOW_DEFAULT_DB_SIZE <<< "$(get_size)"
+record_result "Shallow import" "${SHALLOW_IMPORT}" "${SHALLOW_SIZE}" "${SHALLOW_GEN_DB_SIZE}" "${SHALLOW_DEFAULT_DB_SIZE}"
+
+echo "simple fasta import benchmark"
+init_test
+SIMPLE_FASTA_IMPORT=$(run_benchmark "Simple FASTA import" ${PROFILE_BIN} profile import fasta ${BASE_DIR}/fixtures/simple.fa --reference reference)
+read -r SIMPLE_FASTA_SIZE SIMPLE_FASTA_GEN_DB_SIZE SIMPLE_FASTA_DEFAULT_DB_SIZE <<< "$(get_size)"
+record_result "Simple FASTA import" "${SIMPLE_FASTA_IMPORT}" "${SIMPLE_FASTA_SIZE}" "${SIMPLE_FASTA_GEN_DB_SIZE}" "${SIMPLE_FASTA_DEFAULT_DB_SIZE}"
+
+echo "multi fasta import benchmark"
+init_test
+MULTI_FASTA_IMPORT=$(run_benchmark "Multi FASTA import" ${PROFILE_BIN} profile import fasta ${BASE_DIR}/fixtures/fastas/multiple.fa --reference reference)
+read -r MULTI_FASTA_SIZE MULTI_FASTA_GEN_DB_SIZE MULTI_FASTA_DEFAULT_DB_SIZE <<< "$(get_size)"
+record_result "Multi FASTA import" "${MULTI_FASTA_IMPORT}" "${MULTI_FASTA_SIZE}" "${MULTI_FASTA_GEN_DB_SIZE}" "${MULTI_FASTA_DEFAULT_DB_SIZE}"
+
+echo "gfa import benchmark"
+init_test
+GFA_IMPORT=$(run_benchmark "GFA import" ${PROFILE_BIN} profile import gfa ${BASE_DIR}/fixtures/chr22_het.gfa --reference reference)
+read -r GFA_IMPORT_SIZE GFA_IMPORT_GEN_DB_SIZE GFA_IMPORT_DEFAULT_DB_SIZE <<< "$(get_size)"
+record_result "GFA import" "${GFA_IMPORT}" "${GFA_IMPORT_SIZE}" "${GFA_IMPORT_GEN_DB_SIZE}" "${GFA_IMPORT_DEFAULT_DB_SIZE}"
+
+echo "simple gfa import benchmark"
+init_test
+SIMPLE_GFA_IMPORT=$(run_benchmark "Simple GFA import" ${PROFILE_BIN} profile import gfa ${BASE_DIR}/fixtures/simple.gfa --reference reference)
+read -r SIMPLE_GFA_IMPORT_SIZE SIMPLE_GFA_IMPORT_GEN_DB_SIZE SIMPLE_GFA_IMPORT_DEFAULT_DB_SIZE <<< "$(get_size)"
+record_result "Simple GFA import" "${SIMPLE_GFA_IMPORT}" "${SIMPLE_GFA_IMPORT_SIZE}" "${SIMPLE_GFA_IMPORT_GEN_DB_SIZE}" "${SIMPLE_GFA_IMPORT_DEFAULT_DB_SIZE}"
+
+echo "gff translation benchmark"
+setup_simple_fasta_repo
+GFF_TRANSLATION=$(run_benchmark "GFF translation" ${PROFILE_BIN} profile translate --gff ${BASE_DIR}/fixtures/simple.gff --sample reference)
+read -r GFF_TRANSLATION_SIZE GFF_TRANSLATION_GEN_DB_SIZE GFF_TRANSLATION_DEFAULT_DB_SIZE <<< "$(get_size)"
+record_result "GFF translation" "${GFF_TRANSLATION}" "${GFF_TRANSLATION_SIZE}" "${GFF_TRANSLATION_GEN_DB_SIZE}" "${GFF_TRANSLATION_DEFAULT_DB_SIZE}"
+
+echo "library update benchmark"
+setup_library_update_repo
+LIBRARY_UPDATE=$(run_benchmark "Library update" ${PROFILE_BIN} profile update library --new-sample library-sample --region-name m123:7-20 --library ${BASE_DIR}/fixtures/combinatorial_design.csv --parts ${BASE_DIR}/fixtures/parts.fa)
+read -r LIBRARY_UPDATE_SIZE LIBRARY_UPDATE_GEN_DB_SIZE LIBRARY_UPDATE_DEFAULT_DB_SIZE <<< "$(get_size)"
+record_result "Library update" "${LIBRARY_UPDATE}" "${LIBRARY_UPDATE_SIZE}" "${LIBRARY_UPDATE_GEN_DB_SIZE}" "${LIBRARY_UPDATE_DEFAULT_DB_SIZE}"
+
+echo "gfa update benchmark"
+setup_gfa_update_repo
+GFA_UPDATE=$(run_benchmark "GFA update" ${PROFILE_BIN} profile update gfa ${BASE_DIR}/fixtures/path-diff.gfa --sample reference --new-sample gfa-update-sample)
+read -r GFA_UPDATE_SIZE GFA_UPDATE_GEN_DB_SIZE GFA_UPDATE_DEFAULT_DB_SIZE <<< "$(get_size)"
+record_result "GFA update" "${GFA_UPDATE}" "${GFA_UPDATE_SIZE}" "${GFA_UPDATE_GEN_DB_SIZE}" "${GFA_UPDATE_DEFAULT_DB_SIZE}"
+
 echo "Update with HG00096 benchmark"
 init_test
-${BASE_DIR}/target/release/gen import -f ${BASE_DIR}/fixtures/chr22.fa.gz --shallow 2> /dev/null > /dev/null
-HG96_IMPORT=$(time_taken ${BASE_DIR}/target/release/gen update --vcf ${BASE_DIR}/fixtures/HG00096.vcf.gz)
-HG96_SIZE=$(get_size)
+${GEN_BIN} import fasta ${BASE_DIR}/fixtures/chr22.fa.gz --reference reference --shallow 2> /dev/null > /dev/null
+HG96_IMPORT=$(run_benchmark "HG00096 Update" ${PROFILE_BIN} profile update vcf ${BASE_DIR}/fixtures/HG00096.vcf.gz --parent-samples reference)
+read -r HG96_SIZE HG96_GEN_DB_SIZE HG96_DEFAULT_DB_SIZE <<< "$(get_size)"
+record_result "HG00096 Update" "${HG96_IMPORT}" "${HG96_SIZE}" "${HG96_GEN_DB_SIZE}" "${HG96_DEFAULT_DB_SIZE}"
+
 echo "Update with HG00097 benchmark"
 init_test
-${BASE_DIR}/target/release/gen import -f ${BASE_DIR}/fixtures/chr22.fa.gz --shallow 2> /dev/null > /dev/null
-HG97_IMPORT=$(time_taken ${BASE_DIR}/target/release/gen update --vcf ${BASE_DIR}/fixtures/HG00097.vcf.gz)
-HG97_SIZE=$(get_size)
+${GEN_BIN} import fasta ${BASE_DIR}/fixtures/chr22.fa.gz --reference reference --shallow 2> /dev/null > /dev/null
+HG97_IMPORT=$(run_benchmark "HG00097 Update" ${PROFILE_BIN} profile update vcf ${BASE_DIR}/fixtures/HG00097.vcf.gz --parent-samples reference)
+read -r HG97_SIZE HG97_GEN_DB_SIZE HG97_DEFAULT_DB_SIZE <<< "$(get_size)"
+record_result "HG00097 Update" "${HG97_IMPORT}" "${HG97_SIZE}" "${HG97_GEN_DB_SIZE}" "${HG97_DEFAULT_DB_SIZE}"
+
 echo "Update with  HG00096 + HG00097 benchmark"
 init_test
-${BASE_DIR}/target/release/gen import -f ${BASE_DIR}/fixtures/chr22.fa.gz --shallow 2> /dev/null > /dev/null
-HG96_IMPORT=$(time_taken ${BASE_DIR}/target/release/gen update --vcf ${BASE_DIR}/fixtures/HG00096.vcf.gz)
-HG97_IMPORT=$(time_taken ${BASE_DIR}/target/release/gen update --vcf ${BASE_DIR}/fixtures/HG00097.vcf.gz)
+${GEN_BIN} import fasta ${BASE_DIR}/fixtures/chr22.fa.gz --reference reference --shallow 2> /dev/null > /dev/null
+HG96_IMPORT=$(run_benchmark "HG00096 Update" --no-profile-record ${PROFILE_BIN} profile update vcf ${BASE_DIR}/fixtures/HG00096.vcf.gz --parent-samples reference)
+HG97_IMPORT=$(run_benchmark "HG00097 Update" --no-profile-record ${PROFILE_BIN} profile update vcf ${BASE_DIR}/fixtures/HG00097.vcf.gz --parent-samples reference)
 SUM=$(echo "${HG96_IMPORT} + ${HG97_IMPORT}" | bc)
-BOTH_SIZE=$(get_size)
+read -r BOTH_SIZE BOTH_GEN_DB_SIZE BOTH_DEFAULT_DB_SIZE <<< "$(get_size)"
+record_result "HG00096 + HG00097 Update" "${SUM}" "${BOTH_SIZE}" "${BOTH_GEN_DB_SIZE}" "${BOTH_DEFAULT_DB_SIZE}"
 
-echo "Benchmark results"
-printf "%-35s %-10s %-10s\n" "Task" "Time (ms)" "Storage (mb)"
-printf "%-35s %-10s %-10s\n" "---------------" "--------" "----------"
-printf "%-35s %-10s %-10s\n" "Full import" ${FULL_IMPORT} ${FULL_SIZE}
-printf "%-35s %-10s %-10s\n" "Shallow import" ${SHALLOW_IMPORT} ${SHALLOW_SIZE}
-printf "%-35s %-10s %-10s\n" "HG00096 Update" ${HG96_IMPORT} ${HG96_SIZE}
-printf "%-35s %-10s %-10s\n" "HG00097 Update" ${HG97_IMPORT} ${HG97_SIZE}
-printf "%-35s %-10s %-10s\n" "HG00096 + HG00097 Update" ${SUM} ${BOTH_SIZE}
+# echo "switch branch benchmark"
+# setup_hg_branch_switch_repo
+# SWITCH_BRANCH=$(run_benchmark "Switch HG branch" ${PROFILE_BIN} profile checkout branch-b)
+# read -r SWITCH_BRANCH_SIZE SWITCH_BRANCH_GEN_DB_SIZE SWITCH_BRANCH_DEFAULT_DB_SIZE <<< "$(get_size)"
+# record_result "Switch HG branch" "${SWITCH_BRANCH}" "${SWITCH_BRANCH_SIZE}" "${SWITCH_BRANCH_GEN_DB_SIZE}" "${SWITCH_BRANCH_DEFAULT_DB_SIZE}"
+
+# echo "merge benchmark"
+# setup_hg_branch_apply_repo
+# MERGE_BRANCH=$(run_benchmark "Merge HG branch" ${PROFILE_BIN} profile merge branch-a)
+# read -r MERGE_BRANCH_SIZE MERGE_BRANCH_GEN_DB_SIZE MERGE_BRANCH_DEFAULT_DB_SIZE <<< "$(get_size)"
+# record_result "Merge HG branch" "${MERGE_BRANCH}" "${MERGE_BRANCH_SIZE}" "${MERGE_BRANCH_GEN_DB_SIZE}" "${MERGE_BRANCH_DEFAULT_DB_SIZE}"
+
+# echo "apply benchmark"
+# setup_hg_branch_apply_repo
+# APPLY_OPERATION=$(run_benchmark "Apply HG operation" ${PROFILE_BIN} profile apply ${BRANCH_A_HASH})
+# read -r APPLY_OPERATION_SIZE APPLY_OPERATION_GEN_DB_SIZE APPLY_OPERATION_DEFAULT_DB_SIZE <<< "$(get_size)"
+# record_result "Apply HG operation" "${APPLY_OPERATION}" "${APPLY_OPERATION_SIZE}" "${APPLY_OPERATION_GEN_DB_SIZE}" "${APPLY_OPERATION_DEFAULT_DB_SIZE}"
+
+# echo "reset benchmark"
+# setup_hg_reset_repo
+# RESET_OPERATION=$(run_benchmark "Reset HG operation" ${PROFILE_BIN} profile reset ${RESET_HASH})
+# read -r RESET_OPERATION_SIZE RESET_OPERATION_GEN_DB_SIZE RESET_OPERATION_DEFAULT_DB_SIZE <<< "$(get_size)"
+# record_result "Reset HG operation" "${RESET_OPERATION}" "${RESET_OPERATION_SIZE}" "${RESET_OPERATION_GEN_DB_SIZE}" "${RESET_OPERATION_DEFAULT_DB_SIZE}"
+
+print_results

--- a/gen-models/Cargo.toml
+++ b/gen-models/Cargo.toml
@@ -10,6 +10,7 @@ include = ["src", "migrations"]
 
 [features]
 benchmark = []
+profiling = ["dep:tracing"]
 
 [dev-dependencies]
 rand = "0.10.1"
@@ -33,9 +34,11 @@ rusqlite = { version = "0.32.1", features = ["bundled", "array", "limits", "sess
 rusqlite_migration = { version = "1.3.1" , features = ["from-directory"]}
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
+postcard = { version = "1.1.3", default-features = false, features = ["use-std"] }
 sha2 = "0.10.8"
 thiserror = "2.0.12"
 tokio = { version = "1.52.1", features = ["rt-multi-thread"] }
 url = "2.5.0"
 indexmap = "2.11.3"
 anyhow = "1.0.100"
+tracing = { version = "0.1.41", optional = true }

--- a/gen-models/src/block_group.rs
+++ b/gen-models/src/block_group.rs
@@ -240,6 +240,10 @@ impl<'a> PathCache<'a> {
 }
 
 impl BlockGroup {
+    #[cfg_attr(
+        all(debug_assertions, feature = "profiling"),
+        tracing::instrument(skip(conn, new_block_group))
+    )]
     pub fn create(
         conn: &GraphConnection,
         new_block_group: NewBlockGroup<'_>,
@@ -384,6 +388,10 @@ impl BlockGroup {
         Ok(())
     }
 
+    #[cfg_attr(
+        all(debug_assertions, feature = "profiling"),
+        tracing::instrument(skip(conn, collection_name, sample_name, group_name, parent_samples))
+    )]
     pub fn get_or_create_sample_block_groups(
         conn: &GraphConnection,
         collection_name: &str,

--- a/gen-models/src/block_group_edge.rs
+++ b/gen-models/src/block_group_edge.rs
@@ -132,6 +132,10 @@ impl Query for BlockGroupEdge {
 }
 
 impl BlockGroupEdge {
+    #[cfg_attr(
+        all(debug_assertions, feature = "profiling"),
+        tracing::instrument(skip(conn, block_group_edges))
+    )]
     pub fn bulk_create(conn: &GraphConnection, block_group_edges: &[BlockGroupEdgeData]) {
         let batch_size = max_rows_per_batch(conn, 6);
 
@@ -169,6 +173,10 @@ impl BlockGroupEdge {
         BlockGroupEdge::delete_by_ids(conn, &hashes);
     }
 
+    #[cfg_attr(
+        all(debug_assertions, feature = "profiling"),
+        tracing::instrument(skip(conn, block_group_id))
+    )]
     pub fn edges_for_block_group(
         conn: &GraphConnection,
         block_group_id: &HashId,

--- a/gen-models/src/changesets.rs
+++ b/gen-models/src/changesets.rs
@@ -789,6 +789,10 @@ pub fn process_changesetiter(
     Ok((changeset_models, dependency_models))
 }
 
+#[cfg_attr(
+    all(debug_assertions, feature = "profiling"),
+    tracing::instrument(skip(conn, changeset, dependencies))
+)]
 pub fn apply_changeset(
     conn: &GraphConnection,
     changeset: &ChangesetModels,
@@ -1246,6 +1250,10 @@ fn block_groups_parent_first(block_groups: &[BlockGroup]) -> Vec<&BlockGroup> {
     ordered
 }
 
+#[cfg_attr(
+    all(debug_assertions, feature = "profiling"),
+    tracing::instrument(skip(workspace, operation, changes, dependencies))
+)]
 pub fn write_changeset(
     workspace: &Workspace,
     operation: &Operation,

--- a/gen-models/src/collection.rs
+++ b/gen-models/src/collection.rs
@@ -56,6 +56,10 @@ impl Collection {
         stmt.exists([name]).unwrap()
     }
 
+    #[cfg_attr(
+        all(debug_assertions, feature = "profiling"),
+        tracing::instrument(skip(conn, name))
+    )]
     pub fn create(conn: &GraphConnection, name: &str) -> Result<Collection, CollectionError> {
         let mut stmt = match conn.prepare("INSERT INTO collections (name) VALUES (?1) RETURNING *;")
         {

--- a/gen-models/src/edge.rs
+++ b/gen-models/src/edge.rs
@@ -215,6 +215,18 @@ pub enum EdgeError {
 
 impl Edge {
     #[allow(clippy::too_many_arguments)]
+    #[cfg_attr(
+        all(debug_assertions, feature = "profiling"),
+        tracing::instrument(skip(
+            conn,
+            source_node_id,
+            source_coordinate,
+            source_strand,
+            target_node_id,
+            target_coordinate,
+            target_strand
+        ))
+    )]
     pub fn create(
         conn: &GraphConnection,
         source_node_id: HashId,
@@ -268,6 +280,10 @@ impl Edge {
         }
     }
 
+    #[cfg_attr(
+        all(debug_assertions, feature = "profiling"),
+        tracing::instrument(skip(conn, edges))
+    )]
     pub fn bulk_create(conn: &GraphConnection, edges: &[EdgeData]) -> Vec<HashId> {
         let edge_ids = edges.iter().map(|edge| edge.id_hash()).collect::<Vec<_>>();
         let query = Edge::query_by_ids(conn, &edge_ids);

--- a/gen-models/src/files.rs
+++ b/gen-models/src/files.rs
@@ -61,6 +61,10 @@ impl Query for GenDatabase {
 }
 
 impl GenDatabase {
+    #[cfg_attr(
+        all(debug_assertions, feature = "profiling"),
+        tracing::instrument(skip(conn, db_uuid, name, path))
+    )]
     pub fn create(
         conn: &OperationsConnection,
         db_uuid: &str,
@@ -95,6 +99,10 @@ impl GenDatabase {
         )
     }
 
+    #[cfg_attr(
+        all(debug_assertions, feature = "profiling"),
+        tracing::instrument(skip(conn, db_uuid))
+    )]
     pub fn get_by_uuid(conn: &OperationsConnection, db_uuid: &str) -> SQLResult<GenDatabase> {
         GenDatabase::get(
             conn,
@@ -103,6 +111,10 @@ impl GenDatabase {
         )
     }
 
+    #[cfg_attr(
+        all(debug_assertions, feature = "profiling"),
+        tracing::instrument(skip(conn, path))
+    )]
     pub fn get_by_path(conn: &OperationsConnection, path: &str) -> SQLResult<GenDatabase> {
         GenDatabase::get(
             conn,
@@ -111,6 +123,10 @@ impl GenDatabase {
         )
     }
 
+    #[cfg_attr(
+        all(debug_assertions, feature = "profiling"),
+        tracing::instrument(skip(conn, db_uuid, name, path))
+    )]
     pub fn get_or_create(
         conn: &OperationsConnection,
         db_uuid: &str,

--- a/gen-models/src/node.rs
+++ b/gen-models/src/node.rs
@@ -67,6 +67,10 @@ pub enum NodeError {
 }
 
 impl Node {
+    #[cfg_attr(
+        all(debug_assertions, feature = "profiling"),
+        tracing::instrument(skip(conn, sequence_hash, node_hash))
+    )]
     pub fn create(
         conn: &GraphConnection,
         sequence_hash: &HashId,

--- a/gen-models/src/operations.rs
+++ b/gen-models/src/operations.rs
@@ -111,6 +111,10 @@ pub enum HashParseError {
 }
 
 impl Operation {
+    #[cfg_attr(
+        all(debug_assertions, feature = "profiling"),
+        tracing::instrument(skip(conn, change_type, hash))
+    )]
     pub fn create(
         conn: &OperationsConnection,
         change_type: &str,
@@ -156,6 +160,17 @@ impl Operation {
         Ok(operation)
     }
 
+    #[cfg_attr(
+        all(debug_assertions, feature = "profiling"),
+        tracing::instrument(skip(
+            workspace,
+            conn,
+            operation_hash,
+            file_addition,
+            filename,
+            file_path
+        ))
+    )]
     pub fn add_file(
         workspace: &Workspace,
         conn: &OperationsConnection,
@@ -177,6 +192,10 @@ impl Operation {
         Ok(())
     }
 
+    #[cfg_attr(
+        all(debug_assertions, feature = "profiling"),
+        tracing::instrument(skip(conn, operation_hash, db_uuid))
+    )]
     pub fn add_database(
         conn: &OperationsConnection,
         operation_hash: &HashId,
@@ -651,6 +670,10 @@ impl FileAddition {
             .unwrap_or(&self.asset_uri)
     }
 
+    #[cfg_attr(
+        all(debug_assertions, feature = "profiling"),
+        tracing::instrument(skip(workspace, conn, file_path, file_type, checksum_override))
+    )]
     pub fn get_or_create(
         workspace: &Workspace,
         conn: &OperationsConnection,
@@ -729,6 +752,10 @@ impl FileAddition {
             })
     }
 
+    #[cfg_attr(
+        all(debug_assertions, feature = "profiling"),
+        tracing::instrument(skip(self, workspace))
+    )]
     pub fn store_file(&self, workspace: &Workspace) -> Result<(), FileStoreError> {
         let asset_uri = <dyn AssetUri>::new(workspace, &self.asset_uri);
         asset_uri.store_file(self, workspace)
@@ -767,6 +794,10 @@ impl Query for OperationSummary {
 }
 
 impl OperationSummary {
+    #[cfg_attr(
+        all(debug_assertions, feature = "profiling"),
+        tracing::instrument(skip(conn, operation_hash, summary))
+    )]
     pub fn create(
         conn: &OperationsConnection,
         operation_hash: &HashId,
@@ -1319,6 +1350,10 @@ impl Defaults {
 pub struct OperationState {}
 
 impl OperationState {
+    #[cfg_attr(
+        all(debug_assertions, feature = "profiling"),
+        tracing::instrument(skip(conn, op_hash))
+    )]
     pub fn set_operation(conn: &OperationsConnection, op_hash: &HashId) {
         let mut stmt = conn
             .prepare(

--- a/gen-models/src/path.rs
+++ b/gen-models/src/path.rs
@@ -131,6 +131,10 @@ pub struct Annotation {
 }
 
 impl Path {
+    #[cfg_attr(
+        all(debug_assertions, feature = "profiling"),
+        tracing::instrument(skip(conn, edge_ids, block_group_id))
+    )]
     pub fn validate_edges(conn: &GraphConnection, edge_ids: &[HashId], block_group_id: &HashId) {
         let edge_id_set = edge_ids.iter().copied().collect::<HashSet<HashId>>();
 
@@ -188,6 +192,10 @@ impl Path {
         }
     }
 
+    #[cfg_attr(
+        all(debug_assertions, feature = "profiling"),
+        tracing::instrument(skip(conn, name, block_group_id, edge_ids))
+    )]
     pub fn create(
         conn: &GraphConnection,
         name: &str,

--- a/gen-models/src/path_edge.rs
+++ b/gen-models/src/path_edge.rs
@@ -86,6 +86,10 @@ impl Query for PathEdge {
 }
 
 impl PathEdge {
+    #[cfg_attr(
+        all(debug_assertions, feature = "profiling"),
+        tracing::instrument(skip(conn, path_id, index_in_path, edge_id))
+    )]
     pub fn create(
         conn: &GraphConnection,
         path_id: &HashId,
@@ -122,6 +126,10 @@ impl PathEdge {
         }
     }
 
+    #[cfg_attr(
+        all(debug_assertions, feature = "profiling"),
+        tracing::instrument(skip(conn, path_id, edge_ids))
+    )]
     pub fn bulk_create(
         conn: &GraphConnection,
         path_id: &HashId,

--- a/gen-models/src/sample.rs
+++ b/gen-models/src/sample.rs
@@ -80,6 +80,10 @@ impl Sample {
         SampleLineage::get_parents(conn, sample_name)
     }
 
+    #[cfg_attr(
+        all(debug_assertions, feature = "profiling"),
+        tracing::instrument(skip(conn, new_sample))
+    )]
     pub fn create(
         conn: &GraphConnection,
         new_sample: NewSample<'_>,
@@ -107,6 +111,10 @@ impl Sample {
         }
     }
 
+    #[cfg_attr(
+        all(debug_assertions, feature = "profiling"),
+        tracing::instrument(skip(conn, new_sample))
+    )]
     pub fn get_or_create(
         conn: &GraphConnection,
         new_sample: NewSample<'_>,

--- a/gen-models/src/sequence.rs
+++ b/gen-models/src/sequence.rs
@@ -196,6 +196,10 @@ impl<'a> NewSequence<'a> {
         }
     }
 
+    #[cfg_attr(
+        all(debug_assertions, feature = "profiling"),
+        tracing::instrument(skip(self, conn))
+    )]
     pub fn save(self, conn: &GraphConnection) -> Result<Sequence, SequenceError> {
         let mut length = 0;
         if self.sequence.is_none() && self.file_path.is_none() {

--- a/gen-models/src/session_operations.rs
+++ b/gen-models/src/session_operations.rs
@@ -31,6 +31,10 @@ pub fn start_operation(conn: &GraphConnection) -> session::Session<'_> {
 }
 
 #[allow(clippy::too_many_arguments)]
+#[cfg_attr(
+    all(debug_assertions, feature = "profiling"),
+    tracing::instrument(skip(context, session, operation_info, summary_str, force_hash))
+)]
 pub fn end_operation(
     context: &DbContext,
     session: &mut session::Session,
@@ -177,6 +181,10 @@ impl<'a> Capnp<'a> for DependencyModels {
     type Builder = dependency_models::Builder<'a>;
     type Reader = dependency_models::Reader<'a>;
 
+    #[cfg_attr(
+        all(debug_assertions, feature = "profiling"),
+        tracing::instrument(skip(self, builder))
+    )]
     fn write_capnp(&self, builder: &mut Self::Builder) {
         // Write collections
         let mut collections_builder = builder

--- a/src/commands/export/mod.rs
+++ b/src/commands/export/mod.rs
@@ -24,6 +24,10 @@ pub enum Commands {
     Gfa(gfa::Command),
 }
 
+#[cfg_attr(
+    all(debug_assertions, feature = "profiling"),
+    tracing::instrument(skip(ctx, command))
+)]
 pub fn execute(ctx: &CliContext, command: Command) -> anyhow::Result<()> {
     match command.command {
         Commands::Fasta(cmd) => crate::commands::export::fasta::execute(ctx, cmd),

--- a/src/commands/import/fasta.rs
+++ b/src/commands/import/fasta.rs
@@ -31,6 +31,10 @@ pub struct Command {
     reference: Option<String>,
 }
 
+#[cfg_attr(
+    all(debug_assertions, feature = "profiling"),
+    tracing::instrument(skip(cli_context, cmd))
+)]
 pub fn execute(cli_context: &CliContext, cmd: Command) -> Result<()> {
     println!("Fasta import called");
 

--- a/src/commands/import/genbank.rs
+++ b/src/commands/import/genbank.rs
@@ -36,6 +36,10 @@ pub struct Command {
     no_annotations: bool,
 }
 
+#[cfg_attr(
+    all(debug_assertions, feature = "profiling"),
+    tracing::instrument(skip(cli_context, cmd))
+)]
 pub fn execute(cli_context: &CliContext, cmd: Command) -> Result<()> {
     println!("Genbank import called");
 

--- a/src/commands/import/gfa.rs
+++ b/src/commands/import/gfa.rs
@@ -29,6 +29,10 @@ pub struct Command {
     reference: Option<String>,
 }
 
+#[cfg_attr(
+    all(debug_assertions, feature = "profiling"),
+    tracing::instrument(skip(cli_context, cmd))
+)]
 pub fn execute(cli_context: &CliContext, cmd: Command) -> Result<()> {
     println!("GFA import called");
 

--- a/src/commands/import/library.rs
+++ b/src/commands/import/library.rs
@@ -34,6 +34,10 @@ pub struct Command {
     reference: Option<String>,
 }
 
+#[cfg_attr(
+    all(debug_assertions, feature = "profiling"),
+    tracing::instrument(skip(cli_context, cmd))
+)]
 pub fn execute(cli_context: &CliContext, cmd: Command) -> Result<()> {
     println!("Library import called");
 

--- a/src/commands/import/mod.rs
+++ b/src/commands/import/mod.rs
@@ -27,6 +27,10 @@ pub enum Commands {
     Library(library::Command),
 }
 
+#[cfg_attr(
+    all(debug_assertions, feature = "profiling"),
+    tracing::instrument(skip(ctx, command))
+)]
 pub fn execute(ctx: &CliContext, command: Command) -> anyhow::Result<()> {
     match command.command {
         Commands::Fasta(cmd) => crate::commands::import::fasta::execute(ctx, cmd),

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -7,6 +7,8 @@ pub mod derive;
 pub mod export;
 pub mod graph_operations;
 pub mod import;
+#[cfg(all(debug_assertions, feature = "profiling"))]
+pub mod profile;
 pub mod remote;
 pub mod update;
 
@@ -23,6 +25,10 @@ pub enum Commands {
         #[clap(index = 1)]
         url: String,
     },
+    #[cfg(all(debug_assertions, feature = "profiling"))]
+    /// Profile a command in a dev build and print cumulative per-function timings.
+    #[command(arg_required_else_help(true))]
+    Profile(profile::Command),
     /// Commands for importing
     Import(import::Command),
     /// Commands for updating

--- a/src/commands/profile.rs
+++ b/src/commands/profile.rs
@@ -1,0 +1,28 @@
+use std::{error::Error, process::Command as ProcessCommand};
+
+use clap::Args;
+
+#[derive(Debug, Args, Clone)]
+pub struct Command {
+    /// Use sampling instead of tracing spans
+    #[arg(long, action)]
+    pub sample: bool,
+    #[arg(trailing_var_arg = true, allow_hyphen_values = true, num_args = 1..)]
+    pub command: Vec<String>,
+}
+
+pub fn execute(command: Command) -> Result<(), Box<dyn Error>> {
+    let executable = std::env::current_exe()?;
+    let mut child = ProcessCommand::new(executable);
+    child.args(&command.command).env("GEN_PROFILE", "1");
+    if command.sample {
+        child.env("GEN_PROFILE_SAMPLE", "1");
+    }
+    let status = child.status()?;
+
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format!("profiled command exited with status {status}").into())
+    }
+}

--- a/src/commands/update/fasta.rs
+++ b/src/commands/update/fasta.rs
@@ -30,6 +30,10 @@ pub struct Command {
     no_reference_path_update: bool,
 }
 
+#[cfg_attr(
+    all(debug_assertions, feature = "profiling"),
+    tracing::instrument(skip(cli_context, cmd))
+)]
 pub fn execute(cli_context: &CliContext, cmd: Command) -> Result<()> {
     println!("Update with fasta called");
 

--- a/src/commands/update/genbank.rs
+++ b/src/commands/update/genbank.rs
@@ -30,6 +30,10 @@ pub struct Command {
     create_missing: bool,
 }
 
+#[cfg_attr(
+    all(debug_assertions, feature = "profiling"),
+    tracing::instrument(skip(cli_context, cmd))
+)]
 pub fn execute(cli_context: &CliContext, cmd: Command) -> Result<()> {
     println!("Update with GenBank called");
 

--- a/src/commands/update/gfa.rs
+++ b/src/commands/update/gfa.rs
@@ -24,6 +24,10 @@ pub struct Command {
     new_sample: String,
 }
 
+#[cfg_attr(
+    all(debug_assertions, feature = "profiling"),
+    tracing::instrument(skip(cli_context, cmd))
+)]
 pub fn execute(cli_context: &CliContext, cmd: Command) -> Result<()> {
     println!("Update with GFA called");
 

--- a/src/commands/update/library.rs
+++ b/src/commands/update/library.rs
@@ -31,6 +31,10 @@ pub struct Command {
     parts: String,
 }
 
+#[cfg_attr(
+    all(debug_assertions, feature = "profiling"),
+    tracing::instrument(skip(cli_context, cmd))
+)]
 pub fn execute(cli_context: &CliContext, cmd: Command) -> Result<()> {
     println!("Update with library called");
 

--- a/src/commands/update/mod.rs
+++ b/src/commands/update/mod.rs
@@ -36,6 +36,10 @@ pub enum Commands {
     Vcf(vcf::Command),
 }
 
+#[cfg_attr(
+    all(debug_assertions, feature = "profiling"),
+    tracing::instrument(skip(ctx, command))
+)]
 pub fn execute(ctx: &CliContext, command: Command) -> anyhow::Result<()> {
     match command.command {
         Commands::Fasta(cmd) => crate::commands::update::fasta::execute(ctx, cmd),

--- a/src/commands/update/vcf.rs
+++ b/src/commands/update/vcf.rs
@@ -34,6 +34,10 @@ pub struct Command {
     in_place: bool,
 }
 
+#[cfg_attr(
+    all(debug_assertions, feature = "profiling"),
+    tracing::instrument(skip(cli_context, cmd))
+)]
 pub fn execute(cli_context: &CliContext, cmd: Command) -> Result<()> {
     println!("Update with VCF called");
 

--- a/src/imports/fasta.rs
+++ b/src/imports/fasta.rs
@@ -30,6 +30,10 @@ use crate::{
     progress_bar::{add_saving_operation_bar, get_handler, get_progress_bar},
 };
 
+#[cfg_attr(
+    all(debug_assertions, feature = "profiling"),
+    tracing::instrument(skip(context, fasta, collection_name, sample))
+)]
 pub fn import_fasta(
     context: &DbContext,
     fasta: &String,

--- a/src/imports/gfa.rs
+++ b/src/imports/gfa.rs
@@ -53,6 +53,10 @@ pub enum GFAImportError {
     BlockGroupError(#[from] BlockGroupError),
 }
 
+#[cfg_attr(
+    all(debug_assertions, feature = "profiling"),
+    tracing::instrument(skip(context, gfa_path, collection_name, sample_name))
+)]
 pub fn import_gfa(
     context: &DbContext,
     gfa_path: &FilePath,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,8 @@ pub mod imports;
 
 pub mod operation_management;
 pub mod patch;
+#[cfg(all(debug_assertions, feature = "profiling"))]
+pub mod profiling;
 mod progress_bar;
 #[cfg(any(test, debug_assertions))]
 pub mod test_helpers;

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,8 @@ use std::{
 
 use anyhow::anyhow;
 use clap::{Parser, Subcommand};
+#[cfg(all(debug_assertions, feature = "profiling"))]
+use r#gen::profiling::{Profiler, SamplingProfiler};
 use r#gen::{
     annotations::gff::propagate_gff,
     commands::{
@@ -74,6 +76,10 @@ fn call_cli() -> Result<(), Box<dyn std::error::Error>> {
 
     if let Some(Commands::Clone { url }) = &cli.command {
         return r#gen::commands::clone::execute(url, &workspace);
+    }
+    #[cfg(all(debug_assertions, feature = "profiling"))]
+    if let Some(Commands::Profile(cmd)) = &cli.command {
+        return r#gen::commands::profile::execute(cmd.clone());
     }
 
     let operation_conn = get_operation_connection(Some(workspace.gen_db_path()?))?;
@@ -156,6 +162,8 @@ fn call_cli() -> Result<(), Box<dyn std::error::Error>> {
             Ok(())
         }
         Some(Commands::Clone { .. }) => Ok(()),
+        #[cfg(all(debug_assertions, feature = "profiling"))]
+        Some(Commands::Profile(cmd)) => r#gen::commands::profile::execute(cmd.clone()),
         Some(Commands::Import(cmd)) => Ok(r#gen::commands::import::execute(&cli_context, cmd)?),
         Some(Commands::Update(cmd)) => Ok(r#gen::commands::update::execute(&cli_context, cmd)?),
         Some(Commands::Export(cmd)) => Ok(r#gen::commands::export::execute(&cli_context, cmd)?),
@@ -876,7 +884,23 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Start logger (gets log level from RUST_LOG environment variable, sends output to stderr)
     env_logger::init();
-    match call_cli() {
+    let result = if std::env::var_os("GEN_PROFILE").is_some() {
+        #[cfg(all(debug_assertions, feature = "profiling"))]
+        {
+            if std::env::var_os("GEN_PROFILE_SAMPLE").is_some() {
+                SamplingProfiler.run(call_cli)
+            } else {
+                Profiler::default().run(call_cli)
+            }
+        }
+        #[cfg(not(all(debug_assertions, feature = "profiling")))]
+        {
+            call_cli()
+        }
+    } else {
+        call_cli()
+    };
+    match result {
         Ok(_) => Ok(()),
         Err(e) => Err(anyhow!("{e}").into()),
     }

--- a/src/operation_management.rs
+++ b/src/operation_management.rs
@@ -195,6 +195,10 @@ pub fn get_file(path: &PathBuf, mode: FileMode) -> fs::File {
     file.unwrap()
 }
 
+#[cfg_attr(
+    all(debug_assertions, feature = "profiling"),
+    tracing::instrument(skip(context, op_hash))
+)]
 pub fn reset(context: &DbContext, op_hash: &HashId) -> Result<(), ResetError> {
     let operation_conn = context.operations().conn();
     let dest_operation = Operation::get_by_id(operation_conn, op_hash)
@@ -203,6 +207,10 @@ pub fn reset(context: &DbContext, op_hash: &HashId) -> Result<(), ResetError> {
     Ok(())
 }
 
+#[cfg_attr(
+    all(debug_assertions, feature = "profiling"),
+    tracing::instrument(skip(context, op_hash, force_hash))
+)]
 pub fn apply(
     context: &DbContext,
     op_hash: &HashId,
@@ -270,6 +278,10 @@ pub fn apply(
     }
 }
 
+#[cfg_attr(
+    all(debug_assertions, feature = "profiling"),
+    tracing::instrument(skip(context, force_hash))
+)]
 pub fn merge<'a>(
     context: &DbContext,
     source_branch: i64,
@@ -315,6 +327,10 @@ pub fn merge<'a>(
     Ok(new_operations)
 }
 
+#[cfg_attr(
+    all(debug_assertions, feature = "profiling"),
+    tracing::instrument(skip(context, operation))
+)]
 pub fn move_to(context: &DbContext, operation: &Operation) -> Result<(), MoveError> {
     let operation_conn = context.operations().conn();
     let workspace = context.workspace();
@@ -388,6 +404,10 @@ pub fn move_to(context: &DbContext, operation: &Operation) -> Result<(), MoveErr
     Ok(())
 }
 
+#[cfg_attr(
+    all(debug_assertions, feature = "profiling"),
+    tracing::instrument(skip(context, branch_name, operation_hash))
+)]
 pub fn checkout(
     context: &DbContext,
     branch_name: &Option<String>,
@@ -782,6 +802,10 @@ fn push_to_file_remote(
 }
 
 // Pushes the current state of the local repo and branch to the corresponding remote repo and branch
+#[cfg_attr(
+    all(debug_assertions, feature = "profiling"),
+    tracing::instrument(skip(context, remote))
+)]
 pub fn push(context: &DbContext, remote: Option<&str>) -> Result<(), RemoteOperationError> {
     let operation_conn = context.operations().conn();
     let remote_name = &remote
@@ -918,6 +942,10 @@ pub fn push(context: &DbContext, remote: Option<&str>) -> Result<(), RemoteOpera
     }
 }
 
+#[cfg_attr(
+    all(debug_assertions, feature = "profiling"),
+    tracing::instrument(skip(context, remote))
+)]
 pub fn pull(context: &DbContext, remote: Option<&str>) -> Result<(), RemoteOperationError> {
     let operation_conn = context.operations().conn();
     let remote_name = &remote
@@ -1061,6 +1089,10 @@ fn pull_from_remote_server(
     Ok(())
 }
 
+#[cfg_attr(
+    all(debug_assertions, feature = "profiling"),
+    tracing::instrument(skip(context, manifest_operation, repo_root))
+)]
 fn ingest_manifest_operation(
     context: &DbContext,
     manifest_operation: &ManifestOperation,

--- a/src/profiling.rs
+++ b/src/profiling.rs
@@ -1,0 +1,332 @@
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+    time::{Duration, Instant},
+};
+
+#[cfg(debug_assertions)]
+use pprof::{ProfilerGuardBuilder, Report};
+use tracing::{Id, Subscriber, span::Attributes};
+use tracing_subscriber::{
+    layer::{Context, Layer, SubscriberExt as _},
+    registry::{LookupSpan, Registry},
+};
+
+#[derive(Clone, Default)]
+pub struct Profiler {
+    stats: Arc<Mutex<HashMap<String, Stat>>>,
+}
+
+#[derive(Default)]
+struct Stat {
+    calls: u64,
+    total: Duration,
+}
+
+struct SpanState {
+    stack: String,
+    starts: Vec<Instant>,
+}
+
+impl Profiler {
+    pub fn run<T>(self, f: impl FnOnce() -> T) -> T {
+        let subscriber = Registry::default().with(ProfilerLayer {
+            profiler: self.clone(),
+        });
+        tracing::subscriber::with_default(subscriber, || {
+            let result = f();
+            self.print_report();
+            result
+        })
+    }
+
+    fn record(&self, key: String, duration: Duration) {
+        let mut stats = self.stats.lock().unwrap_or_else(|err| err.into_inner());
+        let entry = stats.entry(key).or_default();
+        entry.calls = entry.calls.saturating_add(1);
+        entry.total += duration;
+    }
+
+    fn print_report(&self) {
+        let stats = self.stats.lock().unwrap_or_else(|err| err.into_inner());
+        let mut rows = stats
+            .iter()
+            .map(|(stack, stat)| (stack_frames(stack), stat.calls, stat.total))
+            .collect::<Vec<_>>();
+        rows.sort_by(|left, right| right.2.cmp(&left.2).then_with(|| left.0.cmp(&right.0)));
+        let stack_width = rows
+            .iter()
+            .map(|(frames, _, _)| stack_label_width(frames))
+            .max()
+            .unwrap_or(0)
+            .max("Stack".len());
+
+        println!("Profile results");
+        println!(
+            "{:<stack_width$} {:>10} {:>14} {:>14}",
+            "Stack", "Calls", "Total (ms)", "Avg (us)"
+        );
+        println!(
+            "{:<stack_width$} {:>10} {:>14} {:>14}",
+            "-----", "-----", "----------", "--------"
+        );
+        for (frames, calls, total) in rows {
+            let total_ms = total.as_secs_f64() * 1000.0;
+            let avg_us = if calls == 0 {
+                0.0
+            } else {
+                total.as_secs_f64() * 1_000_000.0 / calls as f64
+            };
+            print_stacked_row(
+                &frames,
+                stack_width,
+                format_args!("{:>10} {:>14.3} {:>14.3}", calls, total_ms, avg_us),
+            );
+        }
+    }
+}
+
+struct ProfilerLayer {
+    profiler: Profiler,
+}
+
+impl<S> Layer<S> for ProfilerLayer
+where
+    S: Subscriber + for<'span> LookupSpan<'span>,
+{
+    fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
+        if let Some(span) = ctx.span(id) {
+            let metadata = attrs.metadata();
+            let current = format!("{}::{}", metadata.target(), metadata.name());
+            let stack = match span.parent() {
+                Some(parent) => parent
+                    .extensions()
+                    .get::<SpanState>()
+                    .map(|state| format!("{} -> {}", state.stack, current))
+                    .unwrap_or(current),
+                None => current,
+            };
+            let mut extensions = span.extensions_mut();
+            extensions.insert(SpanState {
+                stack,
+                starts: Vec::new(),
+            });
+        }
+    }
+
+    fn on_enter(&self, id: &Id, ctx: Context<'_, S>) {
+        if let Some(span) = ctx.span(id) {
+            let mut extensions = span.extensions_mut();
+            if let Some(state) = extensions.get_mut::<SpanState>() {
+                state.starts.push(Instant::now());
+            }
+        }
+    }
+
+    fn on_exit(&self, id: &Id, ctx: Context<'_, S>) {
+        if let Some(span) = ctx.span(id) {
+            let mut extensions = span.extensions_mut();
+            let snapshot = extensions.get_mut::<SpanState>().and_then(|state| {
+                state
+                    .starts
+                    .pop()
+                    .map(|started| (state.stack.clone(), started.elapsed()))
+            });
+            drop(extensions);
+            if let Some((stack, duration)) = snapshot {
+                self.profiler.record(stack, duration);
+            }
+        }
+    }
+}
+
+#[cfg(debug_assertions)]
+#[derive(Clone, Default)]
+pub struct SamplingProfiler;
+
+#[cfg(debug_assertions)]
+impl SamplingProfiler {
+    pub fn run<T>(self, f: impl FnOnce() -> T) -> T {
+        let guard = ProfilerGuardBuilder::default()
+            .frequency(100)
+            .blocklist(&["libc", "libgcc", "pthread", "vdso"])
+            .build()
+            .ok();
+
+        let result = f();
+        if let Some(guard) = guard
+            && let Ok(report) = guard.report().build()
+        {
+            self.print_report(&report);
+        }
+
+        result
+    }
+
+    fn print_report(&self, report: &Report) {
+        let mut stats: HashMap<String, u64> = HashMap::new();
+        let mut total_samples: u64 = 0;
+        let sample_frequency = report.timing.frequency.max(1) as f64;
+
+        for (frames, count) in &report.data {
+            if *count <= 0 {
+                continue;
+            }
+
+            let sample_count = *count as u64;
+            total_samples = total_samples.saturating_add(sample_count);
+
+            if let Some(stack) = sample_stack(frames) {
+                let entry = stats.entry(stack).or_default();
+                *entry = entry.saturating_add(sample_count);
+            }
+        }
+
+        let mut rows = stats
+            .into_iter()
+            .map(|(stack, samples)| (stack_frames(&stack), samples))
+            .collect::<Vec<_>>();
+        rows.sort_by(|left, right| right.1.cmp(&left.1).then_with(|| left.0.cmp(&right.0)));
+        let stack_width = rows
+            .iter()
+            .map(|(frames, _)| stack_label_width(frames))
+            .max()
+            .unwrap_or(0)
+            .max("Stack".len());
+
+        println!("Sampling profile results");
+        println!(
+            "{:<stack_width$} {:>10} {:>14} {:>10}",
+            "Stack", "Samples", "Time (ms)", "Pct"
+        );
+        println!(
+            "{:<stack_width$} {:>10} {:>14} {:>10}",
+            "-----", "-------", "---------", "---"
+        );
+        for (frames, sample_count) in rows {
+            let sample_time = duration_for_samples(sample_count, sample_frequency);
+            let pct = if total_samples == 0 {
+                0.0
+            } else {
+                (sample_count as f64 * 100.0) / total_samples as f64
+            };
+            print_stacked_row(
+                &frames,
+                stack_width,
+                format_args!(
+                    "{:>10} {:>14.3} {:>9.2}%",
+                    sample_count,
+                    sample_time.as_secs_f64() * 1000.0,
+                    pct
+                ),
+            );
+        }
+    }
+}
+
+#[cfg(debug_assertions)]
+fn duration_for_samples(samples: u64, frequency: f64) -> Duration {
+    Duration::from_secs_f64(samples as f64 / frequency)
+}
+
+#[cfg(debug_assertions)]
+fn stack_frames(stack: &str) -> Vec<String> {
+    stack
+        .split(" -> ")
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+}
+
+#[cfg(debug_assertions)]
+fn trim_sample_prefix(frames: &mut Vec<String>) {
+    let prefix = [
+        "gen::main",
+        "gen::profiling::SamplingProfiler::run",
+        "gen::call_cli",
+    ];
+
+    if frames.len() >= prefix.len()
+        && frames
+            .iter()
+            .take(prefix.len())
+            .map(String::as_str)
+            .eq(prefix)
+    {
+        frames.drain(..prefix.len());
+    }
+}
+
+#[cfg(debug_assertions)]
+fn stack_label_width(frames: &[String]) -> usize {
+    match frames.split_last() {
+        Some((leaf, parents)) => parents.len() + leaf.len(),
+        None => "<empty>".len(),
+    }
+}
+
+#[cfg(debug_assertions)]
+fn print_stacked_row(frames: &[String], stack_width: usize, tail: std::fmt::Arguments<'_>) {
+    match frames.split_last() {
+        Some((leaf, parents)) => {
+            for (depth, frame) in parents.iter().enumerate() {
+                println!("{}{}", " ".repeat(depth), frame);
+            }
+            let label = format!("{}{}", " ".repeat(parents.len()), leaf);
+            println!("{:<stack_width$} {}", label, tail);
+        }
+        None => println!("{:<stack_width$} {}", "<empty>", tail),
+    }
+}
+
+#[cfg(debug_assertions)]
+fn sample_stack(frames: &pprof::Frames) -> Option<String> {
+    let mut stack = Vec::new();
+    for frame in frames.frames.iter().rev() {
+        if let Some(name) = frame.iter().find_map(owned_frame_name) {
+            stack.push(name);
+        }
+    }
+
+    if stack.is_empty() {
+        None
+    } else {
+        trim_sample_prefix(&mut stack);
+        if stack.is_empty() {
+            None
+        } else {
+            Some(stack.join(" -> "))
+        }
+    }
+}
+
+#[cfg(debug_assertions)]
+fn owned_frame_name(frame: &pprof::Symbol) -> Option<String> {
+    let name = frame.name();
+    if is_owned_code(&name) {
+        Some(normalize_frame_name(&name))
+    } else {
+        None
+    }
+}
+
+#[cfg(debug_assertions)]
+fn is_owned_code(name: &str) -> bool {
+    matches!(
+        name,
+        n if n.starts_with("gen::")
+            || n.starts_with("r#gen::")
+            || n.starts_with("gen_models::")
+            || n.starts_with("gen_core::")
+            || n.starts_with("gen_graph::")
+            || n.starts_with("gen_diff::")
+            || n.starts_with("gen_annotations::")
+            || n.starts_with("gen_tui::")
+            || n.starts_with("gen_sugiyama::")
+            || n.starts_with("gen_capnp_schemas::")
+    )
+}
+
+#[cfg(debug_assertions)]
+fn normalize_frame_name(name: &str) -> String {
+    name.strip_prefix("r#").unwrap_or(name).to_string()
+}

--- a/src/profiling.rs
+++ b/src/profiling.rs
@@ -12,6 +12,19 @@ use tracing_subscriber::{
     registry::{LookupSpan, Registry},
 };
 
+/// Collects tracing span durations and prints an exact report for every recorded call stack.
+///
+/// `Profiler` measures spans directly through a tracing subscriber, so it is useful when you
+/// want per-stack call counts, total wall-clock time, and average time from span enter/exit
+/// events. This will only measure code that has been instrumented with
+/// ```
+/// #[cfg_attr(
+///    all(debug_assertions, feature = "profiling"),
+///    tracing::instrument(...)
+/// )]
+/// ```
+///
+/// which means profiling is enabled as a feature, and it's a dev build.
 #[derive(Clone, Default)]
 pub struct Profiler {
     stats: Arc<Mutex<HashMap<String, Stat>>>,
@@ -53,6 +66,7 @@ impl Profiler {
             .iter()
             .map(|(stack, stat)| (stack_frames(stack), stat.calls, stat.total))
             .collect::<Vec<_>>();
+        // .2 is total duration of code, .0 is the stack frame names (method calls)
         rows.sort_by(|left, right| right.2.cmp(&left.2).then_with(|| left.0.cmp(&right.0)));
         let stack_width = rows
             .iter()
@@ -94,8 +108,8 @@ impl<S> Layer<S> for ProfilerLayer
 where
     S: Subscriber + for<'span> LookupSpan<'span>,
 {
-    fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
-        if let Some(span) = ctx.span(id) {
+    fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, context: Context<'_, S>) {
+        if let Some(span) = context.span(id) {
             let metadata = attrs.metadata();
             let current = format!("{}::{}", metadata.target(), metadata.name());
             let stack = match span.parent() {
@@ -114,8 +128,8 @@ where
         }
     }
 
-    fn on_enter(&self, id: &Id, ctx: Context<'_, S>) {
-        if let Some(span) = ctx.span(id) {
+    fn on_enter(&self, id: &Id, context: Context<'_, S>) {
+        if let Some(span) = context.span(id) {
             let mut extensions = span.extensions_mut();
             if let Some(state) = extensions.get_mut::<SpanState>() {
                 state.starts.push(Instant::now());
@@ -123,8 +137,8 @@ where
         }
     }
 
-    fn on_exit(&self, id: &Id, ctx: Context<'_, S>) {
-        if let Some(span) = ctx.span(id) {
+    fn on_exit(&self, id: &Id, context: Context<'_, S>) {
+        if let Some(span) = context.span(id) {
             let mut extensions = span.extensions_mut();
             let snapshot = extensions.get_mut::<SpanState>().and_then(|state| {
                 state
@@ -141,6 +155,12 @@ where
 }
 
 #[cfg(debug_assertions)]
+/// Collects periodic samples from a `pprof` guard and prints an approximate hot-path report.
+///
+/// `SamplingProfiler` better suited for broad performance inspection, but it reports sampled
+/// stacks. This means a snapshot of the code is taken every x intervals, and wherever the
+/// code is, is recorded. This means some code that is run may never show up if it is never
+/// sampled during its execution. But this likely means that code is fast and not a bottleneck.
 #[derive(Clone, Default)]
 pub struct SamplingProfiler;
 

--- a/src/updates/gfa.rs
+++ b/src/updates/gfa.rs
@@ -24,6 +24,10 @@ use crate::{
     gfa_reader::{Gfa, Segment},
 };
 
+#[cfg_attr(
+    all(debug_assertions, feature = "profiling"),
+    tracing::instrument(skip(context, gfa_path))
+)]
 pub fn update_with_gfa(
     context: &DbContext,
     collection_name: &str,

--- a/src/updates/library.rs
+++ b/src/updates/library.rs
@@ -80,6 +80,10 @@ impl From<GenRegionError> for UpdateWithLibraryError {
 }
 
 #[allow(clippy::too_many_arguments)]
+#[cfg_attr(
+    all(debug_assertions, feature = "profiling"),
+    tracing::instrument(skip(context, parts_list, library_file_path, parts_file_path))
+)]
 pub fn update_with_library(
     context: &DbContext,
     collection_name: &str,

--- a/src/updates/vcf.rs
+++ b/src/updates/vcf.rs
@@ -327,6 +327,10 @@ fn resolve_parent_samples(
         .clone()
 }
 
+#[cfg_attr(
+    all(debug_assertions, feature = "profiling"),
+    tracing::instrument(skip(context, vcf_path, parent_samples))
+)]
 pub fn update_with_vcf(
     context: &DbContext,
     vcf_path: &String,


### PR DESCRIPTION
Adds a profiling command to identify slow points in the codebase. Adds instrumentation for some functions so they can be profiled. There are 2 profile modes: instrumentation which tracks things with the cfg profile attribute, and a sample based profiler.

profiler is enabled by building with `--features profiling`