### PR TITLE
Add reproduction test for issue #211 bypass-edge bug

### DIFF
--- a/gen-models/src/region.rs
+++ b/gen-models/src/region.rs
@@ -566,7 +566,9 @@ impl ResolvedGenRegion {
         tree: Option<&IntervalTree<i64, NodeIntervalBlock>>,
     ) -> Result<Vec<AugmentedEdgeData>, BlockGroupError> {
         match self.kind {
-            ResolvedRegionKind::Path | ResolvedRegionKind::BlockGroup => {
+            ResolvedRegionKind::Path | ResolvedRegionKind::BlockGroup
+                if self.start_anchors.is_none() || self.end_anchors.is_none() =>
+            {
                 let local_tree;
                 let tree = match tree {
                     Some(tree) => tree,
@@ -577,7 +579,10 @@ impl ResolvedGenRegion {
                 };
                 return BlockGroup::set_up_new_edges(change, tree);
             }
-            ResolvedRegionKind::Annotation | ResolvedRegionKind::Accession => {}
+            ResolvedRegionKind::Path
+            | ResolvedRegionKind::BlockGroup
+            | ResolvedRegionKind::Annotation
+            | ResolvedRegionKind::Accession => {}
         };
 
         let graph_positions_from_tree = |coordinate| {
@@ -874,7 +879,7 @@ mod tests {
             path: None,
             accession: None,
             annotation: None,
-            kind: ResolvedRegionKind::Annotation,
+            kind: ResolvedRegionKind::Path,
             anchor_start: 0,
             anchor_end: 0,
             feature_length: 0,

--- a/gen-models/src/region.rs
+++ b/gen-models/src/region.rs
@@ -630,17 +630,31 @@ impl ResolvedGenRegion {
             .iter()
             .filter(|position| position.coordinate() == position.graph_node.sequence_start)
             .collect::<Vec<_>>();
-        let block_group_edges = if boundary_positions.is_empty() {
-            Vec::new()
-        } else {
-            BlockGroupEdge::edges_for_block_group(conn, &change.region.block_group.id)
-        };
+        let end_boundary_positions = end_positions
+            .iter()
+            .filter(|position| position.coordinate() == position.graph_node.sequence_end)
+            .collect::<Vec<_>>();
+        let block_group_edges =
+            if boundary_positions.is_empty() && end_boundary_positions.is_empty() {
+                Vec::new()
+            } else {
+                BlockGroupEdge::edges_for_block_group(conn, &change.region.block_group.id)
+            };
         let incoming_edges = boundary_positions
             .into_iter()
             .flat_map(|position| {
                 block_group_edges.iter().filter(move |augmented_edge| {
                     augmented_edge.edge.target_node_id == position.graph_node.node_id
                         && augmented_edge.edge.target_coordinate == position.coordinate()
+                })
+            })
+            .collect::<Vec<_>>();
+        let outgoing_edges = end_boundary_positions
+            .into_iter()
+            .flat_map(|position| {
+                block_group_edges.iter().filter(move |augmented_edge| {
+                    augmented_edge.edge.source_node_id == position.graph_node.node_id
+                        && augmented_edge.edge.source_coordinate == position.coordinate()
                 })
             })
             .collect::<Vec<_>>();
@@ -696,6 +710,22 @@ impl ResolvedGenRegion {
                     });
                 }
             }
+            for start_position in &start_positions {
+                for outgoing_edge in &outgoing_edges {
+                    new_edges.push(AugmentedEdgeData {
+                        edge_data: EdgeData {
+                            source_node_id: start_position.graph_node.node_id,
+                            source_coordinate: start_position.coordinate(),
+                            source_strand: Strand::Forward,
+                            target_node_id: outgoing_edge.edge.target_node_id,
+                            target_coordinate: outgoing_edge.edge.target_coordinate,
+                            target_strand: outgoing_edge.edge.target_strand,
+                        },
+                        chromosome_index: change.chromosome_index,
+                        phased: change.phased,
+                    });
+                }
+            }
         } else {
             for start_position in &start_positions {
                 new_edges.push(AugmentedEdgeData {
@@ -739,6 +769,20 @@ impl ResolvedGenRegion {
                     phased: change.phased,
                 });
             }
+            for outgoing_edge in &outgoing_edges {
+                new_edges.push(AugmentedEdgeData {
+                    edge_data: EdgeData {
+                        source_node_id: change.block.node_id,
+                        source_coordinate: change.block.sequence_end,
+                        source_strand: Strand::Forward,
+                        target_node_id: outgoing_edge.edge.target_node_id,
+                        target_coordinate: outgoing_edge.edge.target_coordinate,
+                        target_strand: outgoing_edge.edge.target_strand,
+                    },
+                    chromosome_index: change.chromosome_index,
+                    phased: change.phased,
+                });
+            }
         }
 
         Ok(new_edges)
@@ -757,10 +801,15 @@ impl IntervalTreeSource for ResolvedGenRegion {
 
 #[cfg(test)]
 mod tests {
+    use gen_core::{NO_CHROMOSOME_INDEX, PathBlock, Strand};
+    use gen_graph::{GraphNode, GraphNodePosition};
+
     use super::*;
     use crate::{
         annotations::Annotation,
         block_group::{BlockGroup, PathCache},
+        block_group_edge::{BlockGroupEdge, BlockGroupEdgeData},
+        edge::Edge,
         test_helpers::{get_connection, setup_block_group},
     };
 
@@ -780,6 +829,95 @@ mod tests {
         let annotation =
             Annotation::get_or_create(&conn, "gene-mreB", "genes", &accession.id, None).unwrap();
         (conn, block_group, path, accession, annotation)
+    }
+
+    #[test]
+    fn test_node_end_update_preserves_all_outgoing_edges() {
+        let (conn, block_group, _path, _accession, _annotation) = setup_targets();
+        let t_node_id = HashId::convert_str("test-t-node");
+        let c_node_id = HashId::convert_str("test-c-node");
+        let g_node_id = HashId::convert_str("test-g-node");
+        let extra_outgoing_edge = Edge::create(
+            &conn,
+            t_node_id,
+            10,
+            Strand::Forward,
+            g_node_id,
+            0,
+            Strand::Forward,
+        )
+        .unwrap();
+        BlockGroupEdge::bulk_create(
+            &conn,
+            &[BlockGroupEdgeData {
+                block_group_id: block_group.id,
+                edge_id: extra_outgoing_edge.id,
+                chromosome_index: 0,
+                phased: 0,
+            }],
+        );
+
+        let start_position = GraphNodePosition {
+            graph_node: GraphNode {
+                node_id: t_node_id,
+                sequence_start: 0,
+                sequence_end: 10,
+            },
+            offset: 8,
+        };
+        let end_position = GraphNodePosition {
+            graph_node: start_position.graph_node,
+            offset: 10,
+        };
+        let region = ResolvedGenRegion {
+            block_group,
+            path: None,
+            accession: None,
+            annotation: None,
+            kind: ResolvedRegionKind::Annotation,
+            anchor_start: 0,
+            anchor_end: 0,
+            feature_length: 0,
+            start: 8,
+            end: 10,
+            start_anchors: Some(vec![start_position]),
+            end_anchors: Some(vec![end_position]),
+            remove_ambiguous_positions: false,
+        };
+
+        for (sequence_end, expected_source_node_id, expected_source_coordinate) in [
+            (0, t_node_id, 8),
+            (4, HashId::convert_str("replacement"), 4),
+        ] {
+            let change = BlockGroupChange {
+                region: region.clone(),
+                path_accession: None,
+                block: PathBlock {
+                    node_id: expected_source_node_id,
+                    block_sequence: "N".repeat(sequence_end as usize),
+                    sequence_start: 0,
+                    sequence_end,
+                    path_start: 8,
+                    path_end: 10,
+                    strand: Strand::Forward,
+                },
+                chromosome_index: NO_CHROMOSOME_INDEX,
+                phased: 0,
+                preserve_edge: true,
+            };
+            let edges = region.plan_edges(&conn, &change, None).unwrap();
+            for target_node_id in [c_node_id, g_node_id] {
+                assert!(
+                    edges.iter().any(|edge| {
+                        edge.edge_data.source_node_id == expected_source_node_id
+                            && edge.edge_data.source_coordinate == expected_source_coordinate
+                            && edge.edge_data.target_node_id == target_node_id
+                            && edge.edge_data.target_coordinate == 0
+                    }),
+                    "node-end update should preserve outgoing edge to {target_node_id}",
+                );
+            }
+        }
     }
 
     mod region_resolver {

--- a/gen-models/src/region.rs
+++ b/gen-models/src/region.rs
@@ -643,7 +643,7 @@ impl ResolvedGenRegion {
             if boundary_positions.is_empty() && end_boundary_positions.is_empty() {
                 Vec::new()
             } else {
-                BlockGroupEdge::edges_for_block_group(conn, &change.region.block_group.id)
+                BlockGroupEdge::edges_for_block_group(conn, &change.region.block_group.id, None)
             };
         let incoming_edges = boundary_positions
             .into_iter()

--- a/gen-models/src/region.rs
+++ b/gen-models/src/region.rs
@@ -11,7 +11,7 @@ use crate::{
     accession::{Accession, AccessionError},
     annotations::{Annotation, AnnotationError},
     block_group::{BlockGroup, BlockGroupChange, BlockGroupError, IntervalTreeSource},
-    block_group_edge::AugmentedEdgeData,
+    block_group_edge::{AugmentedEdgeData, BlockGroupEdge},
     db::GraphConnection,
     edge::EdgeData,
     errors::PathError,
@@ -626,6 +626,24 @@ impl ResolvedGenRegion {
             PRESERVE_EDIT_SITE_CHROMOSOME_INDEX
         };
         let mut new_edges = vec![];
+        let boundary_positions = start_positions
+            .iter()
+            .filter(|position| position.coordinate() == position.graph_node.sequence_start)
+            .collect::<Vec<_>>();
+        let block_group_edges = if boundary_positions.is_empty() {
+            Vec::new()
+        } else {
+            BlockGroupEdge::edges_for_block_group(conn, &change.region.block_group.id)
+        };
+        let incoming_edges = boundary_positions
+            .into_iter()
+            .flat_map(|position| {
+                block_group_edges.iter().filter(move |augmented_edge| {
+                    augmented_edge.edge.target_node_id == position.graph_node.node_id
+                        && augmented_edge.edge.target_coordinate == position.coordinate()
+                })
+            })
+            .collect::<Vec<_>>();
 
         for position in start_positions.iter().chain(end_positions.iter()) {
             if !is_terminal(position.graph_node.node_id) {
@@ -662,6 +680,22 @@ impl ResolvedGenRegion {
                     });
                 }
             }
+            for incoming_edge in &incoming_edges {
+                for end_position in &end_positions {
+                    new_edges.push(AugmentedEdgeData {
+                        edge_data: EdgeData {
+                            source_node_id: incoming_edge.edge.source_node_id,
+                            source_coordinate: incoming_edge.edge.source_coordinate,
+                            source_strand: incoming_edge.edge.source_strand,
+                            target_node_id: end_position.graph_node.node_id,
+                            target_coordinate: end_position.coordinate(),
+                            target_strand: Strand::Forward,
+                        },
+                        chromosome_index: change.chromosome_index,
+                        phased: change.phased,
+                    });
+                }
+            }
         } else {
             for start_position in &start_positions {
                 new_edges.push(AugmentedEdgeData {
@@ -669,6 +703,20 @@ impl ResolvedGenRegion {
                         source_node_id: start_position.graph_node.node_id,
                         source_coordinate: start_position.coordinate(),
                         source_strand: Strand::Forward,
+                        target_node_id: change.block.node_id,
+                        target_coordinate: change.block.sequence_start,
+                        target_strand: Strand::Forward,
+                    },
+                    chromosome_index: change.chromosome_index,
+                    phased: change.phased,
+                });
+            }
+            for incoming_edge in &incoming_edges {
+                new_edges.push(AugmentedEdgeData {
+                    edge_data: EdgeData {
+                        source_node_id: incoming_edge.edge.source_node_id,
+                        source_coordinate: incoming_edge.edge.source_coordinate,
+                        source_strand: incoming_edge.edge.source_strand,
                         target_node_id: change.block.node_id,
                         target_coordinate: change.block.sequence_start,
                         target_strand: Strand::Forward,

--- a/src/updates.rs
+++ b/src/updates.rs
@@ -1,4 +1,4 @@
-use gen_core::{HashId, NO_CHROMOSOME_INDEX, PathBlock};
+use gen_core::{HashId, NO_CHROMOSOME_INDEX, PathBlock, Strand};
 use gen_models::{
     block_group::{BlockGroup, BlockGroupChange},
     db::GraphConnection,
@@ -8,6 +8,9 @@ use gen_models::{
         GenRegionError, Region, ResolvedGenRegion, ResolvedRegionKind, resolve_accession,
         resolve_annotation, resolve_path,
     },
+    sample::Sample,
+    sequence::Sequence,
+    traits::Query,
 };
 
 pub mod fasta;
@@ -93,4 +96,134 @@ pub(crate) fn insert_update_change(
         preserve_edge: data.preserve_edge,
     };
     BlockGroup::insert_change(conn, &change)
+}
+
+pub(crate) struct SequenceUpdate<'a> {
+    pub collection_name: &'a str,
+    pub parent_sample_name: &'a str,
+    pub new_sample_name: &'a str,
+    pub region: &'a ResolvedGenRegion,
+    pub disable_reference_path_update: bool,
+}
+
+pub(crate) fn apply_sequence_updates<E>(
+    conn: &GraphConnection,
+    update: &SequenceUpdate<'_>,
+    sequences: impl IntoIterator<Item = String>,
+) -> Result<usize, E>
+where
+    E: From<gen_models::errors::BlockGroupError>
+        + From<gen_models::errors::NodeError>
+        + From<gen_models::errors::PathError>
+        + From<gen_models::errors::QueryError>
+        + From<gen_models::errors::SampleError>
+        + From<gen_models::errors::SequenceError>
+        + From<GenRegionError>,
+{
+    Sample::get_or_create_child(
+        conn,
+        update.collection_name,
+        update.new_sample_name,
+        vec![update.parent_sample_name.to_string()],
+    )?;
+    let block_groups = Sample::get_block_groups(
+        conn,
+        update.collection_name,
+        update.parent_sample_name,
+        None,
+    );
+    let mut target_block_groups = Vec::new();
+    for block_group in block_groups {
+        let new_block_groups = BlockGroup::get_or_create_sample_block_groups(
+            conn,
+            update.collection_name,
+            update.new_sample_name,
+            &block_group.name,
+            vec![update.parent_sample_name.to_string()],
+        )?;
+        if block_group.name == update.region.block_group.name {
+            target_block_groups = new_block_groups;
+        }
+    }
+    if target_block_groups.is_empty() {
+        return Err(E::from(GenRegionError::NotFound(
+            update.region.block_group.name.clone(),
+        )));
+    }
+
+    let sequences = sequences.into_iter().collect::<Vec<_>>();
+    let change_count = target_block_groups.len() * sequences.len();
+    let update_reference_path = !update.disable_reference_path_update && sequences.len() == 1;
+    for target_block_group in target_block_groups {
+        let path = if update.region.kind == ResolvedRegionKind::Path {
+            Some(BlockGroup::get_current_path(
+                conn,
+                &target_block_group.id,
+                None,
+            )?)
+        } else {
+            None
+        };
+        for sequence in &sequences {
+            let (node_id, sequence_end) = if sequence.is_empty() {
+                (HashId::convert_str(""), 0)
+            } else {
+                let saved_sequence = Sequence::new()
+                    .sequence_type("DNA")
+                    .sequence(sequence)
+                    .save(conn)?;
+                let node_id = gen_models::node::Node::create(
+                    conn,
+                    &saved_sequence.hash,
+                    &HashId::convert_str(&format!(
+                        "{block_group_id}:0-{sequence_end}->{sequence_hash}",
+                        block_group_id = target_block_group.id,
+                        sequence_end = saved_sequence.length,
+                        sequence_hash = saved_sequence.hash,
+                    )),
+                )?;
+                (node_id, saved_sequence.length)
+            };
+            let block = PathBlock {
+                node_id,
+                block_sequence: sequence.clone(),
+                sequence_start: 0,
+                sequence_end,
+                path_start: update.region.start,
+                path_end: update.region.end,
+                strand: Strand::Forward,
+            };
+            let target_region =
+                target_update_region(conn, update.region, target_block_group.id, path.as_ref())?;
+            insert_update_change(conn, target_region, InsertChangeData::new(block))?;
+
+            if update_reference_path && let Some(path) = &path {
+                if sequence.is_empty() {
+                    let _ =
+                        path.new_path_with_deletion(conn, update.region.start, update.region.end);
+                } else {
+                    let edge_to_new_node = gen_models::edge::Edge::query(
+                        conn,
+                        "select * from edges where target_node_id = ?1",
+                        rusqlite::params![node_id],
+                    )[0]
+                    .clone();
+                    let edge_from_new_node = gen_models::edge::Edge::query(
+                        conn,
+                        "select * from edges where source_node_id = ?1",
+                        rusqlite::params![node_id],
+                    )[0]
+                    .clone();
+                    path.new_path_with(
+                        conn,
+                        update.region.start,
+                        update.region.end,
+                        &edge_to_new_node,
+                        &edge_from_new_node,
+                    )?;
+                }
+            }
+        }
+    }
+    Ok(change_count)
 }

--- a/src/updates.rs
+++ b/src/updates.rs
@@ -2,7 +2,7 @@ use gen_core::{HashId, NO_CHROMOSOME_INDEX, PathBlock, Strand};
 use gen_graph::{GraphNode, GraphNodePosition};
 use gen_models::{
     block_group::{BlockGroup, BlockGroupChange},
-    block_group_edge::BlockGroupEdge,
+    block_group_edge::{AugmentedEdgeData, BlockGroupEdge, BlockGroupEdgeData},
     db::GraphConnection,
     edge::Edge,
     errors::{
@@ -29,6 +29,29 @@ pub mod gfa;
 pub mod library;
 pub mod sequence;
 pub mod vcf;
+
+pub(crate) fn create_block_group_edges(
+    conn: &GraphConnection,
+    block_group_id: HashId,
+    edges: &[AugmentedEdgeData],
+) -> Vec<HashId> {
+    let edge_ids = Edge::bulk_create(
+        conn,
+        &edges.iter().map(|edge| edge.edge_data).collect::<Vec<_>>(),
+    );
+    let block_group_edges = edge_ids
+        .iter()
+        .zip(edges)
+        .map(|(edge_id, edge)| BlockGroupEdgeData {
+            block_group_id,
+            edge_id: *edge_id,
+            chromosome_index: edge.chromosome_index,
+            phased: edge.phased,
+        })
+        .collect::<Vec<_>>();
+    BlockGroupEdge::bulk_create(conn, &block_group_edges);
+    edge_ids
+}
 
 pub(crate) fn adjacent_boundary_points(
     conn: &GraphConnection,
@@ -133,19 +156,38 @@ impl InsertChangeData {
     }
 }
 
-pub(crate) fn insert_update_change(
-    conn: &GraphConnection,
+impl From<&BlockGroupChange> for InsertChangeData {
+    fn from(change: &BlockGroupChange) -> Self {
+        Self {
+            block: change.block.clone(),
+            path_accession: change.path_accession.clone(),
+            chromosome_index: change.chromosome_index,
+            phased: change.phased,
+            preserve_edge: change.preserve_edge,
+        }
+    }
+}
+
+pub(crate) fn build_update_change(
     region: ResolvedGenRegion,
     data: InsertChangeData,
-) -> Result<(), BlockGroupError> {
-    let change = BlockGroupChange {
+) -> BlockGroupChange {
+    BlockGroupChange {
         region,
         path_accession: data.path_accession,
         block: data.block,
         chromosome_index: data.chromosome_index,
         phased: data.phased,
         preserve_edge: data.preserve_edge,
-    };
+    }
+}
+
+pub(crate) fn insert_update_change(
+    conn: &GraphConnection,
+    region: ResolvedGenRegion,
+    data: InsertChangeData,
+) -> Result<(), BlockGroupError> {
+    let change = build_update_change(region, data);
     BlockGroup::insert_change(conn, &change)
 }
 
@@ -329,6 +371,70 @@ fn update_reference_path(
     Ok(())
 }
 
+pub(crate) fn apply_update_change(
+    conn: &GraphConnection,
+    region: &ResolvedGenRegion,
+    data: InsertChangeData,
+    should_update_reference_path: bool,
+) -> Result<(), BlockGroupError> {
+    let prepared_region = prepare_path_update_region(conn, region)?;
+    let path = prepared_region.path.clone();
+    let node_id = data.block.node_id;
+    let is_deletion = data.block.block_sequence.is_empty();
+    insert_update_change(conn, prepared_region.clone(), data)?;
+
+    if should_update_reference_path && let Some(path) = path {
+        if is_deletion {
+            let _ = path.new_path_with_deletion(conn, region.start, region.end);
+        } else {
+            let (edge_to_new_node, edge_from_new_node) =
+                reference_path_update_edges(conn, node_id, &prepared_region, &path)?;
+            update_reference_path(
+                conn,
+                &path,
+                &prepared_region,
+                &edge_to_new_node,
+                &edge_from_new_node,
+            )?;
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn prepare_child_sample_block_groups<E>(
+    conn: &GraphConnection,
+    collection_name: &str,
+    parent_sample_name: &str,
+    new_sample_name: &str,
+) -> Result<Vec<BlockGroup>, E>
+where
+    E: From<BlockGroupError> + From<SampleError>,
+{
+    Sample::get_or_create_child(
+        conn,
+        collection_name,
+        new_sample_name,
+        vec![parent_sample_name.to_string()],
+    )?;
+    let parent_block_groups =
+        Sample::get_block_groups(conn, collection_name, parent_sample_name, None);
+    for block_group in parent_block_groups {
+        BlockGroup::get_or_create_sample_block_groups(
+            conn,
+            collection_name,
+            new_sample_name,
+            &block_group.name,
+            vec![parent_sample_name.to_string()],
+        )?;
+    }
+    Ok(Sample::get_block_groups(
+        conn,
+        collection_name,
+        new_sample_name,
+        None,
+    ))
+}
+
 pub(crate) fn apply_sequence_updates<E>(
     conn: &GraphConnection,
     update: &SequenceUpdate<'_>,
@@ -337,37 +443,20 @@ pub(crate) fn apply_sequence_updates<E>(
 where
     E: From<BlockGroupError>
         + From<NodeError>
-        + From<PathError>
-        + From<QueryError>
         + From<SampleError>
         + From<SequenceError>
         + From<GenRegionError>,
 {
-    Sample::get_or_create_child(
-        conn,
-        update.collection_name,
-        update.new_sample_name,
-        vec![update.parent_sample_name.to_string()],
-    )?;
-    let block_groups = Sample::get_block_groups(
+    let block_groups = prepare_child_sample_block_groups::<E>(
         conn,
         update.collection_name,
         update.parent_sample_name,
-        None,
-    );
-    let mut target_block_groups = Vec::new();
-    for block_group in block_groups {
-        let new_block_groups = BlockGroup::get_or_create_sample_block_groups(
-            conn,
-            update.collection_name,
-            update.new_sample_name,
-            &block_group.name,
-            vec![update.parent_sample_name.to_string()],
-        )?;
-        if block_group.name == update.region.block_group.name {
-            target_block_groups = new_block_groups;
-        }
-    }
+        update.new_sample_name,
+    )?;
+    let target_block_groups = block_groups
+        .into_iter()
+        .filter(|block_group| block_group.name == update.region.block_group.name)
+        .collect::<Vec<_>>();
     if target_block_groups.is_empty() {
         return Err(E::from(GenRegionError::NotFound(
             update.region.block_group.name.clone(),
@@ -419,26 +508,12 @@ where
             };
             let target_region =
                 target_update_region(conn, update.region, target_block_group.id, path.as_ref())?;
-            let target_region = prepare_path_update_region(conn, &target_region)?;
-            let reference_region = target_region.clone();
-            insert_update_change(conn, target_region, InsertChangeData::new(block))?;
-
-            if should_update_reference_path && let Some(path) = &path {
-                if sequence.is_empty() {
-                    let _ =
-                        path.new_path_with_deletion(conn, update.region.start, update.region.end);
-                } else {
-                    let (edge_to_new_node, edge_from_new_node) =
-                        reference_path_update_edges(conn, node_id, &reference_region, path)?;
-                    update_reference_path(
-                        conn,
-                        path,
-                        &reference_region,
-                        &edge_to_new_node,
-                        &edge_from_new_node,
-                    )?;
-                }
-            }
+            apply_update_change(
+                conn,
+                &target_region,
+                InsertChangeData::new(block),
+                should_update_reference_path,
+            )?;
         }
     }
     Ok(change_count)

--- a/src/updates.rs
+++ b/src/updates.rs
@@ -2,6 +2,7 @@ use gen_core::{HashId, NO_CHROMOSOME_INDEX, PathBlock, Strand};
 use gen_graph::{GraphNode, GraphNodePosition};
 use gen_models::{
     block_group::{BlockGroup, BlockGroupChange},
+    block_group_edge::BlockGroupEdge,
     db::GraphConnection,
     errors::BlockGroupError,
     path::Path,
@@ -14,6 +15,8 @@ use gen_models::{
     traits::Query,
 };
 
+use crate::graphs::NodePoint;
+
 pub mod fasta;
 pub mod gaf;
 pub mod genbank;
@@ -21,6 +24,44 @@ pub mod gfa;
 pub mod library;
 pub mod sequence;
 pub mod vcf;
+
+pub(crate) fn adjacent_boundary_points(
+    conn: &GraphConnection,
+    block_group_id: HashId,
+    start_points: &[NodePoint],
+    end_points: &[NodePoint],
+) -> (Vec<NodePoint>, Vec<NodePoint>) {
+    let edges = BlockGroupEdge::edges_for_block_group(conn, &block_group_id);
+    let mut incoming_points = Vec::new();
+    let mut outgoing_points = Vec::new();
+    for edge in edges {
+        if start_points.iter().any(|point| {
+            edge.edge.target_node_id == point.id && edge.edge.target_coordinate == point.coordinate
+        }) {
+            let point = NodePoint {
+                id: edge.edge.source_node_id,
+                coordinate: edge.edge.source_coordinate,
+                strand: edge.edge.source_strand,
+            };
+            if !incoming_points.contains(&point) {
+                incoming_points.push(point);
+            }
+        }
+        if end_points.iter().any(|point| {
+            edge.edge.source_node_id == point.id && edge.edge.source_coordinate == point.coordinate
+        }) {
+            let point = NodePoint {
+                id: edge.edge.target_node_id,
+                coordinate: edge.edge.target_coordinate,
+                strand: edge.edge.target_strand,
+            };
+            if !outgoing_points.contains(&point) {
+                outgoing_points.push(point);
+            }
+        }
+    }
+    (incoming_points, outgoing_points)
+}
 
 pub(crate) fn resolve_update_region(
     region: &Region,

--- a/src/updates.rs
+++ b/src/updates.rs
@@ -1,4 +1,5 @@
 use gen_core::{HashId, NO_CHROMOSOME_INDEX, PathBlock, Strand};
+use gen_graph::{GraphNode, GraphNodePosition};
 use gen_models::{
     block_group::{BlockGroup, BlockGroupChange},
     db::GraphConnection,
@@ -106,6 +107,62 @@ pub(crate) struct SequenceUpdate<'a> {
     pub disable_reference_path_update: bool,
 }
 
+pub(crate) fn prepare_path_update_region(
+    conn: &GraphConnection,
+    region: &mut ResolvedGenRegion,
+) -> Result<(), BlockGroupError> {
+    if region.kind != ResolvedRegionKind::Path
+        || region.start <= 0
+        || region.end >= region.feature_length
+    {
+        return Ok(());
+    }
+    let path = region
+        .path
+        .as_ref()
+        .expect("should have a path for a path region");
+    let interval_tree = path.intervaltree(conn)?;
+    let start_block = interval_tree
+        .query_point(region.start)
+        .next()
+        .ok_or_else(|| BlockGroupError::ChangeOutOfBounds("missing path start block".to_string()))?
+        .value;
+    let end_coordinate = if region.end == region.start {
+        region.end
+    } else {
+        region.end - 1
+    };
+    let end_block = interval_tree
+        .query_point(end_coordinate)
+        .next()
+        .ok_or_else(|| BlockGroupError::ChangeOutOfBounds("missing path end block".to_string()))?
+        .value;
+    let starts_at_node_boundary =
+        region.start - start_block.start + start_block.sequence_start == start_block.sequence_start;
+    let ends_at_node_boundary =
+        region.end - end_block.start + end_block.sequence_start == end_block.sequence_end;
+    if !starts_at_node_boundary && !ends_at_node_boundary {
+        return Ok(());
+    }
+    region.start_anchors = Some(vec![GraphNodePosition {
+        graph_node: GraphNode {
+            node_id: start_block.node_id,
+            sequence_start: start_block.sequence_start,
+            sequence_end: start_block.sequence_end,
+        },
+        offset: region.start - start_block.start,
+    }]);
+    region.end_anchors = Some(vec![GraphNodePosition {
+        graph_node: GraphNode {
+            node_id: end_block.node_id,
+            sequence_start: end_block.sequence_start,
+            sequence_end: end_block.sequence_end,
+        },
+        offset: region.end - end_block.start,
+    }]);
+    Ok(())
+}
+
 pub(crate) fn apply_sequence_updates<E>(
     conn: &GraphConnection,
     update: &SequenceUpdate<'_>,
@@ -193,8 +250,9 @@ where
                 path_end: update.region.end,
                 strand: Strand::Forward,
             };
-            let target_region =
+            let mut target_region =
                 target_update_region(conn, update.region, target_block_group.id, path.as_ref())?;
+            prepare_path_update_region(conn, &mut target_region)?;
             insert_update_change(conn, target_region, InsertChangeData::new(block))?;
 
             if update_reference_path && let Some(path) = &path {

--- a/src/updates.rs
+++ b/src/updates.rs
@@ -36,7 +36,9 @@ pub(crate) fn adjacent_boundary_points(
     let mut outgoing_points = Vec::new();
     for edge in edges {
         if start_points.iter().any(|point| {
-            edge.edge.target_node_id == point.id && edge.edge.target_coordinate == point.coordinate
+            edge.edge.target_node_id == point.id
+                && edge.edge.target_coordinate == point.coordinate
+                && edge.edge.target_strand == point.strand
         }) {
             let point = NodePoint {
                 id: edge.edge.source_node_id,
@@ -48,7 +50,9 @@ pub(crate) fn adjacent_boundary_points(
             }
         }
         if end_points.iter().any(|point| {
-            edge.edge.source_node_id == point.id && edge.edge.source_coordinate == point.coordinate
+            edge.edge.source_node_id == point.id
+                && edge.edge.source_coordinate == point.coordinate
+                && edge.edge.source_strand == point.strand
         }) {
             let point = NodePoint {
                 id: edge.edge.target_node_id,
@@ -325,4 +329,132 @@ where
         }
     }
     Ok(change_count)
+}
+
+#[cfg(test)]
+mod tests {
+    use gen_core::{HashId, Strand};
+    use gen_models::{
+        block_group_edge::{BlockGroupEdge, BlockGroupEdgeData},
+        db::GraphConnection,
+        edge::Edge,
+    };
+
+    use crate::{
+        graphs::NodePoint,
+        test_helpers::{get_connection, setup_block_group},
+        updates::adjacent_boundary_points,
+    };
+
+    fn update_test_node_ids(
+        conn: &GraphConnection,
+        block_group_id: HashId,
+    ) -> (HashId, HashId, HashId, HashId) {
+        let edges = BlockGroupEdge::edges_for_block_group(conn, &block_group_id);
+        let a_node_id = edges
+            .iter()
+            .find(|edge| edge.edge.is_start_edge())
+            .unwrap()
+            .edge
+            .target_node_id;
+        let t_node_id = edges
+            .iter()
+            .find(|edge| edge.edge.source_node_id == a_node_id)
+            .unwrap()
+            .edge
+            .target_node_id;
+        let c_node_id = edges
+            .iter()
+            .find(|edge| edge.edge.source_node_id == t_node_id)
+            .unwrap()
+            .edge
+            .target_node_id;
+        let g_node_id = edges
+            .iter()
+            .find(|edge| edge.edge.source_node_id == c_node_id)
+            .unwrap()
+            .edge
+            .target_node_id;
+        (a_node_id, t_node_id, c_node_id, g_node_id)
+    }
+
+    #[test]
+    fn test_adjacent_boundary_points_filters_incoming_edges_by_strand() {
+        let conn = get_connection(None).unwrap();
+        let (block_group_id, _) = setup_block_group(&conn);
+        let (a_node_id, t_node_id, _, g_node_id) = update_test_node_ids(&conn, block_group_id);
+        let opposite_strand_edge = Edge::create(
+            &conn,
+            g_node_id,
+            10,
+            Strand::Reverse,
+            t_node_id,
+            0,
+            Strand::Reverse,
+        )
+        .unwrap();
+        BlockGroupEdge::bulk_create(
+            &conn,
+            &[BlockGroupEdgeData {
+                block_group_id,
+                edge_id: opposite_strand_edge.id,
+                chromosome_index: 0,
+                phased: 0,
+            }],
+        );
+
+        let (incoming_points, _) = adjacent_boundary_points(
+            &conn,
+            block_group_id,
+            &[NodePoint {
+                id: t_node_id,
+                coordinate: 0,
+                strand: Strand::Forward,
+            }],
+            &[],
+        );
+
+        assert!(incoming_points.iter().any(|point| point.id == a_node_id));
+        assert!(!incoming_points.iter().any(|point| point.id == g_node_id));
+    }
+
+    #[test]
+    fn test_adjacent_boundary_points_filters_outgoing_edges_by_strand() {
+        let conn = get_connection(None).unwrap();
+        let (block_group_id, _) = setup_block_group(&conn);
+        let (_, t_node_id, c_node_id, g_node_id) = update_test_node_ids(&conn, block_group_id);
+        let opposite_strand_edge = Edge::create(
+            &conn,
+            t_node_id,
+            10,
+            Strand::Reverse,
+            g_node_id,
+            0,
+            Strand::Reverse,
+        )
+        .unwrap();
+        BlockGroupEdge::bulk_create(
+            &conn,
+            &[BlockGroupEdgeData {
+                block_group_id,
+                edge_id: opposite_strand_edge.id,
+                chromosome_index: 0,
+                phased: 0,
+            }],
+        );
+
+        let (_, outgoing_points) = adjacent_boundary_points(
+            &conn,
+            block_group_id,
+            &[],
+            &[NodePoint {
+                id: t_node_id,
+                coordinate: 10,
+                strand: Strand::Forward,
+            }],
+        );
+
+        assert!(outgoing_points.iter().any(|point| point.id == c_node_id));
+        assert!(!outgoing_points.iter().any(|point| point.id == g_node_id));
+    }
 }

--- a/src/updates.rs
+++ b/src/updates.rs
@@ -208,6 +208,125 @@ pub(crate) fn prepare_path_update_region(
     Ok(())
 }
 
+fn reference_path_update_edges(
+    conn: &GraphConnection,
+    node_id: HashId,
+    region: &ResolvedGenRegion,
+    path: &Path,
+) -> Result<(gen_models::edge::Edge, gen_models::edge::Edge), gen_models::errors::QueryError> {
+    let incoming_edges = gen_models::edge::Edge::query(
+        conn,
+        "select * from edges where target_node_id = ?1",
+        rusqlite::params![node_id],
+    );
+    let outgoing_edges = gen_models::edge::Edge::query(
+        conn,
+        "select * from edges where source_node_id = ?1",
+        rusqlite::params![node_id],
+    );
+    let path_edges = gen_models::path_edge::PathEdge::edges_for_path(conn, &path.id);
+    let incoming_edge = match &region.start_anchors {
+        Some(anchors) => path_edges
+            .iter()
+            .find(|path_edge| {
+                anchors.iter().any(|anchor| {
+                    path_edge.target_node_id == anchor.graph_node.node_id
+                        && path_edge.target_coordinate == anchor.coordinate()
+                })
+            })
+            .and_then(|path_edge| {
+                incoming_edges.iter().find(|edge| {
+                    edge.source_node_id == path_edge.source_node_id
+                        && edge.source_coordinate == path_edge.source_coordinate
+                        && edge.source_strand == path_edge.source_strand
+                })
+            }),
+        None if incoming_edges.len() == 1 => incoming_edges.first(),
+        None => None,
+    }
+    .ok_or_else(|| {
+        gen_models::errors::QueryError::ResultsNotFound(format!(
+            "reference-path edge entering update node {node_id}"
+        ))
+    })?;
+    let outgoing_edge = match &region.end_anchors {
+        Some(anchors) => path_edges
+            .iter()
+            .find(|path_edge| {
+                anchors.iter().any(|anchor| {
+                    path_edge.source_node_id == anchor.graph_node.node_id
+                        && path_edge.source_coordinate == anchor.coordinate()
+                })
+            })
+            .and_then(|path_edge| {
+                outgoing_edges.iter().find(|edge| {
+                    edge.target_node_id == path_edge.target_node_id
+                        && edge.target_coordinate == path_edge.target_coordinate
+                        && edge.target_strand == path_edge.target_strand
+                })
+            }),
+        None if outgoing_edges.len() == 1 => outgoing_edges.first(),
+        None => None,
+    }
+    .ok_or_else(|| {
+        gen_models::errors::QueryError::ResultsNotFound(format!(
+            "reference-path edge leaving update node {node_id}"
+        ))
+    })?;
+    Ok((incoming_edge.clone(), outgoing_edge.clone()))
+}
+
+fn update_reference_path(
+    conn: &GraphConnection,
+    path: &Path,
+    region: &ResolvedGenRegion,
+    edge_to_new_node: &gen_models::edge::Edge,
+    edge_from_new_node: &gen_models::edge::Edge,
+) -> Result<(), gen_models::errors::PathError> {
+    let path_edges = gen_models::path_edge::PathEdge::edges_for_path(conn, &path.id);
+    let boundary_indices = region
+        .start_anchors
+        .as_ref()
+        .zip(region.end_anchors.as_ref())
+        .and_then(|(start_anchors, end_anchors)| {
+            let start_index = path_edges.iter().position(|edge| {
+                start_anchors.iter().any(|anchor| {
+                    edge.target_node_id == anchor.graph_node.node_id
+                        && edge.target_coordinate == anchor.coordinate()
+                })
+            })?;
+            let end_index = path_edges.iter().position(|edge| {
+                end_anchors.iter().any(|anchor| {
+                    edge.source_node_id == anchor.graph_node.node_id
+                        && edge.source_coordinate == anchor.coordinate()
+                })
+            })?;
+            Some((start_index, end_index))
+        });
+    if let Some((start_index, end_index)) = boundary_indices {
+        let edge_ids = path_edges[..start_index]
+            .iter()
+            .map(|edge| edge.id)
+            .chain([edge_to_new_node.id, edge_from_new_node.id])
+            .chain(path_edges[end_index + 1..].iter().map(|edge| edge.id))
+            .collect::<Vec<_>>();
+        let name = format!(
+            "{}-start-{}-end-{}-node-{}",
+            path.name, region.start, region.end, edge_to_new_node.target_node_id
+        );
+        Path::create(conn, &name, &path.block_group_id, &edge_ids)?;
+    } else {
+        path.new_path_with(
+            conn,
+            region.start,
+            region.end,
+            edge_to_new_node,
+            edge_from_new_node,
+        )?;
+    }
+    Ok(())
+}
+
 pub(crate) fn apply_sequence_updates<E>(
     conn: &GraphConnection,
     update: &SequenceUpdate<'_>,
@@ -255,7 +374,8 @@ where
 
     let sequences = sequences.into_iter().collect::<Vec<_>>();
     let change_count = target_block_groups.len() * sequences.len();
-    let update_reference_path = !update.disable_reference_path_update && sequences.len() == 1;
+    let should_update_reference_path =
+        !update.disable_reference_path_update && sequences.len() == 1;
     for target_block_group in target_block_groups {
         let path = if update.region.kind == ResolvedRegionKind::Path {
             Some(BlockGroup::get_current_path(
@@ -298,29 +418,20 @@ where
             let mut target_region =
                 target_update_region(conn, update.region, target_block_group.id, path.as_ref())?;
             prepare_path_update_region(conn, &mut target_region)?;
+            let reference_region = target_region.clone();
             insert_update_change(conn, target_region, InsertChangeData::new(block))?;
 
-            if update_reference_path && let Some(path) = &path {
+            if should_update_reference_path && let Some(path) = &path {
                 if sequence.is_empty() {
                     let _ =
                         path.new_path_with_deletion(conn, update.region.start, update.region.end);
                 } else {
-                    let edge_to_new_node = gen_models::edge::Edge::query(
+                    let (edge_to_new_node, edge_from_new_node) =
+                        reference_path_update_edges(conn, node_id, &reference_region, path)?;
+                    update_reference_path(
                         conn,
-                        "select * from edges where target_node_id = ?1",
-                        rusqlite::params![node_id],
-                    )[0]
-                    .clone();
-                    let edge_from_new_node = gen_models::edge::Edge::query(
-                        conn,
-                        "select * from edges where source_node_id = ?1",
-                        rusqlite::params![node_id],
-                    )[0]
-                    .clone();
-                    path.new_path_with(
-                        conn,
-                        update.region.start,
-                        update.region.end,
+                        path,
+                        &reference_region,
                         &edge_to_new_node,
                         &edge_from_new_node,
                     )?;

--- a/src/updates.rs
+++ b/src/updates.rs
@@ -4,8 +4,13 @@ use gen_models::{
     block_group::{BlockGroup, BlockGroupChange},
     block_group_edge::BlockGroupEdge,
     db::GraphConnection,
-    errors::BlockGroupError,
+    edge::Edge,
+    errors::{
+        BlockGroupError, NodeError, PathError, QueryError, QueryError::ResultsNotFound,
+        SampleError, SequenceError,
+    },
     path::Path,
+    path_edge::PathEdge,
     region::{
         GenRegionError, Region, ResolvedGenRegion, ResolvedRegionKind, resolve_accession,
         resolve_annotation, resolve_path,
@@ -154,13 +159,14 @@ pub(crate) struct SequenceUpdate<'a> {
 
 pub(crate) fn prepare_path_update_region(
     conn: &GraphConnection,
-    region: &mut ResolvedGenRegion,
-) -> Result<(), BlockGroupError> {
+    region: &ResolvedGenRegion,
+) -> Result<ResolvedGenRegion, BlockGroupError> {
+    let mut prepared_region = region.clone();
     if region.kind != ResolvedRegionKind::Path
         || region.start <= 0
         || region.end >= region.feature_length
     {
-        return Ok(());
+        return Ok(prepared_region);
     }
     let path = region
         .path
@@ -187,9 +193,9 @@ pub(crate) fn prepare_path_update_region(
     let ends_at_node_boundary =
         region.end - end_block.start + end_block.sequence_start == end_block.sequence_end;
     if !starts_at_node_boundary && !ends_at_node_boundary {
-        return Ok(());
+        return Ok(prepared_region);
     }
-    region.start_anchors = Some(vec![GraphNodePosition {
+    prepared_region.start_anchors = Some(vec![GraphNodePosition {
         graph_node: GraphNode {
             node_id: start_block.node_id,
             sequence_start: start_block.sequence_start,
@@ -197,7 +203,7 @@ pub(crate) fn prepare_path_update_region(
         },
         offset: region.start - start_block.start,
     }]);
-    region.end_anchors = Some(vec![GraphNodePosition {
+    prepared_region.end_anchors = Some(vec![GraphNodePosition {
         graph_node: GraphNode {
             node_id: end_block.node_id,
             sequence_start: end_block.sequence_start,
@@ -205,7 +211,7 @@ pub(crate) fn prepare_path_update_region(
         },
         offset: region.end - end_block.start,
     }]);
-    Ok(())
+    Ok(prepared_region)
 }
 
 fn reference_path_update_edges(
@@ -213,18 +219,18 @@ fn reference_path_update_edges(
     node_id: HashId,
     region: &ResolvedGenRegion,
     path: &Path,
-) -> Result<(gen_models::edge::Edge, gen_models::edge::Edge), gen_models::errors::QueryError> {
-    let incoming_edges = gen_models::edge::Edge::query(
+) -> Result<(Edge, Edge), QueryError> {
+    let incoming_edges = Edge::query(
         conn,
         "select * from edges where target_node_id = ?1",
         rusqlite::params![node_id],
     );
-    let outgoing_edges = gen_models::edge::Edge::query(
+    let outgoing_edges = Edge::query(
         conn,
         "select * from edges where source_node_id = ?1",
         rusqlite::params![node_id],
     );
-    let path_edges = gen_models::path_edge::PathEdge::edges_for_path(conn, &path.id, None);
+    let path_edges = PathEdge::edges_for_path(conn, &path.id, None);
     let incoming_edge = match &region.start_anchors {
         Some(anchors) => path_edges
             .iter()
@@ -245,7 +251,7 @@ fn reference_path_update_edges(
         None => None,
     }
     .ok_or_else(|| {
-        gen_models::errors::QueryError::ResultsNotFound(format!(
+        ResultsNotFound(format!(
             "reference-path edge entering update node {node_id}"
         ))
     })?;
@@ -268,11 +274,7 @@ fn reference_path_update_edges(
         None if outgoing_edges.len() == 1 => outgoing_edges.first(),
         None => None,
     }
-    .ok_or_else(|| {
-        gen_models::errors::QueryError::ResultsNotFound(format!(
-            "reference-path edge leaving update node {node_id}"
-        ))
-    })?;
+    .ok_or_else(|| ResultsNotFound(format!("reference-path edge leaving update node {node_id}")))?;
     Ok((incoming_edge.clone(), outgoing_edge.clone()))
 }
 
@@ -280,10 +282,10 @@ fn update_reference_path(
     conn: &GraphConnection,
     path: &Path,
     region: &ResolvedGenRegion,
-    edge_to_new_node: &gen_models::edge::Edge,
-    edge_from_new_node: &gen_models::edge::Edge,
-) -> Result<(), gen_models::errors::PathError> {
-    let path_edges = gen_models::path_edge::PathEdge::edges_for_path(conn, &path.id, None);
+    edge_to_new_node: &Edge,
+    edge_from_new_node: &Edge,
+) -> Result<(), PathError> {
+    let path_edges = PathEdge::edges_for_path(conn, &path.id, None);
     let boundary_indices = region
         .start_anchors
         .as_ref()
@@ -333,12 +335,12 @@ pub(crate) fn apply_sequence_updates<E>(
     sequences: impl IntoIterator<Item = String>,
 ) -> Result<usize, E>
 where
-    E: From<gen_models::errors::BlockGroupError>
-        + From<gen_models::errors::NodeError>
-        + From<gen_models::errors::PathError>
-        + From<gen_models::errors::QueryError>
-        + From<gen_models::errors::SampleError>
-        + From<gen_models::errors::SequenceError>
+    E: From<BlockGroupError>
+        + From<NodeError>
+        + From<PathError>
+        + From<QueryError>
+        + From<SampleError>
+        + From<SequenceError>
         + From<GenRegionError>,
 {
     Sample::get_or_create_child(
@@ -415,9 +417,9 @@ where
                 path_end: update.region.end,
                 strand: Strand::Forward,
             };
-            let mut target_region =
+            let target_region =
                 target_update_region(conn, update.region, target_block_group.id, path.as_ref())?;
-            prepare_path_update_region(conn, &mut target_region)?;
+            let target_region = prepare_path_update_region(conn, &target_region)?;
             let reference_region = target_region.clone();
             insert_update_change(conn, target_region, InsertChangeData::new(block))?;
 

--- a/src/updates.rs
+++ b/src/updates.rs
@@ -31,7 +31,7 @@ pub(crate) fn adjacent_boundary_points(
     start_points: &[NodePoint],
     end_points: &[NodePoint],
 ) -> (Vec<NodePoint>, Vec<NodePoint>) {
-    let edges = BlockGroupEdge::edges_for_block_group(conn, &block_group_id);
+    let edges = BlockGroupEdge::edges_for_block_group(conn, &block_group_id, None);
     let mut incoming_points = Vec::new();
     let mut outgoing_points = Vec::new();
     for edge in edges {
@@ -224,7 +224,7 @@ fn reference_path_update_edges(
         "select * from edges where source_node_id = ?1",
         rusqlite::params![node_id],
     );
-    let path_edges = gen_models::path_edge::PathEdge::edges_for_path(conn, &path.id);
+    let path_edges = gen_models::path_edge::PathEdge::edges_for_path(conn, &path.id, None);
     let incoming_edge = match &region.start_anchors {
         Some(anchors) => path_edges
             .iter()
@@ -283,7 +283,7 @@ fn update_reference_path(
     edge_to_new_node: &gen_models::edge::Edge,
     edge_from_new_node: &gen_models::edge::Edge,
 ) -> Result<(), gen_models::errors::PathError> {
-    let path_edges = gen_models::path_edge::PathEdge::edges_for_path(conn, &path.id);
+    let path_edges = gen_models::path_edge::PathEdge::edges_for_path(conn, &path.id, None);
     let boundary_indices = region
         .start_anchors
         .as_ref()
@@ -461,7 +461,7 @@ mod tests {
         conn: &GraphConnection,
         block_group_id: HashId,
     ) -> (HashId, HashId, HashId, HashId) {
-        let edges = BlockGroupEdge::edges_for_block_group(conn, &block_group_id);
+        let edges = BlockGroupEdge::edges_for_block_group(conn, &block_group_id, None);
         let a_node_id = edges
             .iter()
             .find(|edge| edge.edge.is_start_edge())

--- a/src/updates/fasta.rs
+++ b/src/updates/fasta.rs
@@ -1,26 +1,14 @@
-use std::str;
-
-use gen_core::{HashId, PathBlock, Strand};
 use gen_models::{
-    block_group::BlockGroup,
     db::DbContext,
-    edge::Edge,
     file_types::FileTypes,
-    node::Node,
     operations::{OperationFile, OperationInfo, OperationSummary},
-    region::{GenRegionError, Region, ResolvedGenRegion, ResolvedRegionKind},
-    sample::Sample,
-    sequence::Sequence,
-    traits::*,
+    region::{GenRegionError, Region},
 };
 use noodles::fasta;
-use rusqlite::{self, types::Value as SQLValue};
 
 use crate::{
     fasta::FastaError,
-    updates::{
-        InsertChangeData, insert_update_change, resolve_update_region, target_update_region,
-    },
+    updates::{SequenceUpdate, apply_sequence_updates, resolve_update_region},
 };
 #[allow(clippy::too_many_arguments)]
 pub fn update_with_fasta(
@@ -36,175 +24,32 @@ pub fn update_with_fasta(
     let parsed_region = Region::parse(region_name).map_err(GenRegionError::from)?;
     let resolved_region =
         resolve_update_region(&parsed_region, conn, collection_name, parent_sample_name)?;
-    let (start_coordinate, end_coordinate) =
-        if parsed_region.start.is_some() || parsed_region.end.is_some() {
-            (resolved_region.start, resolved_region.end)
-        } else {
-            return Err(FastaError::MissingCoordinates(region_name.to_string()));
-        };
+    if parsed_region.start.is_none() && parsed_region.end.is_none() {
+        return Err(FastaError::MissingCoordinates(region_name.to_string()));
+    }
 
     let mut fasta_reader = fasta::io::reader::Builder.build_from_path(fasta_file_path)?;
-
-    let _new_sample = Sample::get_or_create_child(
-        conn,
-        collection_name,
-        new_sample_name,
-        vec![parent_sample_name.to_string()],
-    )?;
-    let block_groups = Sample::get_block_groups(conn, collection_name, parent_sample_name, None);
-
-    let mut target_block_groups = vec![];
-    for block_group in block_groups {
-        let new_block_groups = BlockGroup::get_or_create_sample_block_groups(
-            conn,
-            collection_name,
-            new_sample_name,
-            &block_group.name,
-            vec![parent_sample_name.to_string()],
-        )?;
-
-        if block_group.name == resolved_region.block_group.name {
-            target_block_groups = new_block_groups;
-        }
-    }
-
-    if target_block_groups.is_empty() {
-        return Err(GenRegionError::NotFound(region_name.to_string()).into());
-    }
-
-    struct TargetBlockGroupState {
-        block_group_id: HashId,
-        path: Option<gen_models::path::Path>,
-        first_node: Option<HashId>,
-    }
-
-    let mut target_states = target_block_groups
-        .iter()
-        .map(|target_block_group| -> Result<_, FastaError> {
-            let path = if resolved_region.kind == ResolvedRegionKind::Path {
-                Some(BlockGroup::get_current_path(
-                    conn,
-                    &target_block_group.id,
-                    None,
-                )?)
-            } else {
-                None
-            };
-            Ok(TargetBlockGroupState {
-                block_group_id: target_block_group.id,
-                path,
-                first_node: None,
+    let sequences = fasta_reader
+        .records()
+        .map(|result| {
+            result.map(|record| {
+                str::from_utf8(record.sequence().as_ref())
+                    .unwrap()
+                    .to_string()
             })
         })
         .collect::<Result<Vec<_>, _>>()?;
-
-    let mut change_count = 0;
-
-    for (index, result) in fasta_reader.records().enumerate() {
-        let record = result?;
-        let sequence = str::from_utf8(record.sequence().as_ref()).unwrap();
-
-        for state in &mut target_states {
-            if sequence.is_empty() {
-                let node_id = HashId::convert_str("");
-                let path_block = PathBlock {
-                    node_id,
-                    block_sequence: sequence.to_string(),
-                    sequence_start: 0,
-                    sequence_end: 0,
-                    path_start: start_coordinate,
-                    path_end: end_coordinate,
-                    strand: Strand::Forward,
-                };
-
-                insert_fasta_change(
-                    conn,
-                    &resolved_region,
-                    state.block_group_id,
-                    state.path.as_ref(),
-                    path_block,
-                )?;
-                if index == 0 {
-                    state.first_node = Some(node_id);
-                } else if state.first_node.is_some() {
-                    state.first_node = None;
-                }
-            } else {
-                let seq = Sequence::new()
-                    .sequence_type("DNA")
-                    .sequence(sequence)
-                    .save(conn)?;
-                let node_id = Node::create(
-                    conn,
-                    &seq.hash,
-                    &HashId::convert_str(&format!(
-                        "{block_group_id}:{ref_start}-{ref_end}->{sequence_hash}",
-                        block_group_id = state.block_group_id,
-                        ref_start = 0,
-                        ref_end = seq.length,
-                        sequence_hash = seq.hash
-                    )),
-                )?;
-
-                let path_block = PathBlock {
-                    node_id,
-                    block_sequence: sequence.to_string(),
-                    sequence_start: 0,
-                    sequence_end: seq.length,
-                    path_start: start_coordinate,
-                    path_end: end_coordinate,
-                    strand: Strand::Forward,
-                };
-
-                insert_fasta_change(
-                    conn,
-                    &resolved_region,
-                    state.block_group_id,
-                    state.path.as_ref(),
-                    path_block,
-                )?;
-                if index == 0 {
-                    state.first_node = Some(node_id);
-                } else if state.first_node.is_some() {
-                    state.first_node = None;
-                }
-            }
-            change_count += 1;
-        }
-    }
-
-    for state in target_states {
-        if !disable_reference_path_update
-            && resolved_region.kind == ResolvedRegionKind::Path
-            && let Some(node_id) = state.first_node
-            && let Some(path) = state.path
-        {
-            if node_id == HashId::convert_str("") {
-                let _ = path.new_path_with_deletion(conn, start_coordinate, end_coordinate);
-            } else {
-                let edge_to_new_node = Edge::query(
-                    conn,
-                    "select * from edges where target_node_id = ?1",
-                    rusqlite::params![node_id],
-                )[0]
-                .clone();
-                let edge_from_new_node = Edge::query(
-                    conn,
-                    "select * from edges where source_node_id = ?1",
-                    rusqlite::params!(SQLValue::from(node_id)),
-                )[0]
-                .clone();
-                path.new_path_with(
-                    conn,
-                    start_coordinate,
-                    end_coordinate,
-                    &edge_to_new_node,
-                    &edge_from_new_node,
-                )?;
-            }
-        }
-    }
-
+    let change_count = apply_sequence_updates::<FastaError>(
+        conn,
+        &SequenceUpdate {
+            collection_name,
+            parent_sample_name,
+            new_sample_name,
+            region: &resolved_region,
+            disable_reference_path_update,
+        },
+        sequences,
+    )?;
     let summary_str = format!("{change_count} sequences inserted");
     let operation_summary = OperationSummary::new(
         OperationInfo {
@@ -221,19 +66,6 @@ pub fn update_with_fasta(
     Ok(operation_summary)
 }
 
-fn insert_fasta_change(
-    conn: &gen_models::db::GraphConnection,
-    region: &ResolvedGenRegion,
-    target_block_group_id: HashId,
-    path: Option<&gen_models::path::Path>,
-    block: PathBlock,
-) -> Result<(), FastaError> {
-    let source = target_update_region(conn, region, target_block_group_id, path)?;
-    let data = InsertChangeData::new(block);
-    insert_update_change(conn, source, data)?;
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
     // Note this useful idiom: importing names from outer (for mod tests) scope.
@@ -242,10 +74,14 @@ mod tests {
     use gen_models::{
         annotations::add_annotation,
         assets::{OperationKind, OperationLog},
+        block_group::BlockGroup,
         history::{HistoryStore, dolt::DoltHistoryStore},
         operations::commit_operation_summary,
         path::Path,
+        sample::Sample,
+        traits::Query as _,
     };
+    use rusqlite::types::Value as SQLValue;
     use tempfile::NamedTempFile;
 
     use super::*;

--- a/src/updates/gaf.rs
+++ b/src/updates/gaf.rs
@@ -11,9 +11,9 @@ use csv::Error as CsvError;
 use gen_core::{HashId, PATH_END_NODE_ID, PATH_START_NODE_ID, Strand};
 use gen_models::{
     block_group::BlockGroup,
-    block_group_edge::{BlockGroupEdge, BlockGroupEdgeData},
+    block_group_edge::AugmentedEdgeData,
     db::DbContext,
-    edge::{Edge, EdgeData},
+    edge::EdgeData,
     errors::{NodeError, OperationError, SampleError, SequenceError},
     file_types::FileTypes,
     node::Node,
@@ -26,7 +26,11 @@ use regex::Regex;
 use rusqlite::{params, types::Value};
 use thiserror::Error;
 
-use crate::{graphs::NodePoint, read_lines, updates::adjacent_boundary_points};
+use crate::{
+    graphs::NodePoint,
+    read_lines,
+    updates::{adjacent_boundary_points, create_block_group_edges},
+};
 
 #[derive(Debug, serde::Deserialize)]
 struct CSVRow {
@@ -421,17 +425,15 @@ where
                     left_anchor.as_ref(),
                     right_anchor.as_ref(),
                 );
-                let edge_ids = Edge::bulk_create(conn, &new_edges);
-                let new_block_group_edges = edge_ids
+                let augmented_edges = new_edges
                     .iter()
-                    .map(|edge_id| BlockGroupEdgeData {
-                        block_group_id: bg.id,
-                        edge_id: *edge_id,
+                    .map(|edge_data| AugmentedEdgeData {
+                        edge_data: *edge_data,
                         chromosome_index: 0,
                         phased: 0,
                     })
                     .collect::<Vec<_>>();
-                BlockGroupEdge::bulk_create(conn, &new_block_group_edges);
+                create_block_group_edges(conn, bg.id, &augmented_edges);
             }
         }
     }
@@ -453,7 +455,11 @@ mod tests {
     use std::path::PathBuf;
 
     use gen_graph::{GraphEdge, GraphNode};
-    use gen_models::traits::Query;
+    use gen_models::{
+        block_group_edge::{BlockGroupEdge, BlockGroupEdgeData},
+        edge::Edge,
+        traits::Query,
+    };
     use petgraph::Direction;
 
     use super::*;

--- a/src/updates/gaf.rs
+++ b/src/updates/gaf.rs
@@ -26,7 +26,7 @@ use regex::Regex;
 use rusqlite::{params, types::Value};
 use thiserror::Error;
 
-use crate::read_lines;
+use crate::{graphs::NodePoint, read_lines, updates::adjacent_boundary_points};
 
 #[derive(Debug, serde::Deserialize)]
 struct CSVRow {
@@ -37,6 +37,58 @@ struct CSVRow {
 }
 
 const GEN_PREFIX: &str = "_gen_";
+
+fn plan_gaf_change_edges(
+    conn: &gen_models::db::GraphConnection,
+    block_group_id: HashId,
+    sequence_node_id: HashId,
+    sequence_length: i64,
+    left_anchor: Option<&NodePoint>,
+    right_anchor: Option<&NodePoint>,
+) -> Vec<EdgeData> {
+    let source = left_anchor.cloned().unwrap_or(NodePoint {
+        id: PATH_START_NODE_ID,
+        coordinate: 0,
+        strand: Strand::Forward,
+    });
+    let target = right_anchor.cloned().unwrap_or(NodePoint {
+        id: PATH_END_NODE_ID,
+        coordinate: 0,
+        strand: Strand::Forward,
+    });
+
+    let mut sources = vec![source];
+    let mut targets = vec![target];
+    let (incoming_points, outgoing_points) = adjacent_boundary_points(
+        conn,
+        block_group_id,
+        left_anchor.map(core::slice::from_ref).unwrap_or_default(),
+        right_anchor.map(core::slice::from_ref).unwrap_or_default(),
+    );
+    sources.extend(incoming_points);
+    targets.extend(outgoing_points);
+
+    let mut planned_edges = sources
+        .into_iter()
+        .map(|source| EdgeData {
+            source_node_id: source.id,
+            source_coordinate: source.coordinate,
+            source_strand: source.strand,
+            target_node_id: sequence_node_id,
+            target_coordinate: 0,
+            target_strand: Strand::Forward,
+        })
+        .collect::<Vec<_>>();
+    planned_edges.extend(targets.into_iter().map(|target| EdgeData {
+        source_node_id: sequence_node_id,
+        source_coordinate: sequence_length,
+        source_strand: Strand::Forward,
+        target_node_id: target.id,
+        target_coordinate: target.coordinate,
+        target_strand: target.strand,
+    }));
+    planned_edges
+}
 
 #[derive(Debug, Error)]
 pub enum GafUpdateError {
@@ -307,84 +359,69 @@ where
                 )),
             )?;
 
-            let mut new_edges = vec![];
             let mut bg_nodes = vec![];
-
-            if change.left.is_empty() && change.right.is_empty() {
+            let (left_anchor, right_anchor) = if change.left.is_empty() && change.right.is_empty() {
                 panic!("Invalid change specification");
             } else if change.left.is_empty() {
                 // we are inserting at the far left side, so our right node mapping is actually
                 // where we want to be
                 let (node, strand, pos) = path_changes["right"];
                 bg_nodes.push(Value::from(node));
-                new_edges.push(EdgeData {
-                    source_node_id: PATH_START_NODE_ID,
-                    source_coordinate: 0,
-                    source_strand: Strand::Forward,
-                    target_node_id: seq_node,
-                    target_coordinate: 0,
-                    target_strand: Strand::Forward,
-                });
-                new_edges.push(EdgeData {
-                    source_node_id: seq_node,
-                    source_coordinate: sequence.length,
-                    source_strand: Strand::Forward,
-                    target_node_id: node,
-                    target_coordinate: pos,
-                    target_strand: strand,
-                });
+                (
+                    None,
+                    Some(NodePoint {
+                        id: node,
+                        coordinate: pos,
+                        strand,
+                    }),
+                )
             } else if change.right.is_empty() {
                 // we are inserting at the far right side
                 let (node, strand, pos) = path_changes["left"];
                 bg_nodes.push(Value::from(node));
-                new_edges.push(EdgeData {
-                    source_node_id: node,
-                    source_coordinate: pos,
-                    source_strand: strand,
-                    target_node_id: seq_node,
-                    target_coordinate: 0,
-                    target_strand: Strand::Forward,
-                });
-                new_edges.push(EdgeData {
-                    source_node_id: seq_node,
-                    source_coordinate: sequence.length,
-                    source_strand: Strand::Forward,
-                    target_node_id: PATH_END_NODE_ID,
-                    target_coordinate: 0,
-                    target_strand: Strand::Forward,
-                });
+                (
+                    Some(NodePoint {
+                        id: node,
+                        coordinate: pos,
+                        strand,
+                    }),
+                    None,
+                )
             } else {
                 // normal insert
-                let (node, strand, pos) = path_changes["left"];
-                bg_nodes.push(Value::from(node));
-                new_edges.push(EdgeData {
-                    source_node_id: node,
-                    source_coordinate: pos,
-                    source_strand: strand,
-                    target_node_id: seq_node,
-                    target_coordinate: 0,
-                    target_strand: Strand::Forward,
-                });
+                let (left_node, left_strand, left_pos) = path_changes["left"];
+                bg_nodes.push(Value::from(left_node));
+                let (right_node, right_strand, right_pos) = path_changes["right"];
+                bg_nodes.push(Value::from(right_node));
+                (
+                    Some(NodePoint {
+                        id: left_node,
+                        coordinate: left_pos,
+                        strand: left_strand,
+                    }),
+                    Some(NodePoint {
+                        id: right_node,
+                        coordinate: right_pos,
+                        strand: right_strand,
+                    }),
+                )
+            };
 
-                let (node, strand, pos) = path_changes["right"];
-                bg_nodes.push(Value::from(node));
-                new_edges.push(EdgeData {
-                    source_node_id: seq_node,
-                    source_coordinate: sequence.length,
-                    source_strand: Strand::Forward,
-                    target_node_id: node,
-                    target_coordinate: pos,
-                    target_strand: strand,
-                });
-            }
-
-            let edge_ids = Edge::bulk_create(conn, &new_edges);
             let bgs = BlockGroup::query(
                 conn,
                 "select distinct bg.* from block_groups bg left join block_group_edges bge on (bg.id = bge.block_group_id) left join edges e on (e.id = bge.edge_id and (e.source_node_id in rarray(?3) or e.target_node_id in rarray(?3))) where collection_name = ?1 and sample_name = ?2",
                 params!(collection_name.to_string(), sample_name, Rc::new(bg_nodes)),
             );
             for bg in bgs.iter() {
+                let new_edges = plan_gaf_change_edges(
+                    conn,
+                    bg.id,
+                    seq_node,
+                    sequence.length,
+                    left_anchor.as_ref(),
+                    right_anchor.as_ref(),
+                );
+                let edge_ids = Edge::bulk_create(conn, &new_edges);
                 let new_block_group_edges = edge_ids
                     .iter()
                     .map(|edge_id| BlockGroupEdgeData {
@@ -420,7 +457,140 @@ mod tests {
     use petgraph::Direction;
 
     use super::*;
-    use crate::{imports::gfa::import_gfa, test_helpers::setup_gen};
+    use crate::{
+        imports::gfa::import_gfa,
+        test_helpers::{get_connection, setup_block_group, setup_gen},
+    };
+
+    fn gaf_test_node_ids(
+        conn: &gen_models::db::GraphConnection,
+        block_group_id: HashId,
+    ) -> (HashId, HashId, HashId, HashId) {
+        let edges = BlockGroupEdge::edges_for_block_group(conn, &block_group_id);
+        let a_node_id = edges
+            .iter()
+            .find(|edge| edge.edge.source_node_id == PATH_START_NODE_ID)
+            .unwrap()
+            .edge
+            .target_node_id;
+        let t_node_id = edges
+            .iter()
+            .find(|edge| edge.edge.source_node_id == a_node_id)
+            .unwrap()
+            .edge
+            .target_node_id;
+        let c_node_id = edges
+            .iter()
+            .find(|edge| edge.edge.source_node_id == t_node_id)
+            .unwrap()
+            .edge
+            .target_node_id;
+        let g_node_id = edges
+            .iter()
+            .find(|edge| edge.edge.source_node_id == c_node_id)
+            .unwrap()
+            .edge
+            .target_node_id;
+        (a_node_id, t_node_id, c_node_id, g_node_id)
+    }
+
+    #[test]
+    fn test_gaf_change_preserves_incoming_edges_at_start_boundary() {
+        let conn = get_connection(None).unwrap();
+        let (block_group_id, _) = setup_block_group(&conn);
+        let (a_node_id, t_node_id, _, g_node_id) = gaf_test_node_ids(&conn, block_group_id);
+        let sequence_node_id = HashId::convert_str("insert-node");
+        let branch_edge = Edge::create(
+            &conn,
+            g_node_id,
+            10,
+            Strand::Forward,
+            t_node_id,
+            0,
+            Strand::Forward,
+        )
+        .unwrap();
+        BlockGroupEdge::bulk_create(
+            &conn,
+            &[BlockGroupEdgeData {
+                block_group_id,
+                edge_id: branch_edge.id,
+                chromosome_index: 0,
+                phased: 0,
+            }],
+        );
+
+        let edges = plan_gaf_change_edges(
+            &conn,
+            block_group_id,
+            sequence_node_id,
+            2,
+            Some(&NodePoint {
+                id: t_node_id,
+                coordinate: 0,
+                strand: Strand::Forward,
+            }),
+            None,
+        );
+
+        for source_node_id in [a_node_id, g_node_id] {
+            assert!(
+                edges.iter().any(|edge| {
+                    edge.source_node_id == source_node_id && edge.target_node_id == sequence_node_id
+                }),
+                "GAF update should retain incoming route from {source_node_id}",
+            );
+        }
+    }
+
+    #[test]
+    fn test_gaf_change_preserves_outgoing_edges_at_end_boundary() {
+        let conn = get_connection(None).unwrap();
+        let (block_group_id, _) = setup_block_group(&conn);
+        let (_, t_node_id, c_node_id, g_node_id) = gaf_test_node_ids(&conn, block_group_id);
+        let sequence_node_id = HashId::convert_str("insert-node");
+        let branch_edge = Edge::create(
+            &conn,
+            t_node_id,
+            10,
+            Strand::Forward,
+            g_node_id,
+            0,
+            Strand::Forward,
+        )
+        .unwrap();
+        BlockGroupEdge::bulk_create(
+            &conn,
+            &[BlockGroupEdgeData {
+                block_group_id,
+                edge_id: branch_edge.id,
+                chromosome_index: 0,
+                phased: 0,
+            }],
+        );
+
+        let edges = plan_gaf_change_edges(
+            &conn,
+            block_group_id,
+            sequence_node_id,
+            2,
+            None,
+            Some(&NodePoint {
+                id: t_node_id,
+                coordinate: 10,
+                strand: Strand::Forward,
+            }),
+        );
+
+        for target_node_id in [c_node_id, g_node_id] {
+            assert!(
+                edges.iter().any(|edge| {
+                    edge.source_node_id == sequence_node_id && edge.target_node_id == target_node_id
+                }),
+                "GAF update should retain outgoing route to {target_node_id}",
+            );
+        }
+    }
 
     mod test_transform {
         use super::*;

--- a/src/updates/gaf.rs
+++ b/src/updates/gaf.rs
@@ -459,14 +459,14 @@ mod tests {
     use super::*;
     use crate::{
         imports::gfa::import_gfa,
-        test_helpers::{get_connection, setup_block_group, setup_gen},
+        test_helpers::{setup_block_group, setup_gen},
     };
 
     fn gaf_test_node_ids(
         conn: &gen_models::db::GraphConnection,
         block_group_id: HashId,
     ) -> (HashId, HashId, HashId, HashId) {
-        let edges = BlockGroupEdge::edges_for_block_group(conn, &block_group_id);
+        let edges = BlockGroupEdge::edges_for_block_group(conn, &block_group_id, None);
         let a_node_id = edges
             .iter()
             .find(|edge| edge.edge.source_node_id == PATH_START_NODE_ID)
@@ -494,24 +494,23 @@ mod tests {
         (a_node_id, t_node_id, c_node_id, g_node_id)
     }
 
-    #[test]
-    fn test_gaf_change_preserves_incoming_edges_at_start_boundary() {
-        let conn = get_connection(None).unwrap();
-        let (block_group_id, _) = setup_block_group(&conn);
-        let (a_node_id, t_node_id, _, g_node_id) = gaf_test_node_ids(&conn, block_group_id);
-        let sequence_node_id = HashId::convert_str("insert-node");
+    fn run_gaf_boundary_update(incoming: bool) -> (DbContext, HashId, HashId, [HashId; 2]) {
+        let context = setup_gen();
+        let conn = context.graph().conn();
+        let (block_group_id, _) = setup_block_group(conn);
+        let (_, t_node_id, c_node_id, g_node_id) = gaf_test_node_ids(conn, block_group_id);
         let branch_edge = Edge::create(
-            &conn,
-            g_node_id,
+            conn,
+            t_node_id,
             10,
             Strand::Forward,
-            t_node_id,
+            g_node_id,
             0,
             Strand::Forward,
         )
         .unwrap();
         BlockGroupEdge::bulk_create(
-            &conn,
+            conn,
             &[BlockGroupEdgeData {
                 block_group_id,
                 edge_id: branch_edge.id,
@@ -520,75 +519,73 @@ mod tests {
             }],
         );
 
-        let edges = plan_gaf_change_edges(
-            &conn,
-            block_group_id,
-            sequence_node_id,
-            2,
-            Some(&NodePoint {
-                id: t_node_id,
-                coordinate: 0,
-                strand: Strand::Forward,
-            }),
-            None,
-        );
+        let (anchor_node_id, left_coordinate, right_coordinate, adjacent_node_ids) = if incoming {
+            (g_node_id, 0, 2, [c_node_id, t_node_id])
+        } else {
+            (t_node_id, 8, 10, [c_node_id, g_node_id])
+        };
+        let mut csv_file = tempfile::NamedTempFile::new().unwrap();
+        writeln!(csv_file, "id,left,sequence,right\nchange,A,NN,C").unwrap();
+        let mut gaf_file = tempfile::NamedTempFile::new().unwrap();
+        writeln!(
+            gaf_file,
+            "change_left\t1\t0\t1\t+\t>{anchor_node_id}\t10\t{left_coordinate}\t{left_coordinate}\t{left_coordinate}\t1\t60\ttp:A:P\tcg:Z:1M"
+        )
+        .unwrap();
+        writeln!(
+            gaf_file,
+            "change_right\t1\t0\t1\t+\t>{anchor_node_id}\t10\t{right_coordinate}\t{right_coordinate}\t1\t1\t60\ttp:A:P\tcg:Z:1M"
+        )
+        .unwrap();
+        update_with_gaf(
+            &context,
+            gaf_file.path(),
+            csv_file.path(),
+            "test",
+            "updated",
+            Some("test"),
+        )
+        .unwrap();
 
-        for source_node_id in [a_node_id, g_node_id] {
-            assert!(
-                edges.iter().any(|edge| {
-                    edge.source_node_id == source_node_id && edge.target_node_id == sequence_node_id
-                }),
-                "GAF update should retain incoming route from {source_node_id}",
-            );
+        let updated_block_group = crate::test_helpers::get_sample_bg(conn, "test", "updated");
+        let new_node_id = Node::query(
+            conn,
+            "select n.* from nodes n left join sequences s on n.sequence_hash = s.hash where s.sequence = ?1",
+            params!["NN"],
+        )[0]
+        .id;
+        (
+            context,
+            updated_block_group.id,
+            new_node_id,
+            adjacent_node_ids,
+        )
+    }
+
+    #[test]
+    fn test_update_with_gaf_preserves_all_incoming_edges_at_node_start() {
+        let (context, block_group_id, new_node_id, source_node_ids) = run_gaf_boundary_update(true);
+        let edges =
+            BlockGroupEdge::edges_for_block_group(context.graph().conn(), &block_group_id, None);
+        for source_node_id in source_node_ids {
+            assert!(edges.iter().any(|edge| {
+                edge.edge.source_node_id == source_node_id
+                    && edge.edge.target_node_id == new_node_id
+            }));
         }
     }
 
     #[test]
-    fn test_gaf_change_preserves_outgoing_edges_at_end_boundary() {
-        let conn = get_connection(None).unwrap();
-        let (block_group_id, _) = setup_block_group(&conn);
-        let (_, t_node_id, c_node_id, g_node_id) = gaf_test_node_ids(&conn, block_group_id);
-        let sequence_node_id = HashId::convert_str("insert-node");
-        let branch_edge = Edge::create(
-            &conn,
-            t_node_id,
-            10,
-            Strand::Forward,
-            g_node_id,
-            0,
-            Strand::Forward,
-        )
-        .unwrap();
-        BlockGroupEdge::bulk_create(
-            &conn,
-            &[BlockGroupEdgeData {
-                block_group_id,
-                edge_id: branch_edge.id,
-                chromosome_index: 0,
-                phased: 0,
-            }],
-        );
-
-        let edges = plan_gaf_change_edges(
-            &conn,
-            block_group_id,
-            sequence_node_id,
-            2,
-            None,
-            Some(&NodePoint {
-                id: t_node_id,
-                coordinate: 10,
-                strand: Strand::Forward,
-            }),
-        );
-
-        for target_node_id in [c_node_id, g_node_id] {
-            assert!(
-                edges.iter().any(|edge| {
-                    edge.source_node_id == sequence_node_id && edge.target_node_id == target_node_id
-                }),
-                "GAF update should retain outgoing route to {target_node_id}",
-            );
+    fn test_update_with_gaf_preserves_all_outgoing_edges_at_node_end() {
+        let (context, block_group_id, new_node_id, target_node_ids) =
+            run_gaf_boundary_update(false);
+        let edges =
+            BlockGroupEdge::edges_for_block_group(context.graph().conn(), &block_group_id, None);
+        for target_node_id in target_node_ids {
+            assert!(edges.iter().any(|edge| {
+                edge.edge.source_node_id == new_node_id
+                    && edge.edge.target_node_id == target_node_id
+            }));
         }
     }
 

--- a/src/updates/genbank.rs
+++ b/src/updates/genbank.rs
@@ -3,7 +3,7 @@ use std::{io::Read, str};
 use gb_io::reader;
 use gen_core::{HashId, PATH_END_NODE_ID, PATH_START_NODE_ID, PathBlock, Strand};
 use gen_models::{
-    block_group::{BlockGroup, BlockGroupChange, NewBlockGroup},
+    block_group::{BlockGroup, NewBlockGroup},
     block_group_edge::{BlockGroupEdge, BlockGroupEdgeData},
     collection::Collection,
     db::DbContext,
@@ -21,7 +21,7 @@ use rusqlite::{params, types::Value};
 
 use crate::{
     genbank::{EditType, GenBankError, process_sequence},
-    updates::prepare_path_update_region,
+    updates::{InsertChangeData, apply_update_change},
 };
 
 pub fn update_with_genbank<'a, R>(
@@ -164,8 +164,7 @@ where
                     let end = edit.end;
                     let region =
                         ResolvedGenRegion::from_path(conn, block_group.id, &path, start, end)?;
-                    let region = prepare_path_update_region(conn, &region)?;
-                    let change = match edit.edit_type {
+                    let data = match edit.edit_type {
                         EditType::Insertion | EditType::Replacement => {
                             let change_seq = Sequence::new()
                                 .sequence(&edit.new_sequence)
@@ -184,8 +183,7 @@ where
                                     new_hash = change_seq.hash,
                                 )),
                             )?;
-                            BlockGroupChange {
-                                region: region.clone(),
+                            InsertChangeData {
                                 path_accession: None,
                                 block: PathBlock {
                                     node_id: change_node,
@@ -201,8 +199,7 @@ where
                                 preserve_edge: true,
                             }
                         }
-                        EditType::Deletion => BlockGroupChange {
-                            region,
+                        EditType::Deletion => InsertChangeData {
                             path_accession: None,
                             block: PathBlock {
                                 node_id: wt_node_id,
@@ -218,7 +215,7 @@ where
                             preserve_edge: true,
                         },
                     };
-                    BlockGroup::insert_change(conn, &change).unwrap();
+                    apply_update_change(conn, &region, data, false)?;
                 }
             }
             Err(e) => return Err(GenBankError::ParseError(format!("Failed to parse {e}"))),

--- a/src/updates/genbank.rs
+++ b/src/updates/genbank.rs
@@ -19,7 +19,10 @@ use gen_models::{
 use itertools::Itertools;
 use rusqlite::{params, types::Value};
 
-use crate::genbank::{EditType, GenBankError, process_sequence};
+use crate::{
+    genbank::{EditType, GenBankError, process_sequence},
+    updates::prepare_path_update_region,
+};
 
 pub fn update_with_genbank<'a, R>(
     context: &DbContext,
@@ -159,8 +162,9 @@ where
                 for edit in locus.changes_to_wt() {
                     let start = edit.start;
                     let end = edit.end;
-                    let region =
+                    let mut region =
                         ResolvedGenRegion::from_path(conn, block_group.id, &path, start, end)?;
+                    prepare_path_update_region(conn, &mut region)?;
                     let change = match edit.edit_type {
                         EditType::Insertion | EditType::Replacement => {
                             let change_seq = Sequence::new()

--- a/src/updates/genbank.rs
+++ b/src/updates/genbank.rs
@@ -162,9 +162,9 @@ where
                 for edit in locus.changes_to_wt() {
                     let start = edit.start;
                     let end = edit.end;
-                    let mut region =
+                    let region =
                         ResolvedGenRegion::from_path(conn, block_group.id, &path, start, end)?;
-                    prepare_path_update_region(conn, &mut region)?;
+                    let region = prepare_path_update_region(conn, &region)?;
                     let change = match edit.edit_type {
                         EditType::Insertion | EditType::Replacement => {
                             let change_seq = Sequence::new()

--- a/src/updates/gfa.rs
+++ b/src/updates/gfa.rs
@@ -21,7 +21,67 @@ use crate::{
     errors::SequenceUpdateError,
     gfa::bool_to_strand,
     gfa_reader::{Gfa, Segment},
+    graphs::NodePoint,
+    updates::adjacent_boundary_points,
 };
+
+fn plan_gfa_boundary_edges(
+    conn: &GraphConnection,
+    block_group_id: HashId,
+    source: &NodePoint,
+    target: &NodePoint,
+) -> Vec<EdgeData> {
+    let (incoming_points, outgoing_points) = adjacent_boundary_points(
+        conn,
+        block_group_id,
+        core::slice::from_ref(source),
+        core::slice::from_ref(target),
+    );
+    let mut edges = vec![gfa_edge(source, target)];
+    edges.extend(incoming_points.into_iter().map(|incoming| EdgeData {
+        source_node_id: incoming.id,
+        source_coordinate: incoming.coordinate,
+        source_strand: incoming.strand,
+        ..gfa_edge(source, target)
+    }));
+    edges.extend(outgoing_points.into_iter().map(|outgoing| EdgeData {
+        target_node_id: outgoing.id,
+        target_coordinate: outgoing.coordinate,
+        target_strand: outgoing.strand,
+        ..gfa_edge(source, target)
+    }));
+    edges
+}
+
+fn gfa_edge(source: &NodePoint, target: &NodePoint) -> EdgeData {
+    EdgeData {
+        source_node_id: source.id,
+        source_coordinate: source.coordinate,
+        source_strand: source.strand,
+        target_node_id: target.id,
+        target_coordinate: target.coordinate,
+        target_strand: target.strand,
+    }
+}
+
+fn add_gfa_boundary_edges(
+    path_edges: &mut Vec<AugmentedEdgeData>,
+    boundary_edges: &mut Vec<AugmentedEdgeData>,
+    planned_edges: Vec<EdgeData>,
+) {
+    for (index, edge_data) in planned_edges.into_iter().enumerate() {
+        let edge = AugmentedEdgeData {
+            edge_data,
+            chromosome_index: 1,
+            phased: 0,
+        };
+        if index == 0 {
+            path_edges.push(edge);
+        } else {
+            boundary_edges.push(edge);
+        }
+    }
+}
 
 #[cfg_attr(
     all(debug_assertions, feature = "profiling"),
@@ -240,6 +300,7 @@ fn create_new_path_from_existing(
     gfa: &Gfa<String, (), ()>,
     segments_by_id: &HashMap<String, &Segment<String, ()>>,
 ) -> Result<(), SequenceUpdateError> {
+    let block_group_id = existing_path.block_group_id;
     let interval_tree = existing_path.intervaltree(conn)?;
     let mut existing_path_ranges_by_segment_id = HashMap::new();
     let mut existing_path_position = 0;
@@ -266,7 +327,9 @@ fn create_new_path_from_existing(
     let mut previous_node_id = PATH_START_NODE_ID;
     let mut previous_node_coordinate = -1;
     let mut previous_node_strand = Strand::Forward;
+    let mut previous_node_is_new = false;
     let mut new_path_edges = vec![];
+    let mut boundary_edges = vec![];
     let mut healing_edges = vec![];
     for (i, segment_id) in unmatched_path_segment_ids.iter().enumerate() {
         if let Some((path_start, path_end)) = existing_path_ranges_by_segment_id.get(segment_id) {
@@ -296,18 +359,29 @@ fn create_new_path_from_existing(
             // NOTE: We're assuming that if the previous segment was on the same node ID as the
             // block with the start coordinate, they are contiguous, so no new edge is needed
             if previous_node_id != block_with_start.node_id {
-                new_path_edges.push(AugmentedEdgeData {
-                    edge_data: EdgeData {
-                        source_node_id: previous_node_id,
-                        source_coordinate: previous_node_coordinate,
-                        source_strand: previous_node_strand,
-                        target_node_id: block_with_start.node_id,
-                        target_coordinate,
-                        target_strand: block_with_start.strand,
-                    },
-                    chromosome_index: 1,
-                    phased: 0,
-                });
+                let source = NodePoint {
+                    id: previous_node_id,
+                    coordinate: previous_node_coordinate,
+                    strand: previous_node_strand,
+                };
+                let target = NodePoint {
+                    id: block_with_start.node_id,
+                    coordinate: target_coordinate,
+                    strand: block_with_start.strand,
+                };
+                if previous_node_is_new {
+                    add_gfa_boundary_edges(
+                        &mut new_path_edges,
+                        &mut boundary_edges,
+                        plan_gfa_boundary_edges(conn, block_group_id, &source, &target),
+                    );
+                } else {
+                    add_gfa_boundary_edges(
+                        &mut new_path_edges,
+                        &mut boundary_edges,
+                        vec![gfa_edge(&source, &target)],
+                    );
+                }
 
                 // Create the boundary edges that will be interrupted by the new path
                 if !is_terminal(block_with_start.node_id) && *path_start > 0 {
@@ -345,6 +419,7 @@ fn create_new_path_from_existing(
             previous_node_coordinate =
                 block_with_end.sequence_start + existing_path_position - block_with_end.start;
             previous_node_strand = block_with_end.strand;
+            previous_node_is_new = false;
         } else {
             // Current segment is new.  Create a sequence and node for it, then add an edge to the
             // new node
@@ -371,18 +446,24 @@ fn create_new_path_from_existing(
                         index: i,
                     }
                 })?);
-            new_path_edges.push(AugmentedEdgeData {
-                edge_data: EdgeData {
-                    source_node_id: previous_node_id,
-                    source_coordinate: previous_node_coordinate,
-                    source_strand: previous_node_strand,
-                    target_node_id: node_id,
-                    target_coordinate: 0,
-                    target_strand: next_node_strand,
-                },
-                chromosome_index: 1,
-                phased: 0,
-            });
+            add_gfa_boundary_edges(
+                &mut new_path_edges,
+                &mut boundary_edges,
+                plan_gfa_boundary_edges(
+                    conn,
+                    block_group_id,
+                    &NodePoint {
+                        id: previous_node_id,
+                        coordinate: previous_node_coordinate,
+                        strand: previous_node_strand,
+                    },
+                    &NodePoint {
+                        id: node_id,
+                        coordinate: 0,
+                        strand: next_node_strand,
+                    },
+                ),
+            );
             healing_edges.push(AugmentedEdgeData {
                 edge_data: EdgeData {
                     source_node_id: previous_node_id,
@@ -398,6 +479,7 @@ fn create_new_path_from_existing(
             previous_node_id = node_id;
             previous_node_coordinate = segment_sequence.len() as i64;
             previous_node_strand = next_node_strand;
+            previous_node_is_new = true;
         }
     }
 
@@ -426,18 +508,24 @@ fn create_new_path_from_existing(
             phased: 0,
         });
     } else {
-        new_path_edges.push(AugmentedEdgeData {
-            edge_data: EdgeData {
-                source_node_id: previous_node_id,
-                source_coordinate: previous_node_coordinate,
-                source_strand: previous_node_strand,
-                target_node_id: PATH_END_NODE_ID,
-                target_coordinate: 0,
-                target_strand: Strand::Forward,
-            },
-            chromosome_index: 1,
-            phased: 0,
-        });
+        add_gfa_boundary_edges(
+            &mut new_path_edges,
+            &mut boundary_edges,
+            plan_gfa_boundary_edges(
+                conn,
+                block_group_id,
+                &NodePoint {
+                    id: previous_node_id,
+                    coordinate: previous_node_coordinate,
+                    strand: previous_node_strand,
+                },
+                &NodePoint {
+                    id: PATH_END_NODE_ID,
+                    coordinate: 0,
+                    strand: Strand::Forward,
+                },
+            ),
+        );
         healing_edges.push(AugmentedEdgeData {
             edge_data: EdgeData {
                 source_node_id: previous_node_id,
@@ -452,7 +540,6 @@ fn create_new_path_from_existing(
         });
     }
 
-    let block_group_id = existing_path.block_group_id;
     let new_edge_ids = Edge::bulk_create(
         conn,
         &new_path_edges
@@ -467,8 +554,15 @@ fn create_new_path_from_existing(
             .map(|edge| edge.edge_data)
             .collect::<Vec<EdgeData>>(),
     );
-    let all_edges = [new_path_edges, healing_edges].concat();
-    let all_edge_ids = [new_edge_ids.clone(), healing_edge_ids].concat();
+    let boundary_edge_ids = Edge::bulk_create(
+        conn,
+        &boundary_edges
+            .iter()
+            .map(|edge| edge.edge_data)
+            .collect::<Vec<EdgeData>>(),
+    );
+    let all_edges = [new_path_edges, healing_edges, boundary_edges].concat();
+    let all_edge_ids = [new_edge_ids.clone(), healing_edge_ids, boundary_edge_ids].concat();
     let block_group_edges = all_edge_ids
         .iter()
         .enumerate()
@@ -494,7 +588,142 @@ mod tests {
     use rusqlite::types::Value as SQLValue;
 
     use super::*;
-    use crate::{imports::fasta::import_fasta, test_helpers::setup_gen};
+    use crate::{
+        imports::fasta::import_fasta,
+        test_helpers::{get_connection, setup_block_group, setup_gen},
+    };
+
+    fn gfa_test_node_ids(
+        conn: &GraphConnection,
+        block_group_id: HashId,
+    ) -> (HashId, HashId, HashId, HashId) {
+        let edges = BlockGroupEdge::edges_for_block_group(conn, &block_group_id);
+        let a_node_id = edges
+            .iter()
+            .find(|edge| edge.edge.source_node_id == PATH_START_NODE_ID)
+            .unwrap()
+            .edge
+            .target_node_id;
+        let t_node_id = edges
+            .iter()
+            .find(|edge| edge.edge.source_node_id == a_node_id)
+            .unwrap()
+            .edge
+            .target_node_id;
+        let c_node_id = edges
+            .iter()
+            .find(|edge| edge.edge.source_node_id == t_node_id)
+            .unwrap()
+            .edge
+            .target_node_id;
+        let g_node_id = edges
+            .iter()
+            .find(|edge| edge.edge.source_node_id == c_node_id)
+            .unwrap()
+            .edge
+            .target_node_id;
+        (a_node_id, t_node_id, c_node_id, g_node_id)
+    }
+
+    #[test]
+    fn test_gfa_change_preserves_incoming_edges_at_start_boundary() {
+        let conn = get_connection(None).unwrap();
+        let (block_group_id, _) = setup_block_group(&conn);
+        let (a_node_id, t_node_id, _, g_node_id) = gfa_test_node_ids(&conn, block_group_id);
+        let branch_edge = Edge::create(
+            &conn,
+            g_node_id,
+            10,
+            Strand::Forward,
+            t_node_id,
+            0,
+            Strand::Forward,
+        )
+        .unwrap();
+        BlockGroupEdge::bulk_create(
+            &conn,
+            &[BlockGroupEdgeData {
+                block_group_id,
+                edge_id: branch_edge.id,
+                chromosome_index: 0,
+                phased: 0,
+            }],
+        );
+        let new_node_id = HashId::convert_str("gfa-new-node");
+        let edges = plan_gfa_boundary_edges(
+            &conn,
+            block_group_id,
+            &NodePoint {
+                id: t_node_id,
+                coordinate: 0,
+                strand: Strand::Forward,
+            },
+            &NodePoint {
+                id: new_node_id,
+                coordinate: 0,
+                strand: Strand::Forward,
+            },
+        );
+
+        for source_node_id in [a_node_id, g_node_id] {
+            assert!(
+                edges.iter().any(|edge| {
+                    edge.source_node_id == source_node_id && edge.target_node_id == new_node_id
+                }),
+                "GFA update should retain incoming route from {source_node_id}",
+            );
+        }
+    }
+
+    #[test]
+    fn test_gfa_change_preserves_outgoing_edges_at_end_boundary() {
+        let conn = get_connection(None).unwrap();
+        let (block_group_id, _) = setup_block_group(&conn);
+        let (_, t_node_id, c_node_id, g_node_id) = gfa_test_node_ids(&conn, block_group_id);
+        let branch_edge = Edge::create(
+            &conn,
+            t_node_id,
+            10,
+            Strand::Forward,
+            g_node_id,
+            0,
+            Strand::Forward,
+        )
+        .unwrap();
+        BlockGroupEdge::bulk_create(
+            &conn,
+            &[BlockGroupEdgeData {
+                block_group_id,
+                edge_id: branch_edge.id,
+                chromosome_index: 0,
+                phased: 0,
+            }],
+        );
+        let new_node_id = HashId::convert_str("gfa-new-node");
+        let edges = plan_gfa_boundary_edges(
+            &conn,
+            block_group_id,
+            &NodePoint {
+                id: new_node_id,
+                coordinate: 2,
+                strand: Strand::Forward,
+            },
+            &NodePoint {
+                id: t_node_id,
+                coordinate: 10,
+                strand: Strand::Forward,
+            },
+        );
+
+        for target_node_id in [c_node_id, g_node_id] {
+            assert!(
+                edges.iter().any(|edge| {
+                    edge.source_node_id == new_node_id && edge.target_node_id == target_node_id
+                }),
+                "GFA update should retain outgoing route to {target_node_id}",
+            );
+        }
+    }
 
     #[test]
     fn test_basic_update() {

--- a/src/updates/gfa.rs
+++ b/src/updates/gfa.rs
@@ -582,10 +582,11 @@ fn create_new_path_from_existing(
 #[cfg(test)]
 mod tests {
     // Note this useful idiom: importing names from outer (for mod tests) scope.
-    use std::path::PathBuf;
+    use std::{io::Write as _, path::PathBuf};
 
     use gen_models::traits::Query;
     use rusqlite::types::Value as SQLValue;
+    use tempfile::NamedTempFile;
 
     use super::*;
     use crate::{
@@ -623,6 +624,122 @@ mod tests {
             .edge
             .target_node_id;
         (a_node_id, t_node_id, c_node_id, g_node_id)
+    }
+
+    fn run_gfa_boundary_update(incoming: bool) -> (DbContext, HashId, HashId, HashId) {
+        let context = setup_gen();
+        let conn = context.graph().conn();
+        let mut fasta_file = NamedTempFile::new().unwrap();
+        writeln!(fasta_file, ">chr1\nAAAAAAAAAATTTTTTTTTTCCCCCCCCCC").unwrap();
+        import_fasta(
+            &context,
+            &fasta_file.path().to_str().unwrap().to_string(),
+            "test",
+            Sample::DEFAULT_NAME,
+            false,
+        )
+        .unwrap();
+        let block_group = crate::test_helpers::get_sample_bg(conn, "test", Sample::DEFAULT_NAME);
+        let path = BlockGroup::get_current_path(conn, &block_group.id, None).unwrap();
+        let path_edges = gen_models::path_edge::PathEdge::edges_for_path(conn, &path.id);
+        let original_node_id = path_edges
+            .iter()
+            .find(|edge| edge.source_node_id == PATH_START_NODE_ID)
+            .unwrap()
+            .target_node_id;
+        let branch_sequence = Sequence::new()
+            .sequence_type("DNA")
+            .sequence("GG")
+            .save(conn)
+            .unwrap();
+        let branch_node_id = Node::create(
+            conn,
+            &branch_sequence.hash,
+            &HashId::convert_str(&format!("gfa-branch-{incoming}")),
+        )
+        .unwrap();
+        let branch_edge = if incoming {
+            Edge::create(
+                conn,
+                branch_node_id,
+                branch_sequence.length,
+                Strand::Forward,
+                original_node_id,
+                10,
+                Strand::Forward,
+            )
+        } else {
+            Edge::create(
+                conn,
+                original_node_id,
+                20,
+                Strand::Forward,
+                branch_node_id,
+                0,
+                Strand::Forward,
+            )
+        }
+        .unwrap();
+        BlockGroupEdge::bulk_create(
+            conn,
+            &[BlockGroupEdgeData {
+                block_group_id: block_group.id,
+                edge_id: branch_edge.id,
+                chromosome_index: 0,
+                phased: 0,
+            }],
+        );
+
+        let mut gfa_file = NamedTempFile::new().unwrap();
+        write!(
+            gfa_file,
+            "S\ta\tAAAAAAAAAA\t*\n\
+             S\tt\tTTTTTTTTTT\t*\n\
+             S\tc\tCCCCCCCCCC\t*\n\
+             S\tnew\tNN\t*\n\
+             P\tmatched\ta+,t+,c+\t*\n\
+             P\tchanged\ta+,new+,c+\t*\n"
+        )
+        .unwrap();
+        update_with_gfa(
+            &context,
+            "test",
+            Sample::DEFAULT_NAME,
+            "updated",
+            gfa_file.path().to_str().unwrap(),
+        )
+        .unwrap();
+
+        let updated_block_group = crate::test_helpers::get_sample_bg(conn, "test", "updated");
+        let new_node_id = Node::query(
+            conn,
+            "select n.* from nodes n left join sequences s on n.sequence_hash = s.hash where s.sequence = ?1",
+            rusqlite::params!["NN"],
+        )[0]
+        .id;
+        (context, updated_block_group.id, new_node_id, branch_node_id)
+    }
+
+    #[test]
+    fn test_gfa_update_preserves_incoming_edges_at_actual_divergence() {
+        let (context, block_group_id, new_node_id, branch_node_id) = run_gfa_boundary_update(true);
+        let conn = context.graph().conn();
+        let edges = BlockGroupEdge::edges_for_block_group(conn, &block_group_id);
+
+        assert!(edges.iter().any(|edge| {
+            edge.edge.source_node_id == branch_node_id && edge.edge.target_node_id == new_node_id
+        }));
+    }
+
+    #[test]
+    fn test_gfa_update_preserves_outgoing_edges_at_actual_rejoin() {
+        let (context, block_group_id, new_node_id, branch_node_id) = run_gfa_boundary_update(false);
+        let conn = context.graph().conn();
+        let edges = BlockGroupEdge::edges_for_block_group(conn, &block_group_id);
+
+        assert!(edges.iter().any(|edge| {
+            edge.edge.source_node_id == new_node_id && edge.edge.target_node_id == branch_node_id
+        }));
     }
 
     #[test]

--- a/src/updates/gfa.rs
+++ b/src/updates/gfa.rs
@@ -598,7 +598,7 @@ mod tests {
         conn: &GraphConnection,
         block_group_id: HashId,
     ) -> (HashId, HashId, HashId, HashId) {
-        let edges = BlockGroupEdge::edges_for_block_group(conn, &block_group_id);
+        let edges = BlockGroupEdge::edges_for_block_group(conn, &block_group_id, None);
         let a_node_id = edges
             .iter()
             .find(|edge| edge.edge.source_node_id == PATH_START_NODE_ID)
@@ -641,7 +641,7 @@ mod tests {
         .unwrap();
         let block_group = crate::test_helpers::get_sample_bg(conn, "test", Sample::DEFAULT_NAME);
         let path = BlockGroup::get_current_path(conn, &block_group.id, None).unwrap();
-        let path_edges = gen_models::path_edge::PathEdge::edges_for_path(conn, &path.id);
+        let path_edges = gen_models::path_edge::PathEdge::edges_for_path(conn, &path.id, None);
         let original_node_id = path_edges
             .iter()
             .find(|edge| edge.source_node_id == PATH_START_NODE_ID)
@@ -724,7 +724,7 @@ mod tests {
     fn test_gfa_update_preserves_incoming_edges_at_actual_divergence() {
         let (context, block_group_id, new_node_id, branch_node_id) = run_gfa_boundary_update(true);
         let conn = context.graph().conn();
-        let edges = BlockGroupEdge::edges_for_block_group(conn, &block_group_id);
+        let edges = BlockGroupEdge::edges_for_block_group(conn, &block_group_id, None);
 
         assert!(edges.iter().any(|edge| {
             edge.edge.source_node_id == branch_node_id && edge.edge.target_node_id == new_node_id
@@ -735,7 +735,7 @@ mod tests {
     fn test_gfa_update_preserves_outgoing_edges_at_actual_rejoin() {
         let (context, block_group_id, new_node_id, branch_node_id) = run_gfa_boundary_update(false);
         let conn = context.graph().conn();
-        let edges = BlockGroupEdge::edges_for_block_group(conn, &block_group_id);
+        let edges = BlockGroupEdge::edges_for_block_group(conn, &block_group_id, None);
 
         assert!(edges.iter().any(|edge| {
             edge.edge.source_node_id == new_node_id && edge.edge.target_node_id == branch_node_id
@@ -746,13 +746,13 @@ mod tests {
     fn test_gfa_change_preserves_incoming_edges_at_start_boundary() {
         let conn = get_connection(None).unwrap();
         let (block_group_id, _) = setup_block_group(&conn);
-        let (a_node_id, t_node_id, _, g_node_id) = gfa_test_node_ids(&conn, block_group_id);
+        let (_, t_node_id, c_node_id, g_node_id) = gfa_test_node_ids(&conn, block_group_id);
         let branch_edge = Edge::create(
             &conn,
-            g_node_id,
+            t_node_id,
             10,
             Strand::Forward,
-            t_node_id,
+            g_node_id,
             0,
             Strand::Forward,
         )
@@ -771,7 +771,7 @@ mod tests {
             &conn,
             block_group_id,
             &NodePoint {
-                id: t_node_id,
+                id: g_node_id,
                 coordinate: 0,
                 strand: Strand::Forward,
             },
@@ -782,7 +782,7 @@ mod tests {
             },
         );
 
-        for source_node_id in [a_node_id, g_node_id] {
+        for source_node_id in [c_node_id, t_node_id] {
             assert!(
                 edges.iter().any(|edge| {
                     edge.source_node_id == source_node_id && edge.target_node_id == new_node_id

--- a/src/updates/gfa.rs
+++ b/src/updates/gfa.rs
@@ -1,19 +1,15 @@
-use std::{
-    collections::{HashMap, HashSet},
-    io::Error as IOError,
-};
+use std::collections::{HashMap, HashSet};
 
 use gen_core::{HashId, PATH_END_NODE_ID, PATH_START_NODE_ID, Strand, is_terminal};
 use gen_models::{
     block_group::BlockGroup,
-    block_group_edge::{AugmentedEdgeData, BlockGroupEdge, BlockGroupEdgeData},
+    block_group_edge::AugmentedEdgeData,
     db::{DbContext, GraphConnection},
-    edge::{Edge, EdgeData},
+    edge::EdgeData,
     file_types::FileTypes,
     node::Node,
     operations::{OperationFile, OperationInfo, OperationSummary},
     path::Path,
-    sample::Sample,
     sequence::Sequence,
 };
 
@@ -22,7 +18,9 @@ use crate::{
     gfa::bool_to_strand,
     gfa_reader::{Gfa, Segment},
     graphs::NodePoint,
-    updates::adjacent_boundary_points,
+    updates::{
+        adjacent_boundary_points, create_block_group_edges, prepare_child_sample_block_groups,
+    },
 };
 
 fn plan_gfa_boundary_edges(
@@ -106,14 +104,12 @@ pub fn update_with_gfa(
     */
     let conn = context.graph().conn();
 
-    let _new_sample = Sample::get_or_create_child(
+    let block_groups = prepare_child_sample_block_groups::<SequenceUpdateError>(
         conn,
         collection_name,
+        parent_sample_name,
         new_sample_name,
-        vec![parent_sample_name.to_string()],
-    )
-    .map_err(IOError::other)?;
-    let block_groups = Sample::get_block_groups(conn, collection_name, new_sample_name, None);
+    )?;
 
     // NOTE: Only getting the current path for each block group because it's the most likely one to
     // be the basis for an update
@@ -540,40 +536,9 @@ fn create_new_path_from_existing(
         });
     }
 
-    let new_edge_ids = Edge::bulk_create(
-        conn,
-        &new_path_edges
-            .iter()
-            .map(|edge| edge.edge_data)
-            .collect::<Vec<EdgeData>>(),
-    );
-    let healing_edge_ids = Edge::bulk_create(
-        conn,
-        &healing_edges
-            .iter()
-            .map(|edge| edge.edge_data)
-            .collect::<Vec<EdgeData>>(),
-    );
-    let boundary_edge_ids = Edge::bulk_create(
-        conn,
-        &boundary_edges
-            .iter()
-            .map(|edge| edge.edge_data)
-            .collect::<Vec<EdgeData>>(),
-    );
-    let all_edges = [new_path_edges, healing_edges, boundary_edges].concat();
-    let all_edge_ids = [new_edge_ids.clone(), healing_edge_ids, boundary_edge_ids].concat();
-    let block_group_edges = all_edge_ids
-        .iter()
-        .enumerate()
-        .map(|(i, edge_id)| BlockGroupEdgeData {
-            block_group_id,
-            edge_id: *edge_id,
-            chromosome_index: all_edges[i].chromosome_index,
-            phased: all_edges[i].phased,
-        })
-        .collect::<Vec<BlockGroupEdgeData>>();
-    BlockGroupEdge::bulk_create(conn, &block_group_edges);
+    let new_edge_ids = create_block_group_edges(conn, block_group_id, &new_path_edges);
+    create_block_group_edges(conn, block_group_id, &healing_edges);
+    create_block_group_edges(conn, block_group_id, &boundary_edges);
     Path::create(conn, unmatched_path_name, &block_group_id, &new_edge_ids)?;
 
     Ok(())
@@ -584,7 +549,12 @@ mod tests {
     // Note this useful idiom: importing names from outer (for mod tests) scope.
     use std::{io::Write as _, path::PathBuf};
 
-    use gen_models::traits::Query;
+    use gen_models::{
+        block_group_edge::{BlockGroupEdge, BlockGroupEdgeData},
+        edge::Edge,
+        sample::Sample,
+        traits::Query,
+    };
     use rusqlite::types::Value as SQLValue;
     use tempfile::NamedTempFile;
 

--- a/src/updates/library.rs
+++ b/src/updates/library.rs
@@ -10,6 +10,7 @@ use gen_models::{
     errors::{BlockGroupError, OperationError, PathError, SampleError},
     file_types::FileTypes,
     operations::{OperationFile, OperationInfo, OperationSummary},
+    path::Path,
     region::{GenRegionError, Region, ResolvedGenRegion, ResolvedRegionKind},
     sample::Sample,
 };
@@ -301,6 +302,13 @@ fn update_path_library(
         Some(target_block_group.id),
         false,
     )?;
+    let (incoming_boundary_points, outgoing_boundary_points) = path_boundary_points(
+        conn,
+        target_block_group.id,
+        &parent_path,
+        start_coordinate,
+        end_coordinate,
+    )?;
 
     let (library_block_group_chunk, part_nodes) = create_library(
         conn,
@@ -331,13 +339,17 @@ fn update_path_library(
     if start_coordinate > 0 {
         let start_chunk = derived_block_group_chunks[0].clone();
         reference_block_group_chunks.push(start_chunk.clone());
-        let pathless_start_chunk = BlockGroupChunk {
+        let mut pathless_start_chunk = BlockGroupChunk {
             entry_node_points: start_chunk.entry_node_points.clone(),
             exit_node_points: start_chunk.exit_node_points.clone(),
             path_edges: vec![],
             path_start_point: None,
             path_end_point: None,
         };
+        extend_unique_points(
+            &mut pathless_start_chunk.exit_node_points,
+            incoming_boundary_points.clone(),
+        );
         block_group_chunks.push(pathless_start_chunk);
 
         chunk_index += 1;
@@ -351,13 +363,17 @@ fn update_path_library(
     if end_coordinate < parent_path_length {
         let end_chunk = derived_block_group_chunks[chunk_index].clone();
         reference_block_group_chunks.push(end_chunk.clone());
-        let pathless_end_chunk = BlockGroupChunk {
+        let mut pathless_end_chunk = BlockGroupChunk {
             entry_node_points: end_chunk.entry_node_points.clone(),
             exit_node_points: end_chunk.exit_node_points.clone(),
             path_edges: vec![],
             path_start_point: None,
             path_end_point: None,
         };
+        extend_unique_points(
+            &mut pathless_end_chunk.entry_node_points,
+            outgoing_boundary_points.clone(),
+        );
         block_group_chunks.push(pathless_end_chunk);
     }
 
@@ -379,6 +395,88 @@ fn update_path_library(
     )?;
 
     Ok(())
+}
+
+fn path_boundary_points(
+    conn: &gen_models::db::GraphConnection,
+    block_group_id: gen_core::HashId,
+    path: &Path,
+    start_coordinate: i64,
+    end_coordinate: i64,
+) -> Result<(Vec<NodePoint>, Vec<NodePoint>), UpdateWithLibraryError> {
+    let interval_tree = path.intervaltree(conn)?;
+    let start_block = interval_tree
+        .query_point(start_coordinate)
+        .next()
+        .ok_or_else(|| UpdateWithLibraryError::BlockGroupLookupFailed(path.name.clone()))?
+        .value;
+    let end_block = interval_tree
+        .query_point(end_coordinate - 1)
+        .next()
+        .ok_or_else(|| UpdateWithLibraryError::BlockGroupLookupFailed(path.name.clone()))?
+        .value;
+    let start_node_coordinate = start_coordinate - start_block.start + start_block.sequence_start;
+    let end_node_coordinate = end_coordinate - end_block.start + end_block.sequence_start;
+    adjacent_boundary_points(
+        conn,
+        block_group_id,
+        &[NodePoint {
+            id: start_block.node_id,
+            coordinate: start_node_coordinate,
+            strand: start_block.strand,
+        }],
+        &[NodePoint {
+            id: end_block.node_id,
+            coordinate: end_node_coordinate,
+            strand: end_block.strand,
+        }],
+    )
+}
+
+fn adjacent_boundary_points(
+    conn: &gen_models::db::GraphConnection,
+    block_group_id: gen_core::HashId,
+    start_points: &[NodePoint],
+    end_points: &[NodePoint],
+) -> Result<(Vec<NodePoint>, Vec<NodePoint>), UpdateWithLibraryError> {
+    let edges = BlockGroupEdge::edges_for_block_group(conn, &block_group_id);
+    let incoming_points = edges
+        .iter()
+        .filter(|edge| {
+            start_points.iter().any(|point| {
+                edge.edge.target_node_id == point.id
+                    && edge.edge.target_coordinate == point.coordinate
+            })
+        })
+        .map(|edge| NodePoint {
+            id: edge.edge.source_node_id,
+            coordinate: edge.edge.source_coordinate,
+            strand: edge.edge.source_strand,
+        })
+        .collect();
+    let outgoing_points = edges
+        .iter()
+        .filter(|edge| {
+            end_points.iter().any(|point| {
+                edge.edge.source_node_id == point.id
+                    && edge.edge.source_coordinate == point.coordinate
+            })
+        })
+        .map(|edge| NodePoint {
+            id: edge.edge.target_node_id,
+            coordinate: edge.edge.target_coordinate,
+            strand: edge.edge.target_strand,
+        })
+        .collect();
+    Ok((incoming_points, outgoing_points))
+}
+
+fn extend_unique_points(points: &mut Vec<NodePoint>, additional_points: Vec<NodePoint>) {
+    for point in additional_points {
+        if !points.contains(&point) {
+            points.push(point);
+        }
+    }
 }
 
 fn update_graph_native_library(
@@ -412,20 +510,30 @@ fn update_graph_native_library(
         &part_nodes,
     )?;
 
-    let start_chunk = BlockGroupChunk {
-        entry_node_points: graph_node_positions_to_points(start_positions),
-        exit_node_points: graph_node_positions_to_points(start_positions),
+    let start_node_points = graph_node_positions_to_points(start_positions);
+    let end_node_points = graph_node_positions_to_points(end_positions);
+    let (incoming_boundary_points, outgoing_boundary_points) = adjacent_boundary_points(
+        conn,
+        target_block_group.id,
+        &start_node_points,
+        &end_node_points,
+    )?;
+    let mut start_chunk = BlockGroupChunk {
+        entry_node_points: start_node_points.clone(),
+        exit_node_points: start_node_points,
         path_edges: vec![],
         path_start_point: None,
         path_end_point: None,
     };
-    let end_chunk = BlockGroupChunk {
-        entry_node_points: graph_node_positions_to_points(end_positions),
-        exit_node_points: graph_node_positions_to_points(end_positions),
+    extend_unique_points(&mut start_chunk.exit_node_points, incoming_boundary_points);
+    let mut end_chunk = BlockGroupChunk {
+        entry_node_points: end_node_points.clone(),
+        exit_node_points: end_node_points,
         path_edges: vec![],
         path_start_point: None,
         path_end_point: None,
     };
+    extend_unique_points(&mut end_chunk.entry_node_points, outgoing_boundary_points);
 
     let stitched_start = stitch(conn, &start_chunk, &library_chunk, target_block_group.id)?;
     let _stitched_end = stitch(conn, &stitched_start, &end_chunk, target_block_group.id)?;
@@ -499,11 +607,16 @@ mod tests {
     use std::{collections::HashSet, path::PathBuf};
 
     use anyhow::Result;
+    use gen_core::{HashId, PATH_END_NODE_ID, PATH_START_NODE_ID, Strand};
     use gen_models::{
         annotations::{Annotation, add_annotation},
         block_group::BlockGroup,
+        block_group_edge::{BlockGroupEdge, BlockGroupEdgeData},
+        edge::Edge,
+        node::Node,
         path::Path,
         sample_lineage::SampleLineage,
+        sequence::Sequence,
     };
 
     use super::*;
@@ -511,6 +624,259 @@ mod tests {
         graphs::combinatorial_library::parse_library, imports::fasta::import_fasta,
         test_helpers::setup_gen,
     };
+
+    fn test_parts(sequences: &[&str]) -> Vec<Vec<SequencePart>> {
+        vec![
+            sequences
+                .iter()
+                .enumerate()
+                .map(|(index, sequence)| SequencePart {
+                    name: format!("part-{index}"),
+                    sequence: sequence.to_string(),
+                    sequence_length: sequence.len() as i64,
+                })
+                .collect(),
+        ]
+    }
+
+    fn setup_path_library_boundary_test(
+        incoming: bool,
+        annotation_range: Option<&str>,
+    ) -> (DbContext, HashId, Vec<HashId>) {
+        let context = setup_gen();
+        let conn = context.graph().conn();
+        let fasta_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("fixtures/simple.fa");
+        import_fasta(
+            &context,
+            &fasta_path.to_str().unwrap().to_string(),
+            "test",
+            Sample::DEFAULT_NAME,
+            false,
+        )
+        .unwrap();
+        let block_group = crate::test_helpers::get_sample_bg(conn, "test", Sample::DEFAULT_NAME);
+        let path = BlockGroup::get_current_path(conn, &block_group.id, None).unwrap();
+        let original_node_id = path
+            .intervaltree(conn)
+            .unwrap()
+            .query_point(10)
+            .next()
+            .unwrap()
+            .value
+            .node_id;
+        if let Some(annotation_range) = annotation_range {
+            add_annotation(
+                &context,
+                "test",
+                "boundary",
+                None,
+                Sample::DEFAULT_NAME,
+                annotation_range,
+            )
+            .unwrap();
+        }
+        let mut branch_node_ids = Vec::new();
+        let mut edge_ids = Vec::new();
+        for index in 0..3 {
+            let sequence = Sequence::new()
+                .sequence_type("DNA")
+                .sequence("NN")
+                .save(conn)
+                .unwrap();
+            let node_id = Node::create(
+                conn,
+                &sequence.hash,
+                &HashId::convert_str(&format!("boundary-branch-{incoming}-{index}")),
+            )
+            .unwrap();
+            branch_node_ids.push(node_id);
+            let edges = if incoming {
+                [
+                    Edge::create(
+                        conn,
+                        PATH_START_NODE_ID,
+                        0,
+                        Strand::Forward,
+                        node_id,
+                        0,
+                        Strand::Forward,
+                    )
+                    .unwrap(),
+                    Edge::create(
+                        conn,
+                        node_id,
+                        2,
+                        Strand::Forward,
+                        original_node_id,
+                        20,
+                        Strand::Forward,
+                    )
+                    .unwrap(),
+                ]
+            } else {
+                [
+                    Edge::create(
+                        conn,
+                        original_node_id,
+                        7,
+                        Strand::Forward,
+                        node_id,
+                        0,
+                        Strand::Forward,
+                    )
+                    .unwrap(),
+                    Edge::create(
+                        conn,
+                        node_id,
+                        2,
+                        Strand::Forward,
+                        PATH_END_NODE_ID,
+                        0,
+                        Strand::Forward,
+                    )
+                    .unwrap(),
+                ]
+            };
+            edge_ids.extend(edges.map(|edge| edge.id));
+        }
+        BlockGroupEdge::bulk_create(
+            conn,
+            &edge_ids
+                .iter()
+                .map(|edge_id| BlockGroupEdgeData {
+                    block_group_id: block_group.id,
+                    edge_id: *edge_id,
+                    chromosome_index: 0,
+                    phased: 0,
+                })
+                .collect::<Vec<_>>(),
+        );
+        (context, original_node_id, branch_node_ids)
+    }
+
+    #[test]
+    fn test_path_library_preserves_incoming_edges_at_start_boundary() {
+        let (context, original_node_id, branch_node_ids) =
+            setup_path_library_boundary_test(true, None);
+        update_with_library(
+            &context,
+            "test",
+            Sample::DEFAULT_NAME,
+            "updated",
+            "m123:20-25",
+            test_parts(&["GG"]),
+            None,
+            None,
+        )
+        .unwrap();
+
+        let conn = context.graph().conn();
+        let block_group = crate::test_helpers::get_sample_bg(conn, "test", "updated");
+        let edges = BlockGroupEdge::edges_for_block_group(conn, &block_group.id);
+        for branch_node_id in branch_node_ids {
+            assert!(
+                edges.iter().any(|edge| {
+                    edge.edge.source_node_id == branch_node_id
+                        && edge.edge.target_node_id != original_node_id
+                        && edge.edge.target_coordinate == 0
+                }),
+                "library update should retain incoming route from {branch_node_id}",
+            );
+        }
+    }
+
+    #[test]
+    fn test_path_library_preserves_outgoing_edges_at_end_boundary() {
+        let (context, original_node_id, branch_node_ids) =
+            setup_path_library_boundary_test(false, None);
+        update_with_library(
+            &context,
+            "test",
+            Sample::DEFAULT_NAME,
+            "updated",
+            "m123:2-7",
+            test_parts(&["GG"]),
+            None,
+            None,
+        )
+        .unwrap();
+
+        let conn = context.graph().conn();
+        let block_group = crate::test_helpers::get_sample_bg(conn, "test", "updated");
+        let edges = BlockGroupEdge::edges_for_block_group(conn, &block_group.id);
+        for branch_node_id in branch_node_ids {
+            assert!(
+                edges.iter().any(|edge| {
+                    edge.edge.source_node_id != original_node_id
+                        && edge.edge.source_node_id != PATH_START_NODE_ID
+                        && edge.edge.target_node_id == branch_node_id
+                }),
+                "library update should retain outgoing route to {branch_node_id}",
+            );
+        }
+    }
+
+    #[test]
+    fn test_graph_library_preserves_incoming_edges_at_start_boundary() {
+        let (context, original_node_id, branch_node_ids) =
+            setup_path_library_boundary_test(true, Some("m123:20-25"));
+        update_with_library(
+            &context,
+            "test",
+            Sample::DEFAULT_NAME,
+            "updated",
+            "boundary",
+            test_parts(&["GG"]),
+            None,
+            None,
+        )
+        .unwrap();
+
+        let conn = context.graph().conn();
+        let block_group = crate::test_helpers::get_sample_bg(conn, "test", "updated");
+        let edges = BlockGroupEdge::edges_for_block_group(conn, &block_group.id);
+        for branch_node_id in branch_node_ids {
+            assert!(
+                edges.iter().any(|edge| {
+                    edge.edge.source_node_id == branch_node_id
+                        && edge.edge.target_node_id != original_node_id
+                        && edge.edge.target_coordinate == 0
+                }),
+                "graph library update should retain incoming route from {branch_node_id}",
+            );
+        }
+    }
+
+    #[test]
+    fn test_graph_library_preserves_outgoing_edges_at_end_boundary() {
+        let (context, original_node_id, branch_node_ids) =
+            setup_path_library_boundary_test(false, Some("m123:2-7"));
+        update_with_library(
+            &context,
+            "test",
+            Sample::DEFAULT_NAME,
+            "updated",
+            "boundary",
+            test_parts(&["GG"]),
+            None,
+            None,
+        )
+        .unwrap();
+
+        let conn = context.graph().conn();
+        let block_group = crate::test_helpers::get_sample_bg(conn, "test", "updated");
+        let edges = BlockGroupEdge::edges_for_block_group(conn, &block_group.id);
+        for branch_node_id in branch_node_ids {
+            assert!(
+                edges.iter().any(|edge| {
+                    edge.edge.source_node_id != original_node_id
+                        && edge.edge.source_node_id != PATH_START_NODE_ID
+                        && edge.edge.target_node_id == branch_node_id
+                }),
+                "graph library update should retain outgoing route to {branch_node_id}",
+            );
+        }
+    }
 
     #[test]
     fn makes_a_pool() -> Result<()> {

--- a/src/updates/library.rs
+++ b/src/updates/library.rs
@@ -4,15 +4,13 @@ use gen_core::Strand;
 use gen_models::{
     accession::{Accession, AccessionSpan, NewAccession},
     block_group::BlockGroup,
-    block_group_edge::{BlockGroupEdge, BlockGroupEdgeData},
+    block_group_edge::AugmentedEdgeData,
     db::DbContext,
-    edge::Edge,
     errors::{BlockGroupError, OperationError, PathError, SampleError},
     file_types::FileTypes,
     operations::{OperationFile, OperationInfo, OperationSummary},
     path::Path,
     region::{GenRegionError, Region, ResolvedGenRegion, ResolvedRegionKind},
-    sample::Sample,
 };
 use thiserror::Error;
 
@@ -26,7 +24,10 @@ use crate::{
         operators::{GraphOperationError, derive_chunks, make_stitch_from_block_groups},
         stitch,
     },
-    updates::{adjacent_boundary_points, resolve_update_region},
+    updates::{
+        adjacent_boundary_points, create_block_group_edges, prepare_child_sample_block_groups,
+        resolve_update_region,
+    },
 };
 
 /// Creates a top-level accession anchored at a single resolved graph
@@ -227,28 +228,16 @@ fn target_library_block_groups(
     new_sample_name: &str,
     resolved_region: &ResolvedGenRegion,
 ) -> Result<Vec<BlockGroup>, UpdateWithLibraryError> {
-    let _new_sample = Sample::get_or_create_child(
+    let block_groups = prepare_child_sample_block_groups::<UpdateWithLibraryError>(
         conn,
         collection_name,
+        parent_sample_name,
         new_sample_name,
-        vec![parent_sample_name.to_string()],
     )?;
-    let block_groups = Sample::get_block_groups(conn, collection_name, parent_sample_name, None);
-
-    let mut target_block_groups = vec![];
-    for block_group in block_groups {
-        let new_block_groups = BlockGroup::get_or_create_sample_block_groups(
-            conn,
-            collection_name,
-            new_sample_name,
-            &block_group.name,
-            vec![parent_sample_name.to_string()],
-        )?;
-
-        if block_group.name == resolved_region.block_group.name {
-            target_block_groups = new_block_groups;
-        }
-    }
+    let target_block_groups = block_groups
+        .into_iter()
+        .filter(|block_group| block_group.name == resolved_region.block_group.name)
+        .collect::<Vec<_>>();
 
     if target_block_groups.is_empty() {
         return Err(UpdateWithLibraryError::Region(GenRegionError::NotFound(
@@ -536,31 +525,25 @@ fn preserve_library_boundary_points(
     block_group_id: gen_core::HashId,
     positions: &[gen_graph::GraphNodePosition],
 ) -> Result<(), UpdateWithLibraryError> {
-    let edge_data = positions
+    let edges = positions
         .iter()
         .map(|position| {
             let coordinate = position.coordinate();
-            gen_models::edge::EdgeData {
-                source_node_id: position.graph_node.node_id,
-                source_coordinate: coordinate,
-                source_strand: gen_core::Strand::Forward,
-                target_node_id: position.graph_node.node_id,
-                target_coordinate: coordinate,
-                target_strand: gen_core::Strand::Forward,
+            AugmentedEdgeData {
+                edge_data: gen_models::edge::EdgeData {
+                    source_node_id: position.graph_node.node_id,
+                    source_coordinate: coordinate,
+                    source_strand: gen_core::Strand::Forward,
+                    target_node_id: position.graph_node.node_id,
+                    target_coordinate: coordinate,
+                    target_strand: gen_core::Strand::Forward,
+                },
+                chromosome_index: 0,
+                phased: 0,
             }
         })
         .collect::<Vec<_>>();
-    let edge_ids = Edge::bulk_create(conn, &edge_data);
-    let block_group_edges = edge_ids
-        .iter()
-        .map(|edge_id| BlockGroupEdgeData {
-            block_group_id,
-            edge_id: *edge_id,
-            chromosome_index: 0,
-            phased: 0,
-        })
-        .collect::<Vec<_>>();
-    BlockGroupEdge::bulk_create(conn, &block_group_edges);
+    create_block_group_edges(conn, block_group_id, &edges);
     Ok(())
 }
 
@@ -577,6 +560,7 @@ mod tests {
         edge::Edge,
         node::Node,
         path::Path,
+        sample::Sample,
         sample_lineage::SampleLineage,
         sequence::Sequence,
     };

--- a/src/updates/library.rs
+++ b/src/updates/library.rs
@@ -734,7 +734,7 @@ mod tests {
 
         let conn = context.graph().conn();
         let block_group = crate::test_helpers::get_sample_bg(conn, "test", "updated");
-        let edges = BlockGroupEdge::edges_for_block_group(conn, &block_group.id);
+        let edges = BlockGroupEdge::edges_for_block_group(conn, &block_group.id, None);
         for branch_node_id in branch_node_ids {
             assert!(
                 edges.iter().any(|edge| {
@@ -765,7 +765,7 @@ mod tests {
 
         let conn = context.graph().conn();
         let block_group = crate::test_helpers::get_sample_bg(conn, "test", "updated");
-        let edges = BlockGroupEdge::edges_for_block_group(conn, &block_group.id);
+        let edges = BlockGroupEdge::edges_for_block_group(conn, &block_group.id, None);
         for branch_node_id in branch_node_ids {
             assert!(
                 edges.iter().any(|edge| {
@@ -796,7 +796,7 @@ mod tests {
 
         let conn = context.graph().conn();
         let block_group = crate::test_helpers::get_sample_bg(conn, "test", "updated");
-        let edges = BlockGroupEdge::edges_for_block_group(conn, &block_group.id);
+        let edges = BlockGroupEdge::edges_for_block_group(conn, &block_group.id, None);
         for branch_node_id in branch_node_ids {
             assert!(
                 edges.iter().any(|edge| {
@@ -827,7 +827,7 @@ mod tests {
 
         let conn = context.graph().conn();
         let block_group = crate::test_helpers::get_sample_bg(conn, "test", "updated");
-        let edges = BlockGroupEdge::edges_for_block_group(conn, &block_group.id);
+        let edges = BlockGroupEdge::edges_for_block_group(conn, &block_group.id, None);
         for branch_node_id in branch_node_ids {
             assert!(
                 edges.iter().any(|edge| {

--- a/src/updates/library.rs
+++ b/src/updates/library.rs
@@ -26,7 +26,7 @@ use crate::{
         operators::{GraphOperationError, derive_chunks, make_stitch_from_block_groups},
         stitch,
     },
-    updates::resolve_update_region,
+    updates::{adjacent_boundary_points, resolve_update_region},
 };
 
 /// Creates a top-level accession anchored at a single resolved graph
@@ -417,7 +417,7 @@ fn path_boundary_points(
         .value;
     let start_node_coordinate = start_coordinate - start_block.start + start_block.sequence_start;
     let end_node_coordinate = end_coordinate - end_block.start + end_block.sequence_start;
-    adjacent_boundary_points(
+    Ok(adjacent_boundary_points(
         conn,
         block_group_id,
         &[NodePoint {
@@ -430,45 +430,7 @@ fn path_boundary_points(
             coordinate: end_node_coordinate,
             strand: end_block.strand,
         }],
-    )
-}
-
-fn adjacent_boundary_points(
-    conn: &gen_models::db::GraphConnection,
-    block_group_id: gen_core::HashId,
-    start_points: &[NodePoint],
-    end_points: &[NodePoint],
-) -> Result<(Vec<NodePoint>, Vec<NodePoint>), UpdateWithLibraryError> {
-    let edges = BlockGroupEdge::edges_for_block_group(conn, &block_group_id);
-    let incoming_points = edges
-        .iter()
-        .filter(|edge| {
-            start_points.iter().any(|point| {
-                edge.edge.target_node_id == point.id
-                    && edge.edge.target_coordinate == point.coordinate
-            })
-        })
-        .map(|edge| NodePoint {
-            id: edge.edge.source_node_id,
-            coordinate: edge.edge.source_coordinate,
-            strand: edge.edge.source_strand,
-        })
-        .collect();
-    let outgoing_points = edges
-        .iter()
-        .filter(|edge| {
-            end_points.iter().any(|point| {
-                edge.edge.source_node_id == point.id
-                    && edge.edge.source_coordinate == point.coordinate
-            })
-        })
-        .map(|edge| NodePoint {
-            id: edge.edge.target_node_id,
-            coordinate: edge.edge.target_coordinate,
-            strand: edge.edge.target_strand,
-        })
-        .collect();
-    Ok((incoming_points, outgoing_points))
+    ))
 }
 
 fn extend_unique_points(points: &mut Vec<NodePoint>, additional_points: Vec<NodePoint>) {
@@ -517,7 +479,7 @@ fn update_graph_native_library(
         target_block_group.id,
         &start_node_points,
         &end_node_points,
-    )?;
+    );
     let mut start_chunk = BlockGroupChunk {
         entry_node_points: start_node_points.clone(),
         exit_node_points: start_node_points,

--- a/src/updates/sequence.rs
+++ b/src/updates/sequence.rs
@@ -63,6 +63,8 @@ mod tests {
         annotations::{Annotation, add_annotation},
         assets::{OperationKind, OperationLog},
         block_group::{BlockGroup, BlockGroupChange, PathCache},
+        block_group_edge::{BlockGroupEdge, BlockGroupEdgeData},
+        edge::Edge,
         history::{HistoryStore, dolt::DoltHistoryStore},
         node::Node,
         operations::commit_operation_summary,
@@ -80,7 +82,6 @@ mod tests {
         graphs::combinatorial_library::parse_library,
         imports::fasta::import_fasta,
         test_helpers::{get_sample_bg, setup_block_group, setup_gen},
-        track_database,
         updates::library::update_with_library,
     };
 
@@ -105,6 +106,91 @@ mod tests {
             path_end: 0,
             strand: Strand::Forward,
         }
+    }
+
+    #[test]
+    fn test_reference_path_uses_canonical_edges_at_branched_boundaries() {
+        let context = setup_gen();
+        let conn = context.graph().conn();
+        let (block_group_id, _) = setup_block_group(conn);
+        let edges = BlockGroupEdge::edges_for_block_group(conn, &block_group_id);
+        let a_node_id = edges
+            .iter()
+            .find(|edge| edge.edge.is_start_edge())
+            .unwrap()
+            .edge
+            .target_node_id;
+        let t_node_id = edges
+            .iter()
+            .find(|edge| edge.edge.source_node_id == a_node_id)
+            .unwrap()
+            .edge
+            .target_node_id;
+        let c_node_id = edges
+            .iter()
+            .find(|edge| edge.edge.source_node_id == t_node_id)
+            .unwrap()
+            .edge
+            .target_node_id;
+        let g_node_id = edges
+            .iter()
+            .find(|edge| edge.edge.source_node_id == c_node_id)
+            .unwrap()
+            .edge
+            .target_node_id;
+        let branch_edges = [
+            Edge::create(
+                conn,
+                g_node_id,
+                10,
+                Strand::Forward,
+                t_node_id,
+                0,
+                Strand::Forward,
+            )
+            .unwrap(),
+            Edge::create(
+                conn,
+                t_node_id,
+                10,
+                Strand::Forward,
+                a_node_id,
+                0,
+                Strand::Forward,
+            )
+            .unwrap(),
+        ];
+        BlockGroupEdge::bulk_create(
+            conn,
+            &branch_edges
+                .iter()
+                .map(|edge| BlockGroupEdgeData {
+                    block_group_id,
+                    edge_id: edge.id,
+                    chromosome_index: 0,
+                    phased: 0,
+                })
+                .collect::<Vec<_>>(),
+        );
+
+        update_with_sequence(
+            &context,
+            "test",
+            "test",
+            "updated",
+            "chr1:10-20",
+            "NN",
+            false,
+        )
+        .unwrap();
+
+        let updated_block_group = get_sample_bg(conn, "test", "updated");
+        let updated_path =
+            BlockGroup::get_current_path(conn, &updated_block_group.id, None).unwrap();
+        assert_eq!(
+            updated_path.sequence(conn, None).unwrap(),
+            "AAAAAAAAAANNCCCCCCCCCCGGGGGGGGGG"
+        );
     }
 
     #[test]
@@ -698,8 +784,6 @@ mod tests {
     fn test_deletion_inside_combinatorial_library_part_creates_bypass_for_every_entry_point() {
         let context = setup_gen();
         let conn = context.graph().conn();
-        let op_conn = context.operations().conn();
-        track_database(conn, op_conn).unwrap();
 
         let fasta_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("fixtures/simple.fa");
         let collection = "test".to_string();

--- a/src/updates/sequence.rs
+++ b/src/updates/sequence.rs
@@ -1,24 +1,12 @@
-use std::str;
-
-use gen_core::{HashId, PathBlock, Strand};
 use gen_models::{
-    block_group::BlockGroup,
     db::DbContext,
-    edge::Edge,
-    node::Node,
     operations::{OperationInfo, OperationSummary},
-    region::{GenRegionError, Region, ResolvedGenRegion, ResolvedRegionKind},
-    sample::Sample,
-    sequence::Sequence,
-    traits::*,
+    region::{GenRegionError, Region},
 };
-use rusqlite::{self, params};
 
 use crate::{
     errors::SequenceUpdateError,
-    updates::{
-        InsertChangeData, insert_update_change, resolve_update_region, target_update_region,
-    },
+    updates::{SequenceUpdate, apply_sequence_updates, resolve_update_region},
 };
 #[allow(clippy::too_many_arguments)]
 pub fn update_with_sequence(
@@ -39,119 +27,17 @@ pub fn update_with_sequence(
             region_name.to_string(),
         ));
     }
-    let _new_sample = Sample::get_or_create_child(
+    apply_sequence_updates::<SequenceUpdateError>(
         conn,
-        collection_name,
-        new_sample_name,
-        vec![parent_sample_name.to_string()],
-    )?;
-    let block_groups = Sample::get_block_groups(conn, collection_name, parent_sample_name, None);
-
-    let mut target_block_groups = vec![];
-    for block_group in block_groups {
-        let new_block_groups = BlockGroup::get_or_create_sample_block_groups(
-            conn,
+        &SequenceUpdate {
             collection_name,
+            parent_sample_name,
             new_sample_name,
-            &block_group.name,
-            vec![parent_sample_name.to_string()],
-        )?;
-
-        if block_group.name == resolved_region.block_group.name {
-            target_block_groups = new_block_groups;
-        }
-    }
-
-    if target_block_groups.is_empty() {
-        return Err(GenRegionError::NotFound(region_name.to_string()).into());
-    }
-
-    for target_block_group in &target_block_groups {
-        let path = BlockGroup::get_current_path(conn, &target_block_group.id, None)?;
-        let (start_coordinate, end_coordinate) = (resolved_region.start, resolved_region.end);
-        let node_id = if sequence.is_empty() {
-            let node_id = HashId::convert_str("");
-            let path_block = PathBlock {
-                node_id,
-                block_sequence: sequence.to_string(),
-                sequence_start: 0,
-                sequence_end: 0,
-                path_start: start_coordinate,
-                path_end: end_coordinate,
-                strand: Strand::Forward,
-            };
-
-            insert_sequence_change(
-                conn,
-                &resolved_region,
-                target_block_group,
-                &path,
-                path_block,
-            )?;
-            node_id
-        } else {
-            let seq = Sequence::new()
-                .sequence_type("DNA")
-                .sequence(sequence)
-                .save(conn)?;
-            let node_id = Node::create(
-                conn,
-                &seq.hash,
-                &HashId::convert_str(&format!(
-                    "{block_group_id}:{ref_start}-{ref_end}->{sequence_hash}",
-                    block_group_id = target_block_group.id,
-                    ref_start = 0,
-                    ref_end = seq.length,
-                    sequence_hash = seq.hash
-                )),
-            )?;
-
-            let path_block = PathBlock {
-                node_id,
-                block_sequence: sequence.to_string(),
-                sequence_start: 0,
-                sequence_end: seq.length,
-                path_start: start_coordinate,
-                path_end: end_coordinate,
-                strand: Strand::Forward,
-            };
-
-            insert_sequence_change(
-                conn,
-                &resolved_region,
-                target_block_group,
-                &path,
-                path_block,
-            )?;
-            node_id
-        };
-
-        if !disable_reference_path_update && resolved_region.kind == ResolvedRegionKind::Path {
-            if node_id == HashId::convert_str("") {
-                let _ = path.new_path_with_deletion(conn, start_coordinate, end_coordinate);
-            } else {
-                let edge_to_new_node = Edge::query(
-                    conn,
-                    "select * from edges where target_node_id = ?1",
-                    params![node_id],
-                )[0]
-                .clone();
-                let edge_from_new_node = Edge::query(
-                    conn,
-                    "select * from edges where source_node_id = ?1",
-                    params![node_id],
-                )[0]
-                .clone();
-                path.new_path_with(
-                    conn,
-                    start_coordinate,
-                    end_coordinate,
-                    &edge_to_new_node,
-                    &edge_from_new_node,
-                )?;
-            }
-        }
-    }
+            region: &resolved_region,
+            disable_reference_path_update,
+        },
+        [sequence.to_string()],
+    )?;
 
     let summary_str =
         format!("Sequences {mod}", mod=if sequence.is_empty() { "deleted" } else { "inserted" });
@@ -168,34 +54,26 @@ pub fn update_with_sequence(
     Ok(operation_summary)
 }
 
-fn insert_sequence_change(
-    conn: &gen_models::db::GraphConnection,
-    region: &ResolvedGenRegion,
-    target_block_group: &BlockGroup,
-    path: &gen_models::path::Path,
-    block: PathBlock,
-) -> Result<(), SequenceUpdateError> {
-    let source = target_update_region(conn, region, target_block_group.id, Some(path))?;
-    let data = InsertChangeData::new(block);
-    insert_update_change(conn, source, data)?;
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
     use std::{collections::HashSet, path::PathBuf};
 
-    use gen_core::NO_CHROMOSOME_INDEX;
+    use gen_core::{HashId, NO_CHROMOSOME_INDEX, PathBlock, Strand};
     use gen_models::{
         annotations::{Annotation, add_annotation},
         assets::{OperationKind, OperationLog},
         block_group::{BlockGroup, BlockGroupChange, PathCache},
         history::{HistoryStore, dolt::DoltHistoryStore},
+        node::Node,
         operations::commit_operation_summary,
         path::Path,
         region::{ResolvedGenRegion, resolve_annotation},
+        sample::Sample,
         sample_lineage::SampleLineage,
+        sequence::Sequence,
+        traits::Query as _,
     };
+    use rusqlite::params;
 
     use super::*;
     use crate::{
@@ -890,9 +768,9 @@ mod tests {
                 "ATCGATCCAACATGTTAAGGAACACACAGAGA",
                 "ATCGATCCAACATGCTAAGGAACACACAGAGA",
                 // bypass variants: cds1's leading "A" removed, one per entry point
-                "ATCGATCAAAAATGATAGGAACACACAGAGA",
-                "ATCGATCTAATATGATAGGAACACACAGAGA",
-                "ATCGATCCAACATGATAGGAACACACAGAGA",
+                "ATCGATCAAAATGATAAGGAACACACAGAGA",
+                "ATCGATCTAATTGATAAGGAACACACAGAGA",
+                "ATCGATCCAACTGATAAGGAACACACAGAGA",
             ]
             .map(String::from),
         );

--- a/src/updates/sequence.rs
+++ b/src/updates/sequence.rs
@@ -199,8 +199,11 @@ mod tests {
 
     use super::*;
     use crate::{
+        graphs::combinatorial_library::parse_library,
         imports::fasta::import_fasta,
         test_helpers::{get_sample_bg, setup_block_group, setup_gen},
+        track_database,
+        updates::library::update_with_library,
     };
 
     fn insertion_block(
@@ -805,6 +808,97 @@ mod tests {
         assert_eq!(
             latest_path.sequence(conn, None).unwrap(),
             "ATTCGATCGATCGATCGGGAACACACAGAGA"
+        );
+    }
+
+    // Reproduces https://github.com/genhub-bio/gen/issues/211: deleting a
+    // sub-region of a part that a combinatorial library wired in from
+    // multiple entry points (p1/p2/p3 -> cds1) should create a bypass edge
+    // for each entry point, not just one. Mirrors the bash reproduction:
+    // import -> add-annotation -> update library -> update sequence "".
+    #[test]
+    fn test_deletion_inside_combinatorial_library_part_creates_bypass_for_every_entry_point() {
+        let context = setup_gen();
+        let conn = context.graph().conn();
+        let op_conn = context.operations().conn();
+        track_database(conn, op_conn).unwrap();
+
+        let fasta_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("fixtures/simple.fa");
+        let collection = "test".to_string();
+
+        import_fasta(
+            &context,
+            &fasta_path.to_str().unwrap().to_string(),
+            &collection,
+            "wt",
+            false,
+        )
+        .unwrap();
+        add_annotation(&context, &collection, "SITE", None, "wt", "m123:7-20").unwrap();
+
+        let binding = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("fixtures/parts.fa");
+        let parts_path = binding.to_str().unwrap();
+        let binding =
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("fixtures/combinatorial_design.csv");
+        let library_path = binding.to_str().unwrap();
+        let parts_list = parse_library(parts_path, library_path).unwrap();
+
+        update_with_library(
+            &context,
+            &collection,
+            "wt",
+            "design",
+            "SITE",
+            parts_list,
+            Some(parts_path),
+            Some(library_path),
+        )
+        .unwrap();
+
+        // Delete the first base of cds1's start codon, same as
+        // `gen update sequence "" --region-name cds1:0-1` in the issue.
+        let _ = update_with_sequence(
+            &context,
+            &collection,
+            "design",
+            "deleted",
+            "cds1:0-1",
+            "",
+            false,
+        );
+
+        let block_groups = BlockGroup::query(
+            conn,
+            "select * from block_groups where collection_name = ?1 AND sample_name = ?2;",
+            params![collection, "deleted"],
+        );
+        assert_eq!(block_groups.len(), 1);
+
+        // Every combo that routes through cds1 (via p1, p2, or p3) should
+        // gain a bypass-edge variant with the first base of cds1 removed,
+        // alongside the untouched combos and the original unedited route.
+        let expected_sequences = HashSet::from_iter(
+            [
+                "ATCGATCGATCGATCGATCGGGAACACACAGAGA",
+                "ATCGATCAAAAATGATAAGGAACACACAGAGA",
+                "ATCGATCAAAAATGTTAAGGAACACACAGAGA",
+                "ATCGATCAAAAATGCTAAGGAACACACAGAGA",
+                "ATCGATCTAATATGATAAGGAACACACAGAGA",
+                "ATCGATCTAATATGTTAAGGAACACACAGAGA",
+                "ATCGATCTAATATGCTAAGGAACACACAGAGA",
+                "ATCGATCCAACATGATAAGGAACACACAGAGA",
+                "ATCGATCCAACATGTTAAGGAACACACAGAGA",
+                "ATCGATCCAACATGCTAAGGAACACACAGAGA",
+                // bypass variants: cds1's leading "A" removed, one per entry point
+                "ATCGATCAAAAATGATAGGAACACACAGAGA",
+                "ATCGATCTAATATGATAGGAACACACAGAGA",
+                "ATCGATCCAACATGATAGGAACACACAGAGA",
+            ]
+            .map(String::from),
+        );
+        assert_eq!(
+            BlockGroup::get_all_sequences(conn, &block_groups[0].id, false).unwrap(),
+            expected_sequences,
         );
     }
 }

--- a/src/updates/sequence.rs
+++ b/src/updates/sequence.rs
@@ -113,7 +113,7 @@ mod tests {
         let context = setup_gen();
         let conn = context.graph().conn();
         let (block_group_id, _) = setup_block_group(conn);
-        let edges = BlockGroupEdge::edges_for_block_group(conn, &block_group_id);
+        let edges = BlockGroupEdge::edges_for_block_group(conn, &block_group_id, None);
         let a_node_id = edges
             .iter()
             .find(|edge| edge.edge.is_start_edge())
@@ -138,23 +138,44 @@ mod tests {
             .unwrap()
             .edge
             .target_node_id;
+        let branch_sequence = Sequence::new()
+            .sequence_type("DNA")
+            .sequence("GG")
+            .save(conn)
+            .unwrap();
+        let branch_node_id = Node::create(
+            conn,
+            &branch_sequence.hash,
+            &HashId::convert_str("reference-path-branch"),
+        )
+        .unwrap();
         let branch_edges = [
             Edge::create(
                 conn,
-                g_node_id,
+                a_node_id,
                 10,
                 Strand::Forward,
-                t_node_id,
+                c_node_id,
                 0,
                 Strand::Forward,
             )
             .unwrap(),
             Edge::create(
                 conn,
-                t_node_id,
+                c_node_id,
                 10,
                 Strand::Forward,
-                a_node_id,
+                branch_node_id,
+                0,
+                Strand::Forward,
+            )
+            .unwrap(),
+            Edge::create(
+                conn,
+                branch_node_id,
+                branch_sequence.length,
+                Strand::Forward,
+                g_node_id,
                 0,
                 Strand::Forward,
             )
@@ -178,7 +199,7 @@ mod tests {
             "test",
             "test",
             "updated",
-            "chr1:10-20",
+            "chr1:20-30",
             "NN",
             false,
         )
@@ -189,7 +210,7 @@ mod tests {
             BlockGroup::get_current_path(conn, &updated_block_group.id, None).unwrap();
         assert_eq!(
             updated_path.sequence(conn, None).unwrap(),
-            "AAAAAAAAAANNCCCCCCCCCCGGGGGGGGGG"
+            "AAAAAAAAAATTTTTTTTTTNNGGGGGGGGGG"
         );
     }
 

--- a/src/updates/vcf.rs
+++ b/src/updates/vcf.rs
@@ -251,7 +251,7 @@ fn prepare_vcf_entry(
         node_id,
         has_ref,
     )?;
-    prepare_path_update_region(conn, &mut change.region)?;
+    change.region = prepare_path_update_region(conn, &change.region)?;
     Ok(VcfEntry {
         sample_name: sample_name.to_string(),
         change,

--- a/src/updates/vcf.rs
+++ b/src/updates/vcf.rs
@@ -39,6 +39,7 @@ use thiserror::Error;
 use crate::{
     parse_genotype,
     progress_bar::{add_saving_operation_bar, get_handler, get_progress_bar},
+    updates::prepare_path_update_region,
 };
 
 const VCF_CHANGE_APPLY_CHUNK_SIZE: usize = 5_000;
@@ -238,7 +239,7 @@ fn prepare_vcf_entry(
             sequence_hash = sequence.hash
         )),
     )?;
-    let change = prepare_change(
+    let mut change = prepare_change(
         path_region,
         ids,
         ref_start,
@@ -250,6 +251,7 @@ fn prepare_vcf_entry(
         node_id,
         has_ref,
     )?;
+    prepare_path_update_region(conn, &mut change.region)?;
     Ok(VcfEntry {
         sample_name: sample_name.to_string(),
         change,

--- a/src/updates/vcf.rs
+++ b/src/updates/vcf.rs
@@ -1149,7 +1149,7 @@ mod tests {
         let nodes = Node::query(conn, "select * from nodes;", rusqlite::params!());
         assert_eq!(nodes.len(), 5);
 
-        let second_update = update_with_vcf(
+        let _second_update = update_with_vcf(
             &context,
             &vcf_path.to_str().unwrap().to_string(),
             &collection,
@@ -1201,7 +1201,7 @@ mod tests {
         let nodes = Node::query(conn, "select * from nodes;", rusqlite::params!());
         assert_eq!(nodes.len(), 8);
 
-        let second_update = update_with_vcf(
+        let _second_update = update_with_vcf(
             &context,
             &vcf_path.to_str().unwrap().to_string(),
             &collection,

--- a/src/updates/vcf.rs
+++ b/src/updates/vcf.rs
@@ -39,7 +39,7 @@ use thiserror::Error;
 use crate::{
     parse_genotype,
     progress_bar::{add_saving_operation_bar, get_handler, get_progress_bar},
-    updates::prepare_path_update_region,
+    updates::{InsertChangeData, build_update_change, prepare_path_update_region},
 };
 
 const VCF_CHANGE_APPLY_CHUNK_SIZE: usize = 5_000;
@@ -167,14 +167,16 @@ fn prepare_change(
         path_end: ref_end,
         strand: Strand::Forward,
     };
-    Ok(BlockGroupChange {
+    Ok(build_update_change(
         region,
-        path_accession: ids,
-        block: new_block,
-        chromosome_index,
-        phased,
-        preserve_edge,
-    })
+        InsertChangeData {
+            block: new_block,
+            path_accession: ids,
+            chromosome_index,
+            phased,
+            preserve_edge,
+        },
+    ))
 }
 
 #[cfg_attr(
@@ -679,14 +681,7 @@ pub fn update_with_vcf(
                         let mut region = change.region.clone();
                         region.kind = ResolvedRegionKind::BlockGroup;
                         region.remove_ambiguous_positions = true;
-                        BlockGroupChange {
-                            region,
-                            path_accession: change.path_accession.clone(),
-                            block: change.block.clone(),
-                            chromosome_index: change.chromosome_index,
-                            phased: change.phased,
-                            preserve_edge: change.preserve_edge,
-                        }
+                        build_update_change(region, InsertChangeData::from(change))
                     })
                     .collect::<Vec<_>>();
                 BlockGroup::insert_changes(conn, &in_place_changes, Some(&mut tree_map)).unwrap();


### PR DESCRIPTION
## Summary
- Adds a Rust test that mirrors the bash reproduction from #211: import fasta, add an annotation, run `update library`, then delete the first base of one library part (`cds1:0-1`).
- Asserts (via `BlockGroup::get_all_sequences`) that a bypass-deletion variant exists for every entry point into the part (p1, p2, p3), matching what `gen export gfa` + human inspection should show.
- The test currently fails: only 10 of the expected 13 sequences are present, confirming the missing bypass edges described in #211.

Relates to #211 (reproduction only; root cause not fixed here).

## Test plan
- [x] cargo test test_deletion_inside_combinatorial_library_part_creates_bypass_for_every_entry_point (currently fails, demonstrating the bug)