### PR TITLE
Patch operation asset fix

### DIFF
--- a/gen-models/Cargo.toml
+++ b/gen-models/Cargo.toml
@@ -14,7 +14,6 @@ profiling = ["dep:tracing"]
 
 [dev-dependencies]
 rand = "0.10.1"
-tempfile = "3.20.0"
 
 [dependencies]
 gen-capnp-schemas = { path = "../gen-capnp-schemas", version = "0.2.1" }
@@ -38,6 +37,7 @@ postcard = { version = "1.1.3", default-features = false, features = ["use-std"]
 sha2 = "0.10.8"
 thiserror = "2.0.12"
 tokio = { version = "1.52.1", features = ["rt-multi-thread"] }
+tempfile = "3.20.0"
 url = "2.5.0"
 indexmap = "2.11.3"
 anyhow = "1.0.100"

--- a/gen-models/src/annotations.rs
+++ b/gen-models/src/annotations.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::anyhow;
 use gen_core::{
-    DoltHashId, HashId, NodeIntervalBlock, calculate_hash,
+    DoltHashId, HashId, NodeIntervalBlock, Sha256Hash, calculate_hash,
     config::Workspace,
     region::{Region, RegionResolutionError, RegionResolver},
     traits::Capnp,
@@ -742,6 +742,15 @@ pub fn add_annotation(
     ))
 }
 
+/// Optional content checksums collected while annotation assets were already being streamed.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct AnnotationFileChecksumOverrides {
+    /// Checksum of the annotation file.
+    pub annotation: Option<Sha256Hash>,
+    /// Checksum of the annotation index.
+    pub index: Option<Sha256Hash>,
+}
+
 pub fn add_annotation_file(
     context: &DbContext,
     path: &str,
@@ -749,6 +758,7 @@ pub fn add_annotation_file(
     index: Option<&str>,
     name: Option<&str>,
     message: Option<&str>,
+    checksum_overrides: AnnotationFileChecksumOverrides,
 ) -> Result<DoltHashId, Box<dyn std::error::Error>> {
     let workspace = context.workspace();
     let graph_conn = context.graph().conn();
@@ -764,27 +774,32 @@ pub fn add_annotation_file(
             parse_annotation_file_type(&ext)?
         }
     };
-    let file_addition = FileAddition::prepare(workspace, path, file_type, None)?;
+    let file_addition =
+        FileAddition::prepare(workspace, path, file_type, checksum_overrides.annotation)?;
     let annotation_logical_path =
         OperationFile::storage_file_path(workspace, path, file_addition.checksum.as_ref())?;
-    let prepared_index = if let Some(index_path) =
-        annotation_index_file_path(workspace, path, index)
-    {
-        let index_file_type = FileTypes::infer_from_path(&index_path);
-        let file_addition = FileAddition::prepare(workspace, &index_path, index_file_type, None)?;
-        let logical_path = OperationFile::storage_file_path(
-            workspace,
-            &index_path,
-            file_addition.checksum.as_ref(),
-        )?;
-        let name = Path::new(&index_path)
-            .file_name()
-            .and_then(|value| value.to_str())
-            .map(str::to_string);
-        Some((file_addition, logical_path, name))
-    } else {
-        None
-    };
+    let prepared_index =
+        if let Some(index_path) = annotation_index_file_path(workspace, path, index) {
+            let index_file_type = FileTypes::infer_from_path(&index_path);
+            let file_addition = FileAddition::prepare(
+                workspace,
+                &index_path,
+                index_file_type,
+                checksum_overrides.index,
+            )?;
+            let logical_path = OperationFile::storage_file_path(
+                workspace,
+                &index_path,
+                file_addition.checksum.as_ref(),
+            )?;
+            let name = Path::new(&index_path)
+                .file_name()
+                .and_then(|value| value.to_str())
+                .map(str::to_string);
+            Some((file_addition, logical_path, name))
+        } else {
+            None
+        };
     let name_value = name.unwrap_or_default();
     let index_file_addition_id = prepared_index
         .as_ref()
@@ -1437,6 +1452,7 @@ mod tests {
             None,
             Some("track-1"),
             None,
+            AnnotationFileChecksumOverrides::default(),
         )
         .unwrap();
         assert_eq!(history_store.current_head().unwrap(), Some(commit_hash));
@@ -1478,6 +1494,7 @@ mod tests {
             None,
             Some("track-1"),
             None,
+            AnnotationFileChecksumOverrides::default(),
         )
         .unwrap_err();
         let op_err = err
@@ -1517,6 +1534,7 @@ mod tests {
             Some(index_path.to_str().expect("should encode index path")),
             Some("track-with-index"),
             None,
+            AnnotationFileChecksumOverrides::default(),
         )
         .expect("should create annotation file operation");
 
@@ -1561,6 +1579,7 @@ mod tests {
             Some(&index_uri),
             Some("remote-annotation"),
             None,
+            AnnotationFileChecksumOverrides::default(),
         )
         .expect("should track remote annotation assets");
 
@@ -1581,6 +1600,44 @@ mod tests {
                 .iter()
                 .any(|asset_ref| asset_ref.uri == index_uri)
         );
+    }
+
+    #[test]
+    fn test_add_annotation_file_passes_remote_checksum_overrides() {
+        let context = setup_gen();
+        let annotation_uri = "http://127.0.0.1:1/annotation.gff3";
+        let index_uri = "http://127.0.0.1:1/annotation.gff3.csi";
+        let annotation_checksum = Sha256Hash::convert_str("known annotation contents");
+        let index_checksum = Sha256Hash::convert_str("known index contents");
+
+        add_annotation_file(
+            &context,
+            annotation_uri,
+            None,
+            Some(index_uri),
+            Some("remote-annotation"),
+            None,
+            AnnotationFileChecksumOverrides {
+                annotation: Some(annotation_checksum),
+                index: Some(index_checksum),
+            },
+        )
+        .expect("should track checksummed remote assets without reading them");
+
+        let asset_refs = AssetRef::all(context.graph().conn());
+        assert_eq!(asset_refs.len(), 2);
+        let annotation = asset_refs
+            .iter()
+            .find(|asset_ref| asset_ref.role == AssetRole::Annotation)
+            .expect("should track annotation asset");
+        let index = asset_refs
+            .iter()
+            .find(|asset_ref| asset_ref.role == AssetRole::AnnotationIndex)
+            .expect("should track annotation index");
+        assert_eq!(annotation.uri, annotation_uri);
+        assert_eq!(annotation.checksum, Some(annotation_checksum));
+        assert_eq!(index.uri, index_uri);
+        assert_eq!(index.checksum, Some(index_checksum));
     }
 
     #[test]
@@ -1610,6 +1667,7 @@ mod tests {
             Some(index_path),
             None,
             None,
+            AnnotationFileChecksumOverrides::default(),
         )
         .expect("should create annotation file operation");
 

--- a/gen-models/src/annotations.rs
+++ b/gen-models/src/annotations.rs
@@ -751,6 +751,11 @@ pub struct AnnotationFileChecksumOverrides {
     pub index: Option<Sha256Hash>,
 }
 
+/// Adds an annotation asset and optional index to operation history.
+///
+/// Callers pass checksums only when the corresponding remote streams were already consumed for
+/// annotation work. This keeps operation creation independent of remote credentials while local
+/// assets are retained and hashed during preparation.
 pub fn add_annotation_file(
     context: &DbContext,
     path: &str,

--- a/gen-models/src/annotations.rs
+++ b/gen-models/src/annotations.rs
@@ -766,14 +766,17 @@ pub fn add_annotation_file(
     };
     let file_addition = FileAddition::prepare(workspace, path, file_type, None)?;
     let annotation_logical_path =
-        OperationFile::storage_file_path(workspace, path, &file_addition.checksum)?;
+        OperationFile::storage_file_path(workspace, path, file_addition.checksum.as_ref())?;
     let prepared_index = if let Some(index_path) =
         annotation_index_file_path(workspace, path, index)
     {
         let index_file_type = FileTypes::infer_from_path(&index_path);
         let file_addition = FileAddition::prepare(workspace, &index_path, index_file_type, None)?;
-        let logical_path =
-            OperationFile::storage_file_path(workspace, &index_path, &file_addition.checksum)?;
+        let logical_path = OperationFile::storage_file_path(
+            workspace,
+            &index_path,
+            file_addition.checksum.as_ref(),
+        )?;
         let name = Path::new(&index_path)
             .file_name()
             .and_then(|value| value.to_str())
@@ -837,7 +840,7 @@ mod tests {
         block_group::{BlockGroup, PathCache},
         block_group_edge::{BlockGroupEdge, BlockGroupEdgeData},
         errors::OperationError,
-        operations::commit_operation_summary,
+        operations::{calculate_reader_checksum, commit_operation_summary},
         path::Path,
         path_edge::PathEdge,
         sample::Sample,
@@ -1527,6 +1530,14 @@ mod tests {
         assert_eq!(asset_refs.len(), 2);
         assert_eq!(asset_refs[0].role, AssetRole::Annotation);
         assert_eq!(asset_refs[1].role, AssetRole::AnnotationIndex);
+        assert_eq!(
+            asset_refs[0].checksum,
+            Some(calculate_reader_checksum("##gff-version 3\n".as_bytes()).unwrap())
+        );
+        assert_eq!(
+            asset_refs[1].checksum,
+            Some(calculate_reader_checksum("index".as_bytes()).unwrap())
+        );
         assert_eq!(asset_refs[1].file_type.as_str(), "none");
         assert_eq!(
             asset_refs[1]
@@ -1534,6 +1545,41 @@ mod tests {
                 .as_deref()
                 .expect("should store index logical path"),
             "fixtures/annotation-with-index.csi"
+        );
+    }
+
+    #[test]
+    fn test_add_annotation_file_does_not_read_remote_assets() {
+        let context = setup_gen();
+        let annotation_uri = "http://127.0.0.1:1/annotation.gff3".to_string();
+        let index_uri = "http://127.0.0.1:1/annotation.gff3.csi".to_string();
+
+        add_annotation_file(
+            &context,
+            &annotation_uri,
+            None,
+            Some(&index_uri),
+            Some("remote-annotation"),
+            None,
+        )
+        .expect("should track remote annotation assets");
+
+        let asset_refs = AssetRef::all(context.graph().conn());
+        assert_eq!(asset_refs.len(), 2);
+        assert!(
+            asset_refs
+                .iter()
+                .all(|asset_ref| asset_ref.checksum.is_none())
+        );
+        assert!(
+            asset_refs
+                .iter()
+                .any(|asset_ref| asset_ref.uri == annotation_uri)
+        );
+        assert!(
+            asset_refs
+                .iter()
+                .any(|asset_ref| asset_ref.uri == index_uri)
         );
     }
 

--- a/gen-models/src/assets.rs
+++ b/gen-models/src/assets.rs
@@ -99,10 +99,6 @@ fn opendal_file_addition_error(err: opendal::Error) -> FileAdditionError {
     FileAdditionError::FileReadError(io::Error::other(err))
 }
 
-fn opendal_file_store_error(err: opendal::Error) -> FileStoreError {
-    FileStoreError::IoError(io::Error::other(err))
-}
-
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum AssetRole {
     Input,
@@ -624,10 +620,6 @@ impl ChecksumHandle {
         let state = self.state.lock().unwrap();
         if state.complete { state.checksum } else { None }
     }
-
-    pub fn finalized_checksum(&self) -> Option<Sha256Hash> {
-        self.state.lock().unwrap().checksum
-    }
 }
 
 pub struct ChecksummedReader {
@@ -652,32 +644,28 @@ impl ChecksummedReader {
             state: Arc::clone(&self.state),
         }
     }
-}
 
-impl Read for ChecksummedReader {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        let bytes_read = self.inner.read(buf)?;
-        let mut state = self.state.lock().unwrap();
-        if bytes_read == 0 {
-            if state.checksum.is_none() {
-                let finalized = state.hasher.clone().finalize();
-                state.checksum = Some(Sha256Hash(finalized.into()));
-            }
-            state.complete = true;
-        } else {
-            state.hasher.update(&buf[..bytes_read]);
-        }
-        Ok(bytes_read)
-    }
-}
-
-impl Drop for ChecksummedReader {
-    fn drop(&mut self) {
+    fn finish(&self) {
         let mut state = self.state.lock().unwrap();
         if state.checksum.is_none() {
             let finalized = state.hasher.clone().finalize();
             state.checksum = Some(Sha256Hash(finalized.into()));
         }
+        state.complete = true;
+    }
+}
+
+impl Read for ChecksummedReader {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let bytes_read = self.inner.read(buf)?;
+        if bytes_read == 0 {
+            if !buf.is_empty() {
+                self.finish();
+            }
+        } else {
+            self.state.lock().unwrap().hasher.update(&buf[..bytes_read]);
+        }
+        Ok(bytes_read)
     }
 }
 
@@ -765,61 +753,6 @@ impl OpenDalLocation {
             .map_err(opendal_file_addition_error)?;
         Ok(ChecksummedReader::new(Box::new(reader)))
     }
-
-    fn checksum(&self, display_path: &str) -> Result<Sha256Hash, FileAdditionError> {
-        let reader = match self.operator.reader(&self.path) {
-            Ok(reader) => reader,
-            Err(err) => {
-                return match err.kind() {
-                    opendal::ErrorKind::NotFound => {
-                        Err(FileAdditionError::FileNotFound(display_path.to_string()))
-                    }
-                    opendal::ErrorKind::PermissionDenied => Err(
-                        FileAdditionError::FilePermissionDenied(display_path.to_string()),
-                    ),
-                    _ => Err(opendal_file_addition_error(err)),
-                };
-            }
-        }
-        .into_std_read(..)
-        .map_err(opendal_file_addition_error)?;
-
-        match calculate_reader_checksum(reader) {
-            Ok(checksum) => Ok(checksum),
-            Err(err) => match err.kind() {
-                io::ErrorKind::NotFound => {
-                    Err(FileAdditionError::FileNotFound(display_path.to_string()))
-                }
-                io::ErrorKind::PermissionDenied => Err(FileAdditionError::FilePermissionDenied(
-                    display_path.to_string(),
-                )),
-                _ => Err(FileAdditionError::FileReadError(err)),
-            },
-        }
-    }
-
-    fn copy_to_local_path(
-        &self,
-        workspace: &Workspace,
-        destination_path: &Path,
-    ) -> io::Result<u64> {
-        let asset_location =
-            Self::from_workspace_path(workspace, destination_path).map_err(io::Error::other)?;
-        let mut reader = self
-            .operator
-            .reader(&self.path)
-            .map_err(io::Error::other)?
-            .into_std_read(..)
-            .map_err(io::Error::other)?;
-        let mut writer = asset_location
-            .operator
-            .writer(&asset_location.path)
-            .map_err(io::Error::other)?
-            .into_std_write();
-        let bytes_copied = io::copy(&mut reader, &mut writer)?;
-        writer.close()?;
-        Ok(bytes_copied)
-    }
 }
 
 pub trait AssetUri {
@@ -827,7 +760,8 @@ pub trait AssetUri {
 
     fn reader(&self, workspace: &Workspace) -> Result<ChecksummedReader, FileAdditionError>;
 
-    fn checksum(
+    /// Prepares any local storage needed for the asset and returns its known content checksum.
+    fn prepare_asset(
         &self,
         workspace: &Workspace,
         checksum_override: Option<Sha256Hash>,
@@ -838,12 +772,6 @@ pub trait AssetUri {
         workspace: &Workspace,
         checksum: &Sha256Hash,
     ) -> Result<String, FileAdditionError>;
-
-    fn ensure_asset(
-        &self,
-        workspace: &Workspace,
-        checksum: &Sha256Hash,
-    ) -> Result<(), FileAdditionError>;
 
     fn store_file(
         &self,
@@ -978,24 +906,12 @@ impl AssetUri for LocalAssetUri {
             .reader()
     }
 
-    fn checksum(
+    fn prepare_asset(
         &self,
         workspace: &Workspace,
         checksum_override: Option<Sha256Hash>,
     ) -> Result<Option<Sha256Hash>, FileAdditionError> {
-        if let Some(checksum_override) = checksum_override {
-            return Ok(Some(checksum_override));
-        }
-
-        let source_file_path = self.resolved_source_file_path(workspace)?;
-        let checksum_path = if source_file_path.is_file() {
-            source_file_path
-        } else {
-            PathBuf::from(self.file_path())
-        };
-        OpenDalLocation::from_workspace_path(workspace, &checksum_path)
-            .map_err(opendal_file_addition_error)?
-            .checksum(&checksum_path.to_string_lossy())
+        self.stage_asset_copy(workspace, checksum_override)
             .map(Some)
     }
 
@@ -1013,18 +929,6 @@ impl AssetUri for LocalAssetUri {
         let source_asset_uri = Self::new(&source_file_path.to_string_lossy());
         let relative_file_path = Self::asset_relative_path(workspace, &source_asset_uri, checksum)?;
         Ok(Self::asset_uri(&relative_file_path))
-    }
-
-    fn ensure_asset(
-        &self,
-        workspace: &Workspace,
-        checksum: &Sha256Hash,
-    ) -> Result<(), FileAdditionError> {
-        let source_file_path = self.resolved_source_file_path(workspace)?;
-        if source_file_path.is_file() {
-            Self::ensure_asset_copy(workspace, &source_file_path, checksum)?;
-        }
-        Ok(())
     }
 
     fn store_file(
@@ -1309,6 +1213,54 @@ impl LocalAssetUri {
         )))
     }
 
+    fn stage_asset_copy(
+        &self,
+        workspace: &Workspace,
+        checksum_override: Option<Sha256Hash>,
+    ) -> Result<Sha256Hash, FileAdditionError> {
+        let asset_dir = workspace.asset_dir()?;
+        fs::create_dir_all(&asset_dir).map_err(FileAdditionError::FileReadError)?;
+        if let Some(checksum) = checksum_override {
+            let asset_path = asset_dir.join(self.asset_filename(&checksum));
+            if asset_path.exists() {
+                return Ok(checksum);
+            }
+        }
+
+        // Local assets must be retained in the content-addressed store. Hashing this copy while
+        // it is streamed avoids a separate checksum-only read of large genomic files.
+        let mut reader = self.reader(workspace)?;
+        let checksum_handle = reader.checksum_handle();
+        let mut staged_file = tempfile::NamedTempFile::new_in(&asset_dir)
+            .map_err(FileAdditionError::FileReadError)?;
+        io::copy(&mut reader, &mut staged_file).map_err(FileAdditionError::FileReadError)?;
+        staged_file
+            .flush()
+            .map_err(FileAdditionError::FileReadError)?;
+        let checksum = checksum_handle.checksum().ok_or_else(|| {
+            FileAdditionError::ChecksumError(format!(
+                "local asset stream did not reach EOF: {}",
+                self.uri()
+            ))
+        })?;
+        if let Some(expected_checksum) = checksum_override
+            && checksum != expected_checksum
+        {
+            return Err(FileAdditionError::ChecksumError(format!(
+                "local asset checksum does not match the provided checksum: {}",
+                self.uri()
+            )));
+        }
+
+        let asset_path = asset_dir.join(self.asset_filename(&checksum));
+        match staged_file.persist_noclobber(asset_path) {
+            Ok(_) => {}
+            Err(error) if error.error.kind() == io::ErrorKind::AlreadyExists => {}
+            Err(error) => return Err(FileAdditionError::FileReadError(error.error)),
+        }
+        Ok(checksum)
+    }
+
     fn sanitize_relative_path(path: &Path) -> Result<PathBuf, FileAdditionError> {
         let mut sanitized = PathBuf::new();
         for component in path.components() {
@@ -1354,34 +1306,11 @@ impl LocalAssetUri {
         normalized
     }
 
-    /// This exists along with store_file because store_file uses an existing FileAddition
-    /// object to determine where to where to store the file, while this method uses the
-    /// provided source_path.
-    pub fn ensure_asset_copy(
-        workspace: &Workspace,
-        source_path: &Path,
-        checksum: &Sha256Hash,
-    ) -> Result<(), FileAdditionError> {
-        let asset_uri = Self::new(&source_path.to_string_lossy());
-        let asset_path = workspace
-            .asset_dir()?
-            .join(asset_uri.asset_filename(checksum));
-        if asset_path.exists() {
-            return Ok(());
-        }
-
-        OpenDalLocation::from_workspace_path(workspace, source_path)
-            .map_err(opendal_file_addition_error)?
-            .copy_to_local_path(workspace, &asset_path)
-            .map_err(FileAdditionError::FileReadError)?;
-        Ok(())
-    }
-
     pub fn store_file(
         file_addition: &FileAddition,
         workspace: &Workspace,
     ) -> Result<(), FileStoreError> {
-        let asset_filename = file_addition.hashed_filename().ok_or_else(|| {
+        let checksum = file_addition.checksum.ok_or_else(|| {
             FileStoreError::IoError(io::Error::new(
                 io::ErrorKind::InvalidInput,
                 format!(
@@ -1390,25 +1319,22 @@ impl LocalAssetUri {
                 ),
             ))
         })?;
-        let asset_path = workspace.asset_dir()?.join(asset_filename);
+        let asset_uri = Self::new(&file_addition.asset_uri);
+        let asset_path = workspace
+            .asset_dir()?
+            .join(asset_uri.asset_filename(&checksum));
         if asset_path.exists() {
             return Ok(());
         }
 
-        let source_path = Self::resolve_source_path(workspace, &file_addition.asset_uri).map_err(
-            |err| match err {
-                FileAdditionError::FileReadError(err) => FileStoreError::IoError(err),
+        asset_uri
+            .stage_asset_copy(workspace, Some(checksum))
+            .map(|_| ())
+            .map_err(|error| match error {
+                FileAdditionError::ConfigError(error) => FileStoreError::ConfigError(error),
+                FileAdditionError::FileReadError(error) => FileStoreError::IoError(error),
                 other => FileStoreError::IoError(io::Error::other(other)),
-            },
-        )?;
-        if source_path == asset_path {
-            return Ok(());
-        }
-        OpenDalLocation::from_workspace_path(workspace, &source_path)
-            .map_err(opendal_file_store_error)?
-            .copy_to_local_path(workspace, &asset_path)
-            .map_err(FileStoreError::IoError)?;
-        Ok(())
+            })
     }
 }
 
@@ -1472,7 +1398,7 @@ impl AssetUri for RemoteAssetUri {
         OpenDalLocation::from_remote_uri(&self.asset_uri)?.reader()
     }
 
-    fn checksum(
+    fn prepare_asset(
         &self,
         _workspace: &Workspace,
         checksum_override: Option<Sha256Hash>,
@@ -1486,14 +1412,6 @@ impl AssetUri for RemoteAssetUri {
         _checksum: &Sha256Hash,
     ) -> Result<String, FileAdditionError> {
         Ok(self.asset_uri.clone())
-    }
-
-    fn ensure_asset(
-        &self,
-        _workspace: &Workspace,
-        _checksum: &Sha256Hash,
-    ) -> Result<(), FileAdditionError> {
-        Ok(())
     }
 
     fn store_file(
@@ -1526,7 +1444,9 @@ mod tests {
 
     use super::*;
     use crate::{
-        history::dolt::commit_all, operations::calculate_file_checksum, test_helpers::setup_gen,
+        history::dolt::commit_all,
+        operations::{calculate_file_checksum, calculate_reader_checksum},
+        test_helpers::setup_gen,
         traits::Query,
     };
 
@@ -2446,7 +2366,10 @@ mod tests {
         let context = setup_gen();
         let uri = format!("http://{addr}/asset.fa");
         let asset_uri = RemoteAssetUri::new(&uri);
-        assert_eq!(asset_uri.checksum(context.workspace(), None).unwrap(), None);
+        assert_eq!(
+            asset_uri.prepare_asset(context.workspace(), None).unwrap(),
+            None
+        );
         let mut reader = asset_uri.reader(context.workspace()).unwrap();
         let checksum_handle = reader.checksum_handle();
         let mut contents = String::new();

--- a/gen-models/src/assets.rs
+++ b/gen-models/src/assets.rs
@@ -616,12 +616,20 @@ pub struct ChecksumHandle {
 }
 
 impl ChecksumHandle {
+    /// Returns the content checksum only after the associated reader reaches EOF.
+    ///
+    /// Consumers use this after useful streaming work, such as copying an asset into storage, so
+    /// an interrupted read cannot publish the checksum of only a prefix.
     pub fn checksum(&self) -> Option<Sha256Hash> {
         let state = self.state.lock().unwrap();
         if state.complete { state.checksum } else { None }
     }
 }
 
+/// A reader that makes the checksum of a fully consumed stream available through a shared handle.
+///
+/// The handle lets callers hash bytes as they pass them to their real destination rather than
+/// performing a checksum-only read of a potentially large asset.
 pub struct ChecksummedReader {
     inner: Box<dyn Read>,
     state: Arc<Mutex<ChecksumState>>,
@@ -645,6 +653,8 @@ impl ChecksummedReader {
         }
     }
 
+    // Publishing happens only at EOF so consumers never treat a partial stream hash as the asset's
+    // content identity.
     fn finish(&self) {
         let mut state = self.state.lock().unwrap();
         if state.checksum.is_none() {
@@ -760,7 +770,11 @@ pub trait AssetUri {
 
     fn reader(&self, workspace: &Workspace) -> Result<ChecksummedReader, FileAdditionError>;
 
-    /// Prepares any local storage needed for the asset and returns its known content checksum.
+    /// Performs the storage work required before recording an asset and returns a verified
+    /// checksum when one is available.
+    ///
+    /// Local assets are retained and hashed during that copy. Remote assets remain lazy unless a
+    /// caller already obtained a checksum while streaming them for another purpose.
     fn prepare_asset(
         &self,
         workspace: &Workspace,
@@ -806,6 +820,8 @@ pub trait AssetUri {
     where
         Self: Sized,
     {
+        // Checksumless remote assets still need stable database identity. The URI contributes only
+        // to that record ID and is never represented as a content checksum.
         let checksum = checksum.map(Sha256Hash::to_string).unwrap_or_default();
         let combined = format!("{checksum};{asset_uri}");
         HashId(calculate_hash(&combined))
@@ -865,6 +881,10 @@ impl dyn AssetUri {
     }
 }
 
+/// Chooses where an asset should be materialized without inventing a content identity.
+///
+/// Explicit logical paths are usable without a checksum. Content-addressed materialization under
+/// `.gen/assets` requires a verified checksum.
 pub fn materialization_destination_path(
     workspace: &Workspace,
     asset_uri: &str,
@@ -911,6 +931,8 @@ impl AssetUri for LocalAssetUri {
         workspace: &Workspace,
         checksum_override: Option<Sha256Hash>,
     ) -> Result<Option<Sha256Hash>, FileAdditionError> {
+        // Operation creation must retain local bytes, so this copy is also the useful point at
+        // which to verify or calculate their checksum.
         self.stage_asset_copy(workspace, checksum_override)
             .map(Some)
     }
@@ -1213,6 +1235,8 @@ impl LocalAssetUri {
         )))
     }
 
+    // Streams a local asset into content-addressed storage while computing its checksum. Combining
+    // those jobs keeps large files to a single pass and leaves no checksum-only temporary output.
     fn stage_asset_copy(
         &self,
         workspace: &Workspace,
@@ -1227,8 +1251,6 @@ impl LocalAssetUri {
             }
         }
 
-        // Local assets must be retained in the content-addressed store. Hashing this copy while
-        // it is streamed avoids a separate checksum-only read of large genomic files.
         let mut reader = self.reader(workspace)?;
         let checksum_handle = reader.checksum_handle();
         let mut staged_file = tempfile::NamedTempFile::new_in(&asset_dir)
@@ -1403,6 +1425,8 @@ impl AssetUri for RemoteAssetUri {
         _workspace: &Workspace,
         checksum_override: Option<Sha256Hash>,
     ) -> Result<Option<Sha256Hash>, FileAdditionError> {
+        // Recording a remote URI must not require network access or credentials. A caller can pass
+        // a checksum learned during useful streaming work; otherwise it remains unknown.
         Ok(checksum_override)
     }
 

--- a/gen-models/src/assets.rs
+++ b/gen-models/src/assets.rs
@@ -771,7 +771,9 @@ impl OpenDalLocation {
             Ok(reader) => reader,
             Err(err) => {
                 return match err.kind() {
-                    opendal::ErrorKind::NotFound => Ok(Sha256Hash::convert_str("non-existent")),
+                    opendal::ErrorKind::NotFound => {
+                        Err(FileAdditionError::FileNotFound(display_path.to_string()))
+                    }
                     opendal::ErrorKind::PermissionDenied => Err(
                         FileAdditionError::FilePermissionDenied(display_path.to_string()),
                     ),
@@ -785,7 +787,9 @@ impl OpenDalLocation {
         match calculate_reader_checksum(reader) {
             Ok(checksum) => Ok(checksum),
             Err(err) => match err.kind() {
-                io::ErrorKind::NotFound => Ok(Sha256Hash::convert_str("non-existent")),
+                io::ErrorKind::NotFound => {
+                    Err(FileAdditionError::FileNotFound(display_path.to_string()))
+                }
                 io::ErrorKind::PermissionDenied => Err(FileAdditionError::FilePermissionDenied(
                     display_path.to_string(),
                 )),
@@ -827,7 +831,7 @@ pub trait AssetUri {
         &self,
         workspace: &Workspace,
         checksum_override: Option<Sha256Hash>,
-    ) -> Result<Sha256Hash, FileAdditionError>;
+    ) -> Result<Option<Sha256Hash>, FileAdditionError>;
 
     fn stored_asset_uri(
         &self,
@@ -870,10 +874,11 @@ pub trait AssetUri {
             })
     }
 
-    fn generate_file_addition_id(checksum: &Sha256Hash, asset_uri: &str) -> HashId
+    fn generate_file_addition_id(checksum: Option<&Sha256Hash>, asset_uri: &str) -> HashId
     where
         Self: Sized,
     {
+        let checksum = checksum.map(Sha256Hash::to_string).unwrap_or_default();
         let combined = format!("{checksum};{asset_uri}");
         HashId(calculate_hash(&combined))
     }
@@ -977,9 +982,9 @@ impl AssetUri for LocalAssetUri {
         &self,
         workspace: &Workspace,
         checksum_override: Option<Sha256Hash>,
-    ) -> Result<Sha256Hash, FileAdditionError> {
+    ) -> Result<Option<Sha256Hash>, FileAdditionError> {
         if let Some(checksum_override) = checksum_override {
-            return Ok(checksum_override);
+            return Ok(Some(checksum_override));
         }
 
         let source_file_path = self.resolved_source_file_path(workspace)?;
@@ -991,6 +996,7 @@ impl AssetUri for LocalAssetUri {
         OpenDalLocation::from_workspace_path(workspace, &checksum_path)
             .map_err(opendal_file_addition_error)?
             .checksum(&checksum_path.to_string_lossy())
+            .map(Some)
     }
 
     fn stored_asset_uri(
@@ -1375,9 +1381,16 @@ impl LocalAssetUri {
         file_addition: &FileAddition,
         workspace: &Workspace,
     ) -> Result<(), FileStoreError> {
-        let asset_path = workspace
-            .asset_dir()?
-            .join(file_addition.clone().hashed_filename());
+        let asset_filename = file_addition.hashed_filename().ok_or_else(|| {
+            FileStoreError::IoError(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "cannot store local asset without checksum: {}",
+                    file_addition.asset_uri
+                ),
+            ))
+        })?;
+        let asset_path = workspace.asset_dir()?.join(asset_filename);
         if asset_path.exists() {
             return Ok(());
         }
@@ -1463,8 +1476,8 @@ impl AssetUri for RemoteAssetUri {
         &self,
         _workspace: &Workspace,
         checksum_override: Option<Sha256Hash>,
-    ) -> Result<Sha256Hash, FileAdditionError> {
-        Ok(Self::checksum_for_uri(&self.asset_uri, checksum_override))
+    ) -> Result<Option<Sha256Hash>, FileAdditionError> {
+        Ok(checksum_override)
     }
 
     fn stored_asset_uri(
@@ -1497,10 +1510,6 @@ impl RemoteAssetUri {
         Self {
             asset_uri: asset_uri.to_string(),
         }
-    }
-
-    fn checksum_for_uri(asset_uri: &str, checksum_override: Option<Sha256Hash>) -> Sha256Hash {
-        checksum_override.unwrap_or_else(|| Sha256Hash::convert_str(asset_uri))
     }
 }
 
@@ -1926,8 +1935,8 @@ mod tests {
         let checksum = Sha256Hash([1u8; 32]);
         let file_path = "/path/to/file.txt";
 
-        let id1 = LocalAssetUri::generate_file_addition_id(&checksum, file_path);
-        let id2 = LocalAssetUri::generate_file_addition_id(&checksum, file_path);
+        let id1 = LocalAssetUri::generate_file_addition_id(Some(&checksum), file_path);
+        let id2 = LocalAssetUri::generate_file_addition_id(Some(&checksum), file_path);
 
         assert_eq!(id1, id2);
     }
@@ -1938,8 +1947,8 @@ mod tests {
         let file_path1 = "/path/to/file1.txt";
         let file_path2 = "/path/to/file2.txt";
 
-        let id1 = LocalAssetUri::generate_file_addition_id(&checksum, file_path1);
-        let id2 = LocalAssetUri::generate_file_addition_id(&checksum, file_path2);
+        let id1 = LocalAssetUri::generate_file_addition_id(Some(&checksum), file_path1);
+        let id2 = LocalAssetUri::generate_file_addition_id(Some(&checksum), file_path2);
 
         assert_ne!(id1, id2);
     }
@@ -1950,8 +1959,8 @@ mod tests {
         let checksum2 = Sha256Hash([2u8; 32]);
         let file_path = "/path/to/file.txt";
 
-        let id1 = LocalAssetUri::generate_file_addition_id(&checksum1, file_path);
-        let id2 = LocalAssetUri::generate_file_addition_id(&checksum2, file_path);
+        let id1 = LocalAssetUri::generate_file_addition_id(Some(&checksum1), file_path);
+        let id2 = LocalAssetUri::generate_file_addition_id(Some(&checksum2), file_path);
 
         assert_ne!(id1, id2);
     }
@@ -2391,7 +2400,7 @@ mod tests {
     }
 
     #[test]
-    fn test_remote_asset_uri_reads_http_uri() {
+    fn test_remote_asset_uri_checksums_streamed_http_content() {
         let seed = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap()
@@ -2407,8 +2416,8 @@ mod tests {
         let addr = listener.local_addr().unwrap();
         let handle = thread::spawn(move || {
             let started = Instant::now();
-            let mut served_get = false;
-            while !served_get && started.elapsed() < Duration::from_secs(5) {
+            let mut served_get_count = 0;
+            while served_get_count < 1 && started.elapsed() < Duration::from_secs(5) {
                 let Ok((mut stream, _)) = listener.accept() else {
                     thread::sleep(Duration::from_millis(10));
                     continue;
@@ -2416,8 +2425,8 @@ mod tests {
                 let mut request = [0; 1024];
                 let len = stream.read(&mut request).unwrap();
                 let request = String::from_utf8_lossy(&request[..len]);
-                served_get = request.starts_with("GET ");
-                if served_get {
+                if request.starts_with("GET ") {
+                    served_get_count += 1;
                     stream
                         .write_all(
                             b"HTTP/1.1 200 OK\r\nContent-Length: 7\r\nConnection: close\r\n\r\ninitial",
@@ -2431,18 +2440,21 @@ mod tests {
                         .unwrap();
                 }
             }
-            assert!(served_get);
+            assert_eq!(served_get_count, 1);
         });
 
         let context = setup_gen();
         let uri = format!("http://{addr}/asset.fa");
-        let mut reader = RemoteAssetUri::new(&uri)
-            .reader(context.workspace())
-            .unwrap();
+        let asset_uri = RemoteAssetUri::new(&uri);
+        assert_eq!(asset_uri.checksum(context.workspace(), None).unwrap(), None);
+        let mut reader = asset_uri.reader(context.workspace()).unwrap();
+        let checksum_handle = reader.checksum_handle();
         let mut contents = String::new();
         reader.read_to_string(&mut contents).unwrap();
 
         handle.join().unwrap();
-        assert_eq!(contents, "initial");
+        let expected_checksum = calculate_reader_checksum(contents.as_bytes()).unwrap();
+        assert_eq!(checksum_handle.checksum(), Some(expected_checksum));
+        assert_ne!(expected_checksum, Sha256Hash::convert_str(&uri));
     }
 }

--- a/gen-models/src/assets.rs
+++ b/gen-models/src/assets.rs
@@ -20,7 +20,7 @@ use crate::{
     db::GraphConnection,
     errors::{FileAdditionError, FileStoreError, QueryError},
     history::dolt::hash_of,
-    operations::{FileAddition, calculate_reader_checksum},
+    operations::FileAddition,
     traits::Query,
 };
 

--- a/gen-models/src/history/dolt.rs
+++ b/gen-models/src/history/dolt.rs
@@ -891,7 +891,7 @@ mod tests {
         search_branch_names, set_commit_author_email, set_commit_author_name, status_rows,
     };
     use crate::{
-        annotations::add_annotation_file,
+        annotations::{AnnotationFileChecksumOverrides, add_annotation_file},
         assets::{AssetRef, AssetRole, OperationAsset, OperationKind},
         collection::Collection,
         db,
@@ -1644,6 +1644,7 @@ mod tests {
             None,
             Some("fixture-track"),
             Some("annotation diff contract"),
+            AnnotationFileChecksumOverrides::default(),
         )
         .expect("should commit annotation-file asset refs");
 

--- a/gen-models/src/operations.rs
+++ b/gen-models/src/operations.rs
@@ -59,13 +59,7 @@ pub struct OperationFileInfo {
     pub file_path: String,
     pub asset_uri: String,
     pub file_type: FileTypes,
-    pub checksum: Sha256Hash,
-}
-
-impl OperationFileInfo {
-    pub fn hashed_filename(&self) -> String {
-        <dyn AssetUri>::from_uri(&self.asset_uri).hashed_filename(&self.checksum)
-    }
+    pub checksum: Option<Sha256Hash>,
 }
 
 impl OperationFile {
@@ -98,9 +92,14 @@ impl OperationFile {
     pub fn storage_file_path(
         workspace: &Workspace,
         path_or_uri: &str,
-        checksum: &Sha256Hash,
+        checksum: Option<&Sha256Hash>,
     ) -> Result<String, FileAdditionError> {
         if LocalAssetUri::is_local_path_or_file_uri(path_or_uri) {
+            let checksum = checksum.ok_or_else(|| {
+                FileAdditionError::ChecksumError(format!(
+                    "local operation file has no checksum: {path_or_uri}"
+                ))
+            })?;
             LocalAssetUri::operation_file_path(workspace, path_or_uri, checksum)
         } else {
             Ok(path_or_uri.to_string())
@@ -159,7 +158,7 @@ pub fn commit_operation_summary(
             let logical_path = OperationFile::storage_file_path(
                 workspace,
                 &operation_file.file_path,
-                &file_addition.checksum,
+                file_addition.checksum.as_ref(),
             )?;
             Ok((file_addition, logical_path))
         })
@@ -232,7 +231,7 @@ pub(crate) fn track_operation_assets(
         let asset_ref_id = AssetRef::id_hash(
             &asset.file_addition.asset_uri,
             file_type,
-            Some(&asset.file_addition.checksum),
+            asset.file_addition.checksum.as_ref(),
             &asset.role,
             asset.logical_path,
             asset.name,
@@ -241,7 +240,7 @@ pub(crate) fn track_operation_assets(
             id: asset_ref_id,
             uri: asset.file_addition.asset_uri.clone(),
             file_type: file_type.to_string(),
-            checksum: Some(asset.file_addition.checksum),
+            checksum: asset.file_addition.checksum,
             size: None,
             role: asset.role.clone(),
             logical_path: asset.logical_path.map(str::to_string),
@@ -280,7 +279,7 @@ pub fn add_files_operation(
             let file_type = FileTypes::infer_from_path(path);
             let file_addition = FileAddition::prepare(workspace, path, file_type, None)?;
             let operation_file_path =
-                OperationFile::storage_file_path(workspace, path, &file_addition.checksum)?;
+                OperationFile::storage_file_path(workspace, path, file_addition.checksum.as_ref())?;
             Ok::<(FileAddition, String, String), FileAdditionError>((
                 file_addition,
                 OperationFile::new(path.clone()).filename,
@@ -370,7 +369,7 @@ pub struct FileAddition {
     pub id: HashId,
     pub asset_uri: String,
     pub file_type: FileTypes,
-    pub checksum: Sha256Hash,
+    pub checksum: Option<Sha256Hash>,
 }
 
 impl Query for FileAddition {
@@ -407,11 +406,16 @@ impl FileAddition {
     ) -> Result<FileAddition, FileAdditionError> {
         let asset_uri = <dyn AssetUri>::new(workspace, file_path);
         let checksum = asset_uri.checksum(workspace, checksum_override)?;
-        let stored_asset_uri = asset_uri.stored_asset_uri(workspace, &checksum)?;
-        asset_uri.ensure_asset(workspace, &checksum)?;
+        let stored_asset_uri = match checksum.as_ref() {
+            Some(checksum) => asset_uri.stored_asset_uri(workspace, checksum)?,
+            None => asset_uri.uri().to_string(),
+        };
+        if let Some(checksum) = checksum.as_ref() {
+            asset_uri.ensure_asset(workspace, checksum)?;
+        }
 
         Ok(FileAddition {
-            id: LocalAssetUri::generate_file_addition_id(&checksum, &stored_asset_uri),
+            id: LocalAssetUri::generate_file_addition_id(checksum.as_ref(), &stored_asset_uri),
             asset_uri: stored_asset_uri,
             file_type,
             checksum,
@@ -427,8 +431,10 @@ impl FileAddition {
         asset_uri.store_file(self, workspace)
     }
 
-    pub fn hashed_filename(self) -> String {
-        <dyn AssetUri>::from_uri(&self.asset_uri).hashed_filename(&self.checksum)
+    pub fn hashed_filename(&self) -> Option<String> {
+        self.checksum
+            .as_ref()
+            .map(|checksum| <dyn AssetUri>::from_uri(&self.asset_uri).hashed_filename(checksum))
     }
 }
 
@@ -1192,7 +1198,7 @@ mod tests {
         let storage_path = OperationFile::storage_file_path(
             context.workspace(),
             &absolute_path.to_string_lossy(),
-            &checksum,
+            Some(&checksum),
         )
         .unwrap();
 
@@ -1219,14 +1225,14 @@ mod tests {
         let storage_path = OperationFile::storage_file_path(
             context.workspace(),
             &outside_path_string,
-            &file_addition.checksum,
+            file_addition.checksum.as_ref(),
         )
         .unwrap();
+        let checksum = file_addition
+            .checksum
+            .expect("local file addition should have a checksum");
 
-        assert_eq!(
-            storage_path,
-            format!(".gen/assets/{}.fa.bgz", file_addition.checksum)
-        );
+        assert_eq!(storage_path, format!(".gen/assets/{checksum}.fa.bgz"));
         assert_eq!(
             file_addition.asset_uri,
             LocalAssetUri::asset_uri(".gen/outside_root/simple.fa.bgz"),
@@ -1254,7 +1260,7 @@ mod tests {
         assert_eq!(fa1.file_path(), expected_asset_path);
 
         let relative1_id = LocalAssetUri::generate_file_addition_id(
-            &checksum,
+            Some(&checksum),
             &LocalAssetUri::asset_uri(&expected_asset_path),
         );
 
@@ -1264,7 +1270,10 @@ mod tests {
                 .workspace()
                 .asset_dir()
                 .unwrap()
-                .join(fa1.clone().hashed_filename())
+                .join(
+                    fa1.hashed_filename()
+                        .expect("local file addition should have a checksum"),
+                )
                 .exists()
         );
 
@@ -1312,7 +1321,11 @@ mod tests {
                 .workspace()
                 .asset_dir()
                 .unwrap()
-                .join(outside.clone().hashed_filename())
+                .join(
+                    outside
+                        .hashed_filename()
+                        .expect("local file addition should have a checksum"),
+                )
                 .exists()
         );
     }
@@ -1328,6 +1341,7 @@ mod tests {
 
         assert_eq!(addition.asset_uri, asset_uri);
         assert_eq!(addition.file_path(), asset_uri);
+        assert_eq!(addition.checksum, None);
         assert!(
             fs::read_dir(context.workspace().asset_dir().unwrap())
                 .unwrap()
@@ -1340,13 +1354,37 @@ mod tests {
     fn test_file_addition_prepare_remote_uri() {
         let context = setup_gen();
         let asset_uri = "s3://bucket/reference.fa";
+        let checksum = Sha256Hash::convert_str("remote S3 contents");
 
-        let addition =
-            FileAddition::prepare(context.workspace(), asset_uri, FileTypes::Fasta, None)
-                .expect("should prepare remote file addition");
+        let addition = FileAddition::prepare(
+            context.workspace(),
+            asset_uri,
+            FileTypes::Fasta,
+            Some(checksum),
+        )
+        .expect("should prepare remote file addition");
 
         assert_eq!(addition.asset_uri, asset_uri);
         assert_eq!(addition.file_path(), asset_uri);
+        assert_eq!(addition.checksum, Some(checksum));
+    }
+
+    #[test]
+    fn test_add_files_operation_does_not_read_remote_asset() {
+        let context = setup_gen();
+        let asset_uri = "http://127.0.0.1:1/asset.fa".to_string();
+
+        add_files_operation(
+            &context,
+            std::slice::from_ref(&asset_uri),
+            Some("track remote reference"),
+        )
+        .expect("should track remote asset");
+
+        let asset_refs = AssetRef::all(context.graph().conn());
+        assert_eq!(asset_refs.len(), 1);
+        assert_eq!(asset_refs[0].uri, asset_uri);
+        assert_eq!(asset_refs[0].checksum, None);
     }
 
     #[test]

--- a/gen-models/src/operations.rs
+++ b/gen-models/src/operations.rs
@@ -267,7 +267,7 @@ pub(crate) fn track_operation_assets(
 )]
 pub fn add_files_operation(
     context: &DbContext,
-    files: &[String],
+    files: &[OperationFile],
     message: Option<&str>,
 ) -> Result<DoltHashId, AddFilesOperationError> {
     let workspace = context.workspace();
@@ -275,14 +275,21 @@ pub fn add_files_operation(
 
     let file_additions = files
         .iter()
-        .map(|path| {
-            let file_type = FileTypes::infer_from_path(path);
-            let file_addition = FileAddition::prepare(workspace, path, file_type, None)?;
-            let operation_file_path =
-                OperationFile::storage_file_path(workspace, path, file_addition.checksum.as_ref())?;
+        .map(|operation_file| {
+            let file_addition = FileAddition::prepare(
+                workspace,
+                &operation_file.file_path,
+                operation_file.file_type,
+                operation_file.checksum_override,
+            )?;
+            let operation_file_path = OperationFile::storage_file_path(
+                workspace,
+                &operation_file.file_path,
+                file_addition.checksum.as_ref(),
+            )?;
             Ok::<(FileAddition, String, String), FileAdditionError>((
                 file_addition,
-                OperationFile::new(path.clone()).filename,
+                operation_file.filename.clone(),
                 operation_file_path,
             ))
         })
@@ -307,7 +314,7 @@ pub fn add_files_operation(
 
     let summary = message.map(str::to_string).unwrap_or_else(|| {
         if files.len() == 1 {
-            format!("Add file {}", files[0])
+            format!("Add file {}", files[0].file_path)
         } else {
             format!("Add {} files", files.len())
         }
@@ -405,15 +412,11 @@ impl FileAddition {
         checksum_override: Option<Sha256Hash>,
     ) -> Result<FileAddition, FileAdditionError> {
         let asset_uri = <dyn AssetUri>::new(workspace, file_path);
-        let checksum = asset_uri.checksum(workspace, checksum_override)?;
+        let checksum = asset_uri.prepare_asset(workspace, checksum_override)?;
         let stored_asset_uri = match checksum.as_ref() {
             Some(checksum) => asset_uri.stored_asset_uri(workspace, checksum)?,
             None => asset_uri.uri().to_string(),
         };
-        if let Some(checksum) = checksum.as_ref() {
-            asset_uri.ensure_asset(workspace, checksum)?;
-        }
-
         Ok(FileAddition {
             id: LocalAssetUri::generate_file_addition_id(checksum.as_ref(), &stored_asset_uri),
             asset_uri: stored_asset_uri,
@@ -1370,13 +1373,40 @@ mod tests {
     }
 
     #[test]
+    fn test_file_addition_rejects_incorrect_local_checksum_override() {
+        let context = setup_gen();
+        let path = context.workspace().repo_root().unwrap().join("asset.fa");
+        fs::write(&path, "actual contents").expect("should write local asset");
+
+        let error = FileAddition::prepare(
+            context.workspace(),
+            path.to_str().expect("should encode local asset path"),
+            FileTypes::Fasta,
+            Some(Sha256Hash::convert_str("different contents")),
+        )
+        .expect_err("should reject incorrect checksum override");
+
+        assert!(
+            matches!(error, FileAdditionError::ChecksumError(_)),
+            "should report a checksum error: {error}"
+        );
+        assert_eq!(
+            fs::read_dir(context.workspace().asset_dir().unwrap())
+                .expect("should read asset directory")
+                .count(),
+            0
+        );
+    }
+
+    #[test]
     fn test_add_files_operation_does_not_read_remote_asset() {
         let context = setup_gen();
         let asset_uri = "http://127.0.0.1:1/asset.fa".to_string();
+        let operation_file = OperationFile::new(&asset_uri);
 
         add_files_operation(
             &context,
-            std::slice::from_ref(&asset_uri),
+            std::slice::from_ref(&operation_file),
             Some("track remote reference"),
         )
         .expect("should track remote asset");
@@ -1385,6 +1415,26 @@ mod tests {
         assert_eq!(asset_refs.len(), 1);
         assert_eq!(asset_refs[0].uri, asset_uri);
         assert_eq!(asset_refs[0].checksum, None);
+    }
+
+    #[test]
+    fn test_add_files_operation_passes_remote_checksum_override() {
+        let context = setup_gen();
+        let asset_uri = "http://127.0.0.1:1/asset.fa";
+        let checksum = Sha256Hash::convert_str("known remote contents");
+        let operation_file = OperationFile::new(asset_uri).set_checksum_override(checksum);
+
+        add_files_operation(
+            &context,
+            std::slice::from_ref(&operation_file),
+            Some("track checksummed remote reference"),
+        )
+        .expect("should track remote asset without reading it");
+
+        let asset_refs = AssetRef::all(context.graph().conn());
+        assert_eq!(asset_refs.len(), 1);
+        assert_eq!(asset_refs[0].uri, asset_uri);
+        assert_eq!(asset_refs[0].checksum, Some(checksum));
     }
 
     #[test]
@@ -1398,10 +1448,14 @@ mod tests {
         fs::write(repo_root.join("unique.txt"), "unique contents").unwrap();
 
         let _operation_1_hash =
-            add_files_operation(&context, &["shared.txt".to_string()], Some("first")).unwrap();
+            add_files_operation(&context, &[OperationFile::new("shared.txt")], Some("first"))
+                .unwrap();
         let _operation_2_hash = add_files_operation(
             &context,
-            &["shared.txt".to_string(), "unique.txt".to_string()],
+            &[
+                OperationFile::new("shared.txt"),
+                OperationFile::new("unique.txt"),
+            ],
             Some("second"),
         )
         .unwrap();
@@ -1461,8 +1515,8 @@ mod tests {
         add_files_operation(
             &context,
             &[
-                alpha_path.to_string_lossy().to_string(),
-                beta_path.to_string_lossy().to_string(),
+                OperationFile::new(alpha_path.to_string_lossy()),
+                OperationFile::new(beta_path.to_string_lossy()),
             ],
             Some("same asset, different filenames"),
         )?;
@@ -1493,7 +1547,10 @@ mod tests {
 
         let _operation_hash = add_files_operation(
             &context,
-            &["alpha.fa".to_string(), "beta.fa".to_string()],
+            &[
+                OperationFile::new("alpha.fa"),
+                OperationFile::new("beta.fa"),
+            ],
             Some("import references"),
         )
         .unwrap();
@@ -1539,7 +1596,7 @@ mod tests {
 
         let operation_hash = add_files_operation(
             &context,
-            &["alpha.fa".to_string()],
+            &[OperationFile::new("alpha.fa")],
             Some("import reference"),
         )
         .unwrap();

--- a/gen-models/src/operations.rs
+++ b/gen-models/src/operations.rs
@@ -89,6 +89,10 @@ impl OperationFile {
         self
     }
 
+    /// Resolves the path stored in operation metadata without materializing remote assets.
+    ///
+    /// Local inputs use their content-addressed repository path and therefore require a checksum;
+    /// remote inputs keep their URI so they can be accessed lazily.
     pub fn storage_file_path(
         workspace: &Workspace,
         path_or_uri: &str,
@@ -265,6 +269,10 @@ pub(crate) fn track_operation_assets(
     all(debug_assertions, feature = "profiling"),
     tracing::instrument(skip(context, files, message))
 )]
+/// Records files used by an operation, retaining local content and preserving remote URIs.
+///
+/// Checksum overrides are propagated from callers that already streamed remote content, avoiding
+/// a credentials-dependent read whose only purpose would be hashing.
 pub fn add_files_operation(
     context: &DbContext,
     files: &[OperationFile],
@@ -405,6 +413,10 @@ impl FileAddition {
         feature = "profiling",
         tracing::instrument(skip(workspace, checksum_override))
     )]
+    /// Prepares an asset reference for operation storage without eagerly reading remote content.
+    ///
+    /// Local content is copied and hashed as part of retention. Remote content uses an optional
+    /// checksum supplied by a caller that performed useful streaming work.
     pub fn prepare(
         workspace: &Workspace,
         file_path: &str,
@@ -434,6 +446,10 @@ impl FileAddition {
         asset_uri.store_file(self, workspace)
     }
 
+    /// Returns the content-addressed filename when this asset has a verified checksum.
+    ///
+    /// Checksumless remote references do not live under `.gen/assets`, so they have no hashed
+    /// storage filename.
     pub fn hashed_filename(&self) -> Option<String> {
         self.checksum
             .as_ref()

--- a/gen-models/src/patch.rs
+++ b/gen-models/src/patch.rs
@@ -1,6 +1,6 @@
 use std::rc::Rc;
 
-use gen_core::{DoltHashId, HashId, Sha256Hash};
+use gen_core::{DoltHashId, HashId};
 use rusqlite::{ToSql, named_params, params, types::Value};
 use serde::{Deserialize, Serialize};
 
@@ -118,13 +118,7 @@ pub fn operation_asset_files_for_logs(
                 file_path,
                 asset_uri,
                 file_type,
-                checksum: row.get::<_, Option<Sha256Hash>>(3)?.ok_or_else(|| {
-                    rusqlite::Error::InvalidColumnType(
-                        3,
-                        "checksum".to_string(),
-                        rusqlite::types::Type::Blob,
-                    )
-                })?,
+                checksum: row.get(3)?,
             })
         })?
         .collect::<Result<Vec<_>, _>>()
@@ -204,11 +198,19 @@ fn patch_file_name(asset_uri: &str, logical_path: Option<&str>, name: Option<&st
 
 #[cfg(test)]
 mod tests {
-    use gen_core::DoltHashId;
+    use gen_core::{DoltHashId, HashId};
     use rusqlite::Connection;
 
-    use super::{DoltPatchStatement, apply_dolt_patch, load_dolt_patch};
-    use crate::{db::GraphConnection, history::dolt::commit_all};
+    use super::{
+        DoltPatchStatement, apply_dolt_patch, load_dolt_patch, operation_asset_files_for_logs,
+    };
+    use crate::{
+        assets::{AssetRef, AssetRole, OperationAsset, OperationKind, OperationLog},
+        db::GraphConnection,
+        file_types::FileTypes,
+        history::dolt::commit_all,
+        test_helpers::setup_gen,
+    };
 
     fn create_base_connection() -> GraphConnection {
         let conn = GraphConnection(Connection::open_in_memory().expect("should open database"));
@@ -235,6 +237,48 @@ mod tests {
             diff_type: "data".to_string(),
             statement: statement.to_string(),
         }
+    }
+
+    #[test]
+    fn test_operation_asset_files_for_logs_preserves_missing_checksum() {
+        let context = setup_gen();
+        let conn = context.graph().conn();
+        let log = OperationLog {
+            id: HashId::convert_str("checksumless-log"),
+            operation_kind: OperationKind::AddFile,
+            command: "add remote file".to_string(),
+            created_on: 1,
+        };
+        let asset = AssetRef {
+            id: HashId::convert_str("checksumless-asset"),
+            uri: "s3://private-bucket/reference.fa".to_string(),
+            file_type: FileTypes::Fasta.as_str().to_string(),
+            checksum: None,
+            size: None,
+            role: AssetRole::Input,
+            logical_path: Some("inputs/reference.fa".to_string()),
+            name: Some("reference.fa".to_string()),
+            created_on: 1,
+        };
+        OperationLog::create(conn, &log).expect("should create operation log");
+        AssetRef::create(conn, &asset).expect("should create checksumless asset");
+        OperationAsset::create(
+            conn,
+            &OperationAsset {
+                log_id: log.id,
+                asset_ref_id: asset.id,
+                role: AssetRole::Input,
+            },
+        )
+        .expect("should link checksumless asset");
+
+        let files = operation_asset_files_for_logs(conn, &[log.id], None)
+            .expect("should load checksumless operation asset");
+
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].asset_uri, asset.uri);
+        assert_eq!(files[0].file_path, "inputs/reference.fa");
+        assert_eq!(files[0].checksum, None);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,7 @@ use gen_annotations::translate;
 use gen_core::{BranchName, CommitRef, config::Workspace, range::Range, region::Region};
 use gen_diff::operations::collect_operation_diff;
 use gen_models::{
-    annotations::{add_annotation, add_annotation_file},
+    annotations::{AnnotationFileChecksumOverrides, add_annotation, add_annotation_file},
     block_group::BlockGroup,
     collection::Collection,
     db::{ConfigConnection, DbContext, GraphConnection},
@@ -39,7 +39,7 @@ use gen_models::{
         HistoryStore,
         dolt::{DoltHistoryStore, branch_rows},
     },
-    operations::{Defaults, RemoteBranch, add_files_operation},
+    operations::{Defaults, OperationFile, RemoteBranch, add_files_operation},
     reference_alias::ReferenceAlias,
     sample::Sample,
     traits::Query,
@@ -660,12 +660,18 @@ fn call_cli() -> Result<(), Box<dyn std::error::Error>> {
                 index.as_deref(),
                 name.as_deref(),
                 message.as_deref(),
+                AnnotationFileChecksumOverrides::default(),
             )?;
             println!("Annotation file added in operation {commit_hash}");
             Ok(())
         }
         Some(Commands::AddFile { files, message }) => {
-            let commit_hash = add_files_operation(&db_context, &files, message.as_deref())?;
+            let operation_files = files
+                .into_iter()
+                .map(OperationFile::new)
+                .collect::<Vec<_>>();
+            let commit_hash =
+                add_files_operation(&db_context, &operation_files, message.as_deref())?;
             println!("Files added in operation {commit_hash}");
             Ok(())
         }

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -9,7 +9,7 @@ use gen_core::{
     errors::{ConfigError, ConnectionError},
 };
 use gen_models::{
-    assets::OperationKind,
+    assets::{AssetUri, LocalAssetUri, OperationKind},
     db::DbContext,
     errors::{FileAdditionError, OperationError},
     file_types::FileTypes,
@@ -63,23 +63,35 @@ impl PatchFile {
         format!("assets/{checksum}.{}", FileTypes::suffix(file_type))
     }
 
+    fn local_asset_filename(file: &OperationFileInfo) -> Option<String> {
+        if !LocalAssetUri::is_file_uri(&file.asset_uri) {
+            return None;
+        }
+        file.checksum
+            .as_ref()
+            .map(|checksum| <dyn AssetUri>::from_uri(&file.asset_uri).hashed_filename(checksum))
+    }
+
     fn from_file_addition(
         context: &DbContext,
         file: OperationFileInfo,
     ) -> Result<Self, CreatePatchError> {
-        if file.asset_uri.is_empty() {
+        let Some(checksum) = file.checksum else {
             return Ok(Self {
                 archive_path: String::new(),
                 file,
             });
-        }
+        };
+        let Some(asset_filename) = Self::local_asset_filename(&file) else {
+            return Ok(Self {
+                archive_path: String::new(),
+                file,
+            });
+        };
 
-        let source_asset_path = context
-            .workspace()
-            .asset_dir()?
-            .join(file.clone().hashed_filename());
+        let source_asset_path = context.workspace().asset_dir()?.join(asset_filename);
         let archive_path = if source_asset_path.exists() {
-            Self::asset_entry_name(file.checksum, file.file_type)
+            Self::asset_entry_name(checksum, file.file_type)
         } else {
             String::new()
         };
@@ -90,11 +102,10 @@ impl PatchFile {
     fn source_asset_path(
         &self,
         context: &DbContext,
-    ) -> Result<std::path::PathBuf, ConnectionError> {
-        Ok(context
-            .workspace()
-            .asset_dir()?
-            .join(self.file.hashed_filename()))
+    ) -> Result<std::path::PathBuf, CreatePatchError> {
+        let asset_filename = Self::local_asset_filename(&self.file)
+            .ok_or(CreatePatchError::MissingAssetChecksum(self.file.id))?;
+        Ok(context.workspace().asset_dir()?.join(asset_filename))
     }
 
     fn restore_from_archive<R>(
@@ -115,7 +126,9 @@ impl PatchFile {
             .map_err(ConnectionError::from)?;
         fs::create_dir_all(&asset_dir).map_err(|err| PatchError::Io(err.to_string()))?;
 
-        let asset_path = asset_dir.join(self.file.clone().hashed_filename());
+        let asset_filename = Self::local_asset_filename(&self.file)
+            .ok_or(PatchError::MissingAssetChecksum(self.file.id))?;
+        let asset_path = asset_dir.join(asset_filename);
         if asset_path.exists() {
             return Ok(false);
         }
@@ -180,6 +193,8 @@ pub enum PatchError {
     Zip(String),
     #[error("Unsupported patch format version {found}; current version is {current}")]
     UnsupportedFormatVersion { found: u32, current: u32 },
+    #[error("Patch asset {0} has archived content but no checksum")]
+    MissingAssetChecksum(HashId),
     #[error(
         "Cannot apply patch: the working set has uncommitted changes. Commit or reset them first."
     )]
@@ -251,6 +266,8 @@ pub enum CreatePatchError {
     OperationNotFound(DoltHashId),
     #[error("Patch selection does not contain an operation.")]
     EmptySelection,
+    #[error("Patch asset {0} has archived content but no checksum")]
+    MissingAssetChecksum(HashId),
     #[error("SQL Error: {0}")]
     SqliteError(#[from] SQLError),
     #[error("I/O Error: {0}")]
@@ -501,6 +518,7 @@ fn build_operation_patch(
     };
     let files = files
         .into_iter()
+        .filter(|file| LocalAssetUri::is_file_uri(&file.asset_uri))
         .map(|file| PatchFile::from_file_addition(context, file))
         .collect::<Result<Vec<_>, _>>()?;
 
@@ -662,9 +680,11 @@ mod tests {
     use gen_core::BranchName;
     use gen_models::{
         annotations::add_annotation_file,
+        assets::{AssetRef, AssetRole, OperationAsset, OperationKind, OperationLog},
         collection::Collection,
         history::dolt::DoltHistoryStore,
-        operations::{FileAddition, add_files_operation, commit_operation_summary},
+        operations::{add_files_operation, commit_operation_summary},
+        traits::Query,
     };
     use tempfile::Builder;
 
@@ -1354,11 +1374,10 @@ mod tests {
             .unwrap()
             .file;
 
-        let restored_asset_path = target_context
-            .workspace()
-            .asset_dir()
-            .unwrap()
-            .join(restored_file.clone().hashed_filename());
+        let restored_asset_path = target_context.workspace().asset_dir().unwrap().join(
+            PatchFile::local_asset_filename(restored_file)
+                .expect("restored archive asset should have a checksum"),
+        );
         assert!(restored_asset_path.exists());
         assert_eq!(
             fs::read(restored_asset_path).unwrap(),
@@ -1369,24 +1388,80 @@ mod tests {
     #[test]
     fn test_patch_file_skips_archive_for_uri_only_asset() {
         let context = setup_gen_on_disk();
-        let file = FileAddition {
+        let operation_file = OperationFileInfo {
             id: HashId::convert_str("patch-uri"),
             asset_uri: "https://example.com/assets/reference.fa.gz".to_string(),
-            file_type: FileTypes::Fasta,
-            checksum: Sha256Hash::convert_str("checksum"),
-        };
-        let operation_file = OperationFileInfo {
-            id: file.id,
             filename: "reference.fa.gz".to_string(),
-            file_path: file.asset_uri.clone(),
-            asset_uri: file.asset_uri.clone(),
-            file_type: file.file_type,
-            checksum: file.checksum,
+            file_path: "https://example.com/assets/reference.fa.gz".to_string(),
+            file_type: FileTypes::Fasta,
+            checksum: None,
         };
 
         let patch_file = PatchFile::from_file_addition(&context, operation_file.clone()).unwrap();
 
         assert_eq!(patch_file.file, operation_file);
         assert_eq!(patch_file.archive_path, "");
+    }
+
+    #[test]
+    fn test_patch_round_trip_with_only_checksumless_remote_uri() {
+        let source_context = setup_gen_on_disk();
+        let graph_conn = source_context.graph().conn();
+        let operation_log = OperationLog {
+            id: HashId::convert_str("remote-only-operation"),
+            operation_kind: OperationKind::AddFile,
+            command: "track remote URI".to_string(),
+            created_on: 1,
+        };
+        let remote_asset = AssetRef {
+            id: HashId::convert_str("checksumless-remote-asset"),
+            uri: "s3://private-bucket/reference.fa".to_string(),
+            file_type: FileTypes::Fasta.as_str().to_string(),
+            checksum: None,
+            size: None,
+            role: AssetRole::Input,
+            logical_path: Some("inputs/reference.fa".to_string()),
+            name: Some("reference.fa".to_string()),
+            created_on: 1,
+        };
+        OperationLog::create(graph_conn, &operation_log).expect("should create operation log");
+        AssetRef::create(graph_conn, &remote_asset).expect("should create remote asset");
+        OperationAsset::create(
+            graph_conn,
+            &OperationAsset {
+                log_id: operation_log.id,
+                asset_ref_id: remote_asset.id,
+                role: AssetRole::Input,
+            },
+        )
+        .expect("should link remote asset");
+        let operation_hash = DoltHistoryStore::new(graph_conn)
+            .commit_all("track remote URI")
+            .expect("should commit remote asset");
+
+        let mut patch_stream = Cursor::new(Vec::new());
+        create_patch(&source_context, &[operation_hash], &mut patch_stream)
+            .expect("should create remote-only patch");
+        patch_stream.set_position(0);
+        let patches = load_patches(&mut patch_stream);
+        assert_eq!(patches.len(), 1);
+        assert!(
+            patches[0].files.is_empty(),
+            "remote URIs should be carried by Dolt statements, not ZIP asset entries"
+        );
+        assert!(
+            !patches[0].statements.is_empty(),
+            "remote asset metadata should remain in the Dolt patch"
+        );
+
+        let mut target_context = setup_gen_on_disk();
+        patch_stream.set_position(0);
+        apply_patch_archive(&mut target_context, &mut patch_stream)
+            .expect("should apply remote-only patch");
+
+        assert_eq!(
+            AssetRef::all(target_context.graph().conn()),
+            vec![remote_asset]
+        );
     }
 }

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -63,6 +63,8 @@ impl PatchFile {
         format!("assets/{checksum}.{}", FileTypes::suffix(file_type))
     }
 
+    // Only local references can name bytes stored under `.gen/assets`. Remote URIs remain patch
+    // metadata even when a checksum is known.
     fn local_asset_filename(file: &OperationFileInfo) -> Option<String> {
         if !LocalAssetUri::is_file_uri(&file.asset_uri) {
             return None;
@@ -76,6 +78,8 @@ impl PatchFile {
         context: &DbContext,
         file: OperationFileInfo,
     ) -> Result<Self, CreatePatchError> {
+        // A local reference without a checksum cannot identify bytes to archive and must fail
+        // rather than producing an incomplete patch. A remote reference needs no archive entry.
         let Some(checksum) = file.checksum else {
             if LocalAssetUri::is_file_uri(&file.asset_uri) {
                 return Err(CreatePatchError::MissingAssetChecksum(file.id));

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -77,6 +77,9 @@ impl PatchFile {
         file: OperationFileInfo,
     ) -> Result<Self, CreatePatchError> {
         let Some(checksum) = file.checksum else {
+            if LocalAssetUri::is_file_uri(&file.asset_uri) {
+                return Err(CreatePatchError::MissingAssetChecksum(file.id));
+            }
             return Ok(Self {
                 archive_path: String::new(),
                 file,
@@ -679,11 +682,11 @@ mod tests {
 
     use gen_core::BranchName;
     use gen_models::{
-        annotations::add_annotation_file,
+        annotations::{AnnotationFileChecksumOverrides, add_annotation_file},
         assets::{AssetRef, AssetRole, OperationAsset, OperationKind, OperationLog},
         collection::Collection,
         history::dolt::DoltHistoryStore,
-        operations::{add_files_operation, commit_operation_summary},
+        operations::{OperationFile, add_files_operation, commit_operation_summary},
         traits::Query,
     };
     use tempfile::Builder;
@@ -700,7 +703,7 @@ mod tests {
 
         let add_file_commit_hash = add_files_operation(
             context,
-            &[fasta_path.to_string_lossy().to_string()],
+            &[OperationFile::new(fasta_path.to_string_lossy())],
             Some("track fasta fixture"),
         )
         .expect("should commit add-file fixture");
@@ -713,6 +716,7 @@ mod tests {
             None,
             Some("fixture-track"),
             Some("track annotation fixture"),
+            AnnotationFileChecksumOverrides::default(),
         )
         .expect("should commit annotation fixture");
         let annotation_operation = current_history_operation_hash(context);
@@ -1098,7 +1102,7 @@ mod tests {
         let fasta_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("fixtures/simple.fa");
         let _op_1 = add_files_operation(
             &context,
-            &[fasta_path.to_string_lossy().to_string()],
+            &[OperationFile::new(fasta_path.to_string_lossy())],
             Some("track fasta fixture"),
         )
         .expect("should commit main branch fixture");
@@ -1125,6 +1129,7 @@ mod tests {
             None,
             Some("branch-track"),
             Some("track branch annotation"),
+            AnnotationFileChecksumOverrides::default(),
         )
         .expect("should commit branch annotation");
         let op_2 = current_history_operation_hash(&context);
@@ -1352,7 +1357,7 @@ mod tests {
 
         let operation_hash = add_files_operation(
             &source_context,
-            &[external_file.path().to_string_lossy().to_string()],
+            &[OperationFile::new(external_file.path().to_string_lossy())],
             Some("track external fasta"),
         )
         .expect("should commit external fasta");
@@ -1401,6 +1406,53 @@ mod tests {
 
         assert_eq!(patch_file.file, operation_file);
         assert_eq!(patch_file.archive_path, "");
+    }
+
+    #[test]
+    fn test_create_patch_rejects_checksumless_local_asset() {
+        let source_context = setup_gen_on_disk();
+        let graph_conn = source_context.graph().conn();
+        let operation_log = OperationLog {
+            id: HashId::convert_str("checksumless-local-operation"),
+            operation_kind: OperationKind::AddFile,
+            command: "track checksumless local file".to_string(),
+            created_on: 1,
+        };
+        let local_asset = AssetRef {
+            id: HashId::convert_str("checksumless-local-patch-asset"),
+            uri: "file://inputs/reference.fa".to_string(),
+            file_type: FileTypes::Fasta.as_str().to_string(),
+            checksum: None,
+            size: None,
+            role: AssetRole::Input,
+            logical_path: Some("inputs/reference.fa".to_string()),
+            name: Some("reference.fa".to_string()),
+            created_on: 1,
+        };
+        OperationLog::create(graph_conn, &operation_log).expect("should create operation log");
+        AssetRef::create(graph_conn, &local_asset).expect("should create local asset");
+        OperationAsset::create(
+            graph_conn,
+            &OperationAsset {
+                log_id: operation_log.id,
+                asset_ref_id: local_asset.id,
+                role: AssetRole::Input,
+            },
+        )
+        .expect("should link local asset");
+        let operation_hash = DoltHistoryStore::new(graph_conn)
+            .commit_all("track checksumless local file")
+            .expect("should commit local asset");
+
+        let mut patch_stream = Cursor::new(Vec::new());
+        let error = create_patch(&source_context, &[operation_hash], &mut patch_stream)
+            .expect_err("checksumless local patch asset should be rejected");
+
+        assert!(matches!(
+            error,
+            CreatePatchError::MissingAssetChecksum(id)
+                if id == local_asset.id
+        ));
     }
 
     #[test]

--- a/src/views/annotation_files.rs
+++ b/src/views/annotation_files.rs
@@ -11,7 +11,7 @@ pub struct AnnotationAssetEntry {
     pub id: gen_core::HashId,
     pub asset_uri: String,
     pub file_type: FileTypes,
-    pub checksum: gen_core::Sha256Hash,
+    pub checksum: Option<gen_core::Sha256Hash>,
 }
 
 impl AnnotationAssetEntry {
@@ -21,8 +21,10 @@ impl AnnotationAssetEntry {
             .unwrap_or(&self.asset_uri)
     }
 
-    pub fn hashed_filename(&self) -> String {
-        <dyn AssetUri>::from_uri(&self.asset_uri).hashed_filename(&self.checksum)
+    pub fn hashed_filename(&self) -> Option<String> {
+        self.checksum
+            .as_ref()
+            .map(|checksum| <dyn AssetUri>::from_uri(&self.asset_uri).hashed_filename(checksum))
     }
 }
 
@@ -34,13 +36,13 @@ pub struct AnnotationFileEntry {
     pub display_name: String,
 }
 
-fn asset_entry_from_ref(asset_ref: &AssetRef) -> Option<AnnotationAssetEntry> {
-    Some(AnnotationAssetEntry {
+fn asset_entry_from_ref(asset_ref: &AssetRef) -> AnnotationAssetEntry {
+    AnnotationAssetEntry {
         id: asset_ref.id,
         asset_uri: asset_ref.uri.clone(),
         file_type: FileTypes::from_storage_tag(&asset_ref.file_type),
-        checksum: asset_ref.checksum?,
-    })
+        checksum: asset_ref.checksum,
+    }
 }
 
 pub fn load_annotation_file_entries(
@@ -52,13 +54,8 @@ pub fn load_annotation_file_entries(
     let mut entries = Vec::with_capacity(annotation_files.len());
     for annotation_file in annotation_files {
         let asset_ref = &annotation_file.annotation;
-        let Some(file_addition) = asset_entry_from_ref(asset_ref) else {
-            continue;
-        };
-        let index_file_addition = annotation_file
-            .index
-            .as_ref()
-            .and_then(asset_entry_from_ref);
+        let file_addition = asset_entry_from_ref(asset_ref);
+        let index_file_addition = annotation_file.index.as_ref().map(asset_entry_from_ref);
         let name = asset_ref.name.clone();
         let display_name = name.clone().unwrap_or_else(|| {
             FsPath::new(file_addition.file_path())
@@ -80,7 +77,7 @@ pub fn load_annotation_file_entries(
 mod tests {
     use std::path::PathBuf;
 
-    use gen_models::annotations::add_annotation_file;
+    use gen_models::annotations::{AnnotationFileChecksumOverrides, add_annotation_file};
 
     use super::load_annotation_file_entries;
     use crate::test_helpers::setup_gen_on_disk;
@@ -97,6 +94,7 @@ mod tests {
             None,
             Some("fixture-track"),
             Some("add-annotation"),
+            AnnotationFileChecksumOverrides::default(),
         )
         .expect("should create annotation file operation");
 
@@ -109,5 +107,34 @@ mod tests {
             gen_models::file_types::FileTypes::Gff3
         );
         assert!(entries[0].index_file_addition.is_none());
+    }
+
+    #[test]
+    fn test_loads_checksumless_remote_annotation_and_index_entries() {
+        let context = setup_gen_on_disk();
+        let annotation_uri = "https://example.com/annotations/genes.gff3";
+        let index_uri = "https://example.com/annotations/genes.gff3.tbi";
+
+        add_annotation_file(
+            &context,
+            annotation_uri,
+            None,
+            Some(index_uri),
+            Some("remote-track"),
+            Some("add remote annotation"),
+            AnnotationFileChecksumOverrides::default(),
+        )
+        .expect("should create remote annotation file operation");
+
+        let entries = load_annotation_file_entries(context.graph().conn(), None);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].file_addition.asset_uri, annotation_uri);
+        assert_eq!(entries[0].file_addition.checksum, None);
+        let index = entries[0]
+            .index_file_addition
+            .as_ref()
+            .expect("remote index should remain visible");
+        assert_eq!(index.asset_uri, index_uri);
+        assert_eq!(index.checksum, None);
     }
 }

--- a/src/views/annotation_files.rs
+++ b/src/views/annotation_files.rs
@@ -21,6 +21,10 @@ impl AnnotationAssetEntry {
             .unwrap_or(&self.asset_uri)
     }
 
+    /// Returns the content-addressed local filename only when the asset has a checksum.
+    ///
+    /// Views keep checksumless remote annotations visible by using their URI directly instead of
+    /// requiring a `.gen/assets` filename.
     pub fn hashed_filename(&self) -> Option<String> {
         self.checksum
             .as_ref()
@@ -36,6 +40,8 @@ pub struct AnnotationFileEntry {
     pub display_name: String,
 }
 
+// Preserve optional checksums while translating persistence records so checksumless remote
+// annotations and indexes remain usable by collection and TUI views.
 fn asset_entry_from_ref(asset_ref: &AssetRef) -> AnnotationAssetEntry {
     AnnotationAssetEntry {
         id: asset_ref.id,

--- a/src/views/annotations.rs
+++ b/src/views/annotations.rs
@@ -406,7 +406,7 @@ fn resolve_annotation_file_path(
     let asset_path = workspace
         .asset_dir()
         .ok()?
-        .join(file_addition.clone().hashed_filename());
+        .join(file_addition.hashed_filename()?);
     if asset_path.exists() {
         return Some(asset_path);
     }
@@ -1035,13 +1035,13 @@ mod tests {
                 id: HashId::convert_str("annotation"),
                 asset_uri: "file:///tmp/annotation.gff3".to_string(),
                 file_type: FileTypes::Gff3,
-                checksum: gen_core::Sha256Hash::convert_str("annotation-checksum"),
+                checksum: Some(gen_core::Sha256Hash::convert_str("annotation-checksum")),
             },
             index_file_addition: Some(AnnotationAssetEntry {
                 id: HashId::convert_str("index"),
                 asset_uri: "file:///tmp/annotation.csi".to_string(),
                 file_type: FileTypes::None,
-                checksum: gen_core::Sha256Hash::convert_str("index-checksum"),
+                checksum: Some(gen_core::Sha256Hash::convert_str("index-checksum")),
             }),
             name: None,
             display_name: "annotation".to_string(),


### PR DESCRIPTION
The overall change is making the checksum optional in OperationFileInfo. It's currently required in the software but not by the data model. A few things were fixed/combined to make it so checksums could be calculated at the same time as data was being processed. That is the reason for the deletion of checksum/copy_to_local_path/ensure_file/etc. functions. It's centralized in stage_file_asset so we can copy a file and get the checksum at the same time.

The other consideration was dealing with remote uris. Currently we were downloading them just to checksum. I removed this so we don't do downloads just for this. It's the caller's job to download and checksum if that's the only goal.