### PR TITLE
Build the Python extension against the CPython stable ABI

### DIFF
--- a/.github/workflows/python-wheels.yaml
+++ b/.github/workflows/python-wheels.yaml
@@ -12,14 +12,13 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         id: setup-python
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.11"
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Install capnp (macOS)
         if: runner.os == 'macOS'
@@ -43,7 +42,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           command: build
-          args: --release --manifest-path gen-python/Cargo.toml --features extension-module --interpreter python${{ matrix.python-version }} --out gen-python/target/wheels
+          args: --release --manifest-path gen-python/Cargo.toml --features abi3,extension-module --interpreter python3.11 --out gen-python/target/wheels
           manylinux: auto
           container: quay.io/pypa/manylinux_2_28_x86_64:latest
           sccache: true
@@ -68,7 +67,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           command: build
-          args: --release --manifest-path gen-python/Cargo.toml --features extension-module --interpreter ${{ steps.setup-python.outputs.python-path }} --out gen-python/target/wheels
+          args: --release --manifest-path gen-python/Cargo.toml --features abi3,extension-module --interpreter ${{ steps.setup-python.outputs.python-path }} --out gen-python/target/wheels
           sccache: true
           working-directory: .
       - name: Smoke test wheel (macOS, Linux)
@@ -104,9 +103,42 @@ jobs:
           gh release upload "$env:TAG" "gen-python/target/wheels/*.whl"
       - uses: actions/upload-artifact@v4
         with:
-          name: wheels-${{ matrix.os }}-py${{ matrix.python-version }}
+          name: wheels-${{ matrix.os }}
           path: gen-python/target/wheels/*.whl
           if-no-files-found: error
+
+  test-newer-python:
+    needs: build-wheels
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.12", "3.13", "3.14"]
+
+    steps:
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - uses: actions/download-artifact@v4
+        with:
+          name: wheels-${{ matrix.os }}
+          path: wheelhouse
+      - name: Smoke test wheel (macOS, Linux)
+        if: runner.os != 'Windows'
+        run: |
+          python -m pip install --force-reinstall --no-deps wheelhouse/*.whl
+          python -c "import gen; print(gen.__version__)"
+          gen --version
+      - name: Smoke test wheel (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $wheel = Get-ChildItem "wheelhouse/*.whl"
+          python -m pip install --force-reinstall --no-deps "$($wheel.FullName)"
+          python -c "import gen; print(gen.__version__)"
+          gen --version
 
   trigger-pypi-publish:
     needs: build-wheels

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 python:
 	@[ -d .venv ] || python -m venv .venv
 	@.venv/bin/pip show maturin >/dev/null 2>&1 || .venv/bin/pip install maturin
-	.venv/bin/maturin develop --release --manifest-path gen-python/Cargo.toml --features extension-module
+	.venv/bin/maturin develop --release --manifest-path gen-python/Cargo.toml --features abi3,extension-module
 py-package-cli:
 	cargo build --release --locked --bin gen
 	mkdir -p gen.gen.data/scripts
@@ -11,7 +11,7 @@ py-package-cli:
 python-wheel: py-package-cli
 	@[ -d .venv ] || python -m venv .venv
 	@.venv/bin/pip show maturin >/dev/null 2>&1 || .venv/bin/pip install maturin
-	.venv/bin/maturin build --release --manifest-path gen-python/Cargo.toml --features extension-module
+	.venv/bin/maturin build --release --manifest-path gen-python/Cargo.toml --features abi3,extension-module
 # The jupyter widget requires a bundled JS file compiled from the TypeScript sources in gen-python/js/.
 # We check in the compiled jupyter_widget.js alongside the TS so npm is not required to build the widget.
 jupyter: python
@@ -22,7 +22,7 @@ jupyter: python
 		test -f gen-python/python/gen/static/jupyter_widget.js || \
 			(echo "Error: gen-python/python/gen/static/jupyter_widget.js missing. Install npm and run 'make jupyter'." && exit 1); \
 	fi
-	.venv/bin/maturin develop --release --manifest-path gen-python/Cargo.toml --features extension-module --extras jupyter
+	.venv/bin/maturin develop --release --manifest-path gen-python/Cargo.toml --features abi3,extension-module --extras jupyter
 r-test:
 	# CI only: builds and tests inside Linux Docker container
 	@if command -v npm >/dev/null 2>&1; then \

--- a/gen-python/Cargo.toml
+++ b/gen-python/Cargo.toml
@@ -14,6 +14,7 @@ crate-type = ["cdylib"]
 
 [features]
 default = []
+abi3 = ["pyo3/abi3-py311"]
 extension-module = ["pyo3/extension-module"]
 
 [dependencies]

--- a/gen-python/README.md
+++ b/gen-python/README.md
@@ -39,7 +39,9 @@ on `PATH` as `gen` on macOS and Linux or `gen.exe` on Windows.
 ### Rust (`src/python_api/`)
 
 The core of the package. [PyO3](https://pyo3.rs) + [maturin](https://www.maturin.rs)
-compile the Gen engine into a native extension module (`gen.so`). This layer owns:
+compile the Gen engine into a native extension module (`gen.so`). Release wheels
+use CPython's stable ABI with Python 3.11 as the minimum supported version. This
+layer owns:
 
 - **`Repository`** — opens a Gen workspace, drives all import/export operations
   (FASTA, GenBank, GFA, VCF, GAF, …), and exposes node/sample/sequence-graph

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,6 @@ Repository = "https://github.com/genhub-bio/gen"
 
 [tool.maturin]
 manifest-path = "gen-python/Cargo.toml"
-features = ["extension-module"]
+features = ["abi3", "extension-module"]
 python-source = "gen-python/python"
 module-name = "gen.gen"


### PR DESCRIPTION
Switches to pyo3's `abi3-py311` feature so one wheel per OS covers every supported Python version, instead of building once per interpreter (which was about to balloon from 3 platforms × 4 versions to 5 platforms × 4 versions once targets are added).

- `gen-python` builds with `--features abi3,extension-module` against Python 3.11 only
- To make sure it is still compatible with 3.12-3.14 the `test-newer-python` job installs it with those versions
- `verify_wheel.py` now also checks the wheel is tagged `-abi3-`

Stacked PR 2/5: pip-client → pip-abi3 → pip-targets → pip-publish-gating → pip-apple-signing