### PR TITLE
Add Linux arm64, macOS Intel, and Windows wheel targets

### DIFF
--- a/.github/workflows/python-wheels.yaml
+++ b/.github/workflows/python-wheels.yaml
@@ -11,7 +11,12 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, macos-15-intel, windows-latest]
+        include:
+          - os: ubuntu-latest
+            manylinux: quay.io/pypa/manylinux_2_28_x86_64:latest
+          - os: ubuntu-24.04-arm
+            manylinux: quay.io/pypa/manylinux_2_28_aarch64:latest
 
     steps:
       - uses: actions/checkout@v4
@@ -44,7 +49,7 @@ jobs:
           command: build
           args: --release --manifest-path gen-python/Cargo.toml --features abi3,extension-module --interpreter python3.11 --out gen-python/target/wheels
           manylinux: auto
-          container: quay.io/pypa/manylinux_2_28_x86_64:latest
+          container: ${{ matrix.manylinux }}
           sccache: true
           before-script-linux: |
             uv tool install "sccache>=0.10.0"
@@ -113,7 +118,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, macos-15-intel, windows-latest]
         python-version: ["3.12", "3.13", "3.14"]
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,9 +138,33 @@ jobs:
           gh release upload "$RELEASE_NAME" gen.linux-x86_64.zip --clobber
           gh release upload "$RELEASE_NAME" gen.linux-arm64.zip --clobber
 
+  release-windows:
+    runs-on: windows-latest
+    permissions:
+      actions: write
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - name: Install Dependencies
+        run: choco install capnproto
+      - name: Build
+        run: cargo build --release --locked --bin gen
+      - name: Ensure release exists
+        shell: bash
+        run: |
+          gh release view "$RELEASE_NAME" >/dev/null 2>&1 || gh release create "$RELEASE_NAME" --notes "" || gh release view "$RELEASE_NAME"
+      - name: upload-binary
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          Compress-Archive -Path target/release/gen.exe -DestinationPath gen.windows-x86_64.zip
+          gh release upload "$env:RELEASE_NAME" gen.windows-x86_64.zip --clobber
+
   update-release-source:
     runs-on: ubuntu-latest
-    needs: [release-macos, release-ubuntu]
+    needs: [release-macos, release-ubuntu, release-windows]
     permissions:
       actions: write
       contents: write

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Gen brings version control to genetic sequences. With it, you can track variants
 
 ## Install
 
-**Gen client**: prebuilt binaries and installers are on the [releases page](https://github.com/genhub-bio/gen/releases) for [macOS](https://github.com/genhub-bio/gen/releases/download/nightly/gen.macos.pkg) and Linux ([x64](https://github.com/genhub-bio/gen/releases/download/nightly/gen.linux-x86_64.zip) / [arm64](https://github.com/genhub-bio/gen/releases/download/nightly/gen.linux-arm64.zip)). Gen is built primarily for Unix-like systems; on Windows, you can install [WSL](https://learn.microsoft.com/en-us/windows/wsl/) to get a Linux environment, then use the Linux binary above from inside it.
+**Gen client**: prebuilt binaries and installers are on the [releases page](https://github.com/genhub-bio/gen/releases) for [macOS](https://github.com/genhub-bio/gen/releases/download/nightly/gen.macos.pkg), Linux ([x64](https://github.com/genhub-bio/gen/releases/download/nightly/gen.linux-x86_64.zip) / [arm64](https://github.com/genhub-bio/gen/releases/download/nightly/gen.linux-arm64.zip)), and [Windows](https://github.com/genhub-bio/gen/releases/download/nightly/gen.windows-x86_64.zip).
 
 You can also install it with a package manager:
 


### PR DESCRIPTION
Expands the wheel build matrix with `ubuntu-24.04-arm` and `macos-15-intel`, and adds a `release-windows` job so nightly/tagged GitHub releases ship a Windows zip alongside the existing macOS and Linux binaries (otherwise they'd only be in the pip install route).

- `python-wheels.yaml` matrix grows to 5 platforms
- `release.yml` gets a `release-windows` job building `gen.exe` and uploading `gen.windows-x86_64.zip`
- README install section links the Windows release asset

Stacked PR 3/5: pip-client → pip-abi3 → pip-targets → pip-publish-gating → pip-apple-signing