### PR TITLE
Gate PyPI publish on a specific tested wheel-build run

### DIFF
--- a/.github/workflows/publish-pypi-tag.yaml
+++ b/.github/workflows/publish-pypi-tag.yaml
@@ -1,13 +1,15 @@
 name: Publish PyPI Tag
 
 on:
-  push:
-    tags:
-      - "v*"
+  # Python wheels dispatch this workflow only after release gating succeeds.
   workflow_dispatch:
     inputs:
       tag:
         description: Git tag to publish (e.g. v0.4.0)
+        required: true
+        type: string
+      wheel_run_id:
+        description: GitHub Actions run containing the tested wheel artifacts
         required: true
         type: string
       repository:
@@ -20,7 +22,8 @@ on:
           - testpypi
 
 env:
-  PUBLISH_TAG: ${{ github.event.inputs.tag || github.ref_name || (github.ref_type == 'tag' && github.ref_name) || '' }}
+  PUBLISH_TAG: ${{ inputs.tag }}
+  WHEEL_RUN_ID: ${{ inputs.wheel_run_id }}
 
 jobs:
   publish:
@@ -28,53 +31,108 @@ jobs:
     environment:
       name: pypi
     permissions:
+      actions: read
       id-token: write
       contents: read
     steps:
       - name: Ensure tag provided
         run: |
-          if [ -z "${{ env.PUBLISH_TAG }}" ]; then
-            echo "PUBLISH_TAG is required. Run on a tag or provide the workflow_dispatch input 'tag'." >&2
-            exit 1
-          fi
+          case "$PUBLISH_TAG" in
+            v*) ;;
+            *)
+              echo "PUBLISH_TAG must start with 'v'." >&2
+              exit 1
+              ;;
+          esac
 
-      - name: Locate wheel build run
-        id: wheels-run
+      - name: Validate wheel build run
         uses: actions/github-script@v7
         env:
-          WHEEL_SHA: ${{ github.sha }}
+          WHEEL_RUN_ID: ${{ env.WHEEL_RUN_ID }}
           WHEEL_TAG: ${{ env.PUBLISH_TAG }}
         with:
           script: |
-            const sha = process.env.WHEEL_SHA;
+            const runId = Number(process.env.WHEEL_RUN_ID);
             const tag = process.env.WHEEL_TAG;
-            const { data } = await github.rest.actions.listWorkflowRuns({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: "python-wheels.yaml",
-              head_sha: sha,
-              per_page: 100,
-            });
-            const run = data.workflow_runs.find(
-              (r) =>
-                r.head_sha === sha &&
-                r.status === "completed" &&
-                r.conclusion === "success"
-            );
-            if (!run) {
+
+            if (!Number.isSafeInteger(runId) || runId <= 0) {
+              core.setFailed(`Invalid wheel run ID: ${process.env.WHEEL_RUN_ID}`);
+              return;
+            }
+
+            let run;
+            for (let attempt = 1; attempt <= 12; attempt += 1) {
+              const response = await github.rest.actions.getWorkflowRun({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: runId,
+              });
+              run = response.data;
+              if (run.status === "completed") {
+                break;
+              }
+              core.info(
+                `Wheel run ${runId} is ${run.status}; waiting for completion (${attempt}/12).`
+              );
+              await new Promise((resolve) => setTimeout(resolve, 5000));
+            }
+
+            if (run.path !== ".github/workflows/python-wheels.yaml") {
               core.setFailed(
-                `No successful python-wheels run found for tag ${tag} (sha ${sha}). Trigger the wheel build for this tag first.`
+                `Run ${runId} belongs to ${run.path}, not python-wheels.yaml.`
               );
               return;
             }
-            core.setOutput("run_id", run.id.toString());
+            if (run.status !== "completed" || run.conclusion !== "success") {
+              core.setFailed(
+                `Wheel run ${runId} for tag ${tag} did not complete successfully (status: ${run.status}, conclusion: ${run.conclusion}).`
+              );
+              return;
+            }
+
+            const jobsResponse =
+              await github.rest.actions.listJobsForWorkflowRun({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: runId,
+                per_page: 100,
+              });
+            const uploadJob = jobsResponse.data.jobs.find(
+              (job) => job.name === "upload-release-wheels"
+            );
+            if (!uploadJob || uploadJob.conclusion !== "success") {
+              core.setFailed(
+                `Wheel run ${runId} did not successfully upload its tested release wheels.`
+              );
+              return;
+            }
+
+            const tagResponse = await github.rest.git.getRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: `tags/${tag}`,
+            });
+            let tagTarget = tagResponse.data.object;
+            for (let depth = 0; tagTarget.type === "tag" && depth < 5; depth += 1) {
+              const annotatedTag = await github.rest.git.getTag({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                tag_sha: tagTarget.sha,
+              });
+              tagTarget = annotatedTag.data.object;
+            }
+            if (tagTarget.type !== "commit" || tagTarget.sha !== run.head_sha) {
+              core.setFailed(
+                `Tag ${tag} does not point to wheel run ${runId} commit ${run.head_sha}.`
+              );
+            }
 
       - name: Download wheel artifacts
         uses: actions/download-artifact@v4
         with:
           pattern: wheels-*
           path: wheelhouse
-          run-id: ${{ steps.wheels-run.outputs.run_id }}
+          run-id: ${{ env.WHEEL_RUN_ID }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Collect wheels

--- a/.github/workflows/python-wheels.yaml
+++ b/.github/workflows/python-wheels.yaml
@@ -1,6 +1,10 @@
 name: Python API Wheels
 
 on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
   workflow_dispatch:
 
 jobs:
@@ -98,22 +102,6 @@ jobs:
           python -m pip install --force-reinstall --no-deps "$($wheel.FullName)"
           python -c "import gen; print(gen.__version__)"
           gen --version
-      - name: Upload wheels to releases
-        if: runner.os != 'Windows'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          TAG: ${{ github.ref_name }}
-        run: |
-          gh release upload "${TAG}" gen-python/target/wheels/*.whl
-      - name: Upload wheels to releases (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        env:
-          GH_TOKEN: ${{ github.token }}
-          TAG: ${{ github.ref_name }}
-        run: |
-          $ErrorActionPreference = 'Stop'
-          gh release upload "$env:TAG" "gen-python/target/wheels/*.whl"
       - uses: actions/upload-artifact@v4
         with:
           name: wheels-${{ matrix.os }}
@@ -153,10 +141,28 @@ jobs:
           python -c "import gen; print(gen.__version__)"
           gen --version
 
-  trigger-pypi-publish:
-    needs: build-wheels
+  upload-release-wheels:
+    needs: [build-wheels, test-newer-python]
     runs-on: ubuntu-latest
-    if: ${{ needs.build-wheels.result == 'success' }}
+    if: ${{ needs.build-wheels.result == 'success' && needs.test-newer-python.result == 'success' && github.ref_type == 'tag' }}
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: wheels-*
+          path: wheelhouse
+          merge-multiple: true
+      - name: Upload wheels to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: gh release upload "$TAG" wheelhouse/*.whl --clobber
+
+  trigger-pypi-publish:
+    needs: upload-release-wheels
+    runs-on: ubuntu-latest
+    if: ${{ needs.upload-release-wheels.result == 'success' && github.ref_type == 'tag' }}
     permissions:
       actions: write
       contents: read
@@ -164,6 +170,7 @@ jobs:
       TAG: ${{ github.ref_name }}
       GH_TOKEN: ${{ github.token }}
       REPO: ${{ github.repository }}
+      WHEEL_RUN_ID: ${{ github.run_id }}
     steps:
       - name: Ensure tag is available
         run: |
@@ -173,4 +180,8 @@ jobs:
           fi
       - name: Trigger publish-pypi-tag workflow
         run: |
-          gh workflow run publish-pypi-tag.yaml --repo "$REPO" --ref "$TAG" -f tag="$TAG"
+          gh workflow run publish-pypi-tag.yaml \
+            --repo "$REPO" \
+            --ref "$TAG" \
+            -f tag="$TAG" \
+            -f wheel_run_id="$WHEEL_RUN_ID"


### PR DESCRIPTION
Wheels are now built/tested every PR and push to `main`, uploading to the GitHub release and triggering PyPI publish, including code signing (see next PR) still only happen for tag-triggered runs.

The old publishing system did a lookup for wheels made for a given commit, but not all of those are signed (next PR) so that's why `trigger-pypi-publish` now passes its own run ID explicitly, and `publish-pypi-tag.yaml` validates that exact run before downloading artifacts from it:

- correct workflow (`python-wheels.yaml`)
- completed successfully
- its `upload-release-wheels` job succeeded
- the given tag actually points at that run's commit

Stacked PR 4/5: pip-client → pip-abi3 → pip-targets → pip-publish-gating → pip-apple-signing