### PR TITLE
Asset commit range query

### DIFF
--- a/gen-models/src/assets.rs
+++ b/gen-models/src/assets.rs
@@ -316,7 +316,49 @@ impl AssetRef {
         to_hash: Option<&DoltHashId>,
         view: AssetView,
     ) -> Result<Vec<Self>, QueryError> {
-        let query = "WITH RECURSIVE ancestry(commit_hash, depth) AS ( \
+        let (ancestry_boundary, history_depth, view_query) = match view {
+            AssetView::Cumulative => (
+                "AND (:from_hash IS NULL OR ancestry.commit_hash <> :from_hash)",
+                "",
+                "SELECT id, uri, file_type, checksum, size, role, logical_path, name, created_on \
+                 FROM asset_versions \
+                 ORDER BY logical_path, id",
+            ),
+            AssetView::Materialized => (
+                "",
+                ", MAX(bounded_ancestry.depth) AS introduction_depth",
+                ", /* Keep only assets present at the upper bound, then rank each logical path by \
+                      its introduction order in first-parent history. Null paths remain \
+                      independent because they are partitioned by asset ID. */ \
+                 materialized_assets AS ( \
+                     SELECT asset_versions.*, \
+                            ROW_NUMBER() OVER ( \
+                                PARTITION BY asset_versions.logical_path, \
+                                             CASE \
+                                                 WHEN asset_versions.logical_path IS NULL \
+                                                 THEN asset_versions.id \
+                                                 END \
+                                ORDER BY asset_versions.introduction_depth, \
+                                         asset_versions.id \
+                            ) AS materialized_rank \
+                     FROM asset_versions \
+                     JOIN dolt_at_gen_asset_refs( \
+                         COALESCE(:to_hash, dolt_hashof('HEAD')) \
+                     ) AS current_assets \
+                       ON current_assets.id = asset_versions.id \
+                 ) \
+                 SELECT id, uri, file_type, checksum, size, role, logical_path, name, created_on \
+                 FROM materialized_assets \
+                 WHERE materialized_rank = 1 \
+                 ORDER BY logical_path, id",
+            ),
+        };
+        let query = format!(
+            "WITH RECURSIVE \
+                     /* Walk first-parent history from the upper bound. Cumulative queries stop at \
+                        the inclusive lower bound; materialized queries continue to the root so \
+                        version precedence comes from commit order rather than wall-clock time. */ \
+                     ancestry(commit_hash, depth) AS ( \
                          SELECT COALESCE(:to_hash, dolt_hashof('HEAD')), 0 \
                          UNION ALL \
                          SELECT parents.parent_hash, ancestry.depth + 1 \
@@ -325,8 +367,10 @@ impl AssetRef {
                            ON parents.commit_hash = ancestry.commit_hash \
                           AND parents.parent_index = 0 \
                          WHERE parents.parent_hash IS NOT NULL \
-                           AND (:from_hash IS NULL OR ancestry.commit_hash <> :from_hash) \
+                           {ancestry_boundary} \
                      ), \
+                     /* If from_hash is not in the walk, reject the entire range instead of \
+                        returning history from an unrelated commit. */ \
                      bounded_ancestry AS ( \
                          SELECT commit_hash, depth \
                          FROM ancestry \
@@ -336,51 +380,35 @@ impl AssetRef {
                                 WHERE commit_hash = :from_hash \
                             ) \
                      ), \
+                     /* Join the selected commits to Dolt's repeated table snapshots, keep local \
+                        files, and collapse each immutable asset ID. Materialized queries also \
+                        record the oldest depth in the full walk as the version's introduction \
+                        order on the selected ref. */ \
                      asset_versions AS ( \
-                         SELECT historical_assets.*, \
-                                ROW_NUMBER() OVER ( \
-                                    PARTITION BY historical_assets.id \
-                                    ORDER BY bounded_ancestry.depth \
-                                ) AS history_rank, \
-                                MAX(bounded_ancestry.depth) OVER ( \
-                                    PARTITION BY historical_assets.id \
-                                ) AS age \
+                         SELECT historical_assets.id, \
+                                historical_assets.uri, \
+                                historical_assets.file_type, \
+                                historical_assets.checksum, \
+                                historical_assets.size, \
+                                historical_assets.role, \
+                                historical_assets.logical_path, \
+                                historical_assets.name, \
+                                historical_assets.created_on \
+                                {history_depth} \
                          FROM bounded_ancestry \
                          JOIN dolt_history_gen_asset_refs AS historical_assets \
                            ON historical_assets.commit_hash = bounded_ancestry.commit_hash \
                          WHERE historical_assets.uri LIKE 'file://%' \
-                     ), \
-                     selected_assets AS ( \
-                         SELECT asset_versions.*, \
-                                ROW_NUMBER() OVER ( \
-                                    PARTITION BY asset_versions.logical_path, \
-                                                 CASE \
-                                                     WHEN asset_versions.logical_path IS NULL \
-                                                     THEN asset_versions.id \
-                                                 END \
-                                    ORDER BY asset_versions.age, \
-                                             asset_versions.created_on DESC, \
-                                             asset_versions.id \
-                                ) AS materialized_rank \
-                         FROM asset_versions \
-                         LEFT JOIN dolt_at_gen_asset_refs( \
-                             COALESCE(:to_hash, dolt_hashof('HEAD')) \
-                         ) AS current_assets \
-                           ON current_assets.id = asset_versions.id \
-                         WHERE asset_versions.history_rank = 1 \
-                           AND (NOT :materialized OR current_assets.id IS NOT NULL) \
+                         GROUP BY historical_assets.id \
                      ) \
-                     SELECT id, uri, file_type, checksum, size, role, logical_path, name, created_on \
-                     FROM selected_assets \
-                     WHERE NOT :materialized OR materialized_rank = 1 \
-                     ORDER BY logical_path, id";
+                     {view_query}"
+        );
         Self::try_query(
             conn,
-            query,
+            &query,
             named_params! {
                 ":from_hash": from_hash,
                 ":to_hash": to_hash,
-                ":materialized": matches!(view, AssetView::Materialized),
             },
         )
     }
@@ -402,11 +430,11 @@ impl AssetRef {
 
     /// Returns the one-file-per-logical-path workspace view for an inclusive commit range.
     ///
-    /// When multiple committed assets share a logical path, the asset introduced by the most
-    /// recent commit in the selected history represents that path at the upper bound. This
-    /// collapsed view is for deciding which files should be materialized, not for history-aware
-    /// conflict detection. Omitting `to_hash` uses `HEAD`; omitting `from_hash` walks through the
-    /// root commit, so omitting both bounds uses the complete history reachable from `HEAD`.
+    /// When multiple committed assets share a logical path, the asset introduced by the nearest
+    /// first-parent commit to the upper bound represents that path. This collapsed view is for
+    /// deciding which files should be materialized, not for history-aware conflict detection.
+    /// Omitting `to_hash` uses `HEAD`; omitting `from_hash` walks through the root commit, so
+    /// omitting both bounds uses the complete history reachable from `HEAD`.
     pub fn get_materialized_assets_at(
         conn: &GraphConnection,
         from_hash: Option<&DoltHashId>,
@@ -1616,7 +1644,8 @@ mod tests {
 
         /// Builds a linear history where `alpha.fa` gains a replacement, its superseded reference
         /// is later deleted, and `beta.fa` is added at `HEAD`. A persistent `zeta.fa` exercises
-        /// unchanged assets, while an external URI verifies that only local files are returned.
+        /// unchanged assets, while an external URI verifies that only local files are returned. The
+        /// replacement has an older `created_on` value so materialization must use commit order.
         /// The saved commit hashes let each test isolate materialized, cumulative, and bounded
         /// history behavior without repeating the setup.
         struct AssetHistoryFixture {
@@ -1669,7 +1698,7 @@ mod tests {
                     id: HashId::convert_str("second-alpha"),
                     uri: "file://assets/second-alpha.fa".to_string(),
                     checksum: Some(Sha256Hash::convert_str("second-alpha-checksum")),
-                    created_on: 2,
+                    created_on: 0,
                     ..first_alpha.clone()
                 };
                 AssetRef::create(conn, &second_alpha).expect("should insert second alpha asset");
@@ -1731,6 +1760,21 @@ mod tests {
                     Some(&fixture.second_commit),
                 )
                 .expect("should materialize second commit"),
+                vec![fixture.second_alpha.clone(), fixture.zeta.clone()]
+            );
+        }
+
+        #[test]
+        fn test_materialized_assets_at_uses_commit_order_in_a_bounded_range() {
+            let fixture = AssetHistoryFixture::new();
+
+            assert_eq!(
+                AssetRef::get_materialized_assets_at(
+                    fixture.conn(),
+                    Some(&fixture.second_commit),
+                    Some(&fixture.second_commit),
+                )
+                .expect("should materialize using commit order"),
                 vec![fixture.second_alpha.clone(), fixture.zeta.clone()]
             );
         }

--- a/gen-models/src/assets.rs
+++ b/gen-models/src/assets.rs
@@ -7,7 +7,7 @@ use std::{
     sync::{Arc, LazyLock, Mutex},
 };
 
-use gen_core::{HashId, Sha256Hash, Workspace, calculate_hash};
+use gen_core::{DoltHashId, HashId, Sha256Hash, Workspace, calculate_hash};
 use opendal::{blocking, services};
 use rusqlite::{
     Row, ToSql, named_params, params,
@@ -19,6 +19,7 @@ use url::{Position, Url};
 use crate::{
     db::GraphConnection,
     errors::{FileAdditionError, FileStoreError, QueryError},
+    history::dolt::hash_of,
     operations::{FileAddition, calculate_reader_checksum},
     traits::Query,
 };
@@ -161,6 +162,11 @@ impl FromSql for AssetRole {
     }
 }
 
+/// An immutable reference to an asset recorded in repository history.
+///
+/// Several references can have the same logical path because Gen retains every committed version.
+/// Use [`Self::get_cumulative_assets_at`] when that provenance is needed and
+/// [`Self::get_materialized_assets_at`] when constructing the one-file-per-path workspace view.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct AssetRef {
     pub id: HashId,
@@ -175,6 +181,11 @@ pub struct AssetRef {
 }
 
 pub struct Assets;
+
+enum AssetView {
+    Cumulative,
+    Materialized,
+}
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct AnnotationFileAssets {
@@ -289,23 +300,131 @@ impl AssetRef {
         )?;
         Ok(())
     }
+
+    fn get_assets_at(
+        conn: &GraphConnection,
+        from_hash: Option<&DoltHashId>,
+        to_hash: Option<&DoltHashId>,
+        view: AssetView,
+    ) -> Result<Vec<Self>, QueryError> {
+        let query = "WITH RECURSIVE ancestry(commit_hash, depth) AS ( \
+                         SELECT COALESCE(:to_hash, dolt_hashof('HEAD')), 0 \
+                         UNION ALL \
+                         SELECT parents.parent_hash, ancestry.depth + 1 \
+                         FROM ancestry \
+                         JOIN dolt_commit_ancestors AS parents \
+                           ON parents.commit_hash = ancestry.commit_hash \
+                          AND parents.parent_index = 0 \
+                         WHERE parents.parent_hash IS NOT NULL \
+                           AND (:from_hash IS NULL OR ancestry.commit_hash <> :from_hash) \
+                     ), \
+                     bounded_ancestry AS ( \
+                         SELECT commit_hash, depth \
+                         FROM ancestry \
+                         WHERE :from_hash IS NULL \
+                            OR EXISTS ( \
+                                SELECT 1 FROM ancestry \
+                                WHERE commit_hash = :from_hash \
+                            ) \
+                     ), \
+                     asset_versions AS ( \
+                         SELECT historical_assets.*, \
+                                ROW_NUMBER() OVER ( \
+                                    PARTITION BY historical_assets.id \
+                                    ORDER BY bounded_ancestry.depth \
+                                ) AS history_rank, \
+                                MAX(bounded_ancestry.depth) OVER ( \
+                                    PARTITION BY historical_assets.id \
+                                ) AS age \
+                         FROM bounded_ancestry \
+                         JOIN dolt_history_gen_asset_refs AS historical_assets \
+                           ON historical_assets.commit_hash = bounded_ancestry.commit_hash \
+                         WHERE historical_assets.uri LIKE 'file://%' \
+                     ), \
+                     selected_assets AS ( \
+                         SELECT asset_versions.*, \
+                                ROW_NUMBER() OVER ( \
+                                    PARTITION BY asset_versions.logical_path, \
+                                                 CASE \
+                                                     WHEN asset_versions.logical_path IS NULL \
+                                                     THEN asset_versions.id \
+                                                 END \
+                                    ORDER BY asset_versions.age, \
+                                             asset_versions.created_on DESC, \
+                                             asset_versions.id \
+                                ) AS materialized_rank \
+                         FROM asset_versions \
+                         LEFT JOIN dolt_at_gen_asset_refs( \
+                             COALESCE(:to_hash, dolt_hashof('HEAD')) \
+                         ) AS current_assets \
+                           ON current_assets.id = asset_versions.id \
+                         WHERE asset_versions.history_rank = 1 \
+                           AND (NOT :materialized OR current_assets.id IS NOT NULL) \
+                     ) \
+                     SELECT id, uri, file_type, checksum, size, role, logical_path, name, created_on \
+                     FROM selected_assets \
+                     WHERE NOT :materialized OR materialized_rank = 1 \
+                     ORDER BY logical_path, id";
+        Self::try_query(
+            conn,
+            query,
+            named_params! {
+                ":from_hash": from_hash,
+                ":to_hash": to_hash,
+                ":materialized": matches!(view, AssetView::Materialized),
+            },
+        )
+    }
+
+    /// Returns every local asset reference present in an inclusive commit range.
+    ///
+    /// This cumulative view retains superseded or subsequently deleted references.
+    /// Synchronization code needs those versions to recognize previously managed file contents,
+    /// distinguish an intended update from a user edit, and report conflicts correctly. Omitting
+    /// `to_hash` uses `HEAD`; omitting `from_hash` walks through the root commit, so omitting both
+    /// bounds returns the complete history reachable from `HEAD`.
+    pub fn get_cumulative_assets_at(
+        conn: &GraphConnection,
+        from_hash: Option<&DoltHashId>,
+        to_hash: Option<&DoltHashId>,
+    ) -> Result<Vec<Self>, QueryError> {
+        Self::get_assets_at(conn, from_hash, to_hash, AssetView::Cumulative)
+    }
+
+    /// Returns the one-file-per-logical-path workspace view for an inclusive commit range.
+    ///
+    /// When multiple committed assets share a logical path, the asset introduced by the most
+    /// recent commit in the selected history represents that path at the upper bound. This
+    /// collapsed view is for deciding which files should be materialized, not for history-aware
+    /// conflict detection. Omitting `to_hash` uses `HEAD`; omitting `from_hash` walks through the
+    /// root commit, so omitting both bounds uses the complete history reachable from `HEAD`.
+    pub fn get_materialized_assets_at(
+        conn: &GraphConnection,
+        from_hash: Option<&DoltHashId>,
+        to_hash: Option<&DoltHashId>,
+    ) -> Result<Vec<Self>, QueryError> {
+        Self::get_assets_at(conn, from_hash, to_hash, AssetView::Materialized)
+    }
 }
 
 impl Assets {
+    /// Returns the materialized asset view at the commit currently named by a branch or ref.
+    ///
+    /// Resolving the ref before querying gives [`AssetRef::get_materialized_assets_at`] a stable
+    /// commit boundary even if the branch later advances. Call
+    /// [`AssetRef::get_cumulative_assets_at`] directly when superseded versions are needed for
+    /// conflict or update detection.
     pub fn get_branch_assets(
         conn: &GraphConnection,
         branch: &str,
     ) -> Result<HashMap<HashId, AssetRef>, QueryError> {
-        let query = format!(
-            "SELECT * FROM {} ORDER BY id",
-            AssetRef::table_name_with_history_ref(Some(branch))
-        );
-        let assets = AssetRef::try_query(conn, &query, named_params! { ":history_ref": branch })?;
-        Ok(assets
-            .into_iter()
-            .filter(|asset| LocalAssetUri::is_file_uri(&asset.uri))
-            .map(|asset| (asset.id, asset))
-            .collect())
+        let commit_hash = hash_of(conn, branch)?;
+        Ok(
+            AssetRef::get_materialized_assets_at(conn, None, Some(&commit_hash))?
+                .into_iter()
+                .map(|asset| (asset.id, asset))
+                .collect(),
+        )
     }
 
     pub fn get_annotation_files(
@@ -1476,34 +1595,272 @@ mod tests {
         );
     }
 
+    mod asset_history {
+        use gen_core::{DoltHashId, HashId, Sha256Hash};
+
+        use super::{AssetRef, AssetRole};
+        use crate::{
+            db::{DbContext, GraphConnection},
+            history::dolt::commit_all,
+            test_helpers::setup_gen,
+        };
+
+        struct AssetHistoryFixture {
+            context: DbContext,
+            first_alpha: AssetRef,
+            second_alpha: AssetRef,
+            beta: AssetRef,
+            zeta: AssetRef,
+            second_commit: DoltHashId,
+            deletion_commit: DoltHashId,
+            latest_commit: DoltHashId,
+        }
+
+        impl AssetHistoryFixture {
+            fn new() -> Self {
+                let context = setup_gen();
+                let conn = context.graph().conn();
+                let first_alpha = AssetRef {
+                    id: HashId::convert_str("first-alpha"),
+                    uri: "file://assets/first-alpha.fa".to_string(),
+                    file_type: "fasta".to_string(),
+                    checksum: Some(Sha256Hash::convert_str("first-alpha-checksum")),
+                    size: Some(4),
+                    role: AssetRole::Input,
+                    logical_path: Some("alpha.fa".to_string()),
+                    name: Some("alpha.fa".to_string()),
+                    created_on: 1,
+                };
+                let zeta = AssetRef {
+                    id: HashId::convert_str("zeta"),
+                    uri: "file://assets/zeta.fa".to_string(),
+                    checksum: Some(Sha256Hash::convert_str("zeta-checksum")),
+                    logical_path: Some("zeta.fa".to_string()),
+                    name: Some("zeta.fa".to_string()),
+                    ..first_alpha.clone()
+                };
+                let remote_asset = AssetRef {
+                    id: HashId::convert_str("remote-asset"),
+                    uri: "https://example.com/reference.fa".to_string(),
+                    logical_path: Some("remote.fa".to_string()),
+                    name: Some("remote.fa".to_string()),
+                    ..first_alpha.clone()
+                };
+                AssetRef::create(conn, &zeta).expect("should insert zeta asset");
+                AssetRef::create(conn, &first_alpha).expect("should insert first alpha asset");
+                AssetRef::create(conn, &remote_asset).expect("should insert remote asset");
+                commit_all(conn, "add first assets").expect("should commit first assets");
+
+                let second_alpha = AssetRef {
+                    id: HashId::convert_str("second-alpha"),
+                    uri: "file://assets/second-alpha.fa".to_string(),
+                    checksum: Some(Sha256Hash::convert_str("second-alpha-checksum")),
+                    created_on: 2,
+                    ..first_alpha.clone()
+                };
+                AssetRef::create(conn, &second_alpha).expect("should insert second alpha asset");
+                let second_commit = commit_all(conn, "replace alpha asset")
+                    .expect("should commit replacement asset");
+
+                conn.execute("DELETE FROM gen_asset_refs WHERE id = ?1", [first_alpha.id])
+                    .expect("should delete superseded alpha asset");
+                let deletion_commit = commit_all(conn, "delete superseded asset")
+                    .expect("should commit asset deletion");
+
+                let beta = AssetRef {
+                    id: HashId::convert_str("beta"),
+                    uri: "file://assets/beta.fa".to_string(),
+                    checksum: Some(Sha256Hash::convert_str("beta-checksum")),
+                    logical_path: Some("beta.fa".to_string()),
+                    name: Some("beta.fa".to_string()),
+                    created_on: 3,
+                    ..first_alpha.clone()
+                };
+                AssetRef::create(conn, &beta).expect("should insert beta asset");
+                let latest_commit =
+                    commit_all(conn, "add later beta asset").expect("should commit later asset");
+
+                Self {
+                    context,
+                    first_alpha,
+                    second_alpha,
+                    beta,
+                    zeta,
+                    second_commit,
+                    deletion_commit,
+                    latest_commit,
+                }
+            }
+
+            fn conn(&self) -> &GraphConnection {
+                self.context.graph().conn()
+            }
+        }
+
+        fn sorted_assets(mut assets: Vec<AssetRef>) -> Vec<AssetRef> {
+            assets.sort_by(|left, right| {
+                left.logical_path
+                    .cmp(&right.logical_path)
+                    .then_with(|| left.id.cmp(&right.id))
+            });
+            assets
+        }
+
+        #[test]
+        fn test_materialized_assets_at_selects_latest_version_per_path() {
+            let fixture = AssetHistoryFixture::new();
+
+            assert_eq!(
+                AssetRef::get_materialized_assets_at(
+                    fixture.conn(),
+                    None,
+                    Some(&fixture.second_commit),
+                )
+                .expect("should materialize second commit"),
+                vec![fixture.second_alpha.clone(), fixture.zeta.clone()]
+            );
+        }
+
+        #[test]
+        fn test_materialized_assets_at_excludes_deleted_versions() {
+            let fixture = AssetHistoryFixture::new();
+
+            assert_eq!(
+                AssetRef::get_materialized_assets_at(
+                    fixture.conn(),
+                    None,
+                    Some(&fixture.deletion_commit),
+                )
+                .expect("should materialize deletion commit"),
+                vec![fixture.second_alpha.clone(), fixture.zeta.clone()]
+            );
+        }
+
+        #[test]
+        fn test_cumulative_assets_at_retains_superseded_and_deleted_versions() {
+            let fixture = AssetHistoryFixture::new();
+            let expected = sorted_assets(vec![
+                fixture.first_alpha.clone(),
+                fixture.second_alpha.clone(),
+                fixture.zeta.clone(),
+            ]);
+
+            assert_eq!(
+                AssetRef::get_cumulative_assets_at(
+                    fixture.conn(),
+                    None,
+                    Some(&fixture.deletion_commit),
+                )
+                .expect("should read cumulative assets at deletion commit"),
+                expected
+            );
+        }
+
+        #[test]
+        fn test_asset_queries_respect_commit_range() {
+            let fixture = AssetHistoryFixture::new();
+            let expected = vec![
+                fixture.second_alpha.clone(),
+                fixture.beta.clone(),
+                fixture.zeta.clone(),
+            ];
+
+            assert_eq!(
+                AssetRef::get_materialized_assets_at(
+                    fixture.conn(),
+                    Some(&fixture.deletion_commit),
+                    Some(&fixture.latest_commit),
+                )
+                .expect("should materialize bounded range"),
+                expected
+            );
+            assert_eq!(
+                AssetRef::get_cumulative_assets_at(
+                    fixture.conn(),
+                    Some(&fixture.deletion_commit),
+                    Some(&fixture.latest_commit),
+                )
+                .expect("should accumulate bounded range"),
+                sorted_assets(vec![
+                    fixture.second_alpha.clone(),
+                    fixture.beta.clone(),
+                    fixture.zeta.clone(),
+                ])
+            );
+        }
+
+        #[test]
+        fn test_asset_queries_default_missing_upper_bound_to_head() {
+            let fixture = AssetHistoryFixture::new();
+
+            assert_eq!(
+                AssetRef::get_materialized_assets_at(
+                    fixture.conn(),
+                    Some(&fixture.deletion_commit),
+                    None,
+                )
+                .expect("should materialize through HEAD"),
+                vec![
+                    fixture.second_alpha.clone(),
+                    fixture.beta.clone(),
+                    fixture.zeta.clone(),
+                ]
+            );
+        }
+
+        #[test]
+        fn test_cumulative_assets_without_bounds_reads_full_head_history() {
+            let fixture = AssetHistoryFixture::new();
+            let expected = sorted_assets(vec![
+                fixture.first_alpha.clone(),
+                fixture.second_alpha.clone(),
+                fixture.beta.clone(),
+                fixture.zeta.clone(),
+            ]);
+
+            assert_eq!(
+                AssetRef::get_cumulative_assets_at(fixture.conn(), None, None)
+                    .expect("should read full history through HEAD"),
+                expected
+            );
+        }
+    }
+
     #[test]
-    fn test_get_branch_assets_returns_local_assets_from_the_requested_commit() {
+    fn test_get_branch_assets_uses_materialized_assets_at_branch_head() {
         let context = setup_gen();
         let conn = context.graph().conn();
-        let local_asset = AssetRef {
-            id: HashId::convert_str("local-asset"),
-            uri: "file://inputs/reference.fa".to_string(),
+        let first_asset = AssetRef {
+            id: HashId::convert_str("first-asset"),
+            uri: "file://assets/first.fa".to_string(),
             file_type: "fasta".to_string(),
-            checksum: Some(Sha256Hash::convert_str("local-checksum")),
+            checksum: Some(Sha256Hash::convert_str("first-checksum")),
             size: Some(4),
             role: AssetRole::Input,
-            logical_path: Some("inputs/reference.fa".to_string()),
+            logical_path: Some("reference.fa".to_string()),
             name: Some("reference.fa".to_string()),
             created_on: 1,
         };
-        let remote_asset = AssetRef {
-            id: HashId::convert_str("remote-asset"),
-            uri: "https://example.com/reference.fa".to_string(),
-            ..local_asset.clone()
+        AssetRef::create(conn, &first_asset).expect("should insert first asset");
+        commit_all(conn, "add first asset").expect("should commit first asset");
+
+        let replacement_asset = AssetRef {
+            id: HashId::convert_str("replacement-asset"),
+            uri: "file://assets/replacement.fa".to_string(),
+            checksum: Some(Sha256Hash::convert_str("replacement-checksum")),
+            created_on: 2,
+            ..first_asset
         };
-        AssetRef::create(conn, &local_asset).expect("should insert local asset");
-        AssetRef::create(conn, &remote_asset).expect("should insert remote asset");
-        let commit = commit_all(conn, "add assets").expect("should commit assets");
+        AssetRef::create(conn, &replacement_asset).expect("should insert replacement asset");
+        commit_all(conn, "replace asset").expect("should commit replacement asset");
 
-        let assets = Assets::get_branch_assets(conn, &commit.to_string())
-            .expect("should read assets at commit");
+        let assets =
+            Assets::get_branch_assets(conn, "main").expect("should read assets from branch head");
 
-        assert_eq!(assets, HashMap::from([(local_asset.id, local_asset)]));
+        assert_eq!(
+            assets,
+            HashMap::from([(replacement_asset.id, replacement_asset)])
+        );
     }
 
     #[test]

--- a/gen-models/src/assets.rs
+++ b/gen-models/src/assets.rs
@@ -1605,6 +1605,11 @@ mod tests {
             test_helpers::setup_gen,
         };
 
+        /// Builds a linear history where `alpha.fa` gains a replacement, its superseded reference
+        /// is later deleted, and `beta.fa` is added at `HEAD`. A persistent `zeta.fa` exercises
+        /// unchanged assets, while an external URI verifies that only local files are returned.
+        /// The saved commit hashes let each test isolate materialized, cumulative, and bounded
+        /// history behavior without repeating the setup.
         struct AssetHistoryFixture {
             context: DbContext,
             first_alpha: AssetRef,

--- a/gen-models/src/assets.rs
+++ b/gen-models/src/assets.rs
@@ -165,6 +165,14 @@ impl FromSql for AssetRole {
 /// An immutable reference to an asset recorded in repository history.
 ///
 /// Several references can have the same logical path because Gen retains every committed version.
+/// We have two ways to query for assets -- cumulative and materialized. The cumulative query
+/// returns an array of every known version of the asset, including older versions whose local
+/// path has been updated (for example a generic ./input.fa the user keeps updating for operations).
+///
+/// The materialized query returns the latest asset for a given logical path up to a provided ref.
+/// For example if a user imports a genome with a generically named `reference.fa` and does it again,
+/// the materialized query would return the last one.
+///
 /// Use [`Self::get_cumulative_assets_at`] when that provenance is needed and
 /// [`Self::get_materialized_assets_at`] when constructing the one-file-per-path workspace view.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -175,6 +183,7 @@ pub struct AssetRef {
     pub checksum: Option<Sha256Hash>,
     pub size: Option<i64>,
     pub role: AssetRole,
+    // The local path to the asset. This is something like input.fa, data/reference.fa, etc.
     pub logical_path: Option<String>,
     pub name: Option<String>,
     pub created_on: i64,

--- a/src/commands/remote/operations.rs
+++ b/src/commands/remote/operations.rs
@@ -281,7 +281,7 @@ enum DownloadAssetOutcome {
 }
 
 /// This is effectively a dirty file check. On clones/pulls we want to update
-/// files if they match expected checksums. The previous asset set is cumulative
+/// files if they match previously known checksums. The previous asset set is cumulative
 /// so a workspace that still contains any committed version
 /// is safe to advance. Unknown contents remain a conflict and are never overwritten.
 fn destination_matches_previous_asset(

--- a/src/commands/remote/operations.rs
+++ b/src/commands/remote/operations.rs
@@ -336,8 +336,8 @@ fn conflict_destination_path(
 }
 
 /// On downloading an asset, if it is a file we compare the hash on disk to the hashes of the
-/// asset from previous updates. If it matches, we replace it assuming it's a natural evolution
-/// of the file. If the hash is unknown, we download the file and mark it as a conflict via a
+/// asset from previous updates. If it matches the remote hash, we replace it locally assuming it's
+/// a natural evolution. If the hash is unknown, we download the file and mark it as a conflict via a
 /// .conflict extension. Historical assets that are not materialized at the destination commit are
 /// stored in `.gen/assets` so they cannot replace the current workspace file.
 fn download_asset(
@@ -366,18 +366,11 @@ fn download_asset(
         .exists()
         .then(|| calculate_file_checksum(&destination_path))
         .transpose()?;
-    let intended_change = existing_checksum
-        .as_ref()
-        .map(|checksum| {
-            destination_matches_previous_asset(
-                workspace,
-                &destination_path,
-                checksum,
-                previous_assets,
-            )
-        })
-        .transpose()?
-        .unwrap_or(false);
+    let intended_change = if let Some(checksum) = existing_checksum.as_ref() {
+        destination_matches_previous_asset(workspace, &destination_path, checksum, previous_assets)?
+    } else {
+        false
+    };
     let has_conflict = existing_checksum.is_some() && !intended_change;
     if let Some(parent) = destination_path.parent() {
         fs::create_dir_all(parent)?;

--- a/src/commands/remote/operations.rs
+++ b/src/commands/remote/operations.rs
@@ -29,14 +29,15 @@
 //! Only asset records whose URI uses the `file://` scheme represent file bytes managed by
 //! this transfer protocol. Asset URIs with other schemes, such as HTTP or S3, remain
 //! external references in the graph database and are not uploaded to or downloaded from
-//! GenHub. For an HTTP(S) repository remote, GenHub returns a presigned URL for every
-//! branch-local file asset. Push verifies each local file against its recorded checksum
-//! before uploading it with an HTTP PUT. Clone and pull download each file to a temporary
-//! path, verify its checksum, and only then move it to its materialized destination. A
-//! logical path places the file at that safe workspace-relative path; otherwise it is
-//! stored under `.gen/assets` using a checksum-derived name. Stored `file://` paths are
-//! also resolved as safe workspace-relative paths, including `.gen/outside_root` paths
-//! used to represent inputs that originally came from outside the workspace.
+//! GenHub. For an HTTP(S) repository remote, GenHub can return presigned URLs for the complete
+//! branch asset history. Gen uses the previous and destination commits to transfer only newly
+//! required versions. Push verifies each selected local file against its recorded checksum before
+//! uploading it with an HTTP PUT. Clone and pull download each selected file to a temporary path
+//! and verify its checksum. Only the asset version selected by the destination commit's
+//! materialized view is moved to its logical workspace path. Superseded versions are retained
+//! under `.gen/assets` using checksum-derived names. Stored `file://` paths are also resolved as
+//! safe workspace-relative paths, including `.gen/outside_root` paths used to represent inputs
+//! that originally came from outside the workspace.
 //!
 //! Pull records the branch commit from before the Dolt operation so downloads can
 //! distinguish a clean old version from a local modification. If the destination still
@@ -48,21 +49,22 @@
 //! leaves choosing the correct file to them.
 
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
+    error::Error,
     fs,
-    io::Write as _,
+    io::{self, Write as _},
     path::{Path, PathBuf},
 };
 
 use gen_core::{
-    HashId, Sha256Hash,
+    DoltHashId, HashId, Sha256Hash,
     config::{DEFAULT_GRAPH_DB_NAME, Workspace},
 };
 use gen_models::{
-    assets::{AssetRef, Assets, LocalAssetUri, materialization_destination_path},
+    assets::{AssetRef, LocalAssetUri, materialization_destination_path},
     db::{ConfigConnection, GraphConnection},
     history::dolt::{
-        active_branch, add_remote, branch_hash, checkout, clone_remote, fetch, pull, push,
+        active_branch, add_remote, branch_hash, checkout, clone_remote, fetch, hash_of, pull, push,
         push_force, remote_rows, set_remote_url,
     },
     operations::{Defaults, Remote, RemoteBranch, calculate_file_checksum},
@@ -82,7 +84,7 @@ use crate::{
     get_config_connection, get_connection_for_branch, get_raw_connection,
 };
 
-fn file_graph_url(remote_url: &str) -> Result<String, Box<dyn std::error::Error>> {
+fn file_graph_url(remote_url: &str) -> Result<String, Box<dyn Error>> {
     let parsed = Url::parse(remote_url)?;
     let mut path = parsed
         .to_file_path()
@@ -100,7 +102,7 @@ fn transfer_url(
     operation: RemoteOperation,
     branch: Option<&str>,
     force: bool,
-) -> Result<String, Box<dyn std::error::Error>> {
+) -> Result<String, Box<dyn Error>> {
     if remote.url.starts_with("file://") {
         return file_graph_url(&remote.url);
     }
@@ -149,7 +151,7 @@ fn resolve_remote(
     config: &ConfigConnection,
     explicit_remote: Option<&str>,
     branch: &str,
-) -> Result<Remote, Box<dyn std::error::Error>> {
+) -> Result<Remote, Box<dyn Error>> {
     let remote_name = explicit_remote
         .map(str::to_string)
         .or_else(|| RemoteBranch::get_remote(config, branch))
@@ -178,7 +180,7 @@ fn run_graph_transfer(
     branch: &str,
     force: bool,
     mut transfer: impl FnMut() -> Result<(), SqlError>,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<(), Box<dyn Error>> {
     if remote.url.starts_with("file://") {
         let remote_url = transfer_url(remote, operation, Some(branch), force)?;
         ensure_graph_remote(graph, &remote.name, &remote_url)?;
@@ -211,7 +213,7 @@ fn run_graph_transfer(
         .into())
 }
 
-fn asset_checksum(asset: &AssetRef) -> Result<Sha256Hash, Box<dyn std::error::Error>> {
+fn asset_checksum(asset: &AssetRef) -> Result<Sha256Hash, Box<dyn Error>> {
     asset
         .checksum
         .ok_or_else(|| format!("Local asset {} has no checksum", asset.id).into())
@@ -222,7 +224,7 @@ fn upload_asset(
     workspace: &Workspace,
     asset: &AssetRef,
     url: &str,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<(), Box<dyn Error>> {
     let relative_path = LocalAssetUri::path_from_uri(&asset.uri)
         .ok_or_else(|| format!("Invalid local asset URI: {}", asset.uri))?;
     let expected_checksum = asset_checksum(asset)?;
@@ -278,39 +280,39 @@ enum DownloadAssetOutcome {
     Conflict(PathBuf),
 }
 
-/// This is effectively a dirty file check. On clones/pulls we want to update files if they
-/// match expected checksums. This gives the asset that was previously in a path so we can
-/// compare it
-fn previous_asset_for_destination<'asset>(
+/// This is effectively a dirty file check. On clones/pulls we want to update
+/// files if they match expected checksums. The previous asset set is cumulative
+/// so a workspace that still contains any committed version
+/// is safe to advance. Unknown contents remain a conflict and are never overwritten.
+fn destination_matches_previous_asset(
     workspace: &Workspace,
     destination_path: &Path,
-    previous_assets: &'asset HashMap<HashId, AssetRef>,
-) -> Result<Option<&'asset AssetRef>, Box<dyn std::error::Error>> {
-    let mut previous_asset: Option<&AssetRef> = None;
+    existing_checksum: &Sha256Hash,
+    previous_assets: &HashMap<HashId, AssetRef>,
+) -> Result<bool, Box<dyn Error>> {
     for asset in previous_assets.values() {
         let checksum = asset_checksum(asset)?;
+        if checksum != *existing_checksum {
+            continue;
+        }
         let asset_path = materialization_destination_path(
             workspace,
             &asset.uri,
             Some(&checksum),
             asset.logical_path.as_deref(),
         )?;
-        if asset_path == destination_path
-            && previous_asset.is_none_or(|current| {
-                (asset.created_on, asset.id) > (current.created_on, current.id)
-            })
-        {
-            previous_asset = Some(asset);
+        if asset_path == destination_path {
+            return Ok(true);
         }
     }
-    Ok(previous_asset)
+    Ok(false)
 }
 
 /// If a conflict exists for a file we are pulling/cloning, rename it as .conflict for user resolution
 fn conflict_destination_path(
     destination_path: &Path,
     expected_checksum: &Sha256Hash,
-) -> Result<(PathBuf, bool), Box<dyn std::error::Error>> {
+) -> Result<(PathBuf, bool), Box<dyn Error>> {
     let file_name = destination_path
         .file_name()
         .and_then(|name| name.to_str())
@@ -336,20 +338,23 @@ fn conflict_destination_path(
 /// On downloading an asset, if it is a file we compare the hash on disk to the hashes of the
 /// asset from previous updates. If it matches, we replace it assuming it's a natural evolution
 /// of the file. If the hash is unknown, we download the file and mark it as a conflict via a
-/// .conflict extension
+/// .conflict extension. Historical assets that are not materialized at the destination commit are
+/// stored in `.gen/assets` so they cannot replace the current workspace file.
 fn download_asset(
     client: &Client,
     workspace: &Workspace,
     asset: &AssetRef,
     previous_assets: &HashMap<HashId, AssetRef>,
+    // `None` stores a historical version under `.gen/assets` instead of its recorded logical path.
+    destination_logical_path: Option<&str>,
     url: &str,
-) -> Result<DownloadAssetOutcome, Box<dyn std::error::Error>> {
+) -> Result<DownloadAssetOutcome, Box<dyn Error>> {
     let expected_checksum = asset_checksum(asset)?;
     let destination_path = materialization_destination_path(
         workspace,
         &asset.uri,
         Some(&expected_checksum),
-        asset.logical_path.as_deref(),
+        destination_logical_path,
     )?;
     if destination_path.exists()
         && calculate_file_checksum(&destination_path)
@@ -361,15 +366,18 @@ fn download_asset(
         .exists()
         .then(|| calculate_file_checksum(&destination_path))
         .transpose()?;
-    let previous_asset =
-        previous_asset_for_destination(workspace, &destination_path, previous_assets)?;
-    let intended_change =
-        previous_asset
-            .and_then(|asset| asset.checksum)
-            .is_some_and(|previous_checksum| {
-                previous_checksum != expected_checksum
-                    && existing_checksum == Some(previous_checksum)
-            });
+    let intended_change = existing_checksum
+        .as_ref()
+        .map(|checksum| {
+            destination_matches_previous_asset(
+                workspace,
+                &destination_path,
+                checksum,
+                previous_assets,
+            )
+        })
+        .transpose()?
+        .unwrap_or(false);
     let has_conflict = existing_checksum.is_some() && !intended_change;
     if let Some(parent) = destination_path.parent() {
         fs::create_dir_all(parent)?;
@@ -393,7 +401,7 @@ fn download_asset(
             .into());
         }
         let mut file = fs::File::create(&temporary_path)?;
-        std::io::copy(&mut response, &mut file)?;
+        io::copy(&mut response, &mut file)?;
         file.flush()?;
         drop(file);
         if calculate_file_checksum(&temporary_path)? != expected_checksum {
@@ -415,7 +423,7 @@ fn download_asset(
             fs::remove_file(&destination_path)?;
         }
         fs::rename(&temporary_path, &destination_path)?;
-        Ok::<DownloadAssetOutcome, Box<dyn std::error::Error>>(DownloadAssetOutcome::Downloaded)
+        Ok::<DownloadAssetOutcome, Box<dyn Error>>(DownloadAssetOutcome::Downloaded)
     })();
     if result.is_err() {
         let _ = fs::remove_file(&temporary_path);
@@ -429,8 +437,8 @@ fn transfer_assets(
     remote: &Remote,
     operation: RemoteOperation,
     branch: &str,
-    previous_ref: Option<&str>,
-) -> Result<(), Box<dyn std::error::Error>> {
+    previous_hash: Option<&DoltHashId>,
+) -> Result<(), Box<dyn Error>> {
     if remote.url.starts_with("file://") {
         return Ok(());
     }
@@ -440,30 +448,68 @@ fn transfer_assets(
         &AssetTransferRequest { operation, branch },
         login_origin,
     )?;
-    let mut assets = Assets::get_branch_assets(graph, branch)?;
-    let previous_assets = previous_ref
-        .map(|history_ref| Assets::get_branch_assets(graph, history_ref))
-        .transpose()?
-        .unwrap_or_default();
+    // GenHub can return URLs for the entire asset history. Limit byte transfers to asset versions
+    // introduced between the previous and destination states, while retaining the previous history
+    // for dirty-file detection and the full destination view for materialization decisions.
+    let commit_hash = hash_of(graph, branch)?;
+    let current_assets: HashMap<_, _> =
+        AssetRef::get_cumulative_assets_at(graph, previous_hash, Some(&commit_hash))?
+            .into_iter()
+            .map(|asset| (asset.id, asset))
+            .collect();
+    let materialized_asset_ids: HashSet<_> =
+        AssetRef::get_materialized_assets_at(graph, None, Some(&commit_hash))?
+            .into_iter()
+            .map(|asset| asset.id)
+            .collect();
+    let previous_assets = if let Some(previous_hash) = previous_hash {
+        AssetRef::get_cumulative_assets_at(graph, None, Some(previous_hash))?
+            .into_iter()
+            .map(|asset| (asset.id, asset))
+            .collect()
+    } else {
+        HashMap::new()
+    };
+    let mut assets: HashMap<_, _> = current_assets
+        .iter()
+        .filter(|(id, _)| !previous_assets.contains_key(id))
+        .map(|(id, asset)| (*id, asset.clone()))
+        .collect();
     let client = Client::new();
     for transfer in response.assets {
-        let asset = assets.remove(&transfer.id).ok_or_else(|| {
-            format!(
+        let Some(asset) = assets.remove(&transfer.id) else {
+            if current_assets.contains_key(&transfer.id)
+                || previous_assets.contains_key(&transfer.id)
+            {
+                continue;
+            }
+            return Err(format!(
                 "GenHub returned an asset transfer not present on branch '{branch}': {}",
                 transfer.id
             )
-        })?;
+            .into());
+        };
         match operation {
             RemoteOperation::Push => upload_asset(&client, workspace, &asset, &transfer.url)?,
             RemoteOperation::Clone | RemoteOperation::Pull => {
-                if let DownloadAssetOutcome::Conflict(conflict_path) =
-                    download_asset(&client, workspace, &asset, &previous_assets, &transfer.url)?
-                {
+                let destination_logical_path = if materialized_asset_ids.contains(&asset.id) {
+                    asset.logical_path.as_deref()
+                } else {
+                    None
+                };
+                if let DownloadAssetOutcome::Conflict(conflict_path) = download_asset(
+                    &client,
+                    workspace,
+                    &asset,
+                    &previous_assets,
+                    destination_logical_path,
+                    &transfer.url,
+                )? {
                     let destination_path = materialization_destination_path(
                         workspace,
                         &asset.uri,
                         asset.checksum.as_ref(),
-                        asset.logical_path.as_deref(),
+                        destination_logical_path,
                     )?;
                     eprintln!(
                         "Warning: remote asset conflicts with the local file at {}. The local file was preserved and the remote version was written to {}. Choose the correct version before continuing.",
@@ -487,7 +533,7 @@ fn transfer_assets(
 pub fn clone_into_workspace(
     remote: &Remote,
     workspace: &Workspace,
-) -> Result<String, Box<dyn std::error::Error>> {
+) -> Result<String, Box<dyn Error>> {
     workspace.ensure_gen_dir();
     let graph_path = workspace.graph_db_path()?;
     let graph = get_raw_connection(graph_path)?;
@@ -543,7 +589,7 @@ pub fn execute_push(
     explicit_remote: Option<&str>,
     explicit_branch: Option<&str>,
     force: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<(), Box<dyn Error>> {
     let config = get_config_connection(Some(workspace.gen_db_path()?))?;
     let intended_branch = Defaults::get_current_branch(&config);
     let graph = get_connection_for_branch(workspace.graph_db_path()?, intended_branch.as_deref())?;
@@ -553,6 +599,12 @@ pub fn execute_push(
         .or(persisted_branch)
         .unwrap_or(active_branch(&graph)?);
     let remote = resolve_remote(&config, explicit_remote, &branch)?;
+    // A missing or stale tracking ref only makes the transfer conservatively include more assets.
+    // Force pushes cannot use the tracking ref as a lower bound because they may replace history.
+    let tracking_ref = format!("{}/{branch}", remote.name);
+    let previous_hash = (!force)
+        .then(|| hash_of(&graph, &tracking_ref).ok())
+        .flatten();
     run_graph_transfer(
         &graph,
         &remote,
@@ -574,7 +626,7 @@ pub fn execute_push(
         &remote,
         RemoteOperation::Push,
         &branch,
-        None,
+        previous_hash.as_ref(),
     )?;
     if let Err(error) = run_graph_transfer(
         &graph,
@@ -598,7 +650,7 @@ pub fn execute_pull(
     workspace: &Workspace,
     explicit_remote: Option<&str>,
     explicit_branch: Option<&str>,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<(), Box<dyn Error>> {
     let config = get_config_connection(Some(workspace.gen_db_path()?))?;
     let graph_path = workspace.graph_db_path()?;
     if !graph_path.exists() {
@@ -612,7 +664,7 @@ pub fn execute_pull(
         .or(persisted_branch)
         .unwrap_or(active_branch(&graph)?);
     let remote = resolve_remote(&config, explicit_remote, &branch)?;
-    let previous_ref = branch_hash(&graph, &branch)?.map(|hash| hash.to_string());
+    let previous_hash = branch_hash(&graph, &branch)?;
     run_graph_transfer(
         &graph,
         &remote,
@@ -627,14 +679,14 @@ pub fn execute_pull(
         &remote,
         RemoteOperation::Pull,
         &branch,
-        previous_ref.as_deref(),
+        previous_hash.as_ref(),
     )?;
     RemoteBranch::set_remote_validated(&config, &branch, Some(&remote.name))?;
     println!("Pulled branch '{branch}' from '{}'.", remote.name);
     Ok(())
 }
 
-pub fn clone_destination_name(remote_url: &str) -> Result<String, Box<dyn std::error::Error>> {
+pub fn clone_destination_name(remote_url: &str) -> Result<String, Box<dyn Error>> {
     if remote_url.starts_with("http://") || remote_url.starts_with("https://") {
         return Ok(RepositoryRemote::parse(remote_url)?.slug().to_string());
     }
@@ -648,7 +700,7 @@ pub fn clone_destination_name(remote_url: &str) -> Result<String, Box<dyn std::e
         .ok_or_else(|| "Remote URL has no destination name".into())
 }
 
-pub fn canonical_remote_url(remote_url: &str) -> Result<String, Box<dyn std::error::Error>> {
+pub fn canonical_remote_url(remote_url: &str) -> Result<String, Box<dyn Error>> {
     if remote_url.starts_with("http://") || remote_url.starts_with("https://") {
         Ok(RepositoryRemote::parse(remote_url)?
             .canonical_url()
@@ -661,7 +713,7 @@ pub fn canonical_remote_url(remote_url: &str) -> Result<String, Box<dyn std::err
 pub fn clone_destination_path(
     parent: &Workspace,
     remote_url: &str,
-) -> Result<PathBuf, Box<dyn std::error::Error>> {
+) -> Result<PathBuf, Box<dyn Error>> {
     Ok(parent.base_dir().join(clone_destination_name(remote_url)?))
 }
 
@@ -688,11 +740,13 @@ mod tests {
     };
     use reqwest::blocking::Client;
     use rusqlite::{Connection, Error as SqlError};
+    use serde_json::json;
     use tempfile::tempdir;
 
     use super::{
         DownloadAssetOutcome, RemoteOperation, canonical_remote_url, clone_destination_name,
         download_asset, execute_push, file_graph_url, resolve_remote, run_graph_transfer,
+        transfer_assets,
     };
     use crate::{get_config_connection, get_connection};
 
@@ -700,7 +754,7 @@ mod tests {
 
     mod clone {
         use std::{
-            io::{Read as _, Write as _},
+            io::{self, Read as _, Write as _},
             net::TcpListener,
             sync::{
                 Arc,
@@ -805,7 +859,7 @@ mod tests {
                 while requests.len() < 3 && !stop.load(Ordering::Acquire) {
                     let (mut stream, _) = match listener.accept() {
                         Ok(connection) => connection,
-                        Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
                             thread::sleep(Duration::from_millis(10));
                             continue;
                         }
@@ -975,6 +1029,7 @@ mod tests {
             &workspace,
             &remote_asset,
             &HashMap::new(),
+            remote_asset.logical_path.as_deref(),
             &url,
         )
         .expect("should download conflicting asset");
@@ -1005,9 +1060,42 @@ mod tests {
             &workspace,
             &remote_asset,
             &previous_assets,
+            remote_asset.logical_path.as_deref(),
             &url,
         )
         .expect("should replace unchanged tracked file");
+        server.join().expect("asset server should finish");
+
+        assert_eq!(outcome, DownloadAssetOutcome::Downloaded);
+        assert_eq!(fs::read(&destination).unwrap(), remote_contents);
+        assert!(!temp.path().join("reference.fa.conflict").exists());
+    }
+
+    #[test]
+    fn test_download_asset_replaces_any_known_previous_version() {
+        let temp = tempdir().expect("should create workspace");
+        let workspace = Workspace::new(temp.path());
+        workspace.ensure_gen_dir();
+        let destination = temp.path().join("reference.fa");
+        let older_contents = b"older version\n";
+        fs::write(&destination, older_contents).expect("should write older managed file");
+        let older_asset = test_asset(older_contents, "reference.fa", 1);
+        let newer_asset = test_asset(b"newer version\n", "reference.fa", 2);
+        let previous_assets =
+            HashMap::from([(older_asset.id, older_asset), (newer_asset.id, newer_asset)]);
+        let remote_contents = b"remote version\n";
+        let remote_asset = test_asset(remote_contents, "reference.fa", 3);
+        let (url, server) = serve_asset(remote_contents);
+
+        let outcome = download_asset(
+            &Client::new(),
+            &workspace,
+            &remote_asset,
+            &previous_assets,
+            remote_asset.logical_path.as_deref(),
+            &url,
+        )
+        .expect("should replace any previously managed version");
         server.join().expect("asset server should finish");
 
         assert_eq!(outcome, DownloadAssetOutcome::Downloaded);
@@ -1034,6 +1122,7 @@ mod tests {
             &workspace,
             &remote_asset,
             &previous_assets,
+            remote_asset.logical_path.as_deref(),
             &url,
         )
         .expect("should download conflicting asset");
@@ -1043,6 +1132,84 @@ mod tests {
         assert_eq!(outcome, DownloadAssetOutcome::Conflict(conflict.clone()));
         assert_eq!(fs::read(&destination).unwrap(), b"local edits\n");
         assert_eq!(fs::read(conflict).unwrap(), remote_contents);
+    }
+
+    #[test]
+    fn test_pull_transfers_only_assets_after_previous_hash() {
+        let temp = tempdir().expect("should create transfer workspace");
+        let workspace = Workspace::new(temp.path());
+        workspace.ensure_gen_dir();
+        let graph =
+            get_connection(workspace.graph_db_path().unwrap()).expect("should open graph database");
+        let previous_contents = b"previous version\n";
+        let previous_asset = test_asset(previous_contents, "reference.fa", 1);
+        AssetRef::create(&graph, &previous_asset).expect("should insert previous asset");
+        let previous_hash =
+            commit_all(&graph, "add previous asset").expect("should commit previous asset");
+        fs::write(temp.path().join("reference.fa"), previous_contents)
+            .expect("should materialize previous asset");
+
+        let current_contents = b"current version\n";
+        let current_asset = test_asset(current_contents, "reference.fa", 2);
+        AssetRef::create(&graph, &current_asset).expect("should insert current asset");
+        commit_all(&graph, "add current asset").expect("should commit current asset");
+
+        let (current_url, asset_server) = serve_asset(current_contents);
+        let transfer_listener =
+            TcpListener::bind("127.0.0.1:0").expect("should bind transfer server");
+        let transfer_address = transfer_listener
+            .local_addr()
+            .expect("should read transfer server address");
+        let response_body = json!({
+            "assets": [
+                {
+                    "id": previous_asset.id,
+                    "url": "http://127.0.0.1:1/should-not-transfer"
+                },
+                { "id": current_asset.id, "url": current_url }
+            ]
+        })
+        .to_string();
+        let transfer_server = thread::spawn(move || {
+            let (mut stream, _) = transfer_listener
+                .accept()
+                .expect("should accept transfer request");
+            let mut request = [0_u8; 8192];
+            let read = stream
+                .read(&mut request)
+                .expect("should read transfer request");
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{response_body}",
+                response_body.len()
+            )
+            .expect("should write transfer response");
+            String::from_utf8_lossy(&request[..read]).into_owned()
+        });
+        let remote = Remote {
+            name: "origin".to_string(),
+            url: format!("http://{transfer_address}/api/repos/alice/example"),
+        };
+
+        transfer_assets(
+            &graph,
+            &workspace,
+            &remote,
+            RemoteOperation::Pull,
+            "main",
+            Some(&previous_hash),
+        )
+        .expect("should transfer only the asset delta");
+        let transfer_request = transfer_server
+            .join()
+            .expect("transfer server should finish");
+        asset_server.join().expect("asset server should finish");
+
+        assert!(transfer_request.contains("\"operation\":\"pull\""));
+        assert_eq!(
+            fs::read(temp.path().join("reference.fa")).unwrap(),
+            current_contents
+        );
     }
 
     #[test]

--- a/src/commands/remote/operations.rs
+++ b/src/commands/remote/operations.rs
@@ -431,6 +431,12 @@ fn download_asset(
     result
 }
 
+/// Transfers the asset versions needed to move from `previous_hash` to the selected branch state.
+///
+/// GenHub may advertise the branch's complete asset history, so this function filters those URLs
+/// to versions absent from the previous state. The cumulative view supplies that transfer delta
+/// and the checksums used for conflict detection, while the materialized view decides which of the
+/// selected versions belongs at its logical workspace path instead of under `.gen/assets`.
 fn transfer_assets(
     graph: &GraphConnection,
     workspace: &Workspace,
@@ -448,9 +454,7 @@ fn transfer_assets(
         &AssetTransferRequest { operation, branch },
         login_origin,
     )?;
-    // GenHub can return URLs for the entire asset history. Limit byte transfers to asset versions
-    // introduced between the previous and destination states, while retaining the previous history
-    // for dirty-file detection and the full destination view for materialization decisions.
+
     let commit_hash = hash_of(graph, branch)?;
     let current_assets: HashMap<_, _> =
         AssetRef::get_cumulative_assets_at(graph, previous_hash, Some(&commit_hash))?
@@ -470,6 +474,7 @@ fn transfer_assets(
     } else {
         HashMap::new()
     };
+    // These are assets we expect to be in the current batch of transfers
     let mut assets: HashMap<_, _> = current_assets
         .iter()
         .filter(|(id, _)| !previous_assets.contains_key(id))


### PR DESCRIPTION
Before this change, every asset transfer included the branch’s entire file history. This gives a way to scope it to refs. It also gives 2 ways to do the call -- get every version of the file in that range (called cumulative here), or just the last version (called materialized here).

The transfer code was updated to use these new methods along with some expanded test cases