### PR TITLE
Fix deletion bypass graph construction

### DIFF
--- a/gen-models/src/edge.rs
+++ b/gen-models/src/edge.rs
@@ -411,9 +411,17 @@ impl Edge {
         Ok(edges)
     }
 
+    /// Converts stored edge coordinates for one backing node into the sequence slices represented
+    /// by `GroupBlock`s.
+    ///
+    /// `blocks_from_edges` calls this after it has collected every coordinate needed by the block
+    /// group. Non-zero intervals carry sequence, while requested zero-width intervals act as
+    /// junctions between adjacent coordinate jumps. Outer junctions cover edge endpoints that have
+    /// no sequence interval on one side, so every stored edge still has a concrete graph endpoint.
     fn get_block_intervals(
         starts: &HashSet<i64>,
         ends: &HashSet<i64>,
+        junction_coordinates: &HashSet<i64>,
     ) -> Result<Vec<(i64, i64)>, EdgeError> {
         let coordinates = starts.union(ends).sorted().copied().collect::<Vec<_>>();
         if coordinates.is_empty() {
@@ -426,9 +434,83 @@ impl Edge {
             return Ok(vec![(coordinates[0], coordinates[0])]);
         }
 
-        Ok(coordinates.into_iter().tuple_windows().collect())
+        let mut intervals = Vec::new();
+        for (index, coordinate) in coordinates.iter().copied().enumerate() {
+            let is_first_coordinate = index == 0;
+            let is_last_coordinate = index == coordinates.len() - 1;
+            let needs_outer_junction = (is_first_coordinate && ends.contains(&coordinate))
+                || (is_last_coordinate && starts.contains(&coordinate));
+
+            if junction_coordinates.contains(&coordinate) || needs_outer_junction {
+                intervals.push((coordinate, coordinate));
+            }
+            if let Some(next_coordinate) = coordinates.get(index + 1) {
+                intervals.push((coordinate, *next_coordinate));
+            }
+        }
+
+        Ok(intervals)
     }
 
+    /// Records a coordinate jump whose endpoints belong to the same backing node.
+    ///
+    /// `blocks_from_edges` calls this for both its initial edges and any edges fetched while
+    /// completing partially described nodes. The source is an outgoing jump coordinate and the
+    /// target is an incoming jump coordinate. Keeping those sets separate lets block generation
+    /// identify coordinates where one jump arrives and another leaves; those coordinates need
+    /// junctions.
+    fn record_same_node_jump_coordinates(
+        edge: &Edge,
+        outgoing_coordinates_by_node_id: &mut HashMap<HashId, HashSet<i64>>,
+        incoming_coordinates_by_node_id: &mut HashMap<HashId, HashSet<i64>>,
+    ) {
+        if edge.source_node_id == edge.target_node_id
+            && edge.source_coordinate != edge.target_coordinate
+        {
+            outgoing_coordinates_by_node_id
+                .entry(edge.source_node_id)
+                .or_default()
+                .insert(edge.source_coordinate);
+            incoming_coordinates_by_node_id
+                .entry(edge.target_node_id)
+                .or_default()
+                .insert(edge.target_coordinate);
+        }
+    }
+
+    /// Materializes the backing-node slices needed to project stored block-group edges.
+    ///
+    /// Graph construction, sequence enumeration, GFA export, and diff reconstruction use this as
+    /// the first half of the stored-edge-to-`GenGraph` pipeline. The routine gathers coordinates,
+    /// expands incomplete node descriptions from the block group, and asks `get_block_intervals`
+    /// to create both sequence-bearing blocks and any required zero-width junctions.
+    ///
+    /// For example, two adjacent deletions retain each original base while also exposing the path
+    /// that skips both. Parenthesized nodes are zero-width junctions and bracketed nodes contain
+    /// real sequence:
+    ///
+    /// ```text
+    ///                  +----> [A] ----+
+    ///                  |              |
+    /// [TAAT] -> (0,0) -+------------> (1,1) -+----> [T] ----+
+    ///                                           |             |
+    ///                                           +-----------> [GATAA]
+    /// ```
+    ///
+    /// The path `(0,0) -> (1,1)` deletes `A`; `(1,1) -> [GATAA]` deletes `T`. Following both
+    /// edges gives the iterative-deletion route from `[TAAT]` to `[GATAA]` without adding a
+    /// reconstructed bypass edge.
+    ///
+    /// More generally, graph construction can produce a chain of junctions between sequence
+    /// blocks:
+    ///
+    /// ```text
+    /// [real sequence] -> (junction) -> (junction) -> [real sequence]
+    ///                       0 bases       0 bases
+    /// ```
+    ///
+    /// Traversal passes through any number of junctions, consuming zero sequence, until it reaches
+    /// another real block.
     pub fn blocks_from_edges(
         conn: &GraphConnection,
         block_group_id: &HashId,
@@ -438,7 +520,19 @@ impl Edge {
         let mut node_ids = IndexSet::new();
         let mut starts_by_node_id: HashMap<HashId, HashSet<i64>> = HashMap::new();
         let mut ends_by_node_id: HashMap<HashId, HashSet<i64>> = HashMap::new();
+        // A same-node coordinate jump connects two positions without consuming the intervening
+        // sequence. Track where jumps leave and arrive so their intersections can become
+        // junctions.
+        let mut outgoing_jump_coordinates_by_node_id: HashMap<HashId, HashSet<i64>> =
+            HashMap::new();
+        let mut incoming_jump_coordinates_by_node_id: HashMap<HashId, HashSet<i64>> =
+            HashMap::new();
         for edge in edges.iter().map(|edge| &edge.edge) {
+            Self::record_same_node_jump_coordinates(
+                edge,
+                &mut outgoing_jump_coordinates_by_node_id,
+                &mut incoming_jump_coordinates_by_node_id,
+            );
             if !is_terminal(edge.source_node_id) {
                 node_ids.insert(edge.source_node_id);
             }
@@ -475,6 +569,9 @@ impl Edge {
             .filter(|node_id| is_incomplete(node_id, &starts_by_node_id, &ends_by_node_id))
             .collect::<Vec<_>>();
 
+        // A caller may provide a graph fragment whose edges mention only one side of a backing
+        // node. Pulling neighboring stored edges supplies the missing endpoint coordinates so the
+        // resulting blocks use the same slices as a graph built from the complete block group.
         while !incomplete_node_ids.is_empty() {
             queried_node_ids.extend(incomplete_node_ids.iter().copied());
             let mut next_incomplete_node_ids = HashSet::new();
@@ -488,6 +585,11 @@ impl Edge {
             .iter()
             .map(|augmented_edge| &augmented_edge.edge)
             {
+                Self::record_same_node_jump_coordinates(
+                    edge,
+                    &mut outgoing_jump_coordinates_by_node_id,
+                    &mut incoming_jump_coordinates_by_node_id,
+                );
                 if !is_terminal(edge.source_node_id) {
                     node_ids.insert(edge.source_node_id);
                 }
@@ -535,7 +637,25 @@ impl Edge {
             let empty_ends = HashSet::new();
             let starts = starts_by_node_id.get(node_id).unwrap_or(&empty_starts);
             let ends = ends_by_node_id.get(node_id).unwrap_or(&empty_ends);
-            let block_intervals = Edge::get_block_intervals(starts, ends)?;
+            // Adjacent same-node jumps share a coordinate: one jump arrives at k and the next
+            // leaves from k. Materialize k as a junction so the graph connects both jumps:
+            //
+            //     [real sequence] -> (k,k) -> [real sequence]
+            //                           0 bases
+            //
+            // Only coordinates in both sets become junctions. A lone jump has no shared coordinate
+            // and connects real sequence blocks directly.
+            let outgoing_jump_coordinates = outgoing_jump_coordinates_by_node_id
+                .get(node_id)
+                .unwrap_or(&empty_starts);
+            let incoming_jump_coordinates = incoming_jump_coordinates_by_node_id
+                .get(node_id)
+                .unwrap_or(&empty_ends);
+            let junction_coordinates = outgoing_jump_coordinates
+                .intersection(incoming_jump_coordinates)
+                .copied()
+                .collect::<HashSet<_>>();
+            let block_intervals = Edge::get_block_intervals(starts, ends, &junction_coordinates)?;
 
             for (start, end) in block_intervals {
                 blocks.push(GroupBlock::new(block_index, *node_id, sequence, start, end));
@@ -566,15 +686,133 @@ impl Edge {
         Ok(blocks)
     }
 
+    /// Checks whether both endpoints use the same node and coordinate.
+    ///
+    /// `block_connections` uses this structural property when connecting blocks around a junction.
+    /// Whether the edge is a real path choice or an edit-site marker remains separate metadata on
+    /// `AugmentedEdge`.
+    fn is_same_coordinate_edge(&self) -> bool {
+        self.source_node_id == self.target_node_id
+            && self.source_coordinate == self.target_coordinate
+    }
+
+    /// Selects the blocks that an edge endpoint should connect to.
+    ///
+    /// `block_connections` calls this when a stored edge enters or leaves a coordinate. If a
+    /// junction exists, the edge connects to it and traversal continues from there. Otherwise the
+    /// edge connects directly to the sequence block.
+    fn select_junction_or_sequence_blocks<'a>(blocks: &[&'a GroupBlock]) -> Vec<&'a GroupBlock> {
+        let junctions = blocks
+            .iter()
+            .copied()
+            .filter(|block| block.start == block.end)
+            .collect::<Vec<_>>();
+        if junctions.is_empty() {
+            blocks.to_vec()
+        } else {
+            junctions
+        }
+    }
+
+    /// Builds connections for a same-coordinate edge.
+    ///
+    /// At a junction, the source lookup contains the sequence block ending at the coordinate and
+    /// the junction, while the target lookup contains the junction and the sequence block starting
+    /// there. `block_connections` calls this to produce the deliberate `sequence -> junction` and
+    /// `junction -> sequence` connections without adding a junction self-loop. With no junction,
+    /// the Cartesian product keeps the direct connection between sequence blocks.
+    ///
+    /// ```text
+    /// without a junction:  [sequence ending at k] ---> [sequence starting at k]
+    ///
+    /// with a junction:     [sequence ending at k] ---> (k,k) ---> [sequence starting at k]
+    /// ```
+    ///
+    /// The same-coordinate edge therefore preserves the same route after the junction is
+    /// introduced without creating `(k,k) -> (k,k)`.
+    fn same_coordinate_block_connections<'a>(
+        source_blocks: &[&'a GroupBlock],
+        target_blocks: &[&'a GroupBlock],
+    ) -> Vec<(&'a GroupBlock, &'a GroupBlock)> {
+        let source_junctions = source_blocks
+            .iter()
+            .copied()
+            .filter(|block| block.start == block.end)
+            .collect::<Vec<_>>();
+        let target_junctions = target_blocks
+            .iter()
+            .copied()
+            .filter(|block| block.start == block.end)
+            .collect::<Vec<_>>();
+
+        if source_junctions.is_empty() && target_junctions.is_empty() {
+            return source_blocks
+                .iter()
+                .copied()
+                .cartesian_product(target_blocks.iter().copied())
+                .collect();
+        }
+
+        let source_sequence_blocks = source_blocks
+            .iter()
+            .copied()
+            .filter(|block| block.start != block.end);
+        let target_sequence_blocks = target_blocks
+            .iter()
+            .copied()
+            .filter(|block| block.start != block.end);
+
+        // Sequence ending at the coordinate enters the junction, and sequence starting there
+        // leaves it. If neither side has real sequence, there is no connection to add.
+        source_sequence_blocks
+            .cartesian_product(target_junctions)
+            .chain(
+                source_junctions
+                    .into_iter()
+                    .cartesian_product(target_sequence_blocks),
+            )
+            .collect()
+    }
+
+    /// Returns the concrete block connections represented by one stored edge.
+    ///
+    /// `build_graph` calls this after coordinate lookup may have returned both a sequence block and
+    /// a junction. Same-coordinate edges connect the surrounding sequence through that junction;
+    /// all other edges connect to the junction and let the next stored edge continue from it.
+    fn block_connections<'a>(
+        &self,
+        source_blocks: &[&'a GroupBlock],
+        target_blocks: &[&'a GroupBlock],
+    ) -> Vec<(&'a GroupBlock, &'a GroupBlock)> {
+        if self.is_same_coordinate_edge() {
+            return Self::same_coordinate_block_connections(source_blocks, target_blocks);
+        }
+
+        let source_blocks = Self::select_junction_or_sequence_blocks(source_blocks);
+        let target_blocks = Self::select_junction_or_sequence_blocks(target_blocks);
+        source_blocks
+            .into_iter()
+            .cartesian_product(target_blocks)
+            .collect()
+    }
+
+    /// Projects augmented stored edges and their materialized blocks into a `GenGraph`.
+    ///
+    /// `BlockGroup::get_graph`, sequence enumeration, and graph export call this after
+    /// `blocks_from_edges`. The returned node-pair map retains the stored `Edge` responsible for
+    /// each projected graph edge so downstream consumers can recover edge provenance.
     pub fn build_graph(
-        edges: &Vec<AugmentedEdge>,
-        blocks: &Vec<GroupBlock>,
+        edges: &[AugmentedEdge],
+        blocks: &[GroupBlock],
     ) -> (GenGraph, HashMap<(i64, i64), Edge>) {
         let graph_node_for_block = |block: &GroupBlock| GraphNode {
             node_id: block.node_id,
             sequence_start: block.start,
             sequence_end: block.end,
         };
+        // Stored edge sources resolve to blocks ending at their coordinate, and targets resolve to
+        // blocks starting there. A junction belongs to both indexes, which lets one edge arrive at
+        // it and the next edge leave from it.
         let blocks_by_start = blocks
             .iter()
             .map(|block| {
@@ -586,7 +824,7 @@ impl Edge {
                     block,
                 )
             })
-            .collect::<HashMap<BlockKey, &GroupBlock>>();
+            .into_group_map();
         let blocks_by_end = blocks
             .iter()
             .map(|block| {
@@ -598,7 +836,7 @@ impl Edge {
                     block,
                 )
             })
-            .collect::<HashMap<BlockKey, &GroupBlock>>();
+            .into_group_map();
 
         let mut graph = GenGraph::new();
         let mut edges_by_node_pair = HashMap::new();
@@ -611,32 +849,39 @@ impl Edge {
                 node_id: edge.source_node_id,
                 coordinate: edge.source_coordinate,
             };
-            let source_id = blocks_by_end.get(&source_key);
+            let source_blocks = blocks_by_end.get(&source_key);
             let target_key = BlockKey {
                 node_id: edge.target_node_id,
                 coordinate: edge.target_coordinate,
             };
-            let target_id = blocks_by_start.get(&target_key);
+            let target_blocks = blocks_by_start.get(&target_key);
 
-            if let Some(source_block) = source_id
-                && let Some(target_block) = target_id
+            if let Some(source_blocks) = source_blocks
+                && let Some(target_blocks) = target_blocks
             {
-                let source_node = graph_node_for_block(source_block);
-                let target_node = graph_node_for_block(target_block);
-                let graph_edge = GraphEdge {
-                    edge_id: edge.id,
-                    source_strand: edge.source_strand,
-                    target_strand: edge.target_strand,
-                    chromosome_index: augmented_edge.chromosome_index,
-                    phased: augmented_edge.phased,
-                    created_on: augmented_edge.created_on,
-                };
-                if let Some(existing_edges) = graph.edge_weight_mut(source_node, target_node) {
-                    existing_edges.push(graph_edge);
-                } else {
-                    graph.add_edge(source_node, target_node, vec![graph_edge]);
+                // A coordinate may match both a sequence block and a junction. When connecting
+                // to junctions, multiple edges may be needed to fully represent the graph.
+                // `block_connections` orchestrates this.
+                for (source_block, target_block) in
+                    edge.block_connections(source_blocks, target_blocks)
+                {
+                    let source_node = graph_node_for_block(source_block);
+                    let target_node = graph_node_for_block(target_block);
+                    let graph_edge = GraphEdge {
+                        edge_id: edge.id,
+                        source_strand: edge.source_strand,
+                        target_strand: edge.target_strand,
+                        chromosome_index: augmented_edge.chromosome_index,
+                        phased: augmented_edge.phased,
+                        created_on: augmented_edge.created_on,
+                    };
+                    if let Some(existing_edges) = graph.edge_weight_mut(source_node, target_node) {
+                        existing_edges.push(graph_edge);
+                    } else {
+                        graph.add_edge(source_node, target_node, vec![graph_edge]);
+                    }
+                    edges_by_node_pair.insert((source_block.id, target_block.id), edge.clone());
                 }
-                edges_by_node_pair.insert((source_block.id, target_block.id), edge.clone());
             }
         }
 
@@ -689,12 +934,54 @@ mod tests {
             .collect::<Vec<i64>>()
     }
 
+    fn group_block(id: i64, node_id: HashId, start: i64, end: i64) -> GroupBlock {
+        GroupBlock {
+            id,
+            node_id,
+            sequence: Some(String::new()),
+            external_sequence: None,
+            start,
+            end,
+        }
+    }
+
+    fn augmented_edge(
+        id: &str,
+        source_node_id: HashId,
+        source_coordinate: i64,
+        target_node_id: HashId,
+        target_coordinate: i64,
+    ) -> AugmentedEdge {
+        AugmentedEdge {
+            edge: Edge {
+                id: HashId::convert_str(id),
+                source_node_id,
+                source_coordinate,
+                source_strand: Strand::Forward,
+                target_node_id,
+                target_coordinate,
+                target_strand: Strand::Forward,
+            },
+            chromosome_index: 0,
+            phased: 0,
+            created_on: 0,
+        }
+    }
+
+    fn graph_node(block: &GroupBlock) -> GraphNode {
+        GraphNode {
+            node_id: block.node_id,
+            sequence_start: block.start,
+            sequence_end: block.end,
+        }
+    }
+
     #[test]
     fn test_get_block_intervals_splits_sorted_unique_coordinates() {
         let starts = HashSet::from([5, 0, 5]);
         let ends = HashSet::from([10, 3]);
 
-        let intervals = Edge::get_block_intervals(&starts, &ends).unwrap();
+        let intervals = Edge::get_block_intervals(&starts, &ends, &HashSet::new()).unwrap();
 
         assert_eq!(intervals, vec![(0, 3), (3, 5), (5, 10)]);
     }
@@ -704,17 +991,188 @@ mod tests {
         let starts = HashSet::from([3]);
         let ends = HashSet::new();
 
-        let intervals = Edge::get_block_intervals(&starts, &ends).unwrap();
+        let intervals = Edge::get_block_intervals(&starts, &ends, &HashSet::new()).unwrap();
 
         assert_eq!(intervals, vec![(3, 3)]);
     }
 
     #[test]
+    fn test_get_block_intervals_adds_outer_junctions() {
+        let starts = HashSet::from([0, 2, 4]);
+        let ends = HashSet::from([0, 2, 4]);
+
+        let intervals = Edge::get_block_intervals(&starts, &ends, &HashSet::new()).unwrap();
+
+        assert_eq!(intervals, vec![(0, 0), (0, 2), (2, 4), (4, 4)]);
+    }
+
+    #[test]
+    fn test_get_block_intervals_adds_requested_interior_junction() {
+        let starts = HashSet::from([0, 2, 4]);
+        let ends = HashSet::from([0, 2, 4]);
+        let junction_coordinates = HashSet::from([2]);
+
+        let intervals = Edge::get_block_intervals(&starts, &ends, &junction_coordinates).unwrap();
+
+        assert_eq!(intervals, vec![(0, 0), (0, 2), (2, 2), (2, 4), (4, 4)]);
+    }
+
+    #[test]
     fn test_get_block_intervals_errors_without_coordinates() {
         assert!(matches!(
-            Edge::get_block_intervals(&HashSet::new(), &HashSet::new()),
+            Edge::get_block_intervals(&HashSet::new(), &HashSet::new(), &HashSet::new()),
             Err(EdgeError::BlockIntervalError { .. })
         ));
+    }
+
+    #[test]
+    fn test_build_graph_routes_incoming_edge_to_junction() {
+        let source_node_id = HashId::convert_str("incoming-source");
+        let target_node_id = HashId::convert_str("incoming-target");
+        let blocks = vec![
+            group_block(0, source_node_id, 0, 3),
+            group_block(1, target_node_id, 0, 0),
+            group_block(2, target_node_id, 0, 1),
+        ];
+        let edges = vec![augmented_edge(
+            "incoming-edge",
+            source_node_id,
+            3,
+            target_node_id,
+            0,
+        )];
+
+        let (graph, _) = Edge::build_graph(&edges, &blocks);
+
+        assert!(
+            graph.contains_edge(graph_node(&blocks[0]), graph_node(&blocks[1])),
+            "incoming edge should terminate at the junction"
+        );
+        assert!(
+            !graph.contains_edge(graph_node(&blocks[0]), graph_node(&blocks[2])),
+            "incoming edge should not bypass the junction"
+        );
+        assert_eq!(graph.edge_count(), 1, "should project one block edge");
+    }
+
+    #[test]
+    fn test_build_graph_routes_outgoing_edge_from_junction() {
+        let source_node_id = HashId::convert_str("outgoing-source");
+        let target_node_id = HashId::convert_str("outgoing-target");
+        let blocks = vec![
+            group_block(0, source_node_id, 0, 1),
+            group_block(1, source_node_id, 1, 1),
+            group_block(2, target_node_id, 0, 2),
+        ];
+        let edges = vec![augmented_edge(
+            "outgoing-edge",
+            source_node_id,
+            1,
+            target_node_id,
+            0,
+        )];
+
+        let (graph, _) = Edge::build_graph(&edges, &blocks);
+
+        assert!(
+            graph.contains_edge(graph_node(&blocks[1]), graph_node(&blocks[2])),
+            "outgoing edge should originate at the junction"
+        );
+        assert!(
+            !graph.contains_edge(graph_node(&blocks[0]), graph_node(&blocks[2])),
+            "outgoing edge should not bypass the junction"
+        );
+        assert_eq!(graph.edge_count(), 1, "should project one block edge");
+    }
+
+    #[test]
+    fn test_build_graph_projects_same_coordinate_edge_from_start_junction() {
+        let node_id = HashId::convert_str("same-coordinate-node");
+        let blocks = vec![group_block(0, node_id, 0, 0), group_block(1, node_id, 0, 1)];
+        let edges = vec![augmented_edge(
+            "same-coordinate-edge",
+            node_id,
+            0,
+            node_id,
+            0,
+        )];
+
+        let (graph, _) = Edge::build_graph(&edges, &blocks);
+
+        assert!(
+            graph.contains_edge(graph_node(&blocks[0]), graph_node(&blocks[1])),
+            "same-coordinate edge should connect the junction to adjacent sequence"
+        );
+        assert!(
+            !graph.contains_edge(graph_node(&blocks[0]), graph_node(&blocks[0])),
+            "same-coordinate edge should not add a redundant junction self-loop"
+        );
+        assert_eq!(graph.edge_count(), 1, "should project one block edge");
+    }
+
+    #[test]
+    fn test_build_graph_projects_same_coordinate_edge_into_end_junction() {
+        let node_id = HashId::convert_str("ending-same-coordinate-node");
+        let blocks = vec![group_block(0, node_id, 0, 1), group_block(1, node_id, 1, 1)];
+        let edges = vec![augmented_edge(
+            "ending-same-coordinate-edge",
+            node_id,
+            1,
+            node_id,
+            1,
+        )];
+
+        let (graph, _) = Edge::build_graph(&edges, &blocks);
+
+        assert!(
+            graph.contains_edge(graph_node(&blocks[0]), graph_node(&blocks[1])),
+            "same-coordinate edge should connect adjacent sequence into the junction"
+        );
+        assert!(
+            !graph.contains_edge(graph_node(&blocks[1]), graph_node(&blocks[1])),
+            "same-coordinate edge should not add a redundant junction self-loop"
+        );
+        assert_eq!(graph.edge_count(), 1, "should project one block edge");
+    }
+
+    #[test]
+    fn test_build_graph_projects_same_coordinate_edge_without_junction_directly() {
+        let node_id = HashId::convert_str("interior-same-coordinate-node");
+        let blocks = vec![group_block(0, node_id, 0, 1), group_block(1, node_id, 1, 2)];
+        let edges = vec![augmented_edge(
+            "interior-same-coordinate-edge",
+            node_id,
+            1,
+            node_id,
+            1,
+        )];
+
+        let (graph, _) = Edge::build_graph(&edges, &blocks);
+
+        assert!(
+            graph.contains_edge(graph_node(&blocks[0]), graph_node(&blocks[1])),
+            "same-coordinate edge should directly connect sequence blocks without a junction"
+        );
+        assert_eq!(graph.edge_count(), 1, "should project one block edge");
+    }
+
+    #[test]
+    fn test_build_graph_omits_same_coordinate_edge_without_adjacent_sequence() {
+        let node_id = HashId::convert_str("isolated-junction");
+        let blocks = vec![group_block(0, node_id, 0, 0)];
+        let edges = vec![augmented_edge("isolated-edge", node_id, 0, node_id, 0)];
+
+        let (graph, edges_by_node_pair) = Edge::build_graph(&edges, &blocks);
+
+        assert!(
+            !graph.contains_edge(graph_node(&blocks[0]), graph_node(&blocks[0])),
+            "a junction without adjacent sequence should not create a graph self-loop"
+        );
+        assert_eq!(graph.edge_count(), 0, "should not project a block edge");
+        assert!(
+            edges_by_node_pair.is_empty(),
+            "omitted self-loop should not have a block-pair mapping"
+        );
     }
 
     #[test]

--- a/gen-models/src/edge.rs
+++ b/gen-models/src/edge.rs
@@ -411,13 +411,13 @@ impl Edge {
         Ok(edges)
     }
 
-    /// Converts stored edge coordinates for one backing node into the sequence slices represented
+    /// Converts input edge coordinates for one backing node into the sequence slices represented
     /// by `GroupBlock`s.
     ///
     /// `blocks_from_edges` calls this after it has collected every coordinate needed by the block
     /// group. Non-zero intervals carry sequence, while requested zero-width intervals act as
     /// junctions between adjacent coordinate jumps. Outer junctions cover edge endpoints that have
-    /// no sequence interval on one side, so every stored edge still has a concrete graph endpoint.
+    /// no sequence interval on one side, so every input edge still has a concrete graph endpoint.
     fn get_block_intervals(
         starts: &HashSet<i64>,
         ends: &HashSet<i64>,
@@ -478,12 +478,13 @@ impl Edge {
         }
     }
 
-    /// Materializes the backing-node slices needed to project stored block-group edges.
+    /// Computes the backing-node slices from the stored block group edges.
     ///
     /// Graph construction, sequence enumeration, GFA export, and diff reconstruction use this as
-    /// the first half of the stored-edge-to-`GenGraph` pipeline. The routine gathers coordinates,
-    /// expands incomplete node descriptions from the block group, and asks `get_block_intervals`
-    /// to create both sequence-bearing blocks and any required zero-width junctions.
+    /// the first half of the edge-to-`GenGraph` pipeline, the second half being the build_graph
+    /// method below. This method gathers coordinates, expands incomplete node descriptions from
+    /// the block group, and calls `get_block_intervals` to construct both blocks with sequences
+    /// and zero-width junction blocks.
     ///
     /// For example, two adjacent deletions retain each original base while also exposing the path
     /// that skips both. Parenthesized nodes are zero-width junctions and bracketed nodes contain
@@ -570,7 +571,7 @@ impl Edge {
             .collect::<Vec<_>>();
 
         // A caller may provide a graph fragment whose edges mention only one side of a backing
-        // node. Pulling neighboring stored edges supplies the missing endpoint coordinates so the
+        // node. Pulling neighboring input edges supplies the missing endpoint coordinates so the
         // resulting blocks use the same slices as a graph built from the complete block group.
         while !incomplete_node_ids.is_empty() {
             queried_node_ids.extend(incomplete_node_ids.iter().copied());
@@ -638,7 +639,7 @@ impl Edge {
             let starts = starts_by_node_id.get(node_id).unwrap_or(&empty_starts);
             let ends = ends_by_node_id.get(node_id).unwrap_or(&empty_ends);
             // Adjacent same-node jumps share a coordinate: one jump arrives at k and the next
-            // leaves from k. Materialize k as a junction so the graph connects both jumps:
+            // leaves from k. Add k as a junction so the graph connects both jumps:
             //
             //     [real sequence] -> (k,k) -> [real sequence]
             //                           0 bases
@@ -689,8 +690,8 @@ impl Edge {
     /// Checks whether both endpoints use the same node and coordinate.
     ///
     /// `block_connections` uses this structural property when connecting blocks around a junction.
-    /// Whether the edge is a real path choice or an edit-site marker remains separate metadata on
-    /// `AugmentedEdge`.
+    /// Whether the edge is a real path choice or a reference-healing edit-site marker remains
+    /// separate chromosome-index metadata on `AugmentedEdge`.
     fn is_same_coordinate_edge(&self) -> bool {
         self.source_node_id == self.target_node_id
             && self.source_coordinate == self.target_coordinate
@@ -698,7 +699,7 @@ impl Edge {
 
     /// Selects the blocks that an edge endpoint should connect to.
     ///
-    /// `block_connections` calls this when a stored edge enters or leaves a coordinate. If a
+    /// `block_connections` calls this when an input edge enters or leaves a coordinate. If a
     /// junction exists, the edge connects to it and traversal continues from there. Otherwise the
     /// edge connects directly to the sequence block.
     fn select_junction_or_sequence_blocks<'a>(blocks: &[&'a GroupBlock]) -> Vec<&'a GroupBlock> {
@@ -774,11 +775,12 @@ impl Edge {
             .collect()
     }
 
-    /// Returns the concrete block connections represented by one stored edge.
+    /// Returns the in-memory block connections represented by one input edge.
     ///
     /// `build_graph` calls this after coordinate lookup may have returned both a sequence block and
     /// a junction. Same-coordinate edges connect the surrounding sequence through that junction;
-    /// all other edges connect to the junction and let the next stored edge continue from it.
+    /// all other edges connect to the junction and let the next input edge continue from it. These
+    /// returned connections are a graph projection and are not additional database edges.
     fn block_connections<'a>(
         &self,
         source_blocks: &[&'a GroupBlock],
@@ -796,11 +798,31 @@ impl Edge {
             .collect()
     }
 
-    /// Projects augmented stored edges and their materialized blocks into a `GenGraph`.
+    /// Computes a `GenGraph` from augmented edges and their computed blocks.
     ///
     /// `BlockGroup::get_graph`, sequence enumeration, and graph export call this after
-    /// `blocks_from_edges`. The returned node-pair map retains the stored `Edge` responsible for
+    /// `blocks_from_edges`. The returned node-pair map retains the input `Edge` responsible for
     /// each projected graph edge so downstream consumers can recover edge provenance.
+    ///
+    /// Junctions and `PRESERVE_EDIT_SITE_CHROMOSOME_INDEX` have independent jobs:
+    ///
+    /// - A junction is a generated zero-width graph node. It gives adjacent edges a shared endpoint
+    ///   so edges can link to the site of an edit instead of requiring a sequence to link to.
+    ///   This occurs in places such as deleting the first base of a node, or adjacent deletions.
+    /// - `PRESERVE_EDIT_SITE_CHROMOSOME_INDEX` is metadata on an `AugmentedEdge`. It identifies a
+    ///   reference-healing connection. Importantly, these are in the database whereas junctions
+    ///   are in the built graph only.
+    ///
+    /// When a marked same-coordinate edge meets a junction, one input edge can produce two
+    /// in-memory graph connections:
+    ///
+    /// ```text
+    /// [real sequence] -- preserve marker --> (junction) -- preserve marker --> [real sequence]
+    ///                                          0 bases
+    /// ```
+    ///
+    /// The junction is the generated node. The two labels represent copied chromosome-index
+    /// metadata on the projected connections; neither connection is added to the database.
     pub fn build_graph(
         edges: &[AugmentedEdge],
         blocks: &[GroupBlock],
@@ -810,7 +832,7 @@ impl Edge {
             sequence_start: block.start,
             sequence_end: block.end,
         };
-        // Stored edge sources resolve to blocks ending at their coordinate, and targets resolve to
+        // Input edge sources resolve to blocks ending at their coordinate, and targets resolve to
         // blocks starting there. A junction belongs to both indexes, which lets one edge arrive at
         // it and the next edge leave from it.
         let blocks_by_start = blocks
@@ -1082,11 +1104,11 @@ mod tests {
             !graph.contains_edge(graph_node(&blocks[0]), graph_node(&blocks[2])),
             "outgoing edge should not bypass the junction"
         );
-        assert_eq!(graph.edge_count(), 1, "should project one block edge");
+        assert_eq!(graph.edge_count(), 1, "should create one block edge");
     }
 
     #[test]
-    fn test_build_graph_projects_same_coordinate_edge_from_start_junction() {
+    fn test_build_graph_creates_same_coordinate_edge_from_start_junction() {
         let node_id = HashId::convert_str("same-coordinate-node");
         let blocks = vec![group_block(0, node_id, 0, 0), group_block(1, node_id, 0, 1)];
         let edges = vec![augmented_edge(
@@ -1107,11 +1129,11 @@ mod tests {
             !graph.contains_edge(graph_node(&blocks[0]), graph_node(&blocks[0])),
             "same-coordinate edge should not add a redundant junction self-loop"
         );
-        assert_eq!(graph.edge_count(), 1, "should project one block edge");
+        assert_eq!(graph.edge_count(), 1, "should create one block edge");
     }
 
     #[test]
-    fn test_build_graph_projects_same_coordinate_edge_into_end_junction() {
+    fn test_build_graph_creates_same_coordinate_edge_into_end_junction() {
         let node_id = HashId::convert_str("ending-same-coordinate-node");
         let blocks = vec![group_block(0, node_id, 0, 1), group_block(1, node_id, 1, 1)];
         let edges = vec![augmented_edge(
@@ -1132,11 +1154,11 @@ mod tests {
             !graph.contains_edge(graph_node(&blocks[1]), graph_node(&blocks[1])),
             "same-coordinate edge should not add a redundant junction self-loop"
         );
-        assert_eq!(graph.edge_count(), 1, "should project one block edge");
+        assert_eq!(graph.edge_count(), 1, "should create one block edge");
     }
 
     #[test]
-    fn test_build_graph_projects_same_coordinate_edge_without_junction_directly() {
+    fn test_build_graph_creates_same_coordinate_edge_without_junction_directly() {
         let node_id = HashId::convert_str("interior-same-coordinate-node");
         let blocks = vec![group_block(0, node_id, 0, 1), group_block(1, node_id, 1, 2)];
         let edges = vec![augmented_edge(
@@ -1153,7 +1175,7 @@ mod tests {
             graph.contains_edge(graph_node(&blocks[0]), graph_node(&blocks[1])),
             "same-coordinate edge should directly connect sequence blocks without a junction"
         );
-        assert_eq!(graph.edge_count(), 1, "should project one block edge");
+        assert_eq!(graph.edge_count(), 1, "should create one block edge");
     }
 
     #[test]
@@ -1168,7 +1190,7 @@ mod tests {
             !graph.contains_edge(graph_node(&blocks[0]), graph_node(&blocks[0])),
             "a junction without adjacent sequence should not create a graph self-loop"
         );
-        assert_eq!(graph.edge_count(), 0, "should not project a block edge");
+        assert_eq!(graph.edge_count(), 0, "should not create a block edge");
         assert!(
             edges_by_node_pair.is_empty(),
             "omitted self-loop should not have a block-pair mapping"

--- a/gen-tui/src/graph_controller.rs
+++ b/gen-tui/src/graph_controller.rs
@@ -778,7 +778,9 @@ where
             .node_indices()
             .filter_map(|layout_node_idx| {
                 let node = layout.graph.node_weight(layout_node_idx)?;
-                if let NodeRole::Data(domain_idx) = &node.role {
+                if let NodeRole::Data(domain_idx) = &node.role
+                    && self.is_node_selectable(*domain_idx)
+                {
                     // Calculate distance from local origin (0, 0) using Manhattan distance
                     let distance = node.pos.x.abs() + node.pos.y.abs();
                     Some((*domain_idx, distance))
@@ -795,14 +797,50 @@ where
         candidates.first().map(|(idx, _)| *idx)
     }
 
+    fn is_node_selectable(&self, domain_idx: NodeIndex) -> bool {
+        let node_id =
+            NodeIndexable::from_index(&self.partition_controller.graph, domain_idx.index());
+        self.partition_controller.node_sizer.is_selectable(&node_id)
+    }
+
+    fn cursor_is_on_selectable_node(&self) -> bool {
+        self.cursor
+            .node_idx()
+            .is_some_and(|node_idx| self.is_node_selectable(node_idx))
+    }
+
     /// Move the cursor horizontally by `delta` world units.
     pub fn navigate_horizontal(&mut self, delta: i64) -> Result<(), String> {
-        self.cursor.move_horizontal(delta, &self.viewport_graph)
+        let original_cursor = self.cursor.clone();
+        for _ in 0..self.partition_controller.graph.node_count().max(1) {
+            if let Err(error) = self.cursor.move_horizontal(delta, &self.viewport_graph) {
+                self.cursor = original_cursor;
+                return Err(error);
+            }
+            if self.cursor_is_on_selectable_node() {
+                return Ok(());
+            }
+        }
+
+        self.cursor = original_cursor;
+        Err("No selectable node in that direction".to_string())
     }
 
     /// Move the cursor vertically by `delta` world units.
     pub fn navigate_vertical(&mut self, delta: i64) -> Result<(), String> {
-        self.cursor.move_vertical(delta, &self.viewport_graph)
+        let original_cursor = self.cursor.clone();
+        for _ in 0..self.partition_controller.graph.node_count().max(1) {
+            if let Err(error) = self.cursor.move_vertical(delta, &self.viewport_graph) {
+                self.cursor = original_cursor;
+                return Err(error);
+            }
+            if self.cursor_is_on_selectable_node() {
+                return Ok(());
+            }
+        }
+
+        self.cursor = original_cursor;
+        Err("No selectable node in that direction".to_string())
     }
 
     /// Handle keyboard events for graph navigation and control
@@ -823,7 +861,7 @@ where
                 } else {
                     -1
                 };
-                self.cursor.move_horizontal(delta, &self.viewport_graph)?;
+                self.navigate_horizontal(delta)?;
                 self.trigger_rebuild();
             }
             KeyCode::Right | KeyCode::Char('l') => {
@@ -833,7 +871,7 @@ where
                 } else {
                     1
                 };
-                self.cursor.move_horizontal(delta, &self.viewport_graph)?;
+                self.navigate_horizontal(delta)?;
                 self.trigger_rebuild();
             }
             // Note: In world coordinates, Y increases upward
@@ -844,7 +882,7 @@ where
                 } else {
                     1
                 };
-                self.cursor.move_vertical(delta, &self.viewport_graph)?;
+                self.navigate_vertical(delta)?;
                 self.trigger_rebuild();
             }
             KeyCode::Down | KeyCode::Char('j') => {
@@ -854,7 +892,7 @@ where
                 } else {
                     -1
                 };
-                self.cursor.move_vertical(delta, &self.viewport_graph)?; // Move down = negative Y
+                self.navigate_vertical(delta)?; // Move down = negative Y
                 self.trigger_rebuild();
             }
 
@@ -1227,8 +1265,11 @@ where
     /// hide it later via `hide_cursor`.
     ///
     /// The caller is responsible for ensuring the relevant partition is loaded
-    /// and set as anchor before calling this.
+    /// and set as anchor before calling this. Non-selectable nodes are ignored.
     pub fn go_to_node(&mut self, domain_idx: NodeIndex, offset: (f64, f64)) {
+        if !self.is_node_selectable(domain_idx) {
+            return;
+        }
         self.cursor.set_node(domain_idx, offset);
         self.cursor.set_coarse_mode(false);
         self.show_cursor();
@@ -1280,23 +1321,24 @@ where
         };
 
         // Collect the hit result before any mutable borrow to satisfy the borrow checker.
-        let hit =
-            self.viewport_graph
-                .data_nodes()
-                .find_map(|(node_center, domain_idx, layout_node)| {
-                    let rect = BigRect::from_center_and_size(node_center, layout_node.size);
-                    if rect.contains(click_world) {
-                        let frac_x = ((click_world.x - rect.left()) as f64
-                            / layout_node.size.0.max(1) as f64)
-                            .clamp(0.0, 1.0);
-                        let frac_y = ((click_world.y - rect.bottom()) as f64
-                            / layout_node.size.1.max(1) as f64)
-                            .clamp(0.0, 1.0);
-                        Some((domain_idx, (frac_x, frac_y)))
-                    } else {
-                        None
-                    }
-                });
+        let hit = self
+            .viewport_graph
+            .data_nodes()
+            .filter(|(_, domain_idx, _)| self.is_node_selectable(*domain_idx))
+            .find_map(|(node_center, domain_idx, layout_node)| {
+                let rect = BigRect::from_center_and_size(node_center, layout_node.size);
+                if rect.contains(click_world) {
+                    let frac_x = ((click_world.x - rect.left()) as f64
+                        / layout_node.size.0.max(1) as f64)
+                        .clamp(0.0, 1.0);
+                    let frac_y = ((click_world.y - rect.bottom()) as f64
+                        / layout_node.size.1.max(1) as f64)
+                        .clamp(0.0, 1.0);
+                    Some((domain_idx, (frac_x, frac_y)))
+                } else {
+                    None
+                }
+            });
 
         if let Some((domain_idx, frac)) = hit {
             self.cursor.set_node(domain_idx, frac);
@@ -1321,6 +1363,7 @@ where
         let best = self
             .viewport_graph
             .data_nodes()
+            .filter(|(_, domain_idx, _)| self.is_node_selectable(*domain_idx))
             .min_by_key(|(pos, _, layout_node)| {
                 let rect = BigRect::from_center_and_size(*pos, layout_node.size);
                 let closest_x = center.x.clamp(rect.left(), rect.right());
@@ -1360,10 +1403,15 @@ where
 mod tests {
     use std::time::Duration;
 
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+    use petgraph::graph::NodeIndex;
     use ratatui::{buffer::Buffer, layout::Rect, style::Style};
 
     use super::*;
-    use crate::geometry::WorldRect;
+    use crate::{
+        geometry::WorldRect, layout::VisualDetail, plotter::NodeSizer,
+        testing::mocks::MockDomainGraph,
+    };
 
     #[test]
     fn test_coordinate_conversions() {
@@ -1550,12 +1598,6 @@ mod tests {
 
     #[test]
     fn test_disperse_functionality() {
-        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
-        use petgraph::graph::NodeIndex;
-        use ratatui::layout::Rect;
-
-        use crate::{layout::VisualDetail, plotter::NodeSizer, testing::mocks::MockDomainGraph};
-
         // Create a simple NodeSizer for our domain graph
         #[derive(Clone)]
         struct TestNodeSizer;
@@ -1602,5 +1644,52 @@ mod tests {
 
         // If we get here without panicking, the test passes
         println!("Test completed successfully");
+    }
+
+    #[test]
+    fn test_selection_ignores_and_navigates_past_non_selectable_nodes() {
+        #[derive(Clone)]
+        struct SelectiveNodeSizer {
+            non_selectable: NodeIndex,
+        }
+
+        impl NodeSizer<MockDomainGraph> for SelectiveNodeSizer {
+            fn get_node_size(&self, _node: &NodeIndex, _scale: VisualDetail) -> (u64, u64) {
+                (1, 1)
+            }
+
+            fn is_selectable(&self, node: &NodeIndex) -> bool {
+                *node != self.non_selectable
+            }
+        }
+
+        let mut graph = MockDomainGraph::new();
+        let selectable = graph.add_node(());
+        let non_selectable = graph.add_node(());
+        let next_selectable = graph.add_node(());
+        graph.add_edge(selectable, non_selectable, ());
+        graph.add_edge(non_selectable, next_selectable, ());
+        let mut controller = GraphController::new(graph, SelectiveNodeSizer { non_selectable });
+
+        controller.go_to_node(non_selectable, (0.5, 0.5));
+        assert_eq!(controller.cursor.node_idx(), None);
+
+        controller.go_to_node(selectable, (1.0, 0.5));
+        assert_eq!(controller.cursor.node_idx(), Some(selectable));
+
+        controller.viewport_state.viewport_bounds = Rect::new(0, 0, 80, 20);
+        controller.ensure_camera_coverage().unwrap();
+        controller.rebuild_viewport_graph().unwrap();
+        let non_selectable_position = controller.viewport_graph.node_positions[&non_selectable];
+        let (terminal_x, terminal_y) = controller
+            .viewport_state
+            .world_to_terminal(non_selectable_position)
+            .expect("should show the non-selectable node in the viewport");
+
+        assert!(!controller.handle_click(terminal_x, terminal_y));
+        assert_eq!(controller.cursor.node_idx(), Some(selectable));
+
+        controller.navigate_horizontal(1).unwrap();
+        assert_eq!(controller.cursor.node_idx(), Some(next_selectable));
     }
 }

--- a/gen-tui/src/plotter.rs
+++ b/gen-tui/src/plotter.rs
@@ -182,6 +182,11 @@ where
     /// Get the dimensions (width, height) for a node at a specific level of detail
     fn get_node_size(&self, node: &G::NodeId, detail_level: VisualDetail) -> (u64, u64);
 
+    /// Return whether the cursor may select this node.
+    fn is_selectable(&self, _node: &G::NodeId) -> bool {
+        true
+    }
+
     /// Get default dimensions for dummy/routing nodes
     fn get_dummy_size(&self) -> (u64, u64) {
         (1, 1)
@@ -219,6 +224,10 @@ where
 
     fn get_dummy_size(&self) -> (u64, u64) {
         (**self).get_dummy_size()
+    }
+
+    fn is_selectable(&self, node: &G::NodeId) -> bool {
+        (**self).is_selectable(node)
     }
 
     fn map_column(&self, node: &G::NodeId, raw_col: i64, detail_level: VisualDetail) -> i64 {

--- a/src/exports/gfa.rs
+++ b/src/exports/gfa.rs
@@ -332,9 +332,12 @@ fn write_paths(
 
 #[cfg(test)]
 mod tests {
-    // Note this useful idiom: importing names from outer (for mod tests) scope.
+    use std::fs;
+
     use gen_core::{PATH_END_NODE_ID, PATH_START_NODE_ID, Strand, path::PathBlock};
+    use gen_graph::GraphNode;
     use gen_models::{
+        annotations::add_annotation,
         block_group::{BlockGroup, BlockGroupChange},
         block_group_edge::BlockGroupEdgeData,
         collection::Collection,
@@ -343,12 +346,15 @@ mod tests {
         sequence::Sequence,
         traits::Query,
     };
+    use petgraph::Direction;
     use tempfile::tempdir;
 
     use super::*;
     use crate::{
-        imports::gfa::import_gfa,
-        test_helpers::{setup_block_group, setup_gen},
+        graphs::combinatorial_library::parse_library,
+        imports::{fasta::import_fasta, gfa::import_gfa},
+        test_helpers::{get_sample_bg, setup_block_group, setup_gen},
+        updates::{library::update_with_library, sequence::update_with_sequence},
     };
 
     #[test]
@@ -529,6 +535,141 @@ mod tests {
         let paths = Path::query_for_collection(conn, "test collection 2");
         assert_eq!(paths.len(), 1);
         assert_eq!(paths[0].sequence(conn, None).unwrap(), "AAAATTTTGGGGCCCC");
+    }
+
+    #[test]
+    fn test_front_deletion_in_combinatorial_library_exports_junction_routes() {
+        let context = setup_gen();
+        let conn = context.graph().conn();
+        let collection = "test";
+        let fasta_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("fixtures/simple.fa");
+        let parts_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("fixtures/parts.fa");
+        let library_path =
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("fixtures/combinatorial_design.csv");
+        let fasta_path = fasta_path
+            .to_str()
+            .expect("should have a UTF-8 FASTA path")
+            .to_string();
+        let parts_path = parts_path
+            .to_str()
+            .expect("should have a UTF-8 parts path")
+            .to_string();
+        let library_path = library_path
+            .to_str()
+            .expect("should have a UTF-8 library path")
+            .to_string();
+
+        import_fasta(
+            &context,
+            &fasta_path,
+            collection,
+            Sample::DEFAULT_NAME,
+            false,
+        )
+        .unwrap();
+        add_annotation(
+            &context,
+            collection,
+            "SITE",
+            None,
+            Sample::DEFAULT_NAME,
+            "m123:7-20",
+        )
+        .unwrap();
+        update_with_library(
+            &context,
+            collection,
+            Sample::DEFAULT_NAME,
+            "design",
+            "SITE",
+            parse_library(&parts_path, &library_path).unwrap(),
+            Some(&parts_path),
+            Some(&library_path),
+        )
+        .unwrap();
+        update_with_sequence(
+            &context, collection, "design", "deleted", "cds1:0-1", "", false,
+        )
+        .unwrap();
+
+        let block_group = get_sample_bg(conn, collection, "deleted");
+        let graph = BlockGroup::get_graph(conn, &block_group.id, None).unwrap();
+        let node_ids = graph.nodes().map(|node| node.node_id).collect::<Vec<_>>();
+        let sequences = Node::get_sequences_by_node_ids(conn, &node_ids, None);
+        let rendered_sequence = |node: GraphNode| {
+            sequences[&node.node_id]
+                .get_sequence(node.sequence_start, node.sequence_end)
+                .unwrap()
+        };
+        let deleted_target = graph
+            .nodes()
+            .find(|node| rendered_sequence(*node) == "TGATAA")
+            .expect("should contain the remainder of cds1");
+        let original_first_base = graph
+            .nodes()
+            .find(|node| node.node_id == deleted_target.node_id && rendered_sequence(*node) == "A")
+            .expect("should contain the original first base of cds1");
+        let junction = graph
+            .nodes()
+            .find(|node| {
+                node.node_id == deleted_target.node_id
+                    && node.sequence_start == 0
+                    && node.sequence_end == 0
+            })
+            .expect("should contain the front-deletion junction");
+        let upstream_parts = graph
+            .neighbors_directed(junction, Direction::Incoming)
+            .collect::<Vec<_>>();
+        let upstream_sequences = upstream_parts
+            .iter()
+            .map(|node| rendered_sequence(*node))
+            .collect::<HashSet<_>>();
+
+        assert_eq!(
+            upstream_sequences,
+            HashSet::from(["AAAA".to_string(), "TAAT".to_string(), "CAAC".to_string()]),
+            "all combinatorial prefixes should enter the junction"
+        );
+        let temp_dir = tempdir().expect("should create a temporary directory");
+        let gfa_path = temp_dir.path().join("front-deletion.gfa");
+        export_gfa(conn, collection, &gfa_path, "deleted", None, None).unwrap();
+        let gfa_lines = fs::read_to_string(&gfa_path)
+            .expect("should read the exported GFA")
+            .lines()
+            .map(str::to_string)
+            .collect::<HashSet<_>>();
+        let segment_id = |node: GraphNode| {
+            format!(
+                "{}.{}.{}",
+                node.node_id, node.sequence_start, node.sequence_end
+            )
+        };
+        let link_line = |source: GraphNode, target: GraphNode| {
+            format!(
+                "L\t{}\t+\t{}\t+\t0M",
+                segment_id(source),
+                segment_id(target)
+            )
+        };
+
+        assert!(
+            gfa_lines.contains(&format!("S\t{}\t", segment_id(junction))),
+            "the exported links should have a zero-width junction segment as their endpoint"
+        );
+        for upstream_part in upstream_parts {
+            assert!(
+                gfa_lines.contains(&link_line(upstream_part, junction)),
+                "each combinatorial prefix should link to the exported junction"
+            );
+        }
+        assert!(
+            gfa_lines.contains(&link_line(junction, original_first_base)),
+            "GFA export should retain the reference-healing route through the junction"
+        );
+        assert!(
+            gfa_lines.contains(&link_line(junction, deleted_target)),
+            "GFA export should retain the front-deletion route through the junction"
+        );
     }
 
     #[test]

--- a/src/updates/sequence.rs
+++ b/src/updates/sequence.rs
@@ -186,6 +186,7 @@ mod tests {
     use std::{collections::HashSet, path::PathBuf};
 
     use gen_core::NO_CHROMOSOME_INDEX;
+    use gen_graph::GraphNode;
     use gen_models::{
         annotations::{Annotation, add_annotation},
         assets::{OperationKind, OperationLog},
@@ -196,11 +197,14 @@ mod tests {
         region::{ResolvedGenRegion, resolve_annotation},
         sample_lineage::SampleLineage,
     };
+    use petgraph::Direction;
 
     use super::*;
     use crate::{
+        graphs::combinatorial_library::parse_library,
         imports::fasta::import_fasta,
         test_helpers::{get_sample_bg, setup_block_group, setup_gen},
+        updates::library::update_with_library,
     };
 
     fn insertion_block(
@@ -806,5 +810,142 @@ mod tests {
             latest_path.sequence(conn, None).unwrap(),
             "ATTCGATCGATCGATCGGGAACACACAGAGA"
         );
+    }
+
+    #[test]
+    fn test_iterative_deletion_at_combinatorial_part_start_preserves_connectivity() {
+        let context = setup_gen();
+        let conn = context.graph().conn();
+        let collection = "test".to_string();
+        let fasta_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("fixtures/simple.fa");
+        let parts_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("fixtures/parts.fa");
+        let library_path =
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("fixtures/combinatorial_design.csv");
+        let fasta_path = fasta_path.to_str().unwrap().to_string();
+        let parts_path = parts_path.to_str().unwrap().to_string();
+        let library_path = library_path.to_str().unwrap().to_string();
+
+        import_fasta(
+            &context,
+            &fasta_path,
+            &collection,
+            Sample::DEFAULT_NAME,
+            false,
+        )
+        .unwrap();
+        add_annotation(
+            &context,
+            &collection,
+            "SITE",
+            None,
+            Sample::DEFAULT_NAME,
+            "m123:7-20",
+        )
+        .unwrap();
+        update_with_library(
+            &context,
+            &collection,
+            Sample::DEFAULT_NAME,
+            "design",
+            "SITE",
+            parse_library(&parts_path, &library_path).unwrap(),
+            Some(&parts_path),
+            Some(&library_path),
+        )
+        .unwrap();
+        update_with_sequence(
+            &context,
+            &collection,
+            "design",
+            "deleted",
+            "cds1:0-1",
+            "",
+            false,
+        )
+        .unwrap();
+
+        let block_group = get_sample_bg(conn, &collection, "deleted");
+        let graph = BlockGroup::get_graph(conn, &block_group.id, None).unwrap();
+        let node_ids = graph.nodes().map(|node| node.node_id).collect::<Vec<_>>();
+        let sequences = Node::get_sequences_by_node_ids(conn, &node_ids, None);
+        let rendered_sequence = |node: GraphNode| {
+            sequences[&node.node_id]
+                .get_sequence(node.sequence_start, node.sequence_end)
+                .unwrap()
+        };
+        let deleted_target = graph
+            .nodes()
+            .find(|node| rendered_sequence(*node) == "TGATAA")
+            .expect("should contain the remainder of cds1");
+        let original_first_base = graph
+            .nodes()
+            .find(|node| node.node_id == deleted_target.node_id && rendered_sequence(*node) == "A")
+            .expect("should contain the deleted first base of cds1");
+        let deletion_boundary = graph
+            .nodes()
+            .find(|node| {
+                node.node_id == deleted_target.node_id
+                    && node.sequence_start == 0
+                    && node.sequence_end == 0
+            })
+            .expect("should contain a zero-width block at the deletion boundary");
+        let upstream_parts = graph
+            .neighbors_directed(deletion_boundary, Direction::Incoming)
+            .collect::<Vec<_>>();
+
+        assert_eq!(upstream_parts.len(), 3);
+        assert!(graph.contains_edge(deletion_boundary, original_first_base));
+        assert!(graph.contains_edge(deletion_boundary, deleted_target));
+
+        update_with_sequence(
+            &context,
+            &collection,
+            "deleted",
+            "deleted2",
+            "cds1:1-2",
+            "",
+            false,
+        )
+        .unwrap();
+
+        let block_group = get_sample_bg(conn, &collection, "deleted2");
+        let graph = BlockGroup::get_graph(conn, &block_group.id, None).unwrap();
+        let node_ids = graph.nodes().map(|node| node.node_id).collect::<Vec<_>>();
+        let sequences = Node::get_sequences_by_node_ids(conn, &node_ids, None);
+        let rendered_sequence = |node: GraphNode| {
+            sequences[&node.node_id]
+                .get_sequence(node.sequence_start, node.sequence_end)
+                .unwrap()
+        };
+        let upstream_part = graph
+            .nodes()
+            .find(|node| rendered_sequence(*node) == "TAAT")
+            .expect("should contain the upstream combinatorial part");
+        let first_deletion_boundary = graph
+            .nodes()
+            .find(|node| {
+                node.node_id == deleted_target.node_id
+                    && node.sequence_start == 0
+                    && node.sequence_end == 0
+            })
+            .expect("should retain the first deletion boundary");
+        let second_deletion_boundary = graph
+            .nodes()
+            .find(|node| {
+                node.node_id == deleted_target.node_id
+                    && node.sequence_start == 1
+                    && node.sequence_end == 1
+            })
+            .expect("should contain a junction between adjacent deletions");
+        let second_deleted_target = graph
+            .nodes()
+            .find(|node| {
+                node.node_id == deleted_target.node_id && rendered_sequence(*node) == "GATAA"
+            })
+            .expect("should contain the remainder after both deletions");
+
+        assert!(graph.contains_edge(upstream_part, first_deletion_boundary));
+        assert!(graph.contains_edge(first_deletion_boundary, second_deletion_boundary));
+        assert!(graph.contains_edge(second_deletion_boundary, second_deleted_target));
     }
 }

--- a/src/views/gen_graph_widget.rs
+++ b/src/views/gen_graph_widget.rs
@@ -37,6 +37,14 @@ pub mod label {
     pub const END: &str = "╢";
 }
 
+const ZERO_WIDTH_GLYPH: char = '─';
+
+fn is_zero_width_junction(node: &GraphNode) -> bool {
+    !is_start_node(node.node_id)
+        && !is_end_node(node.node_id)
+        && node.sequence_start == node.sequence_end
+}
+
 /// Domain-specific node sizer for GenGraph that calculates visual dimensions
 /// based on genomic sequence length.
 #[derive(Clone)]
@@ -52,6 +60,9 @@ impl NodeSizer<GenGraph> for GenGraphNodeSizer {
         if is_end_node(node.node_id) {
             return (label::END.chars().count() as u64, 1u64);
         }
+        if is_zero_width_junction(node) {
+            return (1, 1);
+        }
 
         let sequence_length = (node.sequence_end - node.sequence_start) as u64;
         match detail_level {
@@ -59,6 +70,10 @@ impl NodeSizer<GenGraph> for GenGraphNodeSizer {
             VisualDetail::Truncated => (sequence_length.min(13), 1u64), // 13 = 5 border + 3 mid + 5 border
             VisualDetail::Full => (sequence_length, 1u64),              // Full sequence length
         }
+    }
+
+    fn is_selectable(&self, node: &GraphNode) -> bool {
+        !is_zero_width_junction(node)
     }
 
     /// Map a raw sequence column to the visual cell it occupies for `detail_level`.
@@ -136,6 +151,12 @@ impl NodeRenderer<GenGraph> for GenGraphNodeRenderer<'_> {
         detail_level: VisualDetail,
     ) {
         let theme = current_theme();
+        if is_zero_width_junction(node_id) {
+            let edge_style = Style::default().bg(theme[0x00]).fg(theme[0x05]);
+            buffer.set_char_styled(area.left_center(), ZERO_WIDTH_GLYPH, edge_style);
+            return;
+        }
+
         let background_style = Style::default().bg(theme[0x05]);
         let text_style = Style::default().bg(theme[0x05]).fg(theme[0x00]);
 
@@ -744,7 +765,7 @@ pub fn locus_midpoint(locus: &GraphLocus) -> Option<(GraphNodeSlice, usize)> {
 mod tests {
     use std::path::PathBuf;
 
-    use gen_core::{HashId, Strand};
+    use gen_core::{HashId, PATH_START_NODE_ID, Strand};
     use gen_models::sample::Sample;
     use gen_tui::{
         geometry::WorldPos,
@@ -752,7 +773,9 @@ mod tests {
         testing::create_test_terminal,
         viewport_state::{ViewportState, WorldBuffer},
     };
-    use ratatui::{backend::TestBackend, widgets::StatefulWidget as _};
+    use ratatui::{
+        backend::TestBackend, buffer::Buffer, layout::Rect, widgets::StatefulWidget as _,
+    };
 
     use super::*;
     use crate::{
@@ -840,6 +863,60 @@ mod tests {
         let s = "hello world";
         let truncated = inner_truncation(s, 3);
         assert_eq!(truncated, NODE_GLYPH.to_string());
+    }
+
+    #[test]
+    fn test_zero_width_junction_is_line_sized_and_not_selectable() {
+        let junction = GraphNode {
+            node_id: HashId::convert_str("zero-width-junction"),
+            sequence_start: 3,
+            sequence_end: 3,
+        };
+        let start = GraphNode {
+            node_id: PATH_START_NODE_ID,
+            sequence_start: 0,
+            sequence_end: 0,
+        };
+
+        for detail_level in [
+            VisualDetail::Minimal,
+            VisualDetail::Truncated,
+            VisualDetail::Full,
+        ] {
+            assert_eq!(
+                GenGraphNodeSizer.get_node_size(&junction, detail_level),
+                (1, 1)
+            );
+        }
+        assert!(!GenGraphNodeSizer.is_selectable(&junction));
+        assert!(GenGraphNodeSizer.is_selectable(&start));
+    }
+
+    #[test]
+    fn test_zero_width_junction_renders_as_line() {
+        let context = setup_gen_on_disk();
+        let junction = GraphNode {
+            node_id: HashId::convert_str("zero-width-junction"),
+            sequence_start: 3,
+            sequence_end: 3,
+        };
+        let mut viewport_state = ViewportState::new();
+        viewport_state.viewport_bounds = Rect::new(0, 0, 5, 5);
+        let mut buffer = Buffer::empty(viewport_state.viewport_bounds);
+        let mut world_buffer = WorldBuffer::new(&mut buffer, &viewport_state);
+        let mut renderer = GenGraphNodeRenderer::new(context.graph().conn());
+
+        renderer.render_node(
+            &mut world_buffer,
+            WorldRect::from_center_and_size(WorldPos::ZERO, (1, 1)),
+            &junction,
+            VisualDetail::Full,
+        );
+
+        assert_eq!(
+            world_buffer.get_char(WorldPos::ZERO),
+            Some(ZERO_WIDTH_GLYPH)
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #211

The stored data looked correct, so I treated it as a graph building problem. Effectively we these changes do 2 things:
* Make zero-width node so we can have connections to edges that affect the very beginning or end of sequence
* Use the same zero-width nodes for internal edges that are zero width as well. Zero width is detected by start_coordinate == end_coordinate for the edge. This is so we can represent processes that iteratively chunk off pieces of the front/end of a block. I also think this will show neighboring deletions better as individual deletions + a combined one.

Overall, this makes our layout and sequence stuff work just fine as it treats it as a junction point but renders it invisible. This seemed to render better than the previous attempt that only used edges and didn't introduce any blocks.

I don't love the variable names, if you have better/more obvious suggestions let me know.

<img width="1002" height="452" alt="image" src="https://github.com/user-attachments/assets/975b376b-4136-4f38-bc2f-3b852e217ca8" />
<img width="1002" height="452" alt="image" src="https://github.com/user-attachments/assets/0f70a9d0-7591-4bc7-a3be-26f8f3868214" />
