### PR TITLE
Add push tracking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1760,6 +1760,7 @@ dependencies = [
  "tui-widget-list",
  "url",
  "url-parse",
+ "uuid",
  "webbrowser",
  "zip",
 ]
@@ -1864,6 +1865,7 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
+ "uuid",
 ]
 
 [[package]]
@@ -4771,6 +4773,7 @@ dependencies = [
  "libdoltlite-sys",
  "smallvec",
  "sqlite-wasm-rs",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -622,6 +622,7 @@ dependencies = [
  "js-sys",
  "num-traits",
  "pure-rust-locales",
+ "serde",
  "wasm-bindgen",
  "windows-link",
 ]
@@ -1707,6 +1708,7 @@ dependencies = [
  "capnp",
  "cargo-deny",
  "cargo-llvm-cov",
+ "chrono",
  "clap",
  "convert_case 0.8.0",
  "crc32c",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ gen-tui = { path = "gen-tui", version = "0.2.1" }
 gen-annotations = { path = "gen-annotations", version = "0.2.1" }
 gen-capnp-schemas = { path = "gen-capnp-schemas", version = "0.2.1" }
 clap = { version = "4.5.32", features = ["derive"] }
+chrono = { version = "0.4.40", features = ["serde"] }
 convert_case = "0.8.0"
 csv = "1.3.1"
 fallible-streaming-iterator = "0.1.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ rat-cursor = "2.0.0"
 tui-widget-list = "0.15.0"
 url-parse = "1.0.10"
 url = "2.5.0"
+uuid = { version = "1.18.1", features = ["serde"] }
 once_cell = "1.21.3"
 webbrowser = "1.0.5"
 reqwest = { version = "0.12.23", default-features = false,features = ["blocking", "json", "multipart", "stream", "rustls-tls"] }

--- a/gen-models/Cargo.toml
+++ b/gen-models/Cargo.toml
@@ -29,7 +29,7 @@ itertools = "0.14.0"
 noodles = { version = "0.101.0", features = ["async", "bed", "bgzf", "core", "fasta", "gff", "gtf", "tabix", "vcf"] }
 opendal = { version = "0.56", features = ["blocking", "services-fs", "services-http", "services-s3", "services-gcs", "services-azblob"] }
 petgraph = "0.6.5"
-rusqlite = { package = "rusqdoltlite", version = "0.40.16", features = ["bundled", "array", "limits", "fallible_uint", "backup"] }
+rusqlite = { package = "rusqdoltlite", version = "0.40.16", features = ["bundled", "array", "limits", "fallible_uint", "backup", "uuid"] }
 rusqlite_migration = { package = "rusqdoltlite_migration", version = "2.6.4" , features = ["from-directory"]}
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
@@ -39,6 +39,7 @@ thiserror = "2.0.12"
 tokio = { version = "1.52.1", features = ["rt-multi-thread"] }
 tempfile = "3.20.0"
 url = "2.5.0"
+uuid = "1.18.1"
 indexmap = "2.11.3"
 anyhow = "1.0.100"
 tracing = { version = "0.1.41", optional = true }

--- a/gen-models/migrations/config/01-initial/up.sql
+++ b/gen-models/migrations/config/01-initial/up.sql
@@ -16,10 +16,11 @@ CREATE TABLE remote_operations (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     remote_name TEXT NOT NULL,
     branch_name TEXT NOT NULL,
-    operation TEXT NOT NULL CHECK(operation IN ('clone', 'pull')),
+    operation TEXT NOT NULL CHECK(operation IN ('clone', 'pull', 'push')),
     from_commit TEXT,
     assets_transfer_checkpoint TEXT,
     to_commit TEXT,
+    transfer_id BLOB CHECK(transfer_id IS NULL OR length(transfer_id) = 16),
     started_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
     completed_at TEXT,
     failed_at TEXT,
@@ -29,6 +30,8 @@ CREATE TABLE remote_operations (
         AND assets_transfer_checkpoint IS NOT NULL
         AND assets_transfer_checkpoint = to_commit
     )),
+    CHECK(operation = 'push' OR transfer_id IS NULL),
+    CHECK(operation != 'push' OR completed_at IS NULL OR transfer_id IS NOT NULL),
     FOREIGN KEY(remote_name) REFERENCES remotes(name) ON DELETE CASCADE
 ) STRICT;
 

--- a/gen-models/migrations/config/01-initial/up.sql
+++ b/gen-models/migrations/config/01-initial/up.sql
@@ -21,6 +21,7 @@ CREATE TABLE remote_operations (
     assets_transfer_checkpoint TEXT,
     to_commit TEXT,
     transfer_id BLOB CHECK(transfer_id IS NULL OR length(transfer_id) = 16),
+    transfer_expires_at INTEGER,
     started_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
     completed_at TEXT,
     failed_at TEXT,
@@ -31,6 +32,7 @@ CREATE TABLE remote_operations (
         AND assets_transfer_checkpoint = to_commit
     )),
     CHECK(operation = 'push' OR transfer_id IS NULL),
+    CHECK((transfer_id IS NULL) = (transfer_expires_at IS NULL)),
     CHECK(operation != 'push' OR completed_at IS NULL OR transfer_id IS NOT NULL),
     FOREIGN KEY(remote_name) REFERENCES remotes(name) ON DELETE CASCADE
 ) STRICT;

--- a/gen-models/src/operations.rs
+++ b/gen-models/src/operations.rs
@@ -27,6 +27,7 @@ use rusqlite::{
 };
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
+use uuid::Uuid;
 
 use crate::{
     assets::{
@@ -641,13 +642,15 @@ impl RemoteBranch {
     }
 }
 
-/// A remote read operation whose graph and asset phases must complete together.
+/// A remote operation whose graph and asset phases must complete together.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum RemoteOperationKind {
     /// Initializes a workspace from a remote repository.
     Clone,
     /// Advances an existing local branch from a remote repository.
     Pull,
+    /// Advances a remote branch from the local repository.
+    Push,
 }
 
 impl RemoteOperationKind {
@@ -655,6 +658,7 @@ impl RemoteOperationKind {
         match self {
             Self::Clone => "clone",
             Self::Pull => "pull",
+            Self::Push => "push",
         }
     }
 }
@@ -664,12 +668,13 @@ impl FromSql for RemoteOperationKind {
         value.as_str().map(|operation| match operation {
             "clone" => Self::Clone,
             "pull" => Self::Pull,
+            "push" => Self::Push,
             _ => unreachable!("remote operation should satisfy its database constraint"),
         })
     }
 }
 
-/// Tracks the commit range for a pull or clone until all local assets are verified.
+/// Tracks a remote operation until its graph and asset phases are complete.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct RemoteOperationRecord {
     /// Config database row identifier.
@@ -686,6 +691,8 @@ pub struct RemoteOperationRecord {
     pub assets_transfer_checkpoint: Option<DoltHashId>,
     /// Destination graph commit whose assets must be transferred.
     pub to_commit: Option<DoltHashId>,
+    /// GenHub push lease retained by a pending operation.
+    pub transfer_id: Option<Uuid>,
     /// Time at which the operation began.
     pub started_at: String,
     /// Time at which both graph and asset transfer completed.
@@ -708,6 +715,7 @@ impl Query for RemoteOperationRecord {
             from_commit: row.get("from_commit").unwrap(),
             assets_transfer_checkpoint: row.get("assets_transfer_checkpoint").unwrap(),
             to_commit: row.get("to_commit").unwrap(),
+            transfer_id: row.get("transfer_id").unwrap(),
             started_at: row.get("started_at").unwrap(),
             completed_at: row.get("completed_at").unwrap(),
             failed_at: row.get("failed_at").unwrap(),
@@ -729,8 +737,9 @@ impl RemoteOperationRecord {
                 "SELECT * FROM remote_operations \
                  WHERE remote_name = ?1 AND branch_name = ?2 \
                    AND completed_at IS NULL AND failed_at IS NULL \
+                   AND (operation = ?3 OR operation = 'clone' AND ?3 = 'pull') \
                  ORDER BY id LIMIT 1",
-                params![remote_name, branch_name],
+                params![remote_name, branch_name, operation.as_str()],
                 |row| Ok(Self::process_row(row)),
             )
             .optional()?;
@@ -763,7 +772,27 @@ impl RemoteOperationRecord {
             .ok_or(rusqlite::Error::QueryReturnedNoRows)
     }
 
-    /// Records the desired end commit an operation is tracking.
+    /// Returns the local branch commit from before the operation for conflict detection.
+    pub const fn from_commit(&self) -> Option<&DoltHashId> {
+        self.from_commit.as_ref()
+    }
+
+    /// Returns the last commit whose complete asset batch was verified locally.
+    pub const fn assets_transfer_checkpoint(&self) -> Option<&DoltHashId> {
+        self.assets_transfer_checkpoint.as_ref()
+    }
+
+    /// Returns the graph commit already transferred by a pending operation.
+    pub const fn to_commit(&self) -> Option<&DoltHashId> {
+        self.to_commit.as_ref()
+    }
+
+    /// Returns the GenHub push lease retained by a pending operation.
+    pub const fn transfer_id(&self) -> Option<Uuid> {
+        self.transfer_id
+    }
+
+    /// Records the graph commit whose assets must be hydrated by this operation.
     pub fn set_destination(
         &mut self,
         conn: &ConfigConnection,
@@ -789,6 +818,22 @@ impl RemoteOperationRecord {
             params![commit, self.id],
         )?;
         self.assets_transfer_checkpoint = Some(*commit);
+        Ok(())
+    }
+
+    /// Records the successful push graph transfer and its capability-scoped lease.
+    pub fn set_push_destination(
+        &mut self,
+        conn: &ConfigConnection,
+        to_commit: &DoltHashId,
+        transfer_id: Uuid,
+    ) -> SQLResult<()> {
+        conn.execute(
+            "UPDATE remote_operations SET to_commit = ?1, transfer_id = ?2 WHERE id = ?3",
+            params![to_commit, transfer_id, self.id],
+        )?;
+        self.to_commit = Some(*to_commit);
+        self.transfer_id = Some(transfer_id);
         Ok(())
     }
 
@@ -1115,6 +1160,7 @@ mod tests {
     #[cfg(test)]
     mod remote_operations {
         use gen_core::DoltHashId;
+        use uuid::Uuid;
 
         use crate::{
             operations::{Remote, RemoteOperationKind, RemoteOperationRecord},
@@ -1256,6 +1302,45 @@ mod tests {
             let failed = RemoteOperationRecord::get_by_id(config, &operation.id, None)
                 .expect("should refetch failed clone operation");
             assert!(failed.failed_at.is_some(), "failed_at should be set");
+        }
+
+        #[test]
+        fn test_push_operation_resumes_transfer_lease() {
+            let context = setup_gen();
+            let config = context.config().conn();
+            Remote::create(config, "origin", "https://example.com/repo")
+                .expect("should create remote");
+            let destination_commit = DoltHashId([3_u8; 20]);
+            let transfer_id = Uuid::from_u128(7);
+            let mut operation = RemoteOperationRecord::begin_or_resume(
+                config,
+                "origin",
+                "main",
+                RemoteOperationKind::Push,
+                None,
+            )
+            .expect("should begin push operation");
+            operation
+                .set_push_destination(config, &destination_commit, transfer_id)
+                .expect("should record push destination and lease");
+
+            let mut resumed = RemoteOperationRecord::begin_or_resume(
+                config,
+                "origin",
+                "main",
+                RemoteOperationKind::Push,
+                None,
+            )
+            .expect("should resume push operation");
+
+            assert_eq!(resumed.to_commit(), Some(&destination_commit));
+            assert_eq!(resumed.transfer_id(), Some(transfer_id));
+            resumed
+                .advance_assets_transfer_checkpoint(config, &destination_commit)
+                .expect("should record completed push assets");
+            resumed
+                .complete(config)
+                .expect("should complete push operation");
         }
     }
 

--- a/gen-models/src/operations.rs
+++ b/gen-models/src/operations.rs
@@ -693,6 +693,8 @@ pub struct RemoteOperationRecord {
     pub to_commit: Option<DoltHashId>,
     /// GenHub push lease retained by a pending operation.
     pub transfer_id: Option<Uuid>,
+    /// Unix timestamp after which GenHub will reject the retained push lease.
+    pub transfer_expires_at: Option<i64>,
     /// Time at which the operation began.
     pub started_at: String,
     /// Time at which both graph and asset transfer completed.
@@ -716,6 +718,7 @@ impl Query for RemoteOperationRecord {
             assets_transfer_checkpoint: row.get("assets_transfer_checkpoint").unwrap(),
             to_commit: row.get("to_commit").unwrap(),
             transfer_id: row.get("transfer_id").unwrap(),
+            transfer_expires_at: row.get("transfer_expires_at").unwrap(),
             started_at: row.get("started_at").unwrap(),
             completed_at: row.get("completed_at").unwrap(),
             failed_at: row.get("failed_at").unwrap(),
@@ -737,6 +740,9 @@ impl RemoteOperationRecord {
                 "SELECT * FROM remote_operations \
                  WHERE remote_name = ?1 AND branch_name = ?2 \
                    AND completed_at IS NULL AND failed_at IS NULL \
+                   -- This is confusing, but this checks whether a clone operation is followed by a pull.
+                   -- If a clone fails to download assets, a pull can finish the operation even though the
+                   -- persisted operation is clone and the requested operation is pull.
                    AND (operation = ?3 OR operation = 'clone' AND ?3 = 'pull') \
                  ORDER BY id LIMIT 1",
                 params![remote_name, branch_name, operation.as_str()],
@@ -772,27 +778,7 @@ impl RemoteOperationRecord {
             .ok_or(rusqlite::Error::QueryReturnedNoRows)
     }
 
-    /// Returns the local branch commit from before the operation for conflict detection.
-    pub const fn from_commit(&self) -> Option<&DoltHashId> {
-        self.from_commit.as_ref()
-    }
-
-    /// Returns the last commit whose complete asset batch was verified locally.
-    pub const fn assets_transfer_checkpoint(&self) -> Option<&DoltHashId> {
-        self.assets_transfer_checkpoint.as_ref()
-    }
-
-    /// Returns the graph commit already transferred by a pending operation.
-    pub const fn to_commit(&self) -> Option<&DoltHashId> {
-        self.to_commit.as_ref()
-    }
-
-    /// Returns the GenHub push lease retained by a pending operation.
-    pub const fn transfer_id(&self) -> Option<Uuid> {
-        self.transfer_id
-    }
-
-    /// Records the graph commit whose assets must be hydrated by this operation.
+    /// Records the desired end commit an operation is tracking.
     pub fn set_destination(
         &mut self,
         conn: &ConfigConnection,
@@ -827,13 +813,16 @@ impl RemoteOperationRecord {
         conn: &ConfigConnection,
         to_commit: &DoltHashId,
         transfer_id: Uuid,
+        transfer_expires_at: i64,
     ) -> SQLResult<()> {
         conn.execute(
-            "UPDATE remote_operations SET to_commit = ?1, transfer_id = ?2 WHERE id = ?3",
-            params![to_commit, transfer_id, self.id],
+            "UPDATE remote_operations \
+             SET to_commit = ?1, transfer_id = ?2, transfer_expires_at = ?3 WHERE id = ?4",
+            params![to_commit, transfer_id, transfer_expires_at, self.id],
         )?;
         self.to_commit = Some(*to_commit);
         self.transfer_id = Some(transfer_id);
+        self.transfer_expires_at = Some(transfer_expires_at);
         Ok(())
     }
 
@@ -1312,6 +1301,7 @@ mod tests {
                 .expect("should create remote");
             let destination_commit = DoltHashId([3_u8; 20]);
             let transfer_id = Uuid::from_u128(7);
+            let transfer_expires_at = 1_900_000_000;
             let mut operation = RemoteOperationRecord::begin_or_resume(
                 config,
                 "origin",
@@ -1321,7 +1311,12 @@ mod tests {
             )
             .expect("should begin push operation");
             operation
-                .set_push_destination(config, &destination_commit, transfer_id)
+                .set_push_destination(
+                    config,
+                    &destination_commit,
+                    transfer_id,
+                    transfer_expires_at,
+                )
                 .expect("should record push destination and lease");
 
             let mut resumed = RemoteOperationRecord::begin_or_resume(
@@ -1333,8 +1328,9 @@ mod tests {
             )
             .expect("should resume push operation");
 
-            assert_eq!(resumed.to_commit(), Some(&destination_commit));
-            assert_eq!(resumed.transfer_id(), Some(transfer_id));
+            assert_eq!(resumed.to_commit.as_ref(), Some(&destination_commit));
+            assert_eq!(resumed.transfer_id, Some(transfer_id));
+            assert_eq!(resumed.transfer_expires_at, Some(transfer_expires_at));
             resumed
                 .advance_assets_transfer_checkpoint(config, &destination_commit)
                 .expect("should record completed push assets");

--- a/src/commands/remote/client.rs
+++ b/src/commands/remote/client.rs
@@ -14,8 +14,9 @@
 //! rejects an expired capability, the operation requests a fresh capability and retries.
 //! After the graph transfer, [`acquire_asset_transfers`] obtains the per-asset upload or
 //! download URLs used to transfer files referenced by the selected branch. A push then
-//! calls [`complete_asset_transfers`] with GCS-validated upload receipts so GenHub can
-//! verify the stored objects before finalizing a new repository.
+//! calls [`complete_asset_transfers`] with the successful capability's transfer ID and
+//! GCS-validated upload receipts so GenHub can verify the stored objects before releasing
+//! the push lease.
 //!
 //! Both acquisition functions use the same authentication sequence. Public clone and
 //! pull requests may first be attempted anonymously; otherwise the client tries
@@ -33,6 +34,7 @@ use reqwest::{
 };
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+use uuid::Uuid;
 
 use crate::commands::remote::{
     server::AuthTokens,
@@ -145,6 +147,8 @@ pub struct CapabilityResponse {
     pub remote_url: String,
     pub expires_at: String,
     pub default_branch: String,
+    /// Identifies the capability's transfer-scoped push lease.
+    pub transfer_id: Uuid,
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -183,6 +187,8 @@ pub struct AssetUploadReceipt {
 /// Signals that all uploads for a pushed branch have completed.
 #[derive(Clone, Debug, Serialize)]
 pub struct AssetTransferCompletionRequest<'request> {
+    /// The capability-scoped owner of the push lease being completed.
+    pub transfer_id: Uuid,
     /// The branch whose expected asset set should be verified.
     pub branch: &'request str,
     /// Provider-checksum receipts for every uploaded or reused object.
@@ -503,11 +509,14 @@ mod tests {
     };
 
     use reqwest::{StatusCode, blocking::Client};
+    use uuid::Uuid;
 
     use super::{
         AuthTokens, CapabilityRequest, CapabilityResponse, RemoteClientError, RemoteOperation,
         RepositoryRemote, TokenStore, acquire_capability_with_store, normalized_origin,
     };
+
+    const TEST_TRANSFER_ID: Uuid = Uuid::from_u128(1);
 
     struct MemoryTokenStore {
         tokens: Mutex<Option<AuthTokens>>,
@@ -614,7 +623,8 @@ mod tests {
         serde_json::json!({
             "remote_url": remote_url,
             "expires_at": "2030-01-01T00:00:00Z",
-            "default_branch": "main"
+            "default_branch": "main",
+            "transfer_id": TEST_TRANSFER_ID
         })
         .to_string()
     }
@@ -703,6 +713,7 @@ mod tests {
                 remote_url: expected_url.to_string(),
                 expires_at: "2030-01-01T00:00:00Z".to_string(),
                 default_branch: "main".to_string(),
+                transfer_id: TEST_TRANSFER_ID,
             }
         );
         assert!(!requests[0].to_ascii_lowercase().contains("x-api-key:"));

--- a/src/commands/remote/client.rs
+++ b/src/commands/remote/client.rs
@@ -27,6 +27,7 @@
 
 use std::{env, io};
 
+use chrono::{DateTime, Utc};
 use gen_core::{DoltHashId, HashId};
 use reqwest::{
     StatusCode, Url,
@@ -145,7 +146,7 @@ pub struct CapabilityRequest<'branch> {
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
 pub struct CapabilityResponse {
     pub remote_url: String,
-    pub expires_at: String,
+    pub expires_at: DateTime<Utc>,
     pub default_branch: String,
     /// Identifies the capability's transfer-scoped push lease.
     pub transfer_id: Uuid,
@@ -711,7 +712,9 @@ mod tests {
             response,
             CapabilityResponse {
                 remote_url: expected_url.to_string(),
-                expires_at: "2030-01-01T00:00:00Z".to_string(),
+                expires_at: "2030-01-01T00:00:00Z"
+                    .parse()
+                    .expect("should parse capability expiry"),
                 default_branch: "main".to_string(),
                 transfer_id: TEST_TRANSFER_ID,
             }

--- a/src/commands/remote/operations.rs
+++ b/src/commands/remote/operations.rs
@@ -39,12 +39,14 @@
 //! resolved as safe workspace-relative paths, including `.gen/outside_root` paths used to
 //! represent inputs that originally came from outside the workspace.
 //!
-//! Network operations are journaled as graph-first distributed operations in the config database.
-//! Clone and pull downloads persist an asset checkpoint after each complete first-parent commit
-//! batch, so a retry resumes after the last verified batch even when Dolt already advanced the
-//! graph. A push retry retains the successful graph capability's transfer ID so GenHub recognizes
-//! the existing lease and releases it only after asset completion. A branch with no successful
-//! operation requests its complete reachable asset history once.
+//! Clones, pushes, and pulls are distributed operations where the graph database is sync'd and
+//! then the assets are transfered. Thus, an asset transfer can fail and need to be resumed. We
+//! track the state of asset transfers and checkpoint after each commit is successfully transfered.
+//! When the entire commit range has been transfered, we mark the operation as complete. For pushes,
+//! a server provides a transfer ID and expiry that serve as a lease. Gen persists both so an
+//! interrupted asset phase can reuse an active lease, while an expired lease triggers fresh graph
+//! authorization. The lease restricts uploads to a single client and is released after assets are
+//! uploaded.
 //!
 //! Pull records the branch commit from before the Dolt operation so downloads can
 //! distinguish a clean old version from a local modification. If the destination still
@@ -64,15 +66,17 @@ use std::{
 };
 
 use base64::{Engine as _, engine::general_purpose};
+use chrono::Utc;
 use crc32c::crc32c_append;
 use gen_core::{
     DoltHashId, HashId, Sha256Hash,
     config::{DEFAULT_GRAPH_DB_NAME, Workspace},
+    errors::{ConfigError, ConnectionError},
 };
 use gen_models::{
     assets::{AssetRef, AssetView, LocalAssetUri, materialization_destination_path},
     db::{ConfigConnection, GraphConnection},
-    errors::QueryError,
+    errors::{QueryError, RemoteError as ModelRemoteError},
     history::dolt::{
         active_branch, add_remote, branch_hash, checkout, clone_remote, fetch, hash_of, pull, push,
         push_force, remote_rows, set_remote_url,
@@ -98,8 +102,8 @@ use crate::{
     commands::remote::{
         client::{
             AssetTransferCompletionRequest, AssetTransferRequest, AssetUploadReceipt,
-            CapabilityRequest, RemoteOperation, RepositoryRemote, acquire_asset_transfers,
-            acquire_capability, complete_asset_transfers,
+            CapabilityRequest, RemoteClientError, RemoteOperation, RepositoryRemote,
+            acquire_asset_transfers, acquire_capability, complete_asset_transfers,
         },
         login_origin,
     },
@@ -163,9 +167,15 @@ fn file_remote_workspace(remote_url: &str) -> Result<Workspace, Box<dyn Error>> 
     Ok(workspace)
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct PushTransferLease {
+    transfer_id: Uuid,
+    expires_at: i64,
+}
+
 struct GraphTransferAuthorization {
     remote_url: String,
-    transfer_id: Option<Uuid>,
+    push_lease: Option<PushTransferLease>,
 }
 
 fn transfer_authorization(
@@ -177,7 +187,7 @@ fn transfer_authorization(
     if remote.url.starts_with("file://") {
         return Ok(GraphTransferAuthorization {
             remote_url: file_graph_url(&remote.url)?,
-            transfer_id: None,
+            push_lease: None,
         });
     }
     let repository = RepositoryRemote::parse(&remote.url)?;
@@ -187,9 +197,13 @@ fn transfer_authorization(
         force,
     };
     let capability = acquire_capability(&repository, &request, login_origin)?;
+    let push_lease = (operation == RemoteOperation::Push).then_some(PushTransferLease {
+        transfer_id: capability.transfer_id,
+        expires_at: capability.expires_at.timestamp(),
+    });
     Ok(GraphTransferAuthorization {
         remote_url: capability.remote_url,
-        transfer_id: Some(capability.transfer_id),
+        push_lease,
     })
 }
 
@@ -257,7 +271,7 @@ fn run_graph_transfer(
     branch: &str,
     force: bool,
     mut transfer: impl FnMut() -> Result<(), SqlError>,
-) -> Result<Option<Uuid>, Box<dyn Error>> {
+) -> Result<Option<PushTransferLease>, Box<dyn Error>> {
     if remote.url.starts_with("file://") {
         let authorization = transfer_authorization(remote, operation, Some(branch), force)?;
         ensure_graph_remote(graph, &remote.name, &authorization.remote_url)?;
@@ -274,7 +288,7 @@ fn run_graph_transfer(
         match transfer() {
             Ok(()) => {
                 restore_canonical_url(graph, remote);
-                return Ok(authorization.transfer_id);
+                return Ok(authorization.push_lease);
             }
             Err(error) if attempt == 0 && is_authorization_error(&error) => {
                 last_error = Some(error);
@@ -1144,29 +1158,67 @@ pub fn clone_into_workspace(
     Ok(branch)
 }
 
+/// Errors that can occur while pushing a branch to a remote repository.
+#[derive(Debug, thiserror::Error)]
+pub enum RemotePushError {
+    /// The workspace paths could not be resolved.
+    #[error(transparent)]
+    Config(#[from] ConfigError),
+    /// A config or graph database connection could not be opened.
+    #[error(transparent)]
+    Connection(#[from] ConnectionError),
+    /// A local database operation failed.
+    #[error(transparent)]
+    Database(#[from] SqlError),
+    /// The configured remote is invalid or could not be updated.
+    #[error(transparent)]
+    Remote(#[from] ModelRemoteError),
+    /// A GenHub request failed.
+    #[error(transparent)]
+    Client(#[from] RemoteClientError),
+    /// The remote could not be selected from the command and repository configuration.
+    #[error("Unable to resolve push remote: {0}")]
+    RemoteResolution(#[source] Box<dyn Error>),
+    /// Dolt could not transfer the graph branch.
+    #[error("Graph transfer failed: {0}")]
+    GraphTransfer(#[source] Box<dyn Error>),
+    /// The branch's assets could not be transferred.
+    #[error("Asset transfer failed: {0}")]
+    AssetTransfer(#[source] Box<dyn Error>),
+    /// A successful GenHub graph push did not return its push lease.
+    #[error("GenHub push did not return a transfer ID")]
+    MissingTransferId,
+    /// A pending push has only part of its persisted transfer lease metadata.
+    #[error("Pending push metadata for branch '{branch}' has an incomplete transfer lease")]
+    IncompleteTransferLease { branch: String },
+}
+
 pub fn execute_push(
     workspace: &Workspace,
     explicit_remote: Option<&str>,
     explicit_branch: Option<&str>,
     force: bool,
-) -> Result<(), Box<dyn Error>> {
+) -> Result<(), RemotePushError> {
     let config = get_config_connection(Some(workspace.gen_db_path()?))?;
     let intended_branch = Defaults::get_current_branch(&config);
     let graph = get_connection_for_branch(workspace.graph_db_path()?, intended_branch.as_deref())?;
     let persisted_branch = connect_persisted_branch(&graph, &config)?;
-    let branch = explicit_branch
-        .map(str::to_string)
-        .or(persisted_branch)
-        .unwrap_or(active_branch(&graph)?);
-    let remote = resolve_remote(&config, explicit_remote, &branch)?;
+    let branch = if let Some(explicit_branch) = explicit_branch {
+        explicit_branch.to_string()
+    } else if let Some(persisted_branch) = persisted_branch {
+        persisted_branch
+    } else {
+        active_branch(&graph)?
+    };
+    let remote = resolve_remote(&config, explicit_remote, &branch)
+        .map_err(RemotePushError::RemoteResolution)?;
     // A missing or stale tracking ref only makes the transfer conservatively include more assets.
     // Force pushes cannot use the tracking ref as a lower bound because they may replace history.
     let tracking_ref = format!("{}/{branch}", remote.name);
     let previous_hash = (!force)
         .then(|| hash_of(&graph, &tracking_ref).ok())
         .flatten();
-    let mut push_operation = None;
-    let transfer_id = if remote.url.starts_with("file://") {
+    let mut push_context = if remote.url.starts_with("file://") {
         run_graph_transfer(
             &graph,
             &remote,
@@ -1174,7 +1226,8 @@ pub fn execute_push(
             &branch,
             force,
             || push_graph_branch(&graph, &remote.name, &branch, force),
-        )?;
+        )
+        .map_err(RemotePushError::GraphTransfer)?;
         None
     } else {
         let mut operation = RemoteOperationRecord::begin_or_resume(
@@ -1185,17 +1238,21 @@ pub fn execute_push(
             previous_hash.as_ref(),
         )?;
         let destination_hash = hash_of(&graph, &branch)?;
-        let transfer_id = match (operation.to_commit(), operation.transfer_id()) {
-            (Some(recorded_destination), Some(transfer_id)) => {
-                if recorded_destination != &destination_hash {
-                    return Err(format!(
-                        "Cannot resume the pending push for branch '{branch}' because its local head changed after the graph transfer"
-                    )
-                    .into());
+        let transfer_lease = match (
+            operation.to_commit.as_ref(),
+            operation.transfer_id,
+            operation.transfer_expires_at,
+        ) {
+            (Some(recorded_destination), Some(transfer_id), Some(expires_at))
+                if recorded_destination == &destination_hash
+                    && expires_at > Utc::now().timestamp() =>
+            {
+                PushTransferLease {
+                    transfer_id,
+                    expires_at,
                 }
-                transfer_id
             }
-            (None, None) => {
+            (Some(_), Some(_), Some(_)) | (None, None, None) => {
                 let graph_transfer = run_graph_transfer(
                     &graph,
                     &remote,
@@ -1204,35 +1261,38 @@ pub fn execute_push(
                     force,
                     || push_graph_branch(&graph, &remote.name, &branch, force),
                 );
-                let transfer_id = match graph_transfer {
-                    Ok(Some(transfer_id)) => transfer_id,
+                let transfer_lease = match graph_transfer {
+                    Ok(Some(transfer_lease)) => transfer_lease,
                     Ok(None) => {
-                        return Err("GenHub push did not return a transfer ID".into());
+                        return Err(RemotePushError::MissingTransferId);
                     }
                     Err(error) => {
-                        if let Err(metadata_error) = operation.fail(&config) {
+                        if operation.to_commit.is_none()
+                            && let Err(metadata_error) = operation.fail(&config)
+                        {
                             eprintln!(
                                 "Warning: failed to record unsuccessful push operation for branch '{branch}': {metadata_error}"
                             );
                         }
-                        return Err(error);
+                        return Err(RemotePushError::GraphTransfer(error));
                     }
                 };
-                operation.set_push_destination(&config, &destination_hash, transfer_id)?;
-                transfer_id
+                operation.set_push_destination(
+                    &config,
+                    &destination_hash,
+                    transfer_lease.transfer_id,
+                    transfer_lease.expires_at,
+                )?;
+                transfer_lease
             }
             _ => {
-                return Err(format!(
-                    "Pending push metadata for branch '{branch}' has an incomplete transfer lease"
-                )
-                .into());
+                return Err(RemotePushError::IncompleteTransferLease { branch });
             }
         };
-        push_operation = Some(operation);
-        Some(transfer_id)
+        Some((operation, transfer_lease, destination_hash))
     };
-    let assets_transfer_checkpoint = if let Some(operation) = push_operation.as_ref() {
-        operation.assets_transfer_checkpoint()
+    let assets_transfer_checkpoint = if let Some((operation, _, _)) = push_context.as_ref() {
+        operation.assets_transfer_checkpoint.as_ref()
     } else {
         previous_hash.as_ref()
     };
@@ -1247,24 +1307,20 @@ pub fn execute_push(
             previous_hash: previous_hash.as_ref(),
         },
         |_| Ok(()),
-    )?;
-    if let Some(operation) = push_operation.as_mut() {
+    )
+    .map_err(RemotePushError::AssetTransfer)?;
+    if let Some((operation, transfer_lease, destination_hash)) = push_context.as_mut() {
         let repository = RepositoryRemote::parse(&remote.url)?;
-        let transfer_id = transfer_id.expect("should retain the GenHub push transfer ID");
         complete_asset_transfers(
             &repository,
             &AssetTransferCompletionRequest {
-                transfer_id,
+                transfer_id: transfer_lease.transfer_id,
                 branch: &branch,
                 assets: &upload_receipts,
             },
             login_origin,
         )?;
-        let destination_hash = operation
-            .to_commit()
-            .copied()
-            .expect("should retain the pushed graph destination");
-        operation.advance_assets_transfer_checkpoint(&config, &destination_hash)?;
+        operation.advance_assets_transfer_checkpoint(&config, destination_hash)?;
         operation.complete(&config)?;
     }
     if let Err(error) = run_graph_transfer(
@@ -1396,6 +1452,7 @@ mod tests {
         thread,
     };
 
+    use chrono::Utc;
     use gen_core::{DoltHashId, HashId, config::Workspace};
     use gen_models::{
         assets::{AssetRef, AssetRole, LocalAssetUri, materialization_destination_path},
@@ -1414,10 +1471,11 @@ mod tests {
     use uuid::Uuid;
 
     use super::{
-        AssetTransferRange, DownloadAssetOutcome, RemoteOperation, canonical_remote_url,
-        clone_destination_name, copy_versioned_asset, download_asset, download_to_versioned_store,
-        execute_pull, execute_push, file_graph_url, get_remaining_assets_to_transfer,
-        resolve_remote, run_graph_transfer, temporary_path, transfer_assets,
+        AssetTransferRange, DownloadAssetOutcome, PushTransferLease, RemoteOperation,
+        canonical_remote_url, clone_destination_name, copy_versioned_asset, download_asset,
+        download_to_versioned_store, execute_pull, execute_push, file_graph_url,
+        get_remaining_assets_to_transfer, resolve_remote, run_graph_transfer, temporary_path,
+        transfer_assets,
     };
     use crate::{get_config_connection, get_connection, get_raw_connection};
 
@@ -2756,7 +2814,7 @@ mod tests {
             url: format!("http://{address}/api/repos/alice/example"),
         };
         let mut attempts = 0;
-        let transfer_id = run_graph_transfer(
+        let transfer_lease = run_graph_transfer(
             &graph,
             &remote,
             RemoteOperation::Push,
@@ -2778,7 +2836,13 @@ mod tests {
         server.join().expect("capability server should finish");
 
         assert_eq!(attempts, 2);
-        assert_eq!(transfer_id, Some(RETRIED_TRANSFER_ID));
+        assert_eq!(
+            transfer_lease,
+            Some(PushTransferLease {
+                transfer_id: RETRIED_TRANSFER_ID,
+                expires_at: 1_893_456_000,
+            })
+        );
         let remotes = remote_rows(&graph).expect("should read restored canonical URL");
         assert!(
             remotes
@@ -2992,6 +3056,271 @@ mod tests {
             )
             .expect("should count pending operations");
         assert_eq!(pending_operations, 0);
+    }
+
+    #[test]
+    fn test_push_retry_pushes_advanced_head_with_new_transfer_lease() {
+        // This tests that if we have a resumed push, but have commited work since the last failed push, the to_commit recorded
+        // as the end state of the push is advanced to the current head commit.
+        let _environment_lock = ENVIRONMENT_LOCK
+            .lock()
+            .expect("should lock process environment");
+        let _api_key = EnvironmentGuard::set("GENHUB_API_KEY", "push-test-key");
+        let listener = TcpListener::bind("127.0.0.1:0").expect("should bind capability server");
+        let address = listener
+            .local_addr()
+            .expect("should read capability server address");
+        let temp = tempdir().expect("should create advanced push retry directory");
+        let remote_graph = temp.path().join("remote.db");
+        let transfer_url = format!("file://{}", remote_graph.display());
+        let server = thread::spawn(move || {
+            let mut requests = Vec::new();
+            for request_index in 0..7 {
+                let (mut stream, _) = listener.accept().expect("should accept GenHub request");
+                let mut request = [0_u8; 8192];
+                let read = stream
+                    .read(&mut request)
+                    .expect("should read GenHub request");
+                requests.push(String::from_utf8_lossy(&request[..read]).into_owned());
+                match request_index {
+                    0 | 3 | 6 => {
+                        let transfer_id = if request_index == 0 {
+                            TEST_TRANSFER_ID
+                        } else {
+                            RETRIED_TRANSFER_ID
+                        };
+                        let body = format!(
+                            "{{\"remote_url\":\"{transfer_url}\",\
+                             \"expires_at\":\"2030-01-01T00:00:00Z\",\
+                             \"default_branch\":\"main\",\
+                             \"transfer_id\":\"{transfer_id}\"}}"
+                        );
+                        write!(
+                            stream,
+                            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
+                            body.len()
+                        )
+                        .expect("should write capability response");
+                    }
+                    1 | 4 => {
+                        let body = "{\"assets\":[]}";
+                        write!(
+                            stream,
+                            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
+                            body.len()
+                        )
+                        .expect("should write asset response");
+                    }
+                    2 => {
+                        let body = "asset verification unavailable";
+                        write!(
+                            stream,
+                            "HTTP/1.1 500 Internal Server Error\r\nContent-Type: text/plain\r\nContent-Length: {}\r\n\r\n{body}",
+                            body.len()
+                        )
+                        .expect("should write failed completion response");
+                    }
+                    5 => {
+                        stream
+                            .write_all(b"HTTP/1.1 204 No Content\r\nContent-Length: 0\r\n\r\n")
+                            .expect("should write completion response");
+                    }
+                    _ => unreachable!("request index should be covered"),
+                }
+            }
+            requests
+        });
+
+        let workspace = Workspace::new(temp.path().join("local"));
+        workspace.ensure_gen_dir();
+        let config = get_config_connection(Some(workspace.gen_db_path().unwrap()))
+            .expect("should open push config");
+        let graph = get_connection(workspace.graph_db_path().unwrap()).expect("should open graph");
+        Collection::create(&graph, "push-retry-fixture").expect("should create push fixture");
+        let original_destination =
+            commit_all(&graph, "push retry fixture").expect("should commit push retry fixture");
+        Remote::create(
+            &config,
+            "origin",
+            &format!("http://{address}/api/repos/alice/example"),
+        )
+        .expect("should configure origin");
+        Defaults::set_default_remote(&config, Some("origin")).expect("should set default remote");
+        drop(graph);
+
+        execute_push(&workspace, None, None, false)
+            .expect_err("first push should retain its lease after completion fails");
+        let pending_transfer: (DoltHashId, Uuid) = config
+            .query_row(
+                "SELECT to_commit, transfer_id FROM remote_operations \
+                 WHERE operation = 'push' AND completed_at IS NULL AND failed_at IS NULL",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("should retain pending push lease");
+        assert_eq!(pending_transfer, (original_destination, TEST_TRANSFER_ID));
+
+        let graph =
+            get_connection(workspace.graph_db_path().unwrap()).expect("should reopen graph");
+        Collection::create(&graph, "advanced-head").expect("should advance local graph");
+        let advanced_destination =
+            commit_all(&graph, "advance push retry").expect("should commit advanced local head");
+        drop(graph);
+
+        execute_push(&workspace, None, None, false).expect("advanced push retry should complete");
+        let requests = server.join().expect("GenHub server should finish");
+
+        assert_eq!(requests.len(), 7);
+        assert!(requests[0].contains("\"operation\":\"push\""));
+        assert!(requests[2].contains(&format!("\"transfer_id\":\"{TEST_TRANSFER_ID}\"")));
+        assert!(requests[3].contains("\"operation\":\"push\""));
+        assert!(requests[4].starts_with("POST /api/repos/alice/example/asset-transfers "));
+        assert!(requests[5].starts_with("POST /api/repos/alice/example/asset-transfers/complete "));
+        assert!(requests[5].contains(&format!("\"transfer_id\":\"{RETRIED_TRANSFER_ID}\"")));
+        assert!(requests[6].contains("\"operation\":\"pull\""));
+        let completed_transfer: (DoltHashId, DoltHashId, Uuid) = config
+            .query_row(
+                "SELECT to_commit, assets_transfer_checkpoint, transfer_id \
+                 FROM remote_operations WHERE operation = 'push' AND completed_at IS NOT NULL",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .expect("should complete advanced push operation");
+        assert_eq!(
+            completed_transfer,
+            (
+                advanced_destination,
+                advanced_destination,
+                RETRIED_TRANSFER_ID
+            )
+        );
+        let graph =
+            get_connection(workspace.graph_db_path().unwrap()).expect("should reopen graph");
+        let tracking_hash = hash_of(&graph, "origin/main").expect("should query tracking branch");
+        assert_eq!(tracking_hash, advanced_destination);
+    }
+
+    #[test]
+    fn test_push_retry_refreshes_expired_transfer_lease() {
+        let _environment_lock = ENVIRONMENT_LOCK
+            .lock()
+            .expect("should lock process environment");
+        let _api_key = EnvironmentGuard::set("GENHUB_API_KEY", "push-test-key");
+        let listener =
+            TcpListener::bind("127.0.0.1:0").expect("should bind expired lease retry server");
+        let address = listener
+            .local_addr()
+            .expect("should read expired lease retry server address");
+        let temp = tempdir().expect("should create expired lease retry directory");
+        let remote_graph = temp.path().join("remote.db");
+        let transfer_url = format!("file://{}", remote_graph.display());
+        let server = thread::spawn(move || {
+            let mut requests = Vec::new();
+            for request_index in 0..7 {
+                let (mut stream, _) = listener.accept().expect("should accept GenHub request");
+                let mut request = [0_u8; 8192];
+                let read = stream
+                    .read(&mut request)
+                    .expect("should read GenHub request");
+                requests.push(String::from_utf8_lossy(&request[..read]).into_owned());
+                match request_index {
+                    0 | 3 | 6 => {
+                        let transfer_id = if request_index == 0 {
+                            TEST_TRANSFER_ID
+                        } else {
+                            RETRIED_TRANSFER_ID
+                        };
+                        let body = format!(
+                            "{{\"remote_url\":\"{transfer_url}\",\
+                             \"expires_at\":\"2030-01-01T00:00:00Z\",\
+                             \"default_branch\":\"main\",\
+                             \"transfer_id\":\"{transfer_id}\"}}"
+                        );
+                        write!(
+                            stream,
+                            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
+                            body.len()
+                        )
+                        .expect("should write capability response");
+                    }
+                    1 | 4 => {
+                        let body = "{\"assets\":[]}";
+                        write!(
+                            stream,
+                            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
+                            body.len()
+                        )
+                        .expect("should write asset response");
+                    }
+                    2 => {
+                        let body = "asset verification unavailable";
+                        write!(
+                            stream,
+                            "HTTP/1.1 500 Internal Server Error\r\nContent-Type: text/plain\r\nContent-Length: {}\r\n\r\n{body}",
+                            body.len()
+                        )
+                        .expect("should write failed completion response");
+                    }
+                    5 => {
+                        stream
+                            .write_all(b"HTTP/1.1 204 No Content\r\nContent-Length: 0\r\n\r\n")
+                            .expect("should write completion response");
+                    }
+                    _ => unreachable!("request index should be covered"),
+                }
+            }
+            requests
+        });
+
+        let workspace = Workspace::new(temp.path().join("local"));
+        workspace.ensure_gen_dir();
+        let config = get_config_connection(Some(workspace.gen_db_path().unwrap()))
+            .expect("should open push config");
+        let graph = get_connection(workspace.graph_db_path().unwrap()).expect("should open graph");
+        Collection::create(&graph, "expired-lease-retry-fixture")
+            .expect("should create expired lease retry fixture");
+        let destination_hash = commit_all(&graph, "expired lease retry fixture")
+            .expect("should commit expired lease retry fixture");
+        Remote::create(
+            &config,
+            "origin",
+            &format!("http://{address}/api/repos/alice/example"),
+        )
+        .expect("should configure origin");
+        Defaults::set_default_remote(&config, Some("origin")).expect("should set default remote");
+        drop(graph);
+
+        execute_push(&workspace, None, None, false)
+            .expect_err("first push should retain its lease after completion fails");
+        config
+            .execute(
+                "UPDATE remote_operations SET transfer_expires_at = 0 \
+                 WHERE operation = 'push' AND completed_at IS NULL AND failed_at IS NULL",
+                [],
+            )
+            .expect("should expire the persisted transfer lease");
+
+        execute_push(&workspace, None, None, false)
+            .expect("expired lease retry should obtain a new transfer");
+        let requests = server.join().expect("GenHub server should finish");
+
+        assert_eq!(requests.len(), 7);
+        assert!(requests[0].contains("\"operation\":\"push\""));
+        assert!(requests[2].contains(&format!("\"transfer_id\":\"{TEST_TRANSFER_ID}\"")));
+        assert!(requests[3].contains("\"operation\":\"push\""));
+        assert!(requests[5].contains(&format!("\"transfer_id\":\"{RETRIED_TRANSFER_ID}\"")));
+        assert!(requests[6].contains("\"operation\":\"pull\""));
+        let completed_transfer: (DoltHashId, Uuid, i64) = config
+            .query_row(
+                "SELECT to_commit, transfer_id, transfer_expires_at \
+                 FROM remote_operations WHERE operation = 'push' AND completed_at IS NOT NULL",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .expect("should complete refreshed transfer lease");
+        assert_eq!(completed_transfer.0, destination_hash);
+        assert_eq!(completed_transfer.1, RETRIED_TRANSFER_ID);
+        assert!(completed_transfer.2 > Utc::now().timestamp());
     }
 
     #[test]

--- a/src/commands/remote/operations.rs
+++ b/src/commands/remote/operations.rs
@@ -39,10 +39,12 @@
 //! resolved as safe workspace-relative paths, including `.gen/outside_root` paths used to
 //! represent inputs that originally came from outside the workspace.
 //!
-//! Clone and pull are distributed operations where the graph database is sync'd and then the assets
-//! are transfered. Thus, an asset transfer can fail and need to be resumed. We track the state of
-//! asset transfers and checkpoint after each commit is successfully transfered. When the entire
-//! commit range has been transfered, we mark the operation as complete.
+//! Network operations are journaled as graph-first distributed operations in the config database.
+//! Clone and pull downloads persist an asset checkpoint after each complete first-parent commit
+//! batch, so a retry resumes after the last verified batch even when Dolt already advanced the
+//! graph. A push retry retains the successful graph capability's transfer ID so GenHub recognizes
+//! the existing lease and releases it only after asset completion. A branch with no successful
+//! operation requests its complete reachable asset history once.
 //!
 //! Pull records the branch commit from before the Dolt operation so downloads can
 //! distinguish a clean old version from a local modification. If the destination still
@@ -90,6 +92,7 @@ use reqwest::{
 use rusqlite::Error as SqlError;
 use sha2::{Digest as _, Sha256};
 use url::Url;
+use uuid::Uuid;
 
 use crate::{
     commands::remote::{
@@ -160,14 +163,22 @@ fn file_remote_workspace(remote_url: &str) -> Result<Workspace, Box<dyn Error>> 
     Ok(workspace)
 }
 
-fn transfer_url(
+struct GraphTransferAuthorization {
+    remote_url: String,
+    transfer_id: Option<Uuid>,
+}
+
+fn transfer_authorization(
     remote: &Remote,
     operation: RemoteOperation,
     branch: Option<&str>,
     force: bool,
-) -> Result<String, Box<dyn Error>> {
+) -> Result<GraphTransferAuthorization, Box<dyn Error>> {
     if remote.url.starts_with("file://") {
-        return file_graph_url(&remote.url);
+        return Ok(GraphTransferAuthorization {
+            remote_url: file_graph_url(&remote.url)?,
+            transfer_id: None,
+        });
     }
     let repository = RepositoryRemote::parse(&remote.url)?;
     let request = CapabilityRequest {
@@ -176,7 +187,10 @@ fn transfer_url(
         force,
     };
     let capability = acquire_capability(&repository, &request, login_origin)?;
-    Ok(capability.remote_url)
+    Ok(GraphTransferAuthorization {
+        remote_url: capability.remote_url,
+        transfer_id: Some(capability.transfer_id),
+    })
 }
 
 fn ensure_graph_remote(
@@ -243,23 +257,24 @@ fn run_graph_transfer(
     branch: &str,
     force: bool,
     mut transfer: impl FnMut() -> Result<(), SqlError>,
-) -> Result<(), Box<dyn Error>> {
+) -> Result<Option<Uuid>, Box<dyn Error>> {
     if remote.url.starts_with("file://") {
-        let remote_url = transfer_url(remote, operation, Some(branch), force)?;
-        ensure_graph_remote(graph, &remote.name, &remote_url)?;
+        let authorization = transfer_authorization(remote, operation, Some(branch), force)?;
+        ensure_graph_remote(graph, &remote.name, &authorization.remote_url)?;
         let result = transfer();
         restore_canonical_url(graph, remote);
-        return Ok(result?);
+        result?;
+        return Ok(None);
     }
 
     let mut last_error = None;
     for attempt in 0..2 {
-        let remote_url = transfer_url(remote, operation, Some(branch), force)?;
-        ensure_graph_remote(graph, &remote.name, &remote_url)?;
+        let authorization = transfer_authorization(remote, operation, Some(branch), force)?;
+        ensure_graph_remote(graph, &remote.name, &authorization.remote_url)?;
         match transfer() {
             Ok(()) => {
                 restore_canonical_url(graph, remote);
-                return Ok(());
+                return Ok(authorization.transfer_id);
             }
             Err(error) if attempt == 0 && is_authorization_error(&error) => {
                 last_error = Some(error);
@@ -274,6 +289,19 @@ fn run_graph_transfer(
     Err(last_error
         .expect("should retain authorization error")
         .into())
+}
+
+fn push_graph_branch(
+    graph: &GraphConnection,
+    remote_name: &str,
+    branch: &str,
+    force: bool,
+) -> Result<(), SqlError> {
+    if force {
+        push_force(graph, remote_name, branch)
+    } else {
+        push(graph, remote_name, branch)
+    }
 }
 
 fn asset_checksum(asset: &AssetRef) -> Result<Sha256Hash, Box<dyn Error>> {
@@ -1057,8 +1085,8 @@ pub fn clone_into_workspace(
     };
     let mut clone_result = None;
     for attempt in 0..attempt_count {
-        let remote_url = transfer_url(remote, RemoteOperation::Clone, None, false)?;
-        match clone_remote(&graph, &remote_url) {
+        let authorization = transfer_authorization(remote, RemoteOperation::Clone, None, false)?;
+        match clone_remote(&graph, &authorization.remote_url) {
             Ok(()) => {
                 clone_result = Some(Ok(()));
                 break;
@@ -1137,21 +1165,77 @@ pub fn execute_push(
     let previous_hash = (!force)
         .then(|| hash_of(&graph, &tracking_ref).ok())
         .flatten();
-    run_graph_transfer(
-        &graph,
-        &remote,
-        RemoteOperation::Push,
-        &branch,
-        force,
-        || {
-            if force {
-                push_force(&graph, &remote.name, &branch)?;
-            } else {
-                push(&graph, &remote.name, &branch)?;
+    let mut push_operation = None;
+    let transfer_id = if remote.url.starts_with("file://") {
+        run_graph_transfer(
+            &graph,
+            &remote,
+            RemoteOperation::Push,
+            &branch,
+            force,
+            || push_graph_branch(&graph, &remote.name, &branch, force),
+        )?;
+        None
+    } else {
+        let mut operation = RemoteOperationRecord::begin_or_resume(
+            &config,
+            &remote.name,
+            &branch,
+            StoredRemoteOperationKind::Push,
+            previous_hash.as_ref(),
+        )?;
+        let destination_hash = hash_of(&graph, &branch)?;
+        let transfer_id = match (operation.to_commit(), operation.transfer_id()) {
+            (Some(recorded_destination), Some(transfer_id)) => {
+                if recorded_destination != &destination_hash {
+                    return Err(format!(
+                        "Cannot resume the pending push for branch '{branch}' because its local head changed after the graph transfer"
+                    )
+                    .into());
+                }
+                transfer_id
             }
-            Ok(())
-        },
-    )?;
+            (None, None) => {
+                let graph_transfer = run_graph_transfer(
+                    &graph,
+                    &remote,
+                    RemoteOperation::Push,
+                    &branch,
+                    force,
+                    || push_graph_branch(&graph, &remote.name, &branch, force),
+                );
+                let transfer_id = match graph_transfer {
+                    Ok(Some(transfer_id)) => transfer_id,
+                    Ok(None) => {
+                        return Err("GenHub push did not return a transfer ID".into());
+                    }
+                    Err(error) => {
+                        if let Err(metadata_error) = operation.fail(&config) {
+                            eprintln!(
+                                "Warning: failed to record unsuccessful push operation for branch '{branch}': {metadata_error}"
+                            );
+                        }
+                        return Err(error);
+                    }
+                };
+                operation.set_push_destination(&config, &destination_hash, transfer_id)?;
+                transfer_id
+            }
+            _ => {
+                return Err(format!(
+                    "Pending push metadata for branch '{branch}' has an incomplete transfer lease"
+                )
+                .into());
+            }
+        };
+        push_operation = Some(operation);
+        Some(transfer_id)
+    };
+    let assets_transfer_checkpoint = if let Some(operation) = push_operation.as_ref() {
+        operation.assets_transfer_checkpoint()
+    } else {
+        previous_hash.as_ref()
+    };
     let upload_receipts = transfer_assets(
         &graph,
         workspace,
@@ -1159,21 +1243,29 @@ pub fn execute_push(
         RemoteOperation::Push,
         &branch,
         AssetTransferRange {
-            from_commit: previous_hash.as_ref(),
+            from_commit: assets_transfer_checkpoint,
             previous_hash: previous_hash.as_ref(),
         },
         |_| Ok(()),
     )?;
-    if !remote.url.starts_with("file://") {
+    if let Some(operation) = push_operation.as_mut() {
         let repository = RepositoryRemote::parse(&remote.url)?;
+        let transfer_id = transfer_id.expect("should retain the GenHub push transfer ID");
         complete_asset_transfers(
             &repository,
             &AssetTransferCompletionRequest {
+                transfer_id,
                 branch: &branch,
                 assets: &upload_receipts,
             },
             login_origin,
         )?;
+        let destination_hash = operation
+            .to_commit()
+            .copied()
+            .expect("should retain the pushed graph destination");
+        operation.advance_assets_transfer_checkpoint(&config, &destination_hash)?;
+        operation.complete(&config)?;
     }
     if let Err(error) = run_graph_transfer(
         &graph,
@@ -1319,6 +1411,7 @@ mod tests {
     use rusqlite::{Connection, Error as SqlError};
     use serde_json::json;
     use tempfile::tempdir;
+    use uuid::Uuid;
 
     use super::{
         AssetTransferRange, DownloadAssetOutcome, RemoteOperation, canonical_remote_url,
@@ -1329,6 +1422,8 @@ mod tests {
     use crate::{get_config_connection, get_connection, get_raw_connection};
 
     static ENVIRONMENT_LOCK: Mutex<()> = Mutex::new(());
+    const TEST_TRANSFER_ID: Uuid = Uuid::from_u128(1);
+    const RETRIED_TRANSFER_ID: Uuid = Uuid::from_u128(2);
 
     mod clone {
         use std::{
@@ -1460,7 +1555,9 @@ mod tests {
                         format!(
                             "{{\"remote_url\":\"{remote_url}\",\
                              \"expires_at\":\"2030-01-01T00:00:00Z\",\
-                             \"default_branch\":\"main\"}}"
+                             \"default_branch\":\"main\",\
+                             \"transfer_id\":\"{}\"}}",
+                            super::TEST_TRANSFER_ID
                         )
                     } else if request.starts_with("POST /api/repos/alice/example/asset-transfers ")
                     {
@@ -1669,7 +1766,8 @@ mod tests {
                     json!({
                         "remote_url": graph_url,
                         "expires_at": "2030-01-01T00:00:00Z",
-                        "default_branch": "main"
+                        "default_branch": "main",
+                        "transfer_id": TEST_TRANSFER_ID
                     })
                     .to_string()
                 } else if request.contains("/asset-transfers ") {
@@ -1726,7 +1824,8 @@ mod tests {
                     json!({
                         "remote_url": graph_url,
                         "expires_at": "2030-01-01T00:00:00Z",
-                        "default_branch": "main"
+                        "default_branch": "main",
+                        "transfer_id": TEST_TRANSFER_ID
                     })
                     .to_string()
                 } else if request.contains("/asset-transfers ") {
@@ -2615,6 +2714,10 @@ mod tests {
 
     #[test]
     fn test_authorization_failure_retries_with_a_fresh_capability() {
+        let _environment_lock = ENVIRONMENT_LOCK
+            .lock()
+            .expect("should lock process environment");
+        let _api_key = EnvironmentGuard::set("GENHUB_API_KEY", "push-test-key");
         let listener = TcpListener::bind("127.0.0.1:0").expect("should bind capability server");
         let address = listener
             .local_addr()
@@ -2629,7 +2732,13 @@ mod tests {
                 let body = format!(
                     "{{\"remote_url\":\"http://127.0.0.1:1/transfer-{attempt}\",\
                      \"expires_at\":\"2030-01-01T00:00:00Z\",\
-                     \"default_branch\":\"main\"}}"
+                     \"default_branch\":\"main\",\
+                     \"transfer_id\":\"{}\"}}",
+                    if attempt == 0 {
+                        TEST_TRANSFER_ID
+                    } else {
+                        RETRIED_TRANSFER_ID
+                    }
                 );
                 write!(
                     stream,
@@ -2647,10 +2756,10 @@ mod tests {
             url: format!("http://{address}/api/repos/alice/example"),
         };
         let mut attempts = 0;
-        run_graph_transfer(
+        let transfer_id = run_graph_transfer(
             &graph,
             &remote,
-            RemoteOperation::Pull,
+            RemoteOperation::Push,
             "main",
             false,
             || {
@@ -2669,6 +2778,7 @@ mod tests {
         server.join().expect("capability server should finish");
 
         assert_eq!(attempts, 2);
+        assert_eq!(transfer_id, Some(RETRIED_TRANSFER_ID));
         let remotes = remote_rows(&graph).expect("should read restored canonical URL");
         assert!(
             remotes
@@ -2713,7 +2823,8 @@ mod tests {
                     format!(
                         "{{\"remote_url\":\"{transfer_url}\",\
                          \"expires_at\":\"2030-01-01T00:00:00Z\",\
-                         \"default_branch\":\"main\"}}"
+                         \"default_branch\":\"main\",\
+                         \"transfer_id\":\"{TEST_TRANSFER_ID}\"}}"
                     )
                 };
                 write!(
@@ -2751,6 +2862,7 @@ mod tests {
         assert!(requests[1].starts_with("POST /api/repos/alice/example/asset-transfers "));
         assert!(requests[1].contains("\"operation\":\"push\""));
         assert!(requests[2].starts_with("POST /api/repos/alice/example/asset-transfers/complete "));
+        assert!(requests[2].contains(&format!("\"transfer_id\":\"{TEST_TRANSFER_ID}\"")));
         assert!(requests[2].contains("\"branch\":\"main\""));
         assert!(requests[2].contains("\"assets\":[]"));
         assert!(requests[3].contains("\"operation\":\"pull\""));
@@ -2759,6 +2871,127 @@ mod tests {
         let local_hash = hash_of(&graph, "main").expect("should query local branch");
         let tracking_hash = hash_of(&graph, "origin/main").expect("should query tracking branch");
         assert_eq!(tracking_hash, local_hash);
+    }
+
+    #[test]
+    fn test_push_retry_reuses_persisted_transfer_lease() {
+        let _environment_lock = ENVIRONMENT_LOCK
+            .lock()
+            .expect("should lock process environment");
+        let _api_key = EnvironmentGuard::set("GENHUB_API_KEY", "push-test-key");
+        let listener = TcpListener::bind("127.0.0.1:0").expect("should bind capability server");
+        let address = listener
+            .local_addr()
+            .expect("should read capability server address");
+        let temp = tempdir().expect("should create push retry directory");
+        let remote_graph = temp.path().join("remote.db");
+        let transfer_url = format!("file://{}", remote_graph.display());
+        let server = thread::spawn(move || {
+            let mut requests = Vec::new();
+            for request_index in 0..6 {
+                let (mut stream, _) = listener.accept().expect("should accept GenHub request");
+                let mut request = [0_u8; 8192];
+                let read = stream
+                    .read(&mut request)
+                    .expect("should read GenHub request");
+                requests.push(String::from_utf8_lossy(&request[..read]).into_owned());
+                match request_index {
+                    0 | 5 => {
+                        let body = format!(
+                            "{{\"remote_url\":\"{transfer_url}\",\
+                             \"expires_at\":\"2030-01-01T00:00:00Z\",\
+                             \"default_branch\":\"main\",\
+                             \"transfer_id\":\"{TEST_TRANSFER_ID}\"}}"
+                        );
+                        write!(
+                            stream,
+                            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
+                            body.len()
+                        )
+                        .expect("should write capability response");
+                    }
+                    1 | 3 => {
+                        let body = "{\"assets\":[]}";
+                        write!(
+                            stream,
+                            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
+                            body.len()
+                        )
+                        .expect("should write asset response");
+                    }
+                    2 => {
+                        let body = "asset verification unavailable";
+                        write!(
+                            stream,
+                            "HTTP/1.1 500 Internal Server Error\r\nContent-Type: text/plain\r\nContent-Length: {}\r\n\r\n{body}",
+                            body.len()
+                        )
+                        .expect("should write failed completion response");
+                    }
+                    4 => {
+                        stream
+                            .write_all(b"HTTP/1.1 204 No Content\r\nContent-Length: 0\r\n\r\n")
+                            .expect("should write completion response");
+                    }
+                    _ => unreachable!("request index should be covered"),
+                }
+            }
+            requests
+        });
+
+        let workspace = Workspace::new(temp.path().join("local"));
+        workspace.ensure_gen_dir();
+        let config = get_config_connection(Some(workspace.gen_db_path().unwrap()))
+            .expect("should open push config");
+        let graph = get_connection(workspace.graph_db_path().unwrap()).expect("should open graph");
+        Collection::create(&graph, "push-retry-fixture").expect("should create push retry fixture");
+        let destination_hash =
+            commit_all(&graph, "push retry fixture").expect("should commit push retry fixture");
+        Remote::create(
+            &config,
+            "origin",
+            &format!("http://{address}/api/repos/alice/example"),
+        )
+        .expect("should configure origin");
+        Defaults::set_default_remote(&config, Some("origin")).expect("should set default remote");
+        drop(graph);
+
+        execute_push(&workspace, None, None, false)
+            .expect_err("first push should retain its lease after completion fails");
+        let pending_transfer: (DoltHashId, Uuid) = config
+            .query_row(
+                "SELECT to_commit, transfer_id FROM remote_operations \
+                 WHERE operation = 'push' AND completed_at IS NULL AND failed_at IS NULL",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("should retain pending push lease");
+        assert_eq!(pending_transfer, (destination_hash, TEST_TRANSFER_ID));
+
+        execute_push(&workspace, None, None, false).expect("push retry should complete");
+        let requests = server.join().expect("GenHub server should finish");
+
+        assert_eq!(requests.len(), 6);
+        assert!(requests[0].contains("\"operation\":\"push\""));
+        assert!(requests[1].starts_with("POST /api/repos/alice/example/asset-transfers "));
+        assert!(requests[2].starts_with("POST /api/repos/alice/example/asset-transfers/complete "));
+        assert!(requests[3].starts_with("POST /api/repos/alice/example/asset-transfers "));
+        assert!(requests[4].starts_with("POST /api/repos/alice/example/asset-transfers/complete "));
+        for request in [&requests[2], &requests[4]] {
+            assert!(request.contains(&format!("\"transfer_id\":\"{TEST_TRANSFER_ID}\"")));
+            assert!(request.contains("\"branch\":\"main\""));
+            assert!(request.contains("\"assets\":[]"));
+        }
+        assert!(requests[5].contains("\"operation\":\"pull\""));
+        let pending_operations = config
+            .query_row(
+                "SELECT COUNT(*) FROM remote_operations \
+                 WHERE completed_at IS NULL AND failed_at IS NULL",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .expect("should count pending operations");
+        assert_eq!(pending_operations, 0);
     }
 
     #[test]
@@ -2796,7 +3029,8 @@ mod tests {
                         format!(
                             "{{\"remote_url\":\"{transfer_url}\",\
                              \"expires_at\":\"2030-01-01T00:00:00Z\",\
-                             \"default_branch\":\"main\"}}"
+                             \"default_branch\":\"main\",\
+                             \"transfer_id\":\"{TEST_TRANSFER_ID}\"}}"
                         )
                     } else {
                         "{\"assets\":[]}".to_string()
@@ -2846,6 +3080,7 @@ mod tests {
         assert!(requests[1].starts_with("POST /api/repos/alice/example/asset-transfers "));
         assert!(requests[1].contains("\"operation\":\"push\""));
         assert!(requests[2].starts_with("POST /api/repos/alice/example/asset-transfers/complete "));
+        assert!(requests[2].contains(&format!("\"transfer_id\":\"{TEST_TRANSFER_ID}\"")));
         assert!(requests[2].contains("\"branch\":\"main\""));
         assert!(requests[3].contains("\"operation\":\"pull\""));
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -169,12 +169,13 @@ fn call_cli() -> Result<(), Box<dyn std::error::Error>> {
         force,
     }) = &cli.command
     {
-        return r#gen::commands::remote::operations::execute_push(
+        r#gen::commands::remote::operations::execute_push(
             &workspace,
             remote.as_deref(),
             branch.as_deref(),
             *force,
-        );
+        )?;
+        return Ok(());
     }
     if let Some(Commands::Pull { remote, branch }) = &cli.command {
         return r#gen::commands::remote::operations::execute_pull(

--- a/tests/history_cli_tests.rs
+++ b/tests/history_cli_tests.rs
@@ -2532,7 +2532,8 @@ mod remotes {
                     json!({
                         "remote_url": graph_url,
                         "expires_at": "2030-01-01T00:00:00Z",
-                        "default_branch": "main"
+                        "default_branch": "main",
+                        "transfer_id": "00000000-0000-0000-0000-000000000001"
                     })
                     .to_string()
                     .into_bytes()


### PR DESCRIPTION
Expands the previous operation tracking to support pushes. This includes a tracking id provided by the server that coordinates pushes across separate clients. The server (for now, maybe we can figure out concurrency better), issues a transfer id when a client requests a capability. The client can use that transfer id when pushing to effectively have a lock on the remote while its working.