### PR TITLE
Transfer versioned assets for file remotes

### DIFF
--- a/src/commands/remote/operations.rs
+++ b/src/commands/remote/operations.rs
@@ -17,13 +17,13 @@
 //!
 //! A repository remote URL and an asset URI have separate meanings here. A repository
 //! `file://` remote points directly to another Dolt database (or a workspace containing
-//! `.gen/default.db`), so graph operations use that path without contacting GenHub and
-//! no separate asset-byte transfer is attempted. An HTTP(S) repository remote stores its
-//! canonical GenHub URL in config. Before each graph operation, Gen requests a scoped,
-//! short-lived transfer capability, installs the returned URL as the graph database's
-//! Dolt remote, performs the operation, and restores the canonical URL. An authorization
-//! failure is retried once with a fresh capability. Failure to restore the canonical URL
-//! is reported as a warning because the graph transfer may already have succeeded.
+//! `.gen/default.db`), so graph operations use that path without contacting GenHub and asset bytes
+//! are copied directly between the workspaces. An HTTP(S) repository remote stores its canonical
+//! GenHub URL in config. Before each graph operation, Gen requests a scoped, short-lived transfer
+//! capability, installs the returned URL as the graph database's Dolt remote, performs the
+//! operation, and restores the canonical URL. An authorization failure is retried once with a
+//! fresh capability. Failure to restore the canonical URL is reported as a warning because the
+//! graph transfer may already have succeeded.
 //!
 //! Assets referenced by the transferred branch are handled after the graph operation.
 //! Only asset records whose URI uses the `file://` scheme represent file bytes managed by
@@ -104,6 +104,50 @@ fn file_graph_url(remote_url: &str) -> Result<String, Box<dyn Error>> {
     Url::from_file_path(&path)
         .map(String::from)
         .map_err(|_| format!("Invalid file remote path: {}", path.display()).into())
+}
+
+/// Resolves a `file://` repository remote to the Gen workspace that owns its asset store.
+///
+/// Graph transfer uses [`file_graph_url`] to address the Dolt database itself. Asset transfer uses
+/// the surrounding workspace so [`copy_to_versioned_store`] can reach `.gen/assets` on both sides.
+fn file_remote_workspace(remote_url: &str) -> Result<Workspace, Box<dyn Error>> {
+    let parsed = Url::parse(remote_url)?;
+    let path = parsed
+        .to_file_path()
+        .map_err(|_| format!("Invalid file remote URL: {remote_url}"))?;
+    let repo_root = if path.extension().and_then(|extension| extension.to_str()) == Some("db") {
+        let gen_dir = path.parent().ok_or_else(|| {
+            format!(
+                "File remote database has no parent directory: {}",
+                path.display()
+            )
+        })?;
+        if gen_dir.file_name().and_then(|name| name.to_str()) != Some(".gen") {
+            return Err(format!(
+                "File remote database is not inside a Gen workspace: {}",
+                path.display()
+            )
+            .into());
+        }
+        gen_dir.parent().ok_or_else(|| {
+            format!(
+                "File remote .gen directory has no workspace root: {}",
+                gen_dir.display()
+            )
+        })?
+    } else {
+        &path
+    };
+    let workspace = Workspace::new(repo_root);
+    let resolved_root = workspace.repo_root()?;
+    if resolved_root != repo_root {
+        return Err(format!(
+            "File remote is not a Gen workspace root: {}",
+            repo_root.display()
+        )
+        .into());
+    }
+    Ok(workspace)
 }
 
 fn transfer_url(
@@ -539,6 +583,60 @@ fn download_to_versioned_store(
     Ok((versioned_path, true))
 }
 
+/// Copies one checksum-addressed version between two `file://` remote workspaces.
+///
+/// [`transfer_file_remote_assets`] calls this in either direction after graph transfer. It verifies
+/// the source before copying, reuses an already-valid destination, and verifies newly copied bytes
+/// before allowing materialization.
+fn copy_to_versioned_store(
+    source_workspace: &Workspace,
+    destination_workspace: &Workspace,
+    asset: &AssetRef,
+) -> Result<(PathBuf, bool), Box<dyn Error>> {
+    let expected_checksum = asset_checksum(asset)?;
+    let source_path = materialization_destination_path(
+        source_workspace,
+        &asset.uri,
+        Some(&expected_checksum),
+        None,
+    )?;
+    let source_checksum = calculate_file_checksum(&source_path).map_err(|error| {
+        format!(
+            "Unable to read versioned asset {} at {}: {error}",
+            asset.id,
+            source_path.display()
+        )
+    })?;
+    if source_checksum != expected_checksum {
+        return Err(format!(
+            "Versioned asset {} at {} does not match its recorded checksum",
+            asset.id,
+            source_path.display()
+        )
+        .into());
+    }
+
+    let destination_path = materialization_destination_path(
+        destination_workspace,
+        &asset.uri,
+        Some(&expected_checksum),
+        None,
+    )?;
+    if destination_path.exists()
+        && calculate_file_checksum(&destination_path)
+            .is_ok_and(|checksum| checksum == expected_checksum)
+    {
+        return Ok((destination_path, false));
+    }
+
+    copy_versioned_asset(&source_path, &destination_path)?;
+    if calculate_file_checksum(&destination_path)? != expected_checksum {
+        fs::remove_file(&destination_path)?;
+        return Err(format!("Copied asset {} failed checksum validation", asset.id).into());
+    }
+    Ok((destination_path, true))
+}
+
 /// Copies a verified versioned asset to another path through a synced staged file.
 ///
 /// [`materialize_versioned_asset`] uses this for logical and conflict files. The `file://` remote
@@ -684,12 +782,64 @@ fn warn_asset_conflict(
     Ok(())
 }
 
+/// Executes the asset portion of a `file://` clone, pull, or push.
+///
+/// [`transfer_assets`] supplies the graph-derived version delta. Push copies those versions into
+/// the remote store; clone and pull copy them locally and then call [`materialize_versioned_asset`]
+/// only for the versions selected at the destination branch head.
+fn transfer_file_remote_assets(
+    workspace: &Workspace,
+    remote: &Remote,
+    operation: RemoteOperation,
+    assets: &HashMap<HashId, AssetRef>,
+    materialized_asset_ids: &HashSet<HashId>,
+    previous_assets: &HashMap<HashId, AssetRef>,
+) -> Result<(), Box<dyn Error>> {
+    if assets.is_empty() {
+        return Ok(());
+    }
+    let remote_workspace = file_remote_workspace(&remote.url)?;
+    for asset in assets.values() {
+        match operation {
+            RemoteOperation::Push => {
+                copy_to_versioned_store(workspace, &remote_workspace, asset)?;
+            }
+            RemoteOperation::Clone | RemoteOperation::Pull => {
+                let destination_logical_path = if materialized_asset_ids.contains(&asset.id) {
+                    asset.logical_path.as_deref()
+                } else {
+                    None
+                };
+                let (versioned_path, versioned_file_created) =
+                    copy_to_versioned_store(&remote_workspace, workspace, asset)?;
+                if let DownloadAssetOutcome::Conflict(conflict_path) = materialize_versioned_asset(
+                    workspace,
+                    asset,
+                    previous_assets,
+                    destination_logical_path,
+                    &versioned_path,
+                    versioned_file_created,
+                )? {
+                    warn_asset_conflict(
+                        workspace,
+                        asset,
+                        destination_logical_path,
+                        &conflict_path,
+                    )?;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
 /// Transfers the asset versions needed after a graph clone, pull, or push.
 ///
 /// The CLI orchestration calls this after Dolt transfers graph history. It derives the asset delta
-/// between `previous_hash` and the destination branch, asks GenHub for transfer URLs, uploads local
-/// versions for push, and sends clone/pull downloads through [`download_asset`]. The cumulative
-/// asset view supplies history and conflict checksums; the materialized view selects the one version
+/// between `previous_hash` and the destination branch, then dispatches `file://` transfers to
+/// [`transfer_file_remote_assets`] or asks GenHub for HTTP transfer URLs. Push uploads local
+/// versions; HTTP clone and pull send downloads through [`download_asset`]. The cumulative asset
+/// view supplies history and conflict checksums, while the materialized view selects the one version
 /// per logical path that is additionally copied out of `.gen/assets`.
 fn transfer_assets(
     graph: &GraphConnection,
@@ -699,7 +849,12 @@ fn transfer_assets(
     branch: &str,
     previous_hash: Option<&DoltHashId>,
 ) -> Result<Vec<AssetUploadReceipt>, Box<dyn Error>> {
-    if remote.url.starts_with("file://") {
+    let has_asset_table = graph.query_row(
+        "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'gen_asset_refs')",
+        [],
+        |row| row.get::<_, bool>(0),
+    )?;
+    if !has_asset_table {
         return Ok(Vec::new());
     }
 
@@ -728,6 +883,18 @@ fn transfer_assets(
         .filter(|(id, _)| !previous_assets.contains_key(id))
         .map(|(id, asset)| (*id, asset.clone()))
         .collect();
+    if remote.url.starts_with("file://") {
+        transfer_file_remote_assets(
+            workspace,
+            remote,
+            operation,
+            &assets,
+            &materialized_asset_ids,
+            &previous_assets,
+        )?;
+        return Ok(Vec::new());
+    }
+
     let repository = RepositoryRemote::parse(&remote.url)?;
     let response = acquire_asset_transfers(
         &repository,

--- a/src/commands/remote/operations.rs
+++ b/src/commands/remote/operations.rs
@@ -17,13 +17,13 @@
 //!
 //! A repository remote URL and an asset URI have separate meanings here. A repository
 //! `file://` remote points directly to another Dolt database (or a workspace containing
-//! `.gen/default.db`), so graph operations use that path without contacting GenHub and asset bytes
-//! are copied directly between the workspaces. An HTTP(S) repository remote stores its canonical
-//! GenHub URL in config. Before each graph operation, Gen requests a scoped, short-lived transfer
-//! capability, installs the returned URL as the graph database's Dolt remote, performs the
-//! operation, and restores the canonical URL. An authorization failure is retried once with a
-//! fresh capability. Failure to restore the canonical URL is reported as a warning because the
-//! graph transfer may already have succeeded.
+//! `.gen/default.db`), so graph operations use that path directly and transfers happen
+//! directly between the workspaces. For an HTTP(S) repository remote, Gen requests a scoped,
+//! short-lived transfer capability, installs the returned URL as the graph database's Dolt
+//! remote, performs the operation, and restores the canonical URL. An authorization failure
+//! is retried once with a fresh capability. Failure to restore the canonical URL is reported
+//! as a warning because the graph transfer may already have succeeded and will be replaced on
+//! the next attempt.
 //!
 //! Assets referenced by the transferred branch are handled after the graph operation.
 //! Only asset records whose URI uses the `file://` scheme represent file bytes managed by
@@ -849,15 +849,6 @@ fn transfer_assets(
     branch: &str,
     previous_hash: Option<&DoltHashId>,
 ) -> Result<Vec<AssetUploadReceipt>, Box<dyn Error>> {
-    let has_asset_table = graph.query_row(
-        "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'gen_asset_refs')",
-        [],
-        |row| row.get::<_, bool>(0),
-    )?;
-    if !has_asset_table {
-        return Ok(Vec::new());
-    }
-
     let commit_hash = hash_of(graph, branch)?;
     let current_assets: HashMap<_, _> =
         AssetRef::get_cumulative_assets_at(graph, previous_hash, Some(&commit_hash))?

--- a/tests/history_cli_tests.rs
+++ b/tests/history_cli_tests.rs
@@ -20,7 +20,6 @@ use gen_models::{
     assets::AssetRef,
     block_group::BlockGroup,
     collection::Collection,
-    db::GraphConnection,
     history::{
         HistoryStore,
         dolt::{DoltHistoryStore, status_rows},
@@ -29,7 +28,7 @@ use gen_models::{
     sample_lineage::SampleLineage,
     traits::Query,
 };
-use rusqlite::{Connection, params};
+use rusqlite::params;
 use tempfile::tempdir;
 
 fn gen_binary() -> PathBuf {
@@ -2166,8 +2165,8 @@ mod remotes {
     use serde_json::json;
 
     use super::{
-        Connection, GraphConnection, Path, PathBuf, assert_success, asset_refs, fs, get_connection,
-        operations_stdout, run_gen, status_rows, tempdir,
+        Path, PathBuf, assert_success, asset_refs, fs, get_connection, operations_stdout, run_gen,
+        tempdir,
     };
 
     fn resolved_ref_hash(repo_root: &Path, reference: &str) -> String {
@@ -2176,13 +2175,6 @@ mod remotes {
         connection
             .query_row("SELECT dolt_hashof(?1)", [reference], |row| row.get(0))
             .unwrap_or_else(|error| panic!("should resolve {reference}: {error}"))
-    }
-
-    fn raw_graph_status(repo_root: &Path) -> Vec<gen_models::history::dolt::DoltStatusRow> {
-        let connection = Connection::open(repo_root.join(".gen/default.db"))
-            .expect("should open graph database without migrations");
-        rusqlite::vtab::array::load_module(&connection).expect("should load array module");
-        status_rows(&GraphConnection(connection)).expect("should query raw Dolt status")
     }
 
     fn collect_files(root: &Path) -> Vec<PathBuf> {
@@ -2440,102 +2432,6 @@ mod remotes {
             requests
         });
         (repository_url, stop, handle)
-    }
-
-    #[test]
-    fn test_clone_of_schema_less_main_is_clean_and_can_checkout_schema_branch() {
-        let remote_repo_dir = tempdir().expect("should create temp remote repo directory");
-        let clone_parent_dir = tempdir().expect("should create temp clone parent directory");
-        let remote_gen_dir = remote_repo_dir.path().join(".gen");
-        fs::create_dir(&remote_gen_dir).expect("should create remote Gen directory");
-        let remote_graph_path = remote_gen_dir.join("default.db");
-
-        let raw_remote =
-            Connection::open(&remote_graph_path).expect("should open raw remote graph");
-        raw_remote
-            .query_row("SELECT dolt_branch('foobar')", [], |row| {
-                row.get::<_, i64>(0)
-            })
-            .expect("should create foobar from the schema-less main branch");
-        raw_remote
-            .query_row("SELECT dolt_checkout('foobar')", [], |row| {
-                row.get::<_, i64>(0)
-            })
-            .expect("should check out foobar");
-        raw_remote
-            .query_row("SELECT dolt_config('user.name', 'Test User')", [], |row| {
-                row.get::<_, i64>(0)
-            })
-            .expect("should configure test committer name");
-        raw_remote
-            .query_row(
-                "SELECT dolt_config('user.email', 'test@example.com')",
-                [],
-                |row| row.get::<_, i64>(0),
-            )
-            .expect("should configure test committer email");
-        raw_remote
-            .execute_batch(
-                "CREATE TABLE branch_only(id INTEGER PRIMARY KEY, value TEXT NOT NULL);
-             INSERT INTO branch_only VALUES(1, 'visible on foobar');",
-            )
-            .expect("should create branch-only graph state");
-        raw_remote
-            .query_row(
-                "SELECT dolt_commit('-A', '-m', 'Add branch-only state')",
-                [],
-                |row| row.get::<_, String>(0),
-            )
-            .expect("should commit the foobar state");
-        raw_remote
-            .query_row("SELECT dolt_checkout('main')", [], |row| {
-                row.get::<_, i64>(0)
-            })
-            .expect("should leave the remote on schema-less main");
-        drop(raw_remote);
-
-        let remote_url = format!("file://{}", remote_repo_dir.path().display());
-        assert_success(
-            &run_gen(clone_parent_dir.path(), &["clone", &remote_url]),
-            "clone from schema-branch remote should succeed",
-        );
-        let cloned_repo_path = clone_parent_dir.path().join(
-            remote_repo_dir
-                .path()
-                .file_name()
-                .expect("remote temp dir should have a basename"),
-        );
-
-        assert!(
-            raw_graph_status(&cloned_repo_path).is_empty(),
-            "clone should not apply uncommitted migrations to main"
-        );
-        let cloned_graph = Connection::open(cloned_repo_path.join(".gen/default.db"))
-            .expect("should open cloned graph for ref inspection");
-        let active_branch: String = cloned_graph
-            .query_row("SELECT active_branch()", [], |row| row.get(0))
-            .expect("should read cloned active branch");
-        let branch_names = cloned_graph
-            .prepare("SELECT name FROM dolt_branches ORDER BY name")
-            .expect("should prepare cloned branch query")
-            .query_map([], |row| row.get::<_, String>(0))
-            .expect("should query cloned branches")
-            .collect::<Result<Vec<_>, _>>()
-            .expect("should collect cloned branches");
-        assert_eq!(active_branch, "main");
-        assert!(
-            branch_names.iter().any(|name| name == "foobar"),
-            "clone should retain foobar; found {branch_names:?}"
-        );
-        drop(cloned_graph);
-        assert_success(
-            &run_gen(&cloned_repo_path, &["checkout", "foobar"]),
-            "checkout of the schema branch after clone should succeed",
-        );
-        assert!(
-            raw_graph_status(&cloned_repo_path).is_empty(),
-            "checking out the migrated branch should remain clean"
-        );
     }
 
     // Direct `file://` clone must preserve graph history, branches, tags, AssetRef rows, and the

--- a/tests/history_cli_tests.rs
+++ b/tests/history_cli_tests.rs
@@ -2298,22 +2298,6 @@ mod remotes {
         );
     }
 
-    fn assert_remote_asset_is_not_materialized(repo_root: &Path) {
-        let repo_asset_path = repo_root.join("simple.gff");
-        assert!(
-            !repo_asset_path.exists(),
-            "remote transfer should keep asset payloads out of the repo checkout: {}",
-            repo_asset_path.display()
-        );
-
-        let asset_cache_dir = repo_root.join(".gen/assets");
-        let asset_cache_files = collect_files(&asset_cache_dir);
-        assert!(
-            asset_cache_files.is_empty(),
-            "remote transfer should keep .gen/assets as an empty cache until materialization is requested: {asset_cache_files:?}"
-        );
-    }
-
     fn managed_asset_payloads(repo_root: &Path) -> HashMap<String, Vec<u8>> {
         let workspace = Workspace::new(repo_root);
         asset_refs(repo_root)
@@ -2554,8 +2538,10 @@ mod remotes {
         );
     }
 
+    // Direct `file://` clone must preserve graph history, branches, tags, AssetRef rows, and the
+    // exact checksum-addressed files stored by the source workspace.
     #[test]
-    fn test_clone_from_file_remote_preserves_history_and_asset_refs() {
+    fn test_clone_from_file_remote_preserves_history_and_versioned_assets() {
         let remote_repo_dir = tempdir().expect("should create temp remote repo directory");
         let clone_parent_dir = tempdir().expect("should create temp clone parent directory");
         let fixtures_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("fixtures");
@@ -2631,7 +2617,7 @@ mod remotes {
                 .any(|asset_ref| asset_ref.name.as_deref() == Some("simple.gff")),
             "cloned graph db should retain the asset reference rows: {refs:?}"
         );
-        assert_remote_asset_is_not_materialized(&cloned_repo_path);
+        assert_asset_store_matches(remote_repo_dir.path(), &cloned_repo_path);
         assert_eq!(
             resolved_ref_hash(&cloned_repo_path, "feature"),
             resolved_ref_hash(remote_repo_dir.path(), "feature"),
@@ -2644,8 +2630,10 @@ mod remotes {
         );
     }
 
+    // A `file://` push must copy committed versioned assets into the remote store so a later clone
+    // can recover them, without transferring unrelated uncommitted graph changes.
     #[test]
-    fn test_push_to_file_remote_and_clone_preserves_history_and_asset_refs() {
+    fn test_push_to_file_remote_and_clone_preserves_versioned_assets() {
         let local_repo_dir = tempdir().expect("should create temp local repo directory");
         let remote_repo_dir = tempdir().expect("should create temp remote repo directory");
         let clone_parent_dir = tempdir().expect("should create temp clone parent directory");
@@ -2747,7 +2735,8 @@ mod remotes {
                 .any(|asset_ref| asset_ref.name.as_deref() == Some("simple.gff")),
             "cloned graph db should retain the pushed asset reference rows: {refs:?}"
         );
-        assert_remote_asset_is_not_materialized(&cloned_repo_path);
+        assert_asset_store_matches(local_repo_dir.path(), remote_repo_dir.path());
+        assert_asset_store_matches(local_repo_dir.path(), &cloned_repo_path);
         let cloned_graph = get_connection(cloned_repo_path.join(".gen/default.db"))
             .expect("should open clone for dirty marker check");
         let dirty_marker_exists: bool = cloned_graph
@@ -2760,6 +2749,111 @@ mod remotes {
         assert!(
             !dirty_marker_exists,
             "push should transfer only committed history, not dirty working-tree changes"
+        );
+    }
+
+    // A `file://` clone must materialize the branch-head file at its logical path; pull must
+    // replace that path while retaining both checksum-addressed versions.
+    #[test]
+    fn test_pull_from_file_remote_populates_versioned_assets() {
+        let remote_repo_dir = tempdir().expect("should create temp remote repo directory");
+        let clone_parent_dir = tempdir().expect("should create temp clone parent directory");
+        let fixtures_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("fixtures");
+        let fasta_fixture_path = fixtures_dir.join("simple.fa");
+        let logical_path = "inputs/simple.fa";
+        let remote_fasta_path = remote_repo_dir.path().join(logical_path);
+        let updated_fasta = b">m123\nATCGATCGATCGATCGATCGGGAACACACAGAGATTT\n";
+
+        assert_success(
+            &run_gen(remote_repo_dir.path(), &["init"]),
+            "remote gen init should succeed",
+        );
+        fs::create_dir_all(
+            remote_fasta_path
+                .parent()
+                .expect("remote FASTA should have a parent directory"),
+        )
+        .expect("should create remote input directory");
+        fs::copy(&fasta_fixture_path, &remote_fasta_path)
+            .expect("should copy FASTA into the remote workspace");
+        assert_success(
+            &run_gen(
+                remote_repo_dir.path(),
+                &[
+                    "import",
+                    "fasta",
+                    logical_path,
+                    "--name",
+                    "test-collection",
+                    "--sample",
+                    "test-sample",
+                ],
+            ),
+            "remote fasta import should succeed",
+        );
+
+        let remote_url = format!("file://{}", remote_repo_dir.path().display());
+        assert_success(
+            &run_gen(clone_parent_dir.path(), &["clone", &remote_url]),
+            "clone from file remote should succeed",
+        );
+        let cloned_repo_path = clone_parent_dir.path().join(
+            remote_repo_dir
+                .path()
+                .file_name()
+                .expect("remote temp dir should have a basename"),
+        );
+        let cloned_assets_before_pull = asset_store_contents(&cloned_repo_path);
+        assert_asset_store_matches(remote_repo_dir.path(), &cloned_repo_path);
+        assert_materialized_assets_match(
+            remote_repo_dir.path(),
+            &cloned_repo_path,
+            &[logical_path],
+        );
+        let cloned_fasta_before_pull = fs::read(cloned_repo_path.join(logical_path))
+            .expect("file clone should materialize the original FASTA");
+
+        fs::write(&remote_fasta_path, updated_fasta)
+            .expect("should update the remote logical FASTA");
+        assert_success(
+            &run_gen(
+                remote_repo_dir.path(),
+                &[
+                    "add-file",
+                    logical_path,
+                    "--message",
+                    "update-fasta-after-clone",
+                ],
+            ),
+            "remote FASTA update should succeed",
+        );
+        assert_success(
+            &run_gen(&cloned_repo_path, &["pull"]),
+            "pull from file remote should succeed",
+        );
+
+        assert!(
+            asset_store_contents(&cloned_repo_path).len() > cloned_assets_before_pull.len(),
+            "pull should add the newly committed versioned asset"
+        );
+        assert_asset_store_matches(remote_repo_dir.path(), &cloned_repo_path);
+        assert_materialized_assets_match(
+            remote_repo_dir.path(),
+            &cloned_repo_path,
+            &[logical_path],
+        );
+        let cloned_fasta_after_pull = fs::read(cloned_repo_path.join(logical_path))
+            .expect("file pull should materialize the updated FASTA");
+        assert_eq!(cloned_fasta_after_pull, updated_fasta);
+        assert_ne!(
+            cloned_fasta_after_pull, cloned_fasta_before_pull,
+            "pull should replace the logical path with its branch-head version"
+        );
+        assert!(
+            asset_store_contents(&cloned_repo_path)
+                .iter()
+                .any(|(_, contents)| contents == &cloned_fasta_before_pull),
+            "the superseded FASTA should remain available only by its versioned filename"
         );
     }
 

--- a/tests/history_cli_tests.rs
+++ b/tests/history_cli_tests.rs
@@ -2752,10 +2752,10 @@ mod remotes {
         );
     }
 
-    // A `file://` clone must materialize the branch-head file at its logical path; pull must
-    // replace that path while retaining both checksum-addressed versions.
+    // Ensure that file:// clones + pulls: download all required versioned files and materialize the correct
+    // assets at logical paths.
     #[test]
-    fn test_pull_from_file_remote_populates_versioned_assets() {
+    fn test_clone_and_pull_from_file_remote_populates_versioned_assets() {
         let remote_repo_dir = tempdir().expect("should create temp remote repo directory");
         let clone_parent_dir = tempdir().expect("should create temp clone parent directory");
         let fixtures_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("fixtures");


### PR DESCRIPTION
This adds in the same asset transfer stuff we just did for http:// remotes but ensures file:// remote urls are also supported. Note: this is a file:// REPOSITORY url, not an asset uri. So stuff like a NAS based server users sync with.