### PR TITLE
Thread Workspace through sequence consumers

### DIFF
--- a/gen-annotations/src/gff.rs
+++ b/gen-annotations/src/gff.rs
@@ -86,7 +86,7 @@ pub fn propagate_gff(
 
     let sequence_lengths_by_path_name = target_paths_by_bg_name
         .iter()
-        .map(|(name, path)| Ok((name.clone(), path.sequence(conn, None)?.len() as i64)))
+        .map(|(name, path)| Ok((name.clone(), path.length(conn, None)?)))
         .collect::<Result<HashMap<String, i64>, PathError>>()?;
 
     for result in reader.record_bufs() {
@@ -156,7 +156,7 @@ mod tests {
     use tempfile::tempdir;
 
     use super::propagate_gff;
-    use crate::test_helpers::get_connection;
+    use crate::test_helpers::{get_connection, test_workspace};
 
     fn create_block_group(conn: &GraphConnection) {
         let collection = Collection::create(conn, "test").unwrap();
@@ -304,7 +304,8 @@ mod tests {
             preserve_edge: true,
         };
 
-        BlockGroup::insert_change(conn, &change).expect("should apply AA update to child sample");
+        BlockGroup::insert_change(conn, test_workspace(), &change)
+            .expect("should apply AA update to child sample");
 
         let edge_to_insert = Edge::query(
             conn,

--- a/gen-annotations/src/test_helpers.rs
+++ b/gen-annotations/src/test_helpers.rs
@@ -1,4 +1,6 @@
-use gen_core::{HashId, PATH_END_NODE_ID, PATH_START_NODE_ID, PathBlock, Strand};
+use std::sync::OnceLock;
+
+use gen_core::{HashId, PATH_END_NODE_ID, PATH_START_NODE_ID, PathBlock, Strand, Workspace};
 use gen_models::{
     block_group::{BlockGroup, BlockGroupChange, NewBlockGroup},
     block_group_edge::{BlockGroupEdge, BlockGroupEdgeData},
@@ -13,6 +15,17 @@ use gen_models::{
     sequence::Sequence,
 };
 use rusqlite::Connection;
+use tempfile::tempdir;
+
+pub fn test_workspace() -> &'static Workspace {
+    static WORKSPACE: OnceLock<Workspace> = OnceLock::new();
+
+    WORKSPACE.get_or_init(|| {
+        let workspace = Workspace::new(tempdir().expect("should create test directory").keep());
+        workspace.ensure_gen_dir();
+        workspace
+    })
+}
 
 pub fn get_connection() -> GraphConnection {
     let mut conn = Connection::open_in_memory().expect("should open in-memory database");
@@ -190,5 +203,6 @@ pub fn setup_test_data(conn: &GraphConnection) {
         preserve_edge: false,
     };
 
-    BlockGroup::insert_change(conn, &change).expect("should apply variant change");
+    BlockGroup::insert_change(conn, test_workspace(), &change)
+        .expect("should apply variant change");
 }

--- a/gen-annotations/src/translate/bed.rs
+++ b/gen-annotations/src/translate/bed.rs
@@ -4,7 +4,7 @@ use std::{
     io::{Read, Write},
 };
 
-use gen_core::{HashId, Strand, is_terminal};
+use gen_core::{HashId, Strand, Workspace, is_terminal};
 use gen_graph::{GraphNode, project_path};
 use gen_models::{
     block_group::BlockGroup,
@@ -35,6 +35,7 @@ pub enum BedError {
 
 pub fn translate_bed<R, W>(
     conn: &GraphConnection,
+    workspace: &Workspace,
     collection: &str,
     sample: &str,
     history_ref: Option<&str>,
@@ -77,10 +78,12 @@ where
                 Entry::Occupied(entry) => entry.into_mut(),
                 Entry::Vacant(entry) => {
                     let path = BlockGroup::get_current_path(conn, &bg.id, history_ref)?;
-                    let graph = BlockGroup::get_graph(conn, &bg.id, history_ref)?;
+                    let graph = BlockGroup::get_graph(conn, workspace, &bg.id, history_ref)?;
                     let mut tree = IntervalTree::default();
                     let mut position: i64 = 0;
-                    for (node, strand) in project_path(&graph, &path.blocks(conn, history_ref)?) {
+                    for (node, strand) in
+                        project_path(&graph, &path.coordinate_blocks(conn, history_ref))
+                    {
                         if !is_terminal(node.node_id) {
                             let end_position = position + node.length();
                             tree.insert(position..end_position, (node, strand));
@@ -130,7 +133,7 @@ mod tests {
     use gen_models::{reference_alias::ReferenceAlias, sample::Sample};
 
     use super::translate_bed;
-    use crate::test_helpers::{get_connection, setup_test_data};
+    use crate::test_helpers::{get_connection, setup_test_data, test_workspace};
 
     #[test]
     fn translates_coordinates_to_nodes() {
@@ -143,6 +146,7 @@ mod tests {
         let mut buffer = Vec::new();
         translate_bed(
             &conn,
+            test_workspace(),
             &collection,
             "foo",
             None,
@@ -167,6 +171,7 @@ mod tests {
         let mut buffer = Vec::new();
         translate_bed(
             &conn,
+            test_workspace(),
             &collection,
             Sample::DEFAULT_NAME,
             None,
@@ -212,6 +217,7 @@ mod tests {
         let mut buffer = Vec::new();
         translate_bed(
             &conn,
+            test_workspace(),
             &collection,
             Sample::DEFAULT_NAME,
             None,

--- a/gen-annotations/src/translate/gff.rs
+++ b/gen-annotations/src/translate/gff.rs
@@ -4,7 +4,7 @@ use std::{
     io::{BufRead, Read, Write},
 };
 
-use gen_core::{HashId, Strand, is_terminal};
+use gen_core::{HashId, Strand, Workspace, is_terminal};
 use gen_graph::{GraphNode, project_path};
 use gen_models::{
     block_group::BlockGroup,
@@ -31,6 +31,7 @@ pub enum GffError {
 
 pub fn translate_gff<R, W>(
     conn: &GraphConnection,
+    workspace: &Workspace,
     collection: &str,
     sample: &str,
     history_ref: Option<&str>,
@@ -72,10 +73,12 @@ where
                 Entry::Occupied(entry) => entry.into_mut(),
                 Entry::Vacant(entry) => {
                     let path = BlockGroup::get_current_path(conn, &bg.id, history_ref)?;
-                    let graph = BlockGroup::get_graph(conn, &bg.id, history_ref)?;
+                    let graph = BlockGroup::get_graph(conn, workspace, &bg.id, history_ref)?;
                     let mut tree = IntervalTree::default();
                     let mut position: i64 = 0;
-                    for (node, strand) in project_path(&graph, &path.blocks(conn, history_ref)?) {
+                    for (node, strand) in
+                        project_path(&graph, &path.coordinate_blocks(conn, history_ref))
+                    {
                         if !is_terminal(node.node_id) {
                             // GFF indexing is one based, inclusive, so we add 1 to the start.
                             // Take a sequence that is 1-4 in our coordinates, this converts to:
@@ -126,7 +129,7 @@ mod tests {
     use gen_models::{reference_alias::ReferenceAlias, sample::Sample};
 
     use super::translate_gff;
-    use crate::test_helpers::{get_connection, setup_test_data};
+    use crate::test_helpers::{get_connection, setup_test_data, test_workspace};
 
     #[test]
     fn translates_coordinates_to_nodes() {
@@ -139,6 +142,7 @@ mod tests {
         let mut buffer = Vec::new();
         translate_gff(
             &conn,
+            test_workspace(),
             &collection,
             "foo",
             None,
@@ -174,6 +178,7 @@ mod tests {
         let mut buffer = Vec::new();
         translate_gff(
             &conn,
+            test_workspace(),
             &collection,
             Sample::DEFAULT_NAME,
             None,
@@ -225,6 +230,7 @@ mod tests {
         let mut buffer = Vec::new();
         translate_gff(
             &conn,
+            test_workspace(),
             &collection,
             Sample::DEFAULT_NAME,
             None,

--- a/gen-diff/src/operations.rs
+++ b/gen-diff/src/operations.rs
@@ -1416,6 +1416,7 @@ mod tests {
 
         let reconstructed_blocks = Edge::blocks_from_edges(
             graph_conn,
+            context.workspace(),
             &block_group.id,
             &reconstructed_edges,
             Some(&target_ref),
@@ -1425,6 +1426,7 @@ mod tests {
             BlockGroupEdge::edges_for_block_group(graph_conn, &block_group.id, Some(&target_ref));
         let target_blocks = Edge::blocks_from_edges(
             graph_conn,
+            context.workspace(),
             &block_group.id,
             &target_edges,
             Some(&target_ref),

--- a/gen-models/src/accession.rs
+++ b/gen-models/src/accession.rs
@@ -1,8 +1,8 @@
 use std::{collections::HashMap, ops::Range as StdRange, rc::Rc};
 
 use gen_core::{
-    HashId, NodeIntervalBlock, PATH_END_NODE_ID, PATH_START_NODE_ID, Strand, calculate_hash,
-    is_terminal,
+    HashId, NodeIntervalBlock, PATH_END_NODE_ID, PATH_START_NODE_ID, Strand, Workspace,
+    calculate_hash, is_terminal,
     range::Range,
     region::{Region, RegionResolutionError, RegionResolver},
     traits::Capnp,
@@ -561,11 +561,12 @@ impl AccessionSpan {
     /// the entire region is used.
     pub fn from_resolved_region(
         conn: &GraphConnection,
+        workspace: &Workspace,
         region: &ResolvedGenRegion,
         ranges: Option<&[StdRange<i64>]>,
     ) -> Result<Vec<AccessionSpan>, AccessionError> {
         let tree = region
-            .intervaltree(conn)
+            .intervaltree(conn, workspace)
             .map_err(|err| AccessionError::RegionProjection(err.to_string()))?;
         match ranges {
             Some(ranges) => Self::from_intervaltree_ranges(&tree, ranges),

--- a/gen-models/src/annotations.rs
+++ b/gen-models/src/annotations.rs
@@ -716,7 +716,12 @@ pub fn add_annotation(
     let graph_conn = context.graph().conn();
     let parsed_region = Region::parse(region)?;
     let resolved_region = crate::region::resolve(&parsed_region, graph_conn, collection, sample)?;
-    let spans = AccessionSpan::from_resolved_region(graph_conn, &resolved_region, None)?;
+    let spans = AccessionSpan::from_resolved_region(
+        graph_conn,
+        context.workspace(),
+        &resolved_region,
+        None,
+    )?;
 
     let accession = Accession::get_or_create(
         graph_conn,

--- a/gen-models/src/block_group.rs
+++ b/gen-models/src/block_group.rs
@@ -7,7 +7,7 @@ use std::{
 use gen_core::{
     HashId, INDETERMINATE_CHROMOSOME_INDEX, NO_CHROMOSOME_INDEX, NodeIntervalBlock,
     PATH_END_NODE_ID, PATH_START_NODE_ID, PRESERVE_EDIT_SITE_CHROMOSOME_INDEX, PathBlock, Strand,
-    calculate_hash, is_end_node, is_start_node, is_terminal,
+    Workspace, calculate_hash, is_end_node, is_start_node, is_terminal,
     range::Range,
     region::{Region, RegionResolutionError, RegionResolver},
     traits::Capnp,
@@ -49,6 +49,15 @@ pub struct BlockGroup {
     pub created_on: i64,
     pub parent_block_group_id: Option<HashId>,
     pub is_default: bool,
+}
+
+/// A graph interval block and the coordinate within its backing sequence that bounds a subgraph.
+#[derive(Clone, Copy, Debug)]
+pub struct SubgraphBoundary<'a> {
+    /// The graph interval block containing the boundary.
+    pub block: &'a NodeIntervalBlock,
+    /// The zero-based coordinate within the block's backing sequence.
+    pub sequence_coordinate: i64,
 }
 
 #[derive(Debug, Error, PartialEq)]
@@ -175,6 +184,7 @@ pub trait IntervalTreeSource {
     fn intervaltree(
         &self,
         conn: &GraphConnection,
+        workspace: &Workspace,
     ) -> Result<IntervalTree<i64, NodeIntervalBlock>, BlockGroupError>;
 }
 
@@ -553,11 +563,12 @@ impl BlockGroup {
 
     pub fn get_graph(
         conn: &GraphConnection,
+        workspace: &Workspace,
         block_group_id: &HashId,
         history_ref: Option<&str>,
     ) -> Result<GenGraph, BlockGroupError> {
         let edges = BlockGroupEdge::edges_for_block_group(conn, block_group_id, history_ref);
-        let blocks = Edge::blocks_from_edges(conn, block_group_id, &edges, history_ref)?;
+        let blocks = Edge::blocks_from_edges(conn, workspace, block_group_id, &edges, history_ref)?;
         let (graph, _) = Edge::build_graph(&edges, &blocks);
         Ok(graph)
     }
@@ -566,10 +577,11 @@ impl BlockGroup {
     /// will expand out automatically to cover it.
     pub fn get_graph_from_edges(
         conn: &GraphConnection,
+        workspace: &Workspace,
         block_group_id: &HashId,
         edges: &[AugmentedEdge],
     ) -> Result<GenGraph, BlockGroupError> {
-        let blocks = Edge::blocks_from_edges(conn, block_group_id, edges, None)?;
+        let blocks = Edge::blocks_from_edges(conn, workspace, block_group_id, edges, None)?;
         let edges_vec = edges.to_vec();
         let (graph, _) = Edge::build_graph(&edges_vec, &blocks);
         Ok(graph)
@@ -632,6 +644,7 @@ impl BlockGroup {
 
     pub fn get_all_sequences(
         conn: &GraphConnection,
+        workspace: &Workspace,
         block_group_id: &HashId,
         _prune: bool,
     ) -> Result<HashSet<String>, BlockGroupError> {
@@ -639,7 +652,7 @@ impl BlockGroup {
             .into_iter()
             .filter(|edge| edge.chromosome_index != PRESERVE_EDIT_SITE_CHROMOSOME_INDEX)
             .collect::<Vec<_>>();
-        let blocks = Edge::blocks_from_edges(conn, block_group_id, &edges, None)?;
+        let blocks = Edge::blocks_from_edges(conn, workspace, block_group_id, &edges, None)?;
 
         let (mut graph, _) = Edge::build_graph(&edges, &blocks);
         BlockGroup::prune_graph(&mut graph);
@@ -743,6 +756,7 @@ impl BlockGroup {
     )]
     pub fn insert_changes(
         conn: &GraphConnection,
+        workspace: &Workspace,
         changes: &[BlockGroupChange],
         tree_map: Option<&mut IntervalTreeCache>,
     ) -> Result<(), BlockGroupError> {
@@ -763,11 +777,11 @@ impl BlockGroup {
             if !tree_map.contains_key(&cache_key) {
                 tree_map.insert(
                     cache_key,
-                    IntervalTreeSource::intervaltree(&change.region, conn)?,
+                    IntervalTreeSource::intervaltree(&change.region, conn, workspace)?,
                 );
             }
             let tree = tree_map.get(&cache_key);
-            let new_augmented_edges = change.region.plan_edges(conn, change, tree)?;
+            let new_augmented_edges = change.region.plan_edges(conn, workspace, change, tree)?;
             new_augmented_edges_by_block_group
                 .entry(change.region.block_group.id)
                 .and_modify(|new_edge_data| new_edge_data.extend(new_augmented_edges.clone()))
@@ -790,9 +804,10 @@ impl BlockGroup {
 
     pub fn insert_change(
         conn: &GraphConnection,
+        workspace: &Workspace,
         change: &BlockGroupChange,
     ) -> Result<(), BlockGroupError> {
-        let new_augmented_edges = change.region.plan_edges(conn, change, None)?;
+        let new_augmented_edges = change.region.plan_edges(conn, workspace, change, None)?;
         let mut new_augmented_edges_by_block_group = HashMap::new();
         new_augmented_edges_by_block_group
             .insert(change.region.block_group.id, new_augmented_edges.clone());
@@ -1123,11 +1138,12 @@ impl BlockGroup {
 
     pub fn intervaltree_for(
         conn: &GraphConnection,
+        workspace: &Workspace,
         block_group_id: &HashId,
         remove_ambiguous_positions: bool,
     ) -> Result<IntervalTree<i64, NodeIntervalBlock>, BlockGroupError> {
         // make a tree where every node has a span in the graph.
-        let mut graph = BlockGroup::get_graph(conn, block_group_id, None)?;
+        let mut graph = BlockGroup::get_graph(conn, workspace, block_group_id, None)?;
         BlockGroup::prune_graph(&mut graph);
         Ok(flatten_to_interval_tree(&graph, remove_ambiguous_positions))
     }
@@ -1174,32 +1190,30 @@ impl BlockGroup {
         Ok(None)
     }
 
-    #[allow(clippy::too_many_arguments)]
     pub fn derive_subgraph(
         conn: &GraphConnection,
+        workspace: &Workspace,
         source_block_group_id: &HashId,
-        start_block: &NodeIntervalBlock,
-        end_block: &NodeIntervalBlock,
-        start_node_coordinate: i64,
-        end_node_coordinate: i64,
+        start: SubgraphBoundary<'_>,
+        end: SubgraphBoundary<'_>,
         target_block_group_id: &HashId,
         create_terminal_edges: bool,
     ) -> Result<(), BlockGroupError> {
-        let current_graph = BlockGroup::get_graph(conn, source_block_group_id, None)?;
+        let current_graph = BlockGroup::get_graph(conn, workspace, source_block_group_id, None)?;
         let start_node = current_graph
             .nodes()
             .find(|node| {
-                node.node_id == start_block.node_id
-                    && node.sequence_start <= start_node_coordinate
-                    && node.sequence_end >= start_node_coordinate
+                node.node_id == start.block.node_id
+                    && node.sequence_start <= start.sequence_coordinate
+                    && node.sequence_end >= start.sequence_coordinate
             })
             .unwrap();
         let end_node = current_graph
             .nodes()
             .find(|node| {
-                node.node_id == end_block.node_id
-                    && node.sequence_start <= end_node_coordinate
-                    && node.sequence_end >= end_node_coordinate
+                node.node_id == end.block.node_id
+                    && node.sequence_start <= end.sequence_coordinate
+                    && node.sequence_end >= end.sequence_coordinate
             })
             .unwrap();
         let subgraph_edges = all_intermediate_edges(&current_graph, start_node, end_node);
@@ -1252,9 +1266,9 @@ impl BlockGroup {
                 PATH_START_NODE_ID,
                 0,
                 Strand::Forward,
-                start_block.node_id,
-                start_node_coordinate,
-                start_block.strand,
+                start.block.node_id,
+                start.sequence_coordinate,
+                start.block.strand,
             )?;
             let new_start_edge_data = BlockGroupEdgeData {
                 block_group_id: *target_block_group_id,
@@ -1264,9 +1278,9 @@ impl BlockGroup {
             };
             let new_end_edge = Edge::create(
                 conn,
-                end_block.node_id,
-                end_node_coordinate,
-                end_block.strand,
+                end.block.node_id,
+                end.sequence_coordinate,
+                end.block.strand,
                 PATH_END_NODE_ID,
                 0,
                 Strand::Forward,
@@ -1353,7 +1367,9 @@ mod tests {
         region::{ResolvedGenRegion, ResolvedRegionKind},
         sample::{NewSample, Sample},
         sequence::Sequence,
-        test_helpers::{create_bg, get_connection, interval_tree_verify, setup_block_group},
+        test_helpers::{
+            create_bg, get_connection, interval_tree_verify, setup_block_group, test_workspace,
+        },
     };
 
     mod region_resolver {
@@ -1719,15 +1735,16 @@ mod tests {
         );
 
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &child_a.id, false).unwrap(),
+            BlockGroup::get_all_sequences(conn, test_workspace(), &child_a.id, false).unwrap(),
             HashSet::from_iter(vec!["AAAA".to_string()])
         );
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &child_b.id, false).unwrap(),
+            BlockGroup::get_all_sequences(conn, test_workspace(), &child_b.id, false).unwrap(),
             HashSet::from_iter(vec!["CCCC".to_string()])
         );
         assert_eq!(
-            Sample::get_all_sequences(conn, "test", "child", false, None).unwrap(),
+            Sample::get_all_sequences(conn, test_workspace(), "test", "child", false, None)
+                .unwrap(),
             HashSet::from_iter(vec!["AAAA".to_string(), "CCCC".to_string()])
         );
     }
@@ -1938,7 +1955,7 @@ mod tests {
         .collect::<Vec<_>>();
 
         BlockGroupEdge::bulk_create(&conn, &block_group_edges);
-        let graph = BlockGroup::get_graph(&conn, &bg.id, None).unwrap();
+        let graph = BlockGroup::get_graph(&conn, test_workspace(), &bg.id, None).unwrap();
 
         // 5 non-terminal nodes: AAA, GGG, TTT, CCC, ATC
         // 2 terminal blocks: START, END
@@ -2311,8 +2328,9 @@ mod tests {
             preserve_edge: true,
         };
 
-        BlockGroup::insert_change(&conn, &change).unwrap();
-        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false).unwrap();
+        BlockGroup::insert_change(&conn, test_workspace(), &change).unwrap();
+        let all_sequences =
+            BlockGroup::get_all_sequences(&conn, test_workspace(), &block_group_id, false).unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec![
@@ -2367,8 +2385,9 @@ mod tests {
             preserve_edge: true,
         };
 
-        BlockGroup::insert_change(&conn, &change).unwrap();
-        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false).unwrap();
+        BlockGroup::insert_change(&conn, test_workspace(), &change).unwrap();
+        let all_sequences =
+            BlockGroup::get_all_sequences(&conn, test_workspace(), &block_group_id, false).unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec![
@@ -2407,9 +2426,10 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        BlockGroup::insert_change(&conn, &change).unwrap();
+        BlockGroup::insert_change(&conn, test_workspace(), &change).unwrap();
 
-        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false).unwrap();
+        let all_sequences =
+            BlockGroup::get_all_sequences(&conn, test_workspace(), &block_group_id, false).unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec![
@@ -2444,8 +2464,9 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        BlockGroup::insert_change(&conn, &change).unwrap();
-        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false).unwrap();
+        BlockGroup::insert_change(&conn, test_workspace(), &change).unwrap();
+        let all_sequences =
+            BlockGroup::get_all_sequences(&conn, test_workspace(), &block_group_id, false).unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec![
@@ -2486,9 +2507,10 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        BlockGroup::insert_change(&conn, &change).unwrap();
+        BlockGroup::insert_change(&conn, test_workspace(), &change).unwrap();
 
-        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false).unwrap();
+        let all_sequences =
+            BlockGroup::get_all_sequences(&conn, test_workspace(), &block_group_id, false).unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec![
@@ -2527,9 +2549,10 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        BlockGroup::insert_change(&conn, &change).unwrap();
+        BlockGroup::insert_change(&conn, test_workspace(), &change).unwrap();
 
-        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false).unwrap();
+        let all_sequences =
+            BlockGroup::get_all_sequences(&conn, test_workspace(), &block_group_id, false).unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec![
@@ -2568,9 +2591,10 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        BlockGroup::insert_change(&conn, &change).unwrap();
+        BlockGroup::insert_change(&conn, test_workspace(), &change).unwrap();
 
-        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false).unwrap();
+        let all_sequences =
+            BlockGroup::get_all_sequences(&conn, test_workspace(), &block_group_id, false).unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec![
@@ -2609,9 +2633,10 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        BlockGroup::insert_change(&conn, &change).unwrap();
+        BlockGroup::insert_change(&conn, test_workspace(), &change).unwrap();
 
-        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false).unwrap();
+        let all_sequences =
+            BlockGroup::get_all_sequences(&conn, test_workspace(), &block_group_id, false).unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec![
@@ -2650,9 +2675,10 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        BlockGroup::insert_change(&conn, &change).unwrap();
+        BlockGroup::insert_change(&conn, test_workspace(), &change).unwrap();
 
-        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false).unwrap();
+        let all_sequences =
+            BlockGroup::get_all_sequences(&conn, test_workspace(), &block_group_id, false).unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec![
@@ -2691,9 +2717,10 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        BlockGroup::insert_change(&conn, &change).unwrap();
+        BlockGroup::insert_change(&conn, test_workspace(), &change).unwrap();
 
-        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false).unwrap();
+        let all_sequences =
+            BlockGroup::get_all_sequences(&conn, test_workspace(), &block_group_id, false).unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec![
@@ -2732,9 +2759,10 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        BlockGroup::insert_change(&conn, &change).unwrap();
+        BlockGroup::insert_change(&conn, test_workspace(), &change).unwrap();
 
-        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false).unwrap();
+        let all_sequences =
+            BlockGroup::get_all_sequences(&conn, test_workspace(), &block_group_id, false).unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec![
@@ -2773,9 +2801,10 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        BlockGroup::insert_change(&conn, &change).unwrap();
+        BlockGroup::insert_change(&conn, test_workspace(), &change).unwrap();
 
-        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false).unwrap();
+        let all_sequences =
+            BlockGroup::get_all_sequences(&conn, test_workspace(), &block_group_id, false).unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec![
@@ -2817,8 +2846,9 @@ mod tests {
         };
 
         // take out an entire block
-        BlockGroup::insert_change(&conn, &change).unwrap();
-        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false).unwrap();
+        BlockGroup::insert_change(&conn, test_workspace(), &change).unwrap();
+        let all_sequences =
+            BlockGroup::get_all_sequences(&conn, test_workspace(), &block_group_id, false).unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec![
@@ -2857,9 +2887,10 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        BlockGroup::insert_change(&conn, &change).unwrap();
+        BlockGroup::insert_change(&conn, test_workspace(), &change).unwrap();
 
-        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false).unwrap();
+        let all_sequences =
+            BlockGroup::get_all_sequences(&conn, test_workspace(), &block_group_id, false).unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec![
@@ -2867,9 +2898,10 @@ mod tests {
                 "AAAAAAANNNNTTTTTCCCCCCCCCCGGGGGGGGGG".to_string()
             ])
         );
-        BlockGroup::insert_change(&conn, &change).unwrap();
+        BlockGroup::insert_change(&conn, test_workspace(), &change).unwrap();
 
-        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false).unwrap();
+        let all_sequences =
+            BlockGroup::get_all_sequences(&conn, test_workspace(), &block_group_id, false).unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec![
@@ -2908,9 +2940,10 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        BlockGroup::insert_change(&conn, &change).unwrap();
+        BlockGroup::insert_change(&conn, test_workspace(), &change).unwrap();
 
-        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false).unwrap();
+        let all_sequences =
+            BlockGroup::get_all_sequences(&conn, test_workspace(), &block_group_id, false).unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec![
@@ -2949,9 +2982,10 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        BlockGroup::insert_change(&conn, &change).unwrap();
+        BlockGroup::insert_change(&conn, test_workspace(), &change).unwrap();
 
-        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false).unwrap();
+        let all_sequences =
+            BlockGroup::get_all_sequences(&conn, test_workspace(), &block_group_id, false).unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec![
@@ -2990,9 +3024,10 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        BlockGroup::insert_change(&conn, &change).unwrap();
+        BlockGroup::insert_change(&conn, test_workspace(), &change).unwrap();
 
-        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false).unwrap();
+        let all_sequences =
+            BlockGroup::get_all_sequences(&conn, test_workspace(), &block_group_id, false).unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec![
@@ -3031,9 +3066,10 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        BlockGroup::insert_change(&conn, &change).unwrap();
+        BlockGroup::insert_change(&conn, test_workspace(), &change).unwrap();
 
-        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false).unwrap();
+        let all_sequences =
+            BlockGroup::get_all_sequences(&conn, test_workspace(), &block_group_id, false).unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec![
@@ -3072,9 +3108,10 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        BlockGroup::insert_change(&conn, &change).unwrap();
+        BlockGroup::insert_change(&conn, test_workspace(), &change).unwrap();
 
-        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false).unwrap();
+        let all_sequences =
+            BlockGroup::get_all_sequences(&conn, test_workspace(), &block_group_id, false).unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec![
@@ -3113,9 +3150,10 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        BlockGroup::insert_change(&conn, &change).unwrap();
+        BlockGroup::insert_change(&conn, test_workspace(), &change).unwrap();
 
-        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false).unwrap();
+        let all_sequences =
+            BlockGroup::get_all_sequences(&conn, test_workspace(), &block_group_id, false).unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec![
@@ -3154,9 +3192,10 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        BlockGroup::insert_change(&conn, &change).unwrap();
+        BlockGroup::insert_change(&conn, test_workspace(), &change).unwrap();
 
-        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false).unwrap();
+        let all_sequences =
+            BlockGroup::get_all_sequences(&conn, test_workspace(), &block_group_id, false).unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec![
@@ -3206,9 +3245,9 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        let res = BlockGroup::insert_change(&conn, &after_end_change);
+        let res = BlockGroup::insert_change(&conn, test_workspace(), &after_end_change);
         assert!(matches!(res, Err(BlockGroupError::ChangeOutOfBounds(_))));
-        let res = BlockGroup::insert_change(&conn, &before_start_change);
+        let res = BlockGroup::insert_change(&conn, test_workspace(), &before_start_change);
         assert!(matches!(res, Err(BlockGroupError::ChangeOutOfBounds(_))));
     }
 
@@ -3241,9 +3280,10 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        BlockGroup::insert_change(&conn, &change).unwrap();
+        BlockGroup::insert_change(&conn, test_workspace(), &change).unwrap();
 
-        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false).unwrap();
+        let all_sequences =
+            BlockGroup::get_all_sequences(&conn, test_workspace(), &block_group_id, false).unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec![
@@ -3282,9 +3322,10 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        BlockGroup::insert_change(&conn, &change).unwrap();
+        BlockGroup::insert_change(&conn, test_workspace(), &change).unwrap();
 
-        let all_sequences = BlockGroup::get_all_sequences(&conn, &block_group_id, false).unwrap();
+        let all_sequences =
+            BlockGroup::get_all_sequences(&conn, test_workspace(), &block_group_id, false).unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec![
@@ -3356,10 +3397,12 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        BlockGroup::insert_change(conn, &change).unwrap();
+        BlockGroup::insert_change(conn, test_workspace(), &change).unwrap();
 
-        let tree = BlockGroup::intervaltree_for(conn, &block_group_id, false).unwrap();
-        let tree2 = BlockGroup::intervaltree_for(conn, &block_group_id, true).unwrap();
+        let tree =
+            BlockGroup::intervaltree_for(conn, test_workspace(), &block_group_id, false).unwrap();
+        let tree2 =
+            BlockGroup::intervaltree_for(conn, test_workspace(), &block_group_id, true).unwrap();
         interval_tree_verify(
             &tree,
             3,
@@ -3410,8 +3453,8 @@ mod tests {
         );
 
         // This blockgroup has a change from positions 7-15 of 4 base pairs -- so any changes after this will be ambiguous
-        let tree = BlockGroup::intervaltree_for(conn, &new_bg_id, false).unwrap();
-        let tree2 = BlockGroup::intervaltree_for(conn, &new_bg_id, true).unwrap();
+        let tree = BlockGroup::intervaltree_for(conn, test_workspace(), &new_bg_id, false).unwrap();
+        let tree2 = BlockGroup::intervaltree_for(conn, test_workspace(), &new_bg_id, true).unwrap();
         interval_tree_verify(
             &tree,
             3,
@@ -3530,8 +3573,9 @@ mod tests {
         };
 
         // note we are making our change against the new blockgroup, and not the parent blockgroup
-        BlockGroup::insert_change(conn, &change).unwrap();
-        let all_sequences = BlockGroup::get_all_sequences(conn, &new_bg_id, true).unwrap();
+        BlockGroup::insert_change(conn, test_workspace(), &change).unwrap();
+        let all_sequences =
+            BlockGroup::get_all_sequences(conn, test_workspace(), &new_bg_id, true).unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec!["AAAAAAANNNNTTTTTCCCCCCCCCCGGGGGGGGGG".to_string(),])
@@ -3592,8 +3636,9 @@ mod tests {
             phased: 0,
             preserve_edge: false,
         };
-        BlockGroup::insert_change(conn, &change).unwrap();
-        let all_sequences = BlockGroup::get_all_sequences(conn, &gc_bg_id, true).unwrap();
+        BlockGroup::insert_change(conn, test_workspace(), &change).unwrap();
+        let all_sequences =
+            BlockGroup::get_all_sequences(conn, test_workspace(), &gc_bg_id, true).unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec!["AAAAAAANNNNTCCCCCCCCCCGGGGGGGGGG".to_string(),])
@@ -3660,8 +3705,9 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        BlockGroup::insert_change(conn, &change).unwrap();
-        let all_sequences = BlockGroup::get_all_sequences(conn, &new_bg_id, true).unwrap();
+        BlockGroup::insert_change(conn, test_workspace(), &change).unwrap();
+        let all_sequences =
+            BlockGroup::get_all_sequences(conn, test_workspace(), &new_bg_id, true).unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec![
@@ -3737,8 +3783,9 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        BlockGroup::insert_change(conn, &change).unwrap();
-        let all_sequences = BlockGroup::get_all_sequences(conn, &gc_bg_id, true).unwrap();
+        BlockGroup::insert_change(conn, test_workspace(), &change).unwrap();
+        let all_sequences =
+            BlockGroup::get_all_sequences(conn, test_workspace(), &gc_bg_id, true).unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec![
@@ -3814,8 +3861,9 @@ mod tests {
         };
 
         // note we are making our change against the new blockgroup, and not the parent blockgroup
-        BlockGroup::insert_change(conn, &change).unwrap();
-        let all_sequences = BlockGroup::get_all_sequences(conn, &new_bg_id, true).unwrap();
+        BlockGroup::insert_change(conn, test_workspace(), &change).unwrap();
+        let all_sequences =
+            BlockGroup::get_all_sequences(conn, test_workspace(), &new_bg_id, true).unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec![
@@ -3887,7 +3935,7 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        BlockGroup::insert_change(conn, &change).unwrap();
+        BlockGroup::insert_change(conn, test_workspace(), &change).unwrap();
     }
 
     mod test_derive_subgraph {
@@ -3991,12 +4039,13 @@ mod tests {
                 .new_path_with(conn, 16, 24, &edge_into_insert, &edge_out_of_insert)
                 .unwrap();
             assert_eq!(
-                insert_path.sequence(conn, None).unwrap(),
+                insert_path.sequence(conn, test_workspace(), None).unwrap(),
                 "AAAAAAAAAATTTTTTAAAAAAAACCCCCCGGGGGGGGGG"
             );
 
             let all_sequences =
-                BlockGroup::get_all_sequences(conn, &block_group1_id, false).unwrap();
+                BlockGroup::get_all_sequences(conn, test_workspace(), &block_group1_id, false)
+                    .unwrap();
             assert_eq!(
                 all_sequences,
                 HashSet::from_iter(vec![
@@ -4019,11 +4068,16 @@ mod tests {
             let node_count_before = Node::query(conn, "SELECT * FROM nodes", params![]).len();
             BlockGroup::derive_subgraph(
                 conn,
+                test_workspace(),
                 &block_group1_id,
-                &start_block,
-                &end_block,
-                start_node_coordinate,
-                end_node_coordinate,
+                SubgraphBoundary {
+                    block: &start_block,
+                    sequence_coordinate: start_node_coordinate,
+                },
+                SubgraphBoundary {
+                    block: &end_block,
+                    sequence_coordinate: end_node_coordinate,
+                },
                 &block_group2.id,
                 true,
             )
@@ -4031,7 +4085,8 @@ mod tests {
             let node_count_after = Node::query(conn, "SELECT * FROM nodes", params![]).len();
             assert_eq!(node_count_after, node_count_before);
             let all_sequences2 =
-                BlockGroup::get_all_sequences(conn, &block_group2.id, false).unwrap();
+                BlockGroup::get_all_sequences(conn, test_workspace(), &block_group2.id, false)
+                    .unwrap();
             assert_eq!(
                 all_sequences2,
                 HashSet::from_iter(vec!["TTTTTCCCCC".to_string(), "TAAAAAAAAC".to_string(),])
@@ -4129,7 +4184,7 @@ mod tests {
                 .new_path_with(conn, 16, 24, &edge_into_insert, &edge_out_of_insert)
                 .unwrap();
             assert_eq!(
-                insert_path.sequence(conn, None).unwrap(),
+                insert_path.sequence(conn, test_workspace(), None).unwrap(),
                 "AAAAAAAAAATTTTTTAAAAAAAACCCCCCGGGGGGGGGG"
             );
 
@@ -4213,12 +4268,13 @@ mod tests {
                 .new_path_with(conn, 28, 32, &edge_into_insert2, &edge_out_of_insert2)
                 .unwrap();
             assert_eq!(
-                insert2_path.sequence(conn, None).unwrap(),
+                insert2_path.sequence(conn, test_workspace(), None).unwrap(),
                 "AAAAAAAAAATTTTTTAAAAAAAACCTTTTTTTTGGGGGG"
             );
 
             let all_sequences =
-                BlockGroup::get_all_sequences(conn, &block_group1_id, false).unwrap();
+                BlockGroup::get_all_sequences(conn, test_workspace(), &block_group1_id, false)
+                    .unwrap();
             assert_eq!(
                 all_sequences,
                 HashSet::from_iter(vec![
@@ -4242,17 +4298,23 @@ mod tests {
             let block_group2 = create_bg(conn, "test", "test", "chr1.1");
             BlockGroup::derive_subgraph(
                 conn,
+                test_workspace(),
                 &block_group1_id,
-                &start_block,
-                &end_block,
-                start_node_coordinate,
-                end_node_coordinate,
+                SubgraphBoundary {
+                    block: &start_block,
+                    sequence_coordinate: start_node_coordinate,
+                },
+                SubgraphBoundary {
+                    block: &end_block,
+                    sequence_coordinate: end_node_coordinate,
+                },
                 &block_group2.id,
                 true,
             )
             .unwrap();
             let all_sequences2 =
-                BlockGroup::get_all_sequences(conn, &block_group2.id, false).unwrap();
+                BlockGroup::get_all_sequences(conn, test_workspace(), &block_group2.id, false)
+                    .unwrap();
             assert_eq!(
                 all_sequences2,
                 HashSet::from_iter(vec![
@@ -4357,7 +4419,7 @@ mod tests {
                 .new_path_with(conn, 16, 24, &edge_into_insert, &edge_out_of_insert)
                 .unwrap();
             assert_eq!(
-                insert_path.sequence(conn, None).unwrap(),
+                insert_path.sequence(conn, test_workspace(), None).unwrap(),
                 "AAAAAAAAAATTTTTTAAAAAAAACCCCCCGGGGGGGGGG"
             );
 
@@ -4440,7 +4502,7 @@ mod tests {
                 .new_path_with(conn, 28, 32, &edge_into_insert2, &edge_out_of_insert2)
                 .unwrap();
             assert_eq!(
-                insert2_path.sequence(conn, None).unwrap(),
+                insert2_path.sequence(conn, test_workspace(), None).unwrap(),
                 "AAAAAAAAAATTTTTTAAAAAAAACCTTTTTTTTGGGGGG"
             );
 
@@ -4498,7 +4560,8 @@ mod tests {
             BlockGroupEdge::bulk_create(conn, &block_group_edges);
 
             let all_sequences =
-                BlockGroup::get_all_sequences(conn, &block_group1_id, false).unwrap();
+                BlockGroup::get_all_sequences(conn, test_workspace(), &block_group1_id, false)
+                    .unwrap();
             assert_eq!(
                 all_sequences,
                 HashSet::from_iter(vec![
@@ -4523,17 +4586,23 @@ mod tests {
             let block_group2 = create_bg(conn, "test", "test", "chr1.1");
             BlockGroup::derive_subgraph(
                 conn,
+                test_workspace(),
                 &block_group1_id,
-                &start_block,
-                &end_block,
-                start_node_coordinate,
-                end_node_coordinate,
+                SubgraphBoundary {
+                    block: &start_block,
+                    sequence_coordinate: start_node_coordinate,
+                },
+                SubgraphBoundary {
+                    block: &end_block,
+                    sequence_coordinate: end_node_coordinate,
+                },
                 &block_group2.id,
                 true,
             )
             .unwrap();
             let all_sequences2 =
-                BlockGroup::get_all_sequences(conn, &block_group2.id, false).unwrap();
+                BlockGroup::get_all_sequences(conn, test_workspace(), &block_group2.id, false)
+                    .unwrap();
             assert_eq!(
                 all_sequences2,
                 // The deletion is not included in the cloned subgraph since one end of it is

--- a/gen-models/src/edge.rs
+++ b/gen-models/src/edge.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use gen_core::{
-    HashId, PATH_END_NODE_ID, PATH_START_NODE_ID, Strand, calculate_hash, is_terminal,
+    HashId, PATH_END_NODE_ID, PATH_START_NODE_ID, Strand, Workspace, calculate_hash, is_terminal,
     traits::Capnp,
 };
 use gen_graph::{GenGraph, GraphEdge, GraphNode};
@@ -21,7 +21,7 @@ use crate::{
     errors::NodeError,
     gen_models_capnp::edge,
     node::Node,
-    sequence::{Sequence, SequenceError, cached_sequence},
+    sequence::{Sequence, SequenceError},
     traits::*,
 };
 
@@ -137,7 +137,7 @@ pub struct GroupBlock {
     pub id: i64,
     pub node_id: HashId,
     sequence: Option<String>,
-    external_sequence: Option<(String, String, bool)>,
+    external_sequence: Option<Sequence>,
     pub start: i64,
     pub end: i64,
 }
@@ -149,11 +149,7 @@ impl GroupBlock {
                 id,
                 node_id,
                 sequence: None,
-                external_sequence: Some((
-                    sequence.file_path.clone(),
-                    sequence.name.clone(),
-                    sequence.sequence_type.eq_ignore_ascii_case("circular"),
-                )),
+                external_sequence: Some(sequence.clone()),
                 start,
                 end,
             }
@@ -172,8 +168,8 @@ impl GroupBlock {
     pub fn sequence(&self) -> String {
         if let Some(sequence) = &self.sequence {
             sequence.to_string()
-        } else if let Some((path, name, circular)) = &self.external_sequence {
-            cached_sequence(path, name, self.start, self.end, *circular).unwrap()
+        } else if let Some(sequence) = &self.external_sequence {
+            sequence.get_sequence(self.start, self.end).unwrap()
         } else {
             panic!("Sequence or external sequence is not set.")
         }
@@ -514,6 +510,7 @@ impl Edge {
     /// another real block.
     pub fn blocks_from_edges(
         conn: &GraphConnection,
+        workspace: &Workspace,
         block_group_id: &HashId,
         edges: &[AugmentedEdge],
         history_ref: Option<&str>,
@@ -620,11 +617,9 @@ impl Edge {
             incomplete_node_ids = next_incomplete_node_ids.into_iter().collect();
         }
 
-        let sequences_by_node_id = Node::get_sequences_by_node_ids(
-            conn,
-            &node_ids.iter().copied().collect::<Vec<HashId>>(),
-            history_ref,
-        );
+        let node_ids = node_ids.iter().copied().collect::<Vec<HashId>>();
+        let sequences_by_node_id =
+            Node::get_sequences_by_node_ids(conn, workspace, &node_ids, history_ref);
 
         let mut blocks = vec![];
         let mut block_index = 0;
@@ -931,7 +926,7 @@ mod tests {
         collection::Collection,
         region::ResolvedGenRegion,
         sequence::Sequence,
-        test_helpers::{get_connection, setup_block_group},
+        test_helpers::{get_connection, setup_block_group, test_workspace},
     };
 
     fn get_block_boundaries(
@@ -1576,7 +1571,9 @@ mod tests {
             },
         ];
 
-        let blocks = Edge::blocks_from_edges(&conn, &bg.id, &augmented_edges, None).unwrap();
+        let blocks =
+            Edge::blocks_from_edges(&conn, test_workspace(), &bg.id, &augmented_edges, None)
+                .unwrap();
 
         // 5 non-terminal nodes: AAA, GGG, TTT, CCC, ATC
         // 2 terminal blocks: START, END
@@ -1704,7 +1701,9 @@ mod tests {
             },
         ];
 
-        let blocks = Edge::blocks_from_edges(&conn, &bg.id, &augmented_edges, None).unwrap();
+        let blocks =
+            Edge::blocks_from_edges(&conn, test_workspace(), &bg.id, &augmented_edges, None)
+                .unwrap();
         let node_blocks = blocks
             .iter()
             .filter(|block| block.node_id == node_id)
@@ -1832,7 +1831,9 @@ mod tests {
             },
         ];
 
-        let blocks = Edge::blocks_from_edges(&conn, &bg.id, &augmented_edges, None).unwrap();
+        let blocks =
+            Edge::blocks_from_edges(&conn, test_workspace(), &bg.id, &augmented_edges, None)
+                .unwrap();
         let mid_intervals = blocks
             .iter()
             .filter(|block| block.node_id == n_mid)
@@ -1911,6 +1912,7 @@ mod tests {
 
         let blocks = Edge::blocks_from_edges(
             &conn,
+            test_workspace(),
             &bg.id,
             &[AugmentedEdge {
                 edge: e_a_b,
@@ -2054,7 +2056,9 @@ mod tests {
         let (block_group_id, path) = setup_block_group(&conn);
 
         let edges = BlockGroupEdge::edges_for_block_group(&conn, &block_group_id, None);
-        let blocks = Edge::blocks_from_edges(&conn, &block_group_id, &edges, None).unwrap();
+        let blocks =
+            Edge::blocks_from_edges(&conn, test_workspace(), &block_group_id, &edges, None)
+                .unwrap();
 
         // 4 actual sequences: 10-length ones of all A, all T, all C, all G
         // 2 terminal node blocks (start/end)
@@ -2086,10 +2090,12 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        BlockGroup::insert_change(&conn, &change).unwrap();
+        BlockGroup::insert_change(&conn, test_workspace(), &change).unwrap();
         let mut edges = BlockGroupEdge::edges_for_block_group(&conn, &block_group_id, None);
 
-        let blocks = Edge::blocks_from_edges(&conn, &block_group_id, &edges, None).unwrap();
+        let blocks =
+            Edge::blocks_from_edges(&conn, test_workspace(), &block_group_id, &edges, None)
+                .unwrap();
 
         // 2 10-length sequences of all C, all G
         // 1 inserted NNNN sequence
@@ -2100,7 +2106,9 @@ mod tests {
 
         // Confirm that ordering doesn't matter
         edges.reverse();
-        let blocks = Edge::blocks_from_edges(&conn, &block_group_id, &edges, None).unwrap();
+        let blocks =
+            Edge::blocks_from_edges(&conn, test_workspace(), &block_group_id, &edges, None)
+                .unwrap();
 
         // 2 10-length sequences of all C, all G
         // 1 inserted NNNN sequence

--- a/gen-models/src/graph.rs
+++ b/gen-models/src/graph.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 
-use gen_core::{HashId, NodeIntervalBlock, is_terminal};
+use gen_core::{HashId, NodeIntervalBlock, Workspace, is_terminal};
 use gen_graph::{GenGraph, GraphError, GraphNode, GraphNodePosition, MergeGraph};
 use intervaltree::IntervalTree;
 use petgraph::Direction;
@@ -20,6 +20,7 @@ pub struct ResolvedGraph {
 /// Returns true if the graph was expanded, false if no new edges were added.
 pub fn expand(
     conn: &GraphConnection,
+    workspace: &Workspace,
     graph: &mut GenGraph,
     block_group_id: &HashId,
     node_id: HashId,
@@ -60,10 +61,11 @@ pub fn expand(
         return false;
     }
 
-    let fragment = match BlockGroup::get_graph_from_edges(conn, block_group_id, &new_edges) {
-        Ok(g) => g,
-        Err(_) => return false,
-    };
+    let fragment =
+        match BlockGroup::get_graph_from_edges(conn, workspace, block_group_id, &new_edges) {
+            Ok(g) => g,
+            Err(_) => return false,
+        };
     graph.merge_graph(&fragment);
     true
 }
@@ -214,6 +216,7 @@ impl ResolvedGraph {
         &self,
         coord: i64,
         conn: &GraphConnection,
+        workspace: &Workspace,
     ) -> Result<GraphNodePosition, GraphError> {
         let mut block = None;
         for item in self.interval_tree.query_point(coord) {
@@ -300,6 +303,7 @@ impl ResolvedGraph {
         let mut expanded_graph = self.graph.clone();
         expand(
             conn,
+            workspace,
             &mut expanded_graph,
             &self.block_group_id,
             boundary_node.node_id,
@@ -309,7 +313,7 @@ impl ResolvedGraph {
             &mut expanded_graph,
             &boundary_anchor,
             boundary_distance,
-            |g, nid| expand(conn, g, &self.block_group_id, nid),
+            |g, nid| expand(conn, workspace, g, &self.block_group_id, nid),
         )?;
 
         anchors.into_iter().next().ok_or(GraphError::NoPath)
@@ -331,7 +335,7 @@ mod tests {
         node::Node,
         sample::{NewSample, Sample},
         sequence::Sequence,
-        test_helpers::get_connection,
+        test_helpers::{get_connection, test_workspace},
     };
 
     fn setup_subset_graph() -> (crate::db::GraphConnection, HashId) {
@@ -531,7 +535,7 @@ mod tests {
         };
 
         let result = find_offset(&mut graph, &anchor, 3, |g, nid| {
-            expand(&conn, g, &bg_id, nid)
+            expand(&conn, test_workspace(), g, &bg_id, nid)
         });
         assert!(
             result.is_ok(),
@@ -561,7 +565,7 @@ mod tests {
         };
 
         let result = find_offset(&mut graph, &anchor, 7, |g, nid| {
-            expand(&conn, g, &bg_id, nid)
+            expand(&conn, test_workspace(), g, &bg_id, nid)
         });
         assert!(
             result.is_ok(),
@@ -610,7 +614,7 @@ mod tests {
         };
 
         let result = find_offset(&mut graph, &anchor, 7, |g, nid| {
-            expand(&conn, g, &bg_id, nid)
+            expand(&conn, test_workspace(), g, &bg_id, nid)
         });
         assert!(
             result.is_ok(),
@@ -643,7 +647,7 @@ mod tests {
         };
 
         let result = find_offset(&mut graph, &anchor, -3, |g, nid| {
-            expand(&conn, g, &bg_id, nid)
+            expand(&conn, test_workspace(), g, &bg_id, nid)
         });
         assert!(
             result.is_ok(),
@@ -676,7 +680,7 @@ mod tests {
         };
 
         let result = find_offset(&mut graph, &anchor, 100, |g, nid| {
-            expand(&conn, g, &bg_id, nid)
+            expand(&conn, test_workspace(), g, &bg_id, nid)
         });
         assert!(result.is_err());
     }
@@ -711,7 +715,7 @@ mod tests {
         };
 
         let result = find_offset(&mut graph, &anchor, 2, |g, nid| {
-            expand(&conn, g, &bg_id, nid)
+            expand(&conn, test_workspace(), g, &bg_id, nid)
         });
         assert!(result.is_ok());
         let positions = result.unwrap();
@@ -746,7 +750,9 @@ mod tests {
             block_group_id: bg_id,
         };
 
-        let position = resolved.resolve_anchor(-2, &conn).unwrap();
+        let position = resolved
+            .resolve_anchor(-2, &conn, test_workspace())
+            .unwrap();
 
         assert_eq!(
             position.graph_node,
@@ -768,7 +774,13 @@ mod tests {
 
         assert_eq!(graph.node_count(), 1);
 
-        let expanded = expand(&conn, &mut graph, &bg_id, HashId::convert_str("node-y"));
+        let expanded = expand(
+            &conn,
+            test_workspace(),
+            &mut graph,
+            &bg_id,
+            HashId::convert_str("node-y"),
+        );
         assert!(expanded, "expand should add new nodes");
         assert!(
             graph.node_count() > 1,

--- a/gen-models/src/locus.rs
+++ b/gen-models/src/locus.rs
@@ -15,7 +15,7 @@
 //! coordinate reference frame (left side = 0). But to store graph changes in
 //! the additive model in the database we must convert back to the Node format.
 
-use gen_core::{HashId, Strand};
+use gen_core::{HashId, Strand, Workspace};
 pub use gen_graph::GraphNodeSlice;
 
 use crate::{db::GraphConnection, node::Node, sequence::reverse_complement};
@@ -30,9 +30,9 @@ pub struct GraphLocus {
 
 impl GraphLocus {
     /// Concatenate the sequence bytes covered by this locus.
-    pub fn sequence(&self, conn: &GraphConnection) -> Vec<u8> {
+    pub fn sequence(&self, conn: &GraphConnection, workspace: &Workspace) -> Vec<u8> {
         let node_ids: Vec<HashId> = self.slices.iter().map(|s| s.block.node_id).collect();
-        let sequences = Node::get_sequences_by_node_ids(conn, &node_ids, None);
+        let sequences = Node::get_sequences_by_node_ids(conn, workspace, &node_ids, None);
 
         let mut out = Vec::new();
         for s in &self.slices {

--- a/gen-models/src/node.rs
+++ b/gen-models/src/node.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use gen_core::{
     HashId, PATH_END_NODE_ID, PATH_END_SEQUENCE_HASH, PATH_START_NODE_ID, PATH_START_SEQUENCE_HASH,
-    Sha256Hash, traits::Capnp,
+    Sha256Hash, Workspace, traits::Capnp,
 };
 use rusqlite::{Row, params, types::Value};
 use serde::{Deserialize, Serialize};
@@ -98,6 +98,7 @@ impl Node {
 
     pub fn get_sequences_by_node_ids(
         conn: &GraphConnection,
+        _workspace: &Workspace,
         node_ids: &[HashId],
         history_ref: Option<&str>,
     ) -> HashMap<HashId, Sequence> {
@@ -107,7 +108,7 @@ impl Node {
             .map(|node| (node.id, node.sequence_hash))
             .collect::<HashMap<HashId, Sha256Hash>>();
         let sequences_by_hash: HashMap<Sha256Hash, Sequence> = HashMap::from_iter(
-            Sequence::query_by_ids(
+            <Sequence as Query>::query_by_ids(
                 conn,
                 &sequence_hashes_by_node_id
                     .values()
@@ -119,12 +120,14 @@ impl Node {
             .map(|seq| (seq.hash, seq.clone())),
         );
         sequence_hashes_by_node_id
-            .clone()
             .into_iter()
             .map(|(node_id, sequence_hash)| {
                 (
                     node_id,
-                    sequences_by_hash.get(&sequence_hash).unwrap().clone(),
+                    sequences_by_hash
+                        .get(&sequence_hash)
+                        .expect("should load sequence for node")
+                        .clone(),
                 )
             })
             .collect::<HashMap<HashId, Sequence>>()

--- a/gen-models/src/path.rs
+++ b/gen-models/src/path.rs
@@ -2,7 +2,7 @@ use core::ops::Range as RustRange;
 use std::collections::{HashMap, HashSet};
 
 use gen_core::{
-    HashId, NodeIntervalBlock, PATH_END_NODE_ID, PATH_START_NODE_ID, PathBlock, Strand,
+    HashId, NodeIntervalBlock, PATH_END_NODE_ID, PATH_START_NODE_ID, PathBlock, Strand, Workspace,
     calculate_hash, is_end_node, is_start_node,
     range::{Range, RangeMapping},
     region::{Region, RegionResolutionError, RegionResolver},
@@ -22,7 +22,7 @@ use crate::{
     gen_models_capnp::path as PathCapnp,
     node::Node,
     path_edge::PathEdge,
-    sequence::{Sequence, SequenceError},
+    sequence::SequenceError,
     traits::*,
 };
 
@@ -274,9 +274,10 @@ impl Path {
     pub fn sequence(
         &self,
         conn: &GraphConnection,
+        workspace: &Workspace,
         history_ref: Option<&str>,
     ) -> Result<String, PathError> {
-        let blocks = self.blocks(conn, history_ref)?;
+        let blocks = self.blocks(conn, workspace, history_ref)?;
         Ok(blocks
             .into_iter()
             .map(|block| block.block_sequence)
@@ -289,69 +290,24 @@ impl Path {
         conn: &GraphConnection,
         history_ref: Option<&str>,
     ) -> Result<i64, PathError> {
-        let blocks = self.blocks(conn, history_ref)?;
-        let end_block = blocks.last().unwrap();
-        // the last block is the terminal node, which starts at the end of the path
-        Ok(end_block.path_start)
+        let edges = PathEdge::edges_for_path(conn, &self.id, history_ref);
+        Ok(edges
+            .into_iter()
+            .tuple_windows()
+            .map(|(into, out_of)| out_of.source_coordinate - into.target_coordinate)
+            .sum())
     }
 
-    pub fn edge_pairs_to_block(
-        &self,
-        into: Edge,
-        out_of: Edge,
-        sequences_by_node_id: &HashMap<HashId, Sequence>,
-        current_path_length: i64,
-    ) -> Result<PathBlock, PathError> {
-        let start = into.target_coordinate;
-        let end = out_of.source_coordinate;
-        let strand = into.target_strand;
-        let block_sequence_length = end - start;
-        let Some(sequence) = sequences_by_node_id.get(&into.target_node_id) else {
-            return Err(PathError::Missing(format!(
-                "Missing sequence for node {} while building path {}",
-                into.target_node_id, self.id
-            )));
-        };
-
-        let block_sequence = if strand == Strand::Reverse {
-            revcomp(&sequence.get_sequence(start, end)?)
-        } else {
-            sequence.get_sequence(start, end)?
-        };
-
-        Ok(PathBlock {
-            node_id: into.target_node_id,
-            block_sequence,
-            sequence_start: start,
-            sequence_end: end,
-            path_start: current_path_length,
-            path_end: current_path_length + block_sequence_length,
-            strand,
-        })
-    }
-
-    pub fn blocks(
+    /// Returns path blocks without loading their sequence content.
+    ///
+    /// Coordinate-only consumers do not need repository access and therefore should not require a
+    /// workspace merely to calculate node ranges or path length.
+    pub fn coordinate_blocks(
         &self,
         conn: &GraphConnection,
         history_ref: Option<&str>,
-    ) -> Result<Vec<PathBlock>, PathError> {
+    ) -> Vec<PathBlock> {
         let edges = PathEdge::edges_for_path(conn, &self.id, history_ref);
-
-        let mut sequence_node_ids = HashSet::new();
-        for edge in &edges {
-            if !is_start_node(edge.source_node_id) {
-                sequence_node_ids.insert(edge.source_node_id);
-            }
-            if !is_end_node(edge.target_node_id) {
-                sequence_node_ids.insert(edge.target_node_id);
-            }
-        }
-        let sequences_by_node_id = Node::get_sequences_by_node_ids(
-            conn,
-            &sequence_node_ids.into_iter().collect::<Vec<_>>(),
-            history_ref,
-        );
-
         let mut blocks = vec![];
         let mut path_length = 0;
 
@@ -369,10 +325,19 @@ impl Path {
         });
 
         for (into, out_of) in edges.into_iter().tuple_windows() {
-            let block =
-                self.edge_pairs_to_block(into, out_of, &sequences_by_node_id, path_length)?;
-            path_length += block.block_sequence.len() as i64;
-            blocks.push(block);
+            let sequence_start = into.target_coordinate;
+            let sequence_end = out_of.source_coordinate;
+            let block_length = sequence_end - sequence_start;
+            blocks.push(PathBlock {
+                node_id: into.target_node_id,
+                block_sequence: String::new(),
+                sequence_start,
+                sequence_end,
+                path_start: path_length,
+                path_end: path_length + block_length,
+                strand: into.target_strand,
+            });
+            path_length += block_length;
         }
 
         // NOTE: Adding an "end block" for the dedicated end sequence with a range from the path
@@ -388,6 +353,43 @@ impl Path {
             strand: Strand::Forward,
         });
 
+        blocks
+    }
+
+    pub fn blocks(
+        &self,
+        conn: &GraphConnection,
+        workspace: &Workspace,
+        history_ref: Option<&str>,
+    ) -> Result<Vec<PathBlock>, PathError> {
+        let mut blocks = self.coordinate_blocks(conn, history_ref);
+        let sequence_node_ids = blocks
+            .iter()
+            .filter(|block| !is_start_node(block.node_id) && !is_end_node(block.node_id))
+            .map(|block| block.node_id)
+            .collect::<HashSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
+        let sequences_by_node_id =
+            Node::get_sequences_by_node_ids(conn, workspace, &sequence_node_ids, history_ref);
+
+        for block in &mut blocks {
+            if is_start_node(block.node_id) || is_end_node(block.node_id) {
+                continue;
+            }
+            let sequence = sequences_by_node_id.get(&block.node_id).ok_or_else(|| {
+                PathError::Missing(format!(
+                    "Missing sequence for node {} while building path {}",
+                    block.node_id, self.id
+                ))
+            })?;
+            block.block_sequence = if block.strand == Strand::Reverse {
+                revcomp(&sequence.get_sequence(block.sequence_start, block.sequence_end)?)
+            } else {
+                sequence.get_sequence(block.sequence_start, block.sequence_end)?
+            };
+        }
+
         Ok(blocks)
     }
 
@@ -395,7 +397,7 @@ impl Path {
         &self,
         conn: &GraphConnection,
     ) -> Result<IntervalTree<i64, NodeIntervalBlock>, PathError> {
-        let blocks = self.blocks(conn, None)?;
+        let blocks = self.coordinate_blocks(conn, None);
         let tree: IntervalTree<i64, NodeIntervalBlock> = blocks
             .into_iter()
             .map(|block| {
@@ -422,8 +424,8 @@ impl Path {
     ) -> Result<Vec<RangeMapping>, PathError> {
         // Given two paths, find the overlapping parts of common nodes/blocks and return a list af
         // mappings from subranges of one path to corresponding shared subranges of the other path
-        let our_blocks = self.blocks(conn, None)?;
-        let their_blocks = other_path.blocks(conn, None)?;
+        let our_blocks = self.coordinate_blocks(conn, None);
+        let their_blocks = other_path.coordinate_blocks(conn, None);
 
         let our_node_ids = our_blocks
             .iter()
@@ -636,11 +638,11 @@ impl Path {
         annotations: Vec<Annotation>,
     ) -> Result<Vec<Annotation>, PathError> {
         let mapping_tree = self.get_mapping_tree(conn, path)?;
-        let sequence_length = path.sequence(conn, None)?.len();
+        let sequence_length = path.length(conn, None)?;
         Ok(annotations
             .into_iter()
             .filter_map(|annotation| {
-                Path::propagate_annotation(annotation, &mapping_tree, sequence_length as i64)
+                Path::propagate_annotation(annotation, &mapping_tree, sequence_length)
             })
             .clone()
             .collect())
@@ -963,7 +965,8 @@ mod tests {
         collection::Collection,
         edge::Edge,
         sample::{NewSample, Sample},
-        test_helpers::{create_bg, get_connection},
+        sequence::Sequence,
+        test_helpers::{create_bg, get_connection, test_workspace},
     };
 
     fn create_test_block_group(conn: &GraphConnection) -> BlockGroup {
@@ -1458,7 +1461,7 @@ mod tests {
 
         let path = Path::create(conn, "chr1", &block_group.id, &edge_ids).unwrap();
         assert_eq!(
-            path.sequence(conn, None).unwrap(),
+            path.sequence(conn, test_workspace(), None).unwrap(),
             "ATCGATCGAAAAAAACCCCCCCGGGGGGG"
         );
     }
@@ -1557,7 +1560,7 @@ mod tests {
 
         let path = Path::create(conn, "chr1", &block_group.id, &edge_ids).unwrap();
         assert_eq!(
-            path.sequence(conn, None).unwrap(),
+            path.sequence(conn, test_workspace(), None).unwrap(),
             "CCCCCCCGGGGGGGTTTTTTTCGATCGAT"
         );
     }
@@ -1822,7 +1825,7 @@ mod tests {
         assert_eq!(block4.strand, Strand::Forward);
 
         assert_eq!(
-            path.sequence(conn, None).unwrap(),
+            path.sequence(conn, test_workspace(), None).unwrap(),
             "ATCGAAAAAAAACCCCCCCCGGGG"
         );
     }
@@ -2099,7 +2102,10 @@ mod tests {
 
         let path2 = Path::create(conn, "chr2", &block_group.id, &edge_ids).unwrap();
 
-        assert_eq!(path2.sequence(conn, None).unwrap(), "ATCGTTTTTTTT");
+        assert_eq!(
+            path2.sequence(conn, test_workspace(), None).unwrap(),
+            "ATCGTTTTTTTT"
+        );
 
         let mappings = path1.find_block_mappings(conn, &path2).unwrap();
         assert_eq!(mappings.len(), 1);
@@ -2217,7 +2223,10 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(path2.sequence(conn, None).unwrap(), "ATCGTTTTTTTTATCG");
+        assert_eq!(
+            path2.sequence(conn, test_workspace(), None).unwrap(),
+            "ATCGTTTTTTTTATCG"
+        );
 
         let mappings = path1.find_block_mappings(conn, &path2).unwrap();
         assert_eq!(mappings.len(), 2);
@@ -2341,7 +2350,10 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(path2.sequence(conn, None).unwrap(), "ATTTTTTTTTCG");
+        assert_eq!(
+            path2.sequence(conn, test_workspace(), None).unwrap(),
+            "ATTTTTTTTTCG"
+        );
 
         let mappings = path1.find_block_mappings(conn, &path2).unwrap();
         assert_eq!(mappings.len(), 2);
@@ -2448,7 +2460,10 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(path2.sequence(conn, None).unwrap(), "ATCG");
+        assert_eq!(
+            path2.sequence(conn, test_workspace(), None).unwrap(),
+            "ATCG"
+        );
 
         let mappings = path1.find_block_mappings(conn, &path2).unwrap();
         assert_eq!(mappings.len(), 2);
@@ -2590,7 +2605,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            path2.sequence(conn, None).unwrap(),
+            path2.sequence(conn, test_workspace(), None).unwrap(),
             "ATCGATCGAAAAAAAATTTTTTTT"
         );
 
@@ -2733,7 +2748,10 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(path2.sequence(conn, None).unwrap(), "ATCGAAAAAAAATTTT");
+        assert_eq!(
+            path2.sequence(conn, test_workspace(), None).unwrap(),
+            "ATCGAAAAAAAATTTT"
+        );
 
         let mappings = path1.find_block_mappings(conn, &path2).unwrap();
         assert_eq!(mappings.len(), 2);
@@ -2857,7 +2875,10 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(path2.sequence(conn, None).unwrap(), "ATCGTTTT");
+        assert_eq!(
+            path2.sequence(conn, test_workspace(), None).unwrap(),
+            "ATCGTTTT"
+        );
 
         let mappings = path1.find_block_mappings(conn, &path2).unwrap();
         assert_eq!(mappings.len(), 2);
@@ -3160,7 +3181,10 @@ mod tests {
 
         let path2 = Path::create(conn, "chr2", &block_group.id, &edge_ids).unwrap();
 
-        assert_eq!(path2.sequence(conn, None).unwrap(), "ATCGTTTTTTTT");
+        assert_eq!(
+            path2.sequence(conn, test_workspace(), None).unwrap(),
+            "ATCGTTTTTTTT"
+        );
 
         let annotation = Annotation {
             name: "foo".to_string(),
@@ -3283,7 +3307,10 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(path2.sequence(conn, None).unwrap(), "ATCGTTTTTTTTATCG");
+        assert_eq!(
+            path2.sequence(conn, test_workspace(), None).unwrap(),
+            "ATCGTTTTTTTTATCG"
+        );
 
         let annotation = Annotation {
             name: "foo".to_string(),
@@ -3410,7 +3437,10 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(path2.sequence(conn, None).unwrap(), "ATTTTTTTTTCG");
+        assert_eq!(
+            path2.sequence(conn, test_workspace(), None).unwrap(),
+            "ATTTTTTTTTCG"
+        );
 
         let annotation = Annotation {
             name: "foo".to_string(),
@@ -3554,7 +3584,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            path2.sequence(conn, None).unwrap(),
+            path2.sequence(conn, test_workspace(), None).unwrap(),
             "ATCGATCGAAAAAAAATTTTTTTT"
         );
 
@@ -3683,7 +3713,10 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(path2.sequence(conn, None).unwrap(), "ATCGTTTT");
+        assert_eq!(
+            path2.sequence(conn, test_workspace(), None).unwrap(),
+            "ATCGTTTT"
+        );
 
         let annotation = Annotation {
             name: "foo".to_string(),
@@ -3764,7 +3797,10 @@ mod tests {
         BlockGroupEdge::bulk_create(conn, &block_group_edges);
 
         let path1 = Path::create(conn, "chr1", &block_group.id, &edge_ids).unwrap();
-        assert_eq!(path1.sequence(conn, None).unwrap(), "ATCGATCGAAAAAAAA");
+        assert_eq!(
+            path1.sequence(conn, test_workspace(), None).unwrap(),
+            "ATCGATCGAAAAAAAA"
+        );
 
         let sequence3 = Sequence::new()
             .sequence_type("DNA")
@@ -3806,7 +3842,10 @@ mod tests {
         BlockGroupEdge::bulk_create(conn, &block_group_edges);
 
         let path2 = path1.new_path_with(conn, 4, 11, &edge4, &edge5).unwrap();
-        assert_eq!(path2.sequence(conn, None).unwrap(), "ATCGCCCCCCCCAAAAA");
+        assert_eq!(
+            path2.sequence(conn, test_workspace(), None).unwrap(),
+            "ATCGCCCCCCCCAAAAA"
+        );
 
         let edge6 = Edge::create(
             conn,
@@ -3842,7 +3881,10 @@ mod tests {
         BlockGroupEdge::bulk_create(conn, &block_group_edges);
 
         let path3 = path1.new_path_with(conn, 4, 7, &edge6, &edge7).unwrap();
-        assert_eq!(path3.sequence(conn, None).unwrap(), "ATCGCCCCCCCCGAAAAAAAA");
+        assert_eq!(
+            path3.sequence(conn, test_workspace(), None).unwrap(),
+            "ATCGCCCCCCCCGAAAAAAAA"
+        );
     }
 
     #[test]
@@ -3906,7 +3948,10 @@ mod tests {
         BlockGroupEdge::bulk_create(conn, &block_group_edges);
 
         let path1 = Path::create(conn, "chr1", &block_group.id, &edge_ids).unwrap();
-        assert_eq!(path1.sequence(conn, None).unwrap(), "ATCGATCGAAAAAAAA");
+        assert_eq!(
+            path1.sequence(conn, test_workspace(), None).unwrap(),
+            "ATCGATCGAAAAAAAA"
+        );
 
         let deletion_edge = Edge::create(
             conn,
@@ -3929,7 +3974,10 @@ mod tests {
         BlockGroupEdge::bulk_create(conn, &[block_group_edge]);
 
         let path2 = path1.new_path_with_deletion(conn, 4, 11).unwrap();
-        assert_eq!(path2.sequence(conn, None).unwrap(), "ATCGAAAAA");
+        assert_eq!(
+            path2.sequence(conn, test_workspace(), None).unwrap(),
+            "ATCGAAAAA"
+        );
     }
 
     #[test]

--- a/gen-models/src/region.rs
+++ b/gen-models/src/region.rs
@@ -1,6 +1,6 @@
 pub use gen_core::region::Region;
 use gen_core::{
-    HashId, NodeIntervalBlock, PRESERVE_EDIT_SITE_CHROMOSOME_INDEX, Strand, is_terminal,
+    HashId, NodeIntervalBlock, PRESERVE_EDIT_SITE_CHROMOSOME_INDEX, Strand, Workspace, is_terminal,
     region::{RegionParseError, RegionResolutionError, RegionResolver},
 };
 use gen_graph::{GraphNode, GraphNodePosition};
@@ -467,6 +467,7 @@ impl ResolvedGenRegion {
     pub fn intervaltree(
         &self,
         conn: &GraphConnection,
+        workspace: &Workspace,
     ) -> Result<IntervalTree<i64, NodeIntervalBlock>, GenRegionError> {
         match self.kind {
             ResolvedRegionKind::Path => {
@@ -490,6 +491,7 @@ impl ResolvedGenRegion {
             }
             ResolvedRegionKind::BlockGroup => Ok(BlockGroup::intervaltree_for(
                 conn,
+                workspace,
                 &self.block_group.id,
                 self.remove_ambiguous_positions,
             )?),
@@ -499,11 +501,12 @@ impl ResolvedGenRegion {
     pub fn find_graph_positions(
         &self,
         conn: &GraphConnection,
+        workspace: &Workspace,
         start_offset: i64,
         end_offset: i64,
     ) -> Result<Self, gen_graph::GraphError> {
         let (start_positions, end_positions) =
-            self.compute_graph_positions(conn, start_offset, end_offset)?;
+            self.compute_graph_positions(conn, workspace, start_offset, end_offset)?;
         let mut region = self.clone();
         region.start_anchors = Some(start_positions);
         region.end_anchors = Some(end_positions);
@@ -513,6 +516,7 @@ impl ResolvedGenRegion {
     fn compute_graph_positions(
         &self,
         conn: &GraphConnection,
+        workspace: &Workspace,
         start_offset: i64,
         end_offset: i64,
     ) -> Result<
@@ -523,7 +527,7 @@ impl ResolvedGenRegion {
         gen_graph::GraphError,
     > {
         let interval_tree = self
-            .intervaltree(conn)
+            .intervaltree(conn, workspace)
             .map_err(|_| gen_graph::GraphError::NoPath)?;
         let filtered: Vec<(std::ops::Range<i64>, gen_core::NodeIntervalBlock)> = interval_tree
             .iter()
@@ -540,16 +544,16 @@ impl ResolvedGenRegion {
             interval_tree: tree,
             block_group_id: self.block_group.id,
         };
-        let start_anchor = resolved.resolve_anchor(self.start, conn)?;
-        let end_anchor = resolved.resolve_anchor(self.end, conn)?;
+        let start_anchor = resolved.resolve_anchor(self.start, conn, workspace)?;
+        let end_anchor = resolved.resolve_anchor(self.end, conn, workspace)?;
 
         let start_positions =
             crate::graph::find_offset(&mut graph, &start_anchor, start_offset, |g, nid| {
-                crate::graph::expand(conn, g, &self.block_group.id, nid)
+                crate::graph::expand(conn, workspace, g, &self.block_group.id, nid)
             })?;
         let end_positions =
             crate::graph::find_offset(&mut graph, &end_anchor, end_offset, |g, nid| {
-                crate::graph::expand(conn, g, &self.block_group.id, nid)
+                crate::graph::expand(conn, workspace, g, &self.block_group.id, nid)
             })?;
 
         Ok((start_positions, end_positions))
@@ -562,6 +566,7 @@ impl ResolvedGenRegion {
     pub fn plan_edges(
         &self,
         conn: &GraphConnection,
+        workspace: &Workspace,
         change: &BlockGroupChange,
         tree: Option<&IntervalTree<i64, NodeIntervalBlock>>,
     ) -> Result<Vec<AugmentedEdgeData>, BlockGroupError> {
@@ -571,7 +576,7 @@ impl ResolvedGenRegion {
                 let tree = match tree {
                     Some(tree) => tree,
                     None => {
-                        local_tree = IntervalTreeSource::intervaltree(self, conn)?;
+                        local_tree = IntervalTreeSource::intervaltree(self, conn, workspace)?;
                         &local_tree
                     }
                 };
@@ -613,7 +618,7 @@ impl ResolvedGenRegion {
                 (start_positions, end_positions)
             } else {
                 let resolved = self
-                    .find_graph_positions(conn, 0, 0)
+                    .find_graph_positions(conn, workspace, 0, 0)
                     .map_err(|err| BlockGroupError::ChangeOutOfBounds(err.to_string()))?;
                 (
                     resolved.start_anchors.expect("should have start anchors"),
@@ -701,8 +706,9 @@ impl IntervalTreeSource for ResolvedGenRegion {
     fn intervaltree(
         &self,
         conn: &GraphConnection,
+        workspace: &Workspace,
     ) -> Result<IntervalTree<i64, NodeIntervalBlock>, BlockGroupError> {
-        ResolvedGenRegion::intervaltree(self, conn)
+        ResolvedGenRegion::intervaltree(self, conn, workspace)
             .map_err(|err| BlockGroupError::ChangeOutOfBounds(err.to_string()))
     }
 }
@@ -713,7 +719,7 @@ mod tests {
     use crate::{
         annotations::Annotation,
         block_group::{BlockGroup, PathCache},
-        test_helpers::{get_connection, setup_block_group},
+        test_helpers::{get_connection, setup_block_group, test_workspace},
     };
 
     fn setup_targets() -> (
@@ -1467,7 +1473,9 @@ mod tests {
             let acc = create_accession(&conn, bg_id, "within", 0, 15);
             let region = make_region(bg, acc, 0, 15, 15, 7, 7);
 
-            let resolved = region.find_graph_positions(&conn, 2, 2).unwrap();
+            let resolved = region
+                .find_graph_positions(&conn, test_workspace(), 2, 2)
+                .unwrap();
             let start_pos = resolved.start_anchors.as_ref().unwrap();
             let end_pos = resolved.end_anchors.as_ref().unwrap();
             assert_eq!(start_pos.len(), 1);
@@ -1488,7 +1496,9 @@ mod tests {
             let acc = create_accession(&conn, bg_id, "fwd", 0, 15);
             let region = make_region(bg, acc, 0, 15, 15, 7, 7);
 
-            let resolved = region.find_graph_positions(&conn, 5, 5).unwrap();
+            let resolved = region
+                .find_graph_positions(&conn, test_workspace(), 5, 5)
+                .unwrap();
             let start_pos = resolved.start_anchors.as_ref().unwrap();
             let end_pos = resolved.end_anchors.as_ref().unwrap();
             assert_eq!(start_pos.len(), 1);
@@ -1509,7 +1519,9 @@ mod tests {
             let acc = create_accession(&conn, bg_id, "bwd", 0, 15);
             let region = make_region(bg, acc, 0, 15, 15, 7, 7);
 
-            let resolved = region.find_graph_positions(&conn, -5, -5).unwrap();
+            let resolved = region
+                .find_graph_positions(&conn, test_workspace(), -5, -5)
+                .unwrap();
             let start_pos = resolved.start_anchors.as_ref().unwrap();
             let end_pos = resolved.end_anchors.as_ref().unwrap();
             assert_eq!(start_pos.len(), 1);
@@ -1530,7 +1542,11 @@ mod tests {
             let acc = create_accession(&conn, bg_id, "oob", 0, 15);
             let region = make_region(bg, acc, 0, 15, 15, 7, 7);
 
-            assert!(region.find_graph_positions(&conn, 100, 100).is_err());
+            assert!(
+                region
+                    .find_graph_positions(&conn, test_workspace(), 100, 100)
+                    .is_err()
+            );
         }
 
         #[test]
@@ -1540,7 +1556,9 @@ mod tests {
             let acc = create_accession(&conn, bg_id, "start", 0, 15);
             let region = make_region(bg, acc, 0, 15, 15, 0, 0);
 
-            let resolved = region.find_graph_positions(&conn, 12, 12).unwrap();
+            let resolved = region
+                .find_graph_positions(&conn, test_workspace(), 12, 12)
+                .unwrap();
             let start_pos = resolved.start_anchors.as_ref().unwrap();
             let end_pos = resolved.end_anchors.as_ref().unwrap();
             assert_eq!(start_pos.len(), 1);
@@ -1561,7 +1579,9 @@ mod tests {
             let acc = create_accession(&conn, bg_id, "end", 0, 15);
             let region = make_region(bg, acc, 0, 15, 15, 14, 14);
 
-            let resolved = region.find_graph_positions(&conn, -14, -14).unwrap();
+            let resolved = region
+                .find_graph_positions(&conn, test_workspace(), -14, -14)
+                .unwrap();
             let start_pos = resolved.start_anchors.as_ref().unwrap();
             let end_pos = resolved.end_anchors.as_ref().unwrap();
             assert_eq!(start_pos.len(), 1);
@@ -1582,7 +1602,9 @@ mod tests {
             let acc = create_accession(&conn, bg_id, "acc-within", 5, 10);
             let region = make_region(bg, acc, 5, 10, 5, 2, 2);
 
-            let resolved = region.find_graph_positions(&conn, 1, 1).unwrap();
+            let resolved = region
+                .find_graph_positions(&conn, test_workspace(), 1, 1)
+                .unwrap();
             let start_pos = resolved.start_anchors.as_ref().unwrap();
             let end_pos = resolved.end_anchors.as_ref().unwrap();
             assert_eq!(start_pos.len(), 1);
@@ -1603,7 +1625,9 @@ mod tests {
             let acc = create_accession(&conn, bg_id, "acc-fwd", 5, 10);
             let region = make_region(bg, acc, 5, 10, 5, 3, 3);
 
-            let resolved = region.find_graph_positions(&conn, 5, 5).unwrap();
+            let resolved = region
+                .find_graph_positions(&conn, test_workspace(), 5, 5)
+                .unwrap();
             let start_pos = resolved.start_anchors.as_ref().unwrap();
             let end_pos = resolved.end_anchors.as_ref().unwrap();
             assert_eq!(start_pos.len(), 1);
@@ -1624,7 +1648,9 @@ mod tests {
             let acc = create_accession(&conn, bg_id, "acc-bwd", 5, 10);
             let region = make_region(bg, acc, 5, 10, 5, 1, 1);
 
-            let resolved = region.find_graph_positions(&conn, -4, -4).unwrap();
+            let resolved = region
+                .find_graph_positions(&conn, test_workspace(), -4, -4)
+                .unwrap();
             let start_pos = resolved.start_anchors.as_ref().unwrap();
             let end_pos = resolved.end_anchors.as_ref().unwrap();
             assert_eq!(start_pos.len(), 1);
@@ -1645,7 +1671,11 @@ mod tests {
             let acc = create_accession(&conn, bg_id, "acc-oob", 5, 10);
             let region = make_region(bg, acc, 5, 10, 5, 2, 2);
 
-            assert!(region.find_graph_positions(&conn, 100, 100).is_err());
+            assert!(
+                region
+                    .find_graph_positions(&conn, test_workspace(), 100, 100)
+                    .is_err()
+            );
         }
 
         #[test]
@@ -1657,7 +1687,9 @@ mod tests {
             let region = make_region(bg, acc, 3, 6, 3, 0, 0);
 
             // Backward 3 from TTT offset 0 → should find AAA and GGG at offset 0
-            let resolved = region.find_graph_positions(&conn, -3, -3).unwrap();
+            let resolved = region
+                .find_graph_positions(&conn, test_workspace(), -3, -3)
+                .unwrap();
             let start_pos = resolved.start_anchors.as_ref().unwrap();
             let end_pos = resolved.end_anchors.as_ref().unwrap();
             assert_eq!(start_pos.len(), 2);
@@ -1682,7 +1714,9 @@ mod tests {
             let region = make_region(bg, acc, 3, 6, 3, 2, 2);
 
             // Forward 3 from TTT offset 2 → should find CCC and ATC at offset 2
-            let resolved = region.find_graph_positions(&conn, 3, 3).unwrap();
+            let resolved = region
+                .find_graph_positions(&conn, test_workspace(), 3, 3)
+                .unwrap();
             let start_pos = resolved.start_anchors.as_ref().unwrap();
             let end_pos = resolved.end_anchors.as_ref().unwrap();
             assert_eq!(start_pos.len(), 2);
@@ -1713,7 +1747,7 @@ mod tests {
             let aaa_region = make_region(bg.clone(), aaa_acc, 0, 3, 3, 2, 2);
 
             let from_aaa = aaa_region
-                .find_graph_positions(&fixture.conn, 2, 2)
+                .find_graph_positions(&fixture.conn, test_workspace(), 2, 2)
                 .unwrap();
             assert_eq!(
                 position_set(&from_aaa.start_anchors.unwrap()),
@@ -1734,7 +1768,7 @@ mod tests {
             let ttt_region = make_region(bg, ttt_acc, 5, 8, 3, 0, 0);
 
             let from_ttt = ttt_region
-                .find_graph_positions(&fixture.conn, -2, -2)
+                .find_graph_positions(&fixture.conn, test_workspace(), -2, -2)
                 .unwrap();
             assert_eq!(
                 position_set(&from_ttt.start_anchors.unwrap()),
@@ -1759,7 +1793,9 @@ mod tests {
             );
             let region = make_region(bg, acc, 0, 3, 3, 1, 1);
 
-            let positions = region.find_graph_positions(&fixture.conn, 1, 1).unwrap();
+            let positions = region
+                .find_graph_positions(&fixture.conn, test_workspace(), 1, 1)
+                .unwrap();
             assert_eq!(
                 position_set(&positions.start_anchors.unwrap()),
                 HashSet::from([(HashId::convert_str("node-aaa"), 2)])
@@ -1780,7 +1816,9 @@ mod tests {
             );
             let region = make_region(bg, acc, 0, 3, 3, 2, 2);
 
-            let positions = region.find_graph_positions(&fixture.conn, 6, 6).unwrap();
+            let positions = region
+                .find_graph_positions(&fixture.conn, test_workspace(), 6, 6)
+                .unwrap();
             assert_eq!(
                 position_set(&positions.start_anchors.unwrap()),
                 HashSet::from([

--- a/gen-models/src/sample.rs
+++ b/gen-models/src/sample.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashSet, rc::Rc};
 
-use gen_core::traits::Capnp;
+use gen_core::{Workspace, traits::Capnp};
 use gen_graph::GenGraph;
 use rusqlite::{Result as SQLResult, Row, params, types::Value as SQLValue};
 use serde::{Deserialize, Serialize};
@@ -181,6 +181,7 @@ impl Sample {
 
     pub fn get_graph(
         conn: &GraphConnection,
+        workspace: &Workspace,
         collection: &str,
         name: &str,
         history_ref: Option<&str>,
@@ -188,7 +189,7 @@ impl Sample {
         let block_groups = Sample::get_block_groups(conn, collection, name, history_ref);
         let mut sample_graph = GenGraph::new();
         for bg in block_groups {
-            let bg_graph = BlockGroup::get_graph(conn, &bg.id, history_ref)?;
+            let bg_graph = BlockGroup::get_graph(conn, workspace, &bg.id, history_ref)?;
             // Add nodes and edges from block group graph to sample graph
             for node in bg_graph.nodes() {
                 sample_graph.add_node(node);
@@ -206,6 +207,7 @@ impl Sample {
 
     pub fn get_all_sequences(
         conn: &GraphConnection,
+        workspace: &Workspace,
         collection_name: &str,
         sample_name: &str,
         prune: bool,
@@ -214,7 +216,12 @@ impl Sample {
         let mut sequences = HashSet::new();
         for block_group in Sample::get_block_groups(conn, collection_name, sample_name, history_ref)
         {
-            sequences.extend(BlockGroup::get_all_sequences(conn, &block_group.id, prune)?);
+            sequences.extend(BlockGroup::get_all_sequences(
+                conn,
+                workspace,
+                &block_group.id,
+                prune,
+            )?);
         }
         Ok(sequences)
     }

--- a/gen-models/src/test_helpers.rs
+++ b/gen-models/src/test_helpers.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Debug, fs, ops::Add};
+use std::{fmt::Debug, fs, ops::Add, sync::OnceLock};
 
 use gen_core::{
     HashId, PATH_END_NODE_ID, PATH_START_NODE_ID, Strand, config::Workspace,
@@ -99,6 +99,16 @@ pub fn setup_gen_on_disk() -> DbContext {
     let graph_conn = get_connection(workspace.graph_db_path().unwrap().to_str().unwrap()).unwrap();
     let config_conn = get_config_connection(workspace.gen_db_path().unwrap().to_str()).unwrap();
     DbContext::new(workspace, graph_conn, config_conn).unwrap()
+}
+
+pub fn test_workspace() -> &'static Workspace {
+    static WORKSPACE: OnceLock<Workspace> = OnceLock::new();
+
+    WORKSPACE.get_or_init(|| {
+        let workspace = Workspace::new(tempdir().unwrap().keep());
+        workspace.ensure_gen_dir();
+        workspace
+    })
 }
 
 pub fn setup_block_group(conn: &GraphConnection) -> (HashId, Path) {

--- a/gen-python/src/python_api/block_group.rs
+++ b/gen-python/src/python_api/block_group.rs
@@ -233,9 +233,10 @@ impl PySequenceGraph {
             )
         })?;
         let conn = context.graph().conn();
-        let graph =
-            BlockGroup::get_graph(conn, &self.id, None).map_err(block_group_err_to_pyerr)?;
-        let matcher = GenGraphMatcher::new_with_sequence_kind(conn, graph, kind);
+        let graph = BlockGroup::get_graph(conn, context.workspace(), &self.id, None)
+            .map_err(block_group_err_to_pyerr)?;
+        let matcher =
+            GenGraphMatcher::new_with_sequence_kind(conn, context.workspace(), graph, kind);
 
         let gen_dir = context.workspace().ensure_gen_dir();
         let index_path = gen_dir
@@ -295,9 +296,10 @@ impl PySequenceGraph {
         fs::create_dir_all(&index_dir)
             .map_err(|e| PyRuntimeError::new_err(format!("Failed to create index dir: {e}")))?;
         let conn = context.graph().conn();
-        let graph =
-            BlockGroup::get_graph(conn, &self.id, None).map_err(block_group_err_to_pyerr)?;
-        let matcher = GenGraphMatcher::new_with_sequence_kind(conn, graph, kind);
+        let graph = BlockGroup::get_graph(conn, context.workspace(), &self.id, None)
+            .map_err(block_group_err_to_pyerr)?;
+        let matcher =
+            GenGraphMatcher::new_with_sequence_kind(conn, context.workspace(), graph, kind);
         let normalized = kind != SequenceKind::Exact;
         let index = SeedIndex::build(&matcher, k, normalized);
         let path = index_dir.join(format!("{}.bin", self.id));
@@ -342,8 +344,10 @@ impl PySequenceGraph {
     /// Raises ``RuntimeError`` if this sequence graph was not created via a
     /// ``Repository``.
     fn get_node_sequence(&self, node: &PyGraphNode) -> PyResult<String> {
-        let conn = self.require_context("get_node_sequence()")?.graph().conn();
-        let sequences = Node::get_sequences_by_node_ids(conn, &[node.node_id], None);
+        let context = self.require_context("get_node_sequence()")?;
+        let conn = context.graph().conn();
+        let sequences =
+            Node::get_sequences_by_node_ids(conn, context.workspace(), &[node.node_id], None);
         let sequence = sequences.get(&node.node_id).ok_or_else(|| {
             pyo3::exceptions::PyValueError::new_err(format!(
                 "Node with id {:?} not found",
@@ -356,9 +360,10 @@ impl PySequenceGraph {
     }
 
     fn to_dict(&self, py: Python<'_>) -> PyResult<PyObject> {
-        let conn = self.require_context("to_dict()")?.graph().conn();
-        let graph =
-            BlockGroup::get_graph(conn, &self.id, None).map_err(block_group_err_to_pyerr)?;
+        let context = self.require_context("to_dict()")?;
+        let conn = context.graph().conn();
+        let graph = BlockGroup::get_graph(conn, context.workspace(), &self.id, None)
+            .map_err(block_group_err_to_pyerr)?;
         let dict = PyDict::new(py);
         let nodes: Vec<PyGraphNode> = graph
             .nodes()
@@ -392,9 +397,10 @@ impl PySequenceGraph {
     }
 
     fn to_rustworkx(&self, py: Python<'_>) -> PyResult<PyObject> {
-        let conn = self.require_context("to_rustworkx()")?.graph().conn();
-        let graph =
-            BlockGroup::get_graph(conn, &self.id, None).map_err(block_group_err_to_pyerr)?;
+        let context = self.require_context("to_rustworkx()")?;
+        let conn = context.graph().conn();
+        let graph = BlockGroup::get_graph(conn, context.workspace(), &self.id, None)
+            .map_err(block_group_err_to_pyerr)?;
         {
             let rustworkx = PyModule::import(py, "rustworkx").map_err(|_| {
                 pyo3::exceptions::PyModuleNotFoundError::new_err(
@@ -434,9 +440,10 @@ impl PySequenceGraph {
     }
 
     fn to_networkx(&self, py: Python<'_>) -> PyResult<PyObject> {
-        let conn = self.require_context("to_networkx()")?.graph().conn();
-        let graph =
-            BlockGroup::get_graph(conn, &self.id, None).map_err(block_group_err_to_pyerr)?;
+        let context = self.require_context("to_networkx()")?;
+        let conn = context.graph().conn();
+        let graph = BlockGroup::get_graph(conn, context.workspace(), &self.id, None)
+            .map_err(block_group_err_to_pyerr)?;
         {
             let networkx = PyModule::import(py, "networkx").map_err(|_| {
                 pyo3::exceptions::PyModuleNotFoundError::new_err(
@@ -496,6 +503,7 @@ impl PySequenceGraph {
         let conn = ctx.graph().conn();
         export_fasta(
             conn,
+            ctx.workspace(),
             &self.collection_name,
             Some(&self.sample_name),
             &PathBuf::from(&filename),
@@ -517,6 +525,7 @@ impl PySequenceGraph {
         let conn = ctx.graph().conn();
         export_gfa(
             conn,
+            ctx.workspace(),
             &self.collection_name,
             &PathBuf::from(&filename),
             &self.sample_name,
@@ -537,7 +546,15 @@ impl PySequenceGraph {
         let writer = fs::File::create(&filename).map_err(|e| {
             PyRuntimeError::new_err(format!("Failed to create '{}': {e}", filename))
         })?;
-        export_genbank(conn, &self.collection_name, &self.sample_name, writer, None).map_err(|e| {
+        export_genbank(
+            conn,
+            ctx.workspace(),
+            &self.collection_name,
+            &self.sample_name,
+            writer,
+            None,
+        )
+        .map_err(|e| {
             PyRuntimeError::new_err(format!("Failed to export GenBank '{}': {e}", filename))
         })
     }
@@ -624,11 +641,11 @@ impl PySequenceGraph {
                 let bg_id = self.id;
                 if let Some(start) = start {
                     run_translation_operation(ctx, &label, || {
-                        translate_from_path(conn, &bg_id, start, params)
+                        translate_from_path(conn, ctx.workspace(), &bg_id, start, params)
                     })
                 } else {
                     run_translation_operation(ctx, &label, || {
-                        translate_block_group(conn, &bg_id, params)
+                        translate_block_group(conn, ctx.workspace(), &bg_id, params)
                     })
                 }
             }
@@ -636,7 +653,13 @@ impl PySequenceGraph {
                 if let Ok(ann) = region.extract::<PyRef<PyAnnotation>>() {
                     let annotation = ann.inner.clone();
                     run_translation_operation(ctx, &annotation.name, || {
-                        translate_annotation(conn, &annotation, Some(&self.id), params)
+                        translate_annotation(
+                            conn,
+                            ctx.workspace(),
+                            &annotation,
+                            Some(&self.id),
+                            params,
+                        )
                     })
                 } else if let Ok(region_str) = region.extract::<&str>() {
                     // Resolution scoped to self: named path first, then annotation in lineage.
@@ -646,7 +669,7 @@ impl PySequenceGraph {
                     if path.is_some() {
                         let coordinate = start.unwrap_or(0);
                         run_translation_operation(ctx, region_str, || {
-                            translate_from_path(conn, &self.id, coordinate, params)
+                            translate_from_path(conn, ctx.workspace(), &self.id, coordinate, params)
                         })
                     } else {
                         let annotation = Annotation::query_with_lineage(
@@ -666,7 +689,13 @@ impl PySequenceGraph {
                         })?;
 
                         run_translation_operation(ctx, region_str, || {
-                            translate_annotation(conn, &annotation, Some(&self.id), params)
+                            translate_annotation(
+                                conn,
+                                ctx.workspace(),
+                                &annotation,
+                                Some(&self.id),
+                                params,
+                            )
                         })
                     }
                 } else {

--- a/gen-python/src/python_api/jupyter_widget.rs
+++ b/gen-python/src/python_api/jupyter_widget.rs
@@ -25,7 +25,7 @@ use r#gen::{
     },
 };
 use gen_annotations::projection::annotation_segments;
-use gen_core::{HashId, is_end_node, is_start_node};
+use gen_core::{HashId, Workspace, is_end_node, is_start_node};
 use gen_graph::GenGraph;
 use gen_models::{
     annotations::{Annotation, AnnotationError},
@@ -268,6 +268,7 @@ fn sort_key_longest_first(span: &AnnotationSpan) -> i64 {
 struct GraphPage {
     name: String,
     db_path: PathBuf,
+    workspace: Workspace,
     pub(crate) block_group_id: Option<HashId>,
     controller: GraphController<GenGraph, GenGraphNodeSizer>,
     /// Annotation and path overlays. The path (added by `show_path`, removed by
@@ -286,6 +287,7 @@ struct GraphPage {
 struct PageRef {
     name: String,
     db_path: PathBuf,
+    workspace: Workspace,
     block_group_id: HashId,
 }
 
@@ -307,13 +309,14 @@ impl Page {
 }
 
 impl GraphPage {
-    fn new(name: String, db_path: PathBuf, graph: GenGraph) -> Self {
+    fn new(name: String, db_path: PathBuf, workspace: Workspace, graph: GenGraph) -> Self {
         let mut controller = GraphController::new(graph, GenGraphNodeSizer);
         controller.set_detail_level(VisualDetail::Truncated);
         controller.hide_cursor();
         Self {
             name,
             db_path,
+            workspace,
             block_group_id: None,
             controller,
             overlays: Vec::new(),
@@ -352,6 +355,7 @@ impl GraphPage {
             .ok_or_else(|| AnnotationError::DatabaseError(rusqlite::Error::QueryReturnedNoRows))?;
         let spans = load_annotations_for_group(&AnnotationGroupTrackRequest {
             conn,
+            workspace: &self.workspace,
             history_ref: None,
             current_block_group: &current_block_group,
             entry: &entry,
@@ -513,7 +517,7 @@ impl GraphPage {
         self.reapply();
         {
             let conn = self.open_conn()?;
-            let renderer = GenGraphNodeRenderer::new(&conn);
+            let renderer = GenGraphNodeRenderer::new(&conn, &self.workspace);
             GraphWidget::with_renderer(renderer).render(graph_area, buf, &mut self.controller);
         }
 
@@ -740,7 +744,7 @@ impl GraphPage {
 
         let path = BlockGroup::get_current_path(&conn, &block_group_id, None)
             .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
-        let path_blocks = path.blocks(&conn, None).unwrap_or_default();
+        let path_blocks = path.coordinate_blocks(&conn, None);
         let path_nodes = project_path_overlay_nodes(self.controller.graph(), &path_blocks);
 
         if path_nodes.is_empty() {
@@ -825,6 +829,7 @@ impl GraphPage {
             let translate_result: Result<(), String> = match ext.as_str() {
                 "gff" | "gff3" => translate_gff(
                     &conn,
+                    &self.workspace,
                     &bg.collection_name,
                     sample,
                     None,
@@ -837,6 +842,7 @@ impl GraphPage {
                 .map_err(|e| e.to_string()),
                 "bed" => translate_bed(
                     &conn,
+                    &self.workspace,
                     &bg.collection_name,
                     sample,
                     None,
@@ -1089,9 +1095,9 @@ fn loaded_page_for_sequence_graph(sg: &PySequenceGraph) -> PyResult<GraphPage> {
         .path()
         .map(PathBuf::from)
         .ok_or_else(|| PyRuntimeError::new_err("graph DB has no file path"))?;
-    let graph =
-        BlockGroup::get_graph(graph_conn, &sg.id, None).map_err(block_group_err_to_pyerr)?;
-    let mut page = GraphPage::new(sg.name.clone(), db_path, graph);
+    let graph = BlockGroup::get_graph(graph_conn, context.workspace(), &sg.id, None)
+        .map_err(block_group_err_to_pyerr)?;
+    let mut page = GraphPage::new(sg.name.clone(), db_path, context.workspace().clone(), graph);
     page.block_group_id = Some(sg.id);
     Ok(page)
 }
@@ -1113,6 +1119,7 @@ fn page_ref_for_sequence_graph(sg: &PySequenceGraph) -> PyResult<PageRef> {
     Ok(PageRef {
         name: sg.name.clone(),
         db_path,
+        workspace: context.workspace().clone(),
         block_group_id: sg.id,
     })
 }
@@ -1148,11 +1155,12 @@ pub struct PyGraphController {
 
 impl PyGraphController {
     /// Wrap a single, already-loaded graph as a one-page controller.
-    pub fn new(db_path: PathBuf, graph: GenGraph) -> Self {
+    pub fn new(db_path: PathBuf, workspace: Workspace, graph: GenGraph) -> Self {
         Self {
             pages: vec![Page::Loaded(Box::new(GraphPage::new(
                 String::new(),
                 db_path,
+                workspace,
                 graph,
             )))],
             current_index: 0,
@@ -1190,9 +1198,15 @@ impl PyGraphController {
         if let Page::Pending(page_ref) = page {
             let conn = get_connection(&page_ref.db_path)
                 .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
-            let graph = BlockGroup::get_graph(&conn, &page_ref.block_group_id, None)
-                .map_err(block_group_err_to_pyerr)?;
-            let mut loaded = GraphPage::new(page_ref.name.clone(), page_ref.db_path.clone(), graph);
+            let graph =
+                BlockGroup::get_graph(&conn, &page_ref.workspace, &page_ref.block_group_id, None)
+                    .map_err(block_group_err_to_pyerr)?;
+            let mut loaded = GraphPage::new(
+                page_ref.name.clone(),
+                page_ref.db_path.clone(),
+                page_ref.workspace.clone(),
+                graph,
+            );
             loaded.block_group_id = Some(page_ref.block_group_id);
             *page = Page::Loaded(Box::new(loaded));
         }
@@ -1514,9 +1528,9 @@ mod tests {
             .map(std::path::PathBuf::from)
             .expect("test DB must be file-backed");
         let (bg_id, _) = setup_block_group(graph_handle.conn());
-        let graph = BlockGroup::get_graph(graph_handle.conn(), &bg_id, None)
+        let graph = BlockGroup::get_graph(graph_handle.conn(), ctx.workspace(), &bg_id, None)
             .map_err(crate::python_api::utils::block_group_err_to_pyerr)?;
-        let mut ctrl = PyGraphController::new(db_path, graph);
+        let mut ctrl = PyGraphController::new(db_path, ctx.workspace().clone(), graph);
         if let Some(node_detail) = detail {
             ctrl.set_detail(node_detail)?;
         }

--- a/gen-python/src/python_api/repository/exports.rs
+++ b/gen-python/src/python_api/repository/exports.rs
@@ -19,6 +19,7 @@ impl PyRepository {
         let collection = collection.unwrap_or_else(|| self.get_default_collection());
         export_fasta(
             conn,
+            self.context.workspace(),
             &collection,
             sample.as_deref(),
             &PathBuf::from(&filename),
@@ -40,6 +41,7 @@ impl PyRepository {
         let sample = sample.unwrap_or_else(|| Sample::DEFAULT_NAME.to_string());
         export_gfa(
             conn,
+            self.context.workspace(),
             &collection,
             &PathBuf::from(&filename),
             &sample,
@@ -62,7 +64,14 @@ impl PyRepository {
         let writer = fs::File::create(&filename).map_err(|e| {
             PyRuntimeError::new_err(format!("Failed to create '{}': {e}", filename))
         })?;
-        export_genbank(conn, &collection, &sample, writer, None)
-            .map_err(|e| PyRuntimeError::new_err(format!("Failed to export '{}': {e}", filename)))
+        export_genbank(
+            conn,
+            self.context.workspace(),
+            &collection,
+            &sample,
+            writer,
+            None,
+        )
+        .map_err(|e| PyRuntimeError::new_err(format!("Failed to export '{}': {e}", filename)))
     }
 }

--- a/gen-python/src/python_api/repository/mod.rs
+++ b/gen-python/src/python_api/repository/mod.rs
@@ -378,8 +378,12 @@ impl PyRepository {
     }
 
     fn get_node_sequence(&self, node_key: &PyGraphNode) -> PyResult<String> {
-        let sequences_by_node_id =
-            Node::get_sequences_by_node_ids(self.context.graph().conn(), &[node_key.node_id], None);
+        let sequences_by_node_id = Node::get_sequences_by_node_ids(
+            self.context.graph().conn(),
+            self.context.workspace(),
+            &[node_key.node_id],
+            None,
+        );
         let sequence = sequences_by_node_id.get(&node_key.node_id).ok_or_else(|| {
             pyo3::exceptions::PyValueError::new_err(format!(
                 "Node with id {:?} not found",

--- a/gen-python/src/python_api/repository/search.rs
+++ b/gen-python/src/python_api/repository/search.rs
@@ -45,9 +45,14 @@ impl PyRepository {
         };
 
         for bg in bgs {
-            let graph =
-                BlockGroup::get_graph(conn, &bg.id, None).map_err(block_group_err_to_pyerr)?;
-            let matcher = GenGraphMatcher::new_with_sequence_kind(conn, graph, kind);
+            let graph = BlockGroup::get_graph(conn, self.context.workspace(), &bg.id, None)
+                .map_err(block_group_err_to_pyerr)?;
+            let matcher = GenGraphMatcher::new_with_sequence_kind(
+                conn,
+                self.context.workspace(),
+                graph,
+                kind,
+            );
             let index = SeedIndex::build(&matcher, k, normalized);
             let path = index_dir.join(format!("{}.bin", bg.id));
             let bytes = index
@@ -93,9 +98,14 @@ impl PyRepository {
         let query_bytes = query.as_bytes();
         let mut results = Vec::new();
         for bg in bgs {
-            let graph =
-                BlockGroup::get_graph(conn, &bg.id, None).map_err(block_group_err_to_pyerr)?;
-            let matcher = GenGraphMatcher::new_with_sequence_kind(conn, graph, kind);
+            let graph = BlockGroup::get_graph(conn, self.context.workspace(), &bg.id, None)
+                .map_err(block_group_err_to_pyerr)?;
+            let matcher = GenGraphMatcher::new_with_sequence_kind(
+                conn,
+                self.context.workspace(),
+                graph,
+                kind,
+            );
 
             let index_path = self
                 .context

--- a/gen-r/src/rust/src/lib.rs
+++ b/gen-r/src/rust/src/lib.rs
@@ -264,12 +264,13 @@ fn annotation_record(conn: &GraphConnection, annotation: &Annotation, graph: &Ge
 /// lineage. Single listing route shared by `SequenceGraph` and `Repository`.
 fn list_annotation_records(
     conn: &GraphConnection,
+    workspace: &Workspace,
     block_group_id: &HashId,
     collection_name: &str,
     sample_name: &str,
     name: &str,
 ) -> std::result::Result<List, Error> {
-    let graph = BlockGroup::get_graph(conn, block_group_id, None)
+    let graph = BlockGroup::get_graph(conn, workspace, block_group_id, None)
         .map_err(|e| Error::Other(e.to_string()))?;
     let annotations = Annotation::query_with_lineage(conn, collection_name, sample_name, name)
         .map_err(|e| Error::Other(e.to_string()))?;
@@ -568,6 +569,7 @@ enum TrackSpec {
 
 fn load_tracks_from_specs(
     conn: &GraphConnection,
+    workspace: &Workspace,
     controller: &GraphController<GenGraph, GenGraphNodeSizer>,
     sequence_graph_id: &HashId,
     tracks_json: &str,
@@ -601,6 +603,7 @@ fn load_tracks_from_specs(
                     };
                     let request = AnnotationGroupTrackRequest {
                         conn,
+                        workspace,
                         history_ref: None,
                         current_block_group: &bg,
                         entry: &entry,
@@ -615,6 +618,7 @@ fn load_tracks_from_specs(
                 let display_name = name.as_deref().unwrap_or(&path);
                 tracks.push(load_annotation_file_as_track(
                     conn,
+                    workspace,
                     sequence_graph_id,
                     &path,
                     display_name,
@@ -629,6 +633,7 @@ fn load_tracks_from_specs(
 
 fn load_annotation_file_as_track(
     conn: &GraphConnection,
+    workspace: &Workspace,
     sequence_graph_id: &HashId,
     file_path: &str,
     display_name: &str,
@@ -652,6 +657,7 @@ fn load_annotation_file_as_track(
                 .and_then(|f| {
                     translate_gff(
                         conn,
+                        workspace,
                         &bg.collection_name,
                         sample_name,
                         None,
@@ -664,7 +670,16 @@ fn load_annotation_file_as_track(
             "bed" => File::open(file_path)
                 .ok()
                 .and_then(|f| {
-                    translate_bed(conn, &bg.collection_name, sample_name, None, f, &mut buffer).ok()
+                    translate_bed(
+                        conn,
+                        workspace,
+                        &bg.collection_name,
+                        sample_name,
+                        None,
+                        f,
+                        &mut buffer,
+                    )
+                    .ok()
                 })
                 .is_some(),
             _ => false,
@@ -1108,7 +1123,8 @@ impl Repository {
     ) -> std::result::Result<String, Error> {
         let conn = self.context.graph().conn();
         let nid = hash_id_from_string(&node_id).map_err(Error::Other)?;
-        let sequences = Node::get_sequences_by_node_ids(conn, &[nid], None);
+        let sequences =
+            Node::get_sequences_by_node_ids(conn, self.context.workspace(), &[nid], None);
         let seq = sequences
             .get(&nid)
             .ok_or_else(|| Error::Other(format!("Node with id {nid} not found")))?;
@@ -1766,6 +1782,7 @@ impl Repository {
         .map_err(Error::Other)?;
         r#gen::exports::fasta::export_fasta(
             self.context.graph().conn(),
+            self.context.workspace(),
             &collection_name,
             nullable_string_to_option(sample).as_deref(),
             &PathBuf::from(&filename),
@@ -1789,6 +1806,7 @@ impl Repository {
         .map_err(Error::Other)?;
         r#gen::exports::gfa::export_gfa(
             self.context.graph().conn(),
+            self.context.workspace(),
             &collection_name,
             &PathBuf::from(&filename),
             &sample,
@@ -1815,6 +1833,7 @@ impl Repository {
         })?);
         r#gen::exports::genbank::export_genbank(
             self.context.graph().conn(),
+            self.context.workspace(),
             &collection_name,
             &sample,
             writer,
@@ -1875,9 +1894,14 @@ impl Repository {
                 .collect()
         };
         for bg in bgs {
-            let graph = BlockGroup::get_graph(conn, &bg.id, None)
+            let graph = BlockGroup::get_graph(conn, self.context.workspace(), &bg.id, None)
                 .map_err(|e| Error::Other(e.to_string()))?;
-            let matcher = GenGraphMatcher::new_with_sequence_kind(conn, graph, kind);
+            let matcher = GenGraphMatcher::new_with_sequence_kind(
+                conn,
+                self.context.workspace(),
+                graph,
+                kind,
+            );
             let index = SeedIndex::build(&matcher, k as usize, normalized);
             let path = index_dir.join(format!("{}.bin", bg.id));
             let bytes = index
@@ -1914,9 +1938,14 @@ impl Repository {
             .join("search_index");
         let mut results = Vec::new();
         for bg in bgs {
-            let graph = BlockGroup::get_graph(conn, &bg.id, None)
+            let graph = BlockGroup::get_graph(conn, self.context.workspace(), &bg.id, None)
                 .map_err(|e| Error::Other(e.to_string()))?;
-            let matcher = GenGraphMatcher::new_with_sequence_kind(conn, graph, kind);
+            let matcher = GenGraphMatcher::new_with_sequence_kind(
+                conn,
+                self.context.workspace(),
+                graph,
+                kind,
+            );
             let index_path = index_dir.join(format!("{}.bin", bg.id));
             let index = fs::read(&index_path)
                 .ok()
@@ -2052,7 +2081,14 @@ impl Repository {
         let bg_id = hash_id_from_string(&sequence_graph_id).map_err(Error::Other)?;
         let bg = BlockGroup::get_by_id(conn, &bg_id, None)
             .map_err(|e| Error::Other(format!("Block group not found: {e}")))?;
-        list_annotation_records(conn, &bg.id, &bg.collection_name, &bg.sample_name, &bg.name)
+        list_annotation_records(
+            conn,
+            self.context.workspace(),
+            &bg.id,
+            &bg.collection_name,
+            &bg.sample_name,
+            &bg.name,
+        )
     }
 
     fn render_frame(
@@ -2067,8 +2103,8 @@ impl Repository {
     ) -> std::result::Result<String, Error> {
         let conn = self.context.graph().conn();
         let bg_id = hash_id_from_string(&sequence_graph_id).map_err(Error::Other)?;
-        let graph =
-            BlockGroup::get_graph(conn, &bg_id, None).map_err(|e| Error::Other(e.to_string()))?;
+        let graph = BlockGroup::get_graph(conn, self.context.workspace(), &bg_id, None)
+            .map_err(|e| Error::Other(e.to_string()))?;
         let node_sizer = GenGraphNodeSizer;
         let mut controller = GraphController::new(graph, node_sizer);
         controller.set_detail_level(visual_detail(&detail).map_err(Error::Other)?);
@@ -2077,7 +2113,13 @@ impl Repository {
         let area = Rect::new(0, 0, cols as u16, rows as u16);
         let mut buf = Buffer::empty(area);
 
-        let tracks = load_tracks_from_specs(conn, &controller, &bg_id, &tracks_json);
+        let tracks = load_tracks_from_specs(
+            conn,
+            self.context.workspace(),
+            &controller,
+            &bg_id,
+            &tracks_json,
+        );
 
         // Parse the caller-supplied color map: id_hex → Some(color) to use that
         // color, None to hide the annotation entirely. Empty map means use the
@@ -2122,7 +2164,7 @@ impl Repository {
         apply_graph_ops(&mut controller, &ops).map_err(Error::Other)?;
 
         // Render graph with highlights applied.
-        let renderer = GenGraphNodeRenderer::new(conn);
+        let renderer = GenGraphNodeRenderer::new(conn, self.context.workspace());
         GraphWidget::with_renderer(renderer).render(area, &mut buf, &mut controller);
 
         // Draw floating labels after the graph, then a single hint if any were hidden.
@@ -2154,8 +2196,8 @@ impl Repository {
     ) -> std::result::Result<bool, Error> {
         let conn = self.context.graph().conn();
         let bg_id = hash_id_from_string(&sequence_graph_id).map_err(Error::Other)?;
-        let graph =
-            BlockGroup::get_graph(conn, &bg_id, None).map_err(|e| Error::Other(e.to_string()))?;
+        let graph = BlockGroup::get_graph(conn, self.context.workspace(), &bg_id, None)
+            .map_err(|e| Error::Other(e.to_string()))?;
         let node_sizer = GenGraphNodeSizer;
         let mut controller = GraphController::new(graph, node_sizer);
         controller.set_detail_level(visual_detail(&detail).map_err(Error::Other)?);
@@ -2268,6 +2310,7 @@ impl SequenceGraph {
         let conn = self.context.graph().conn();
         fasta_export(
             conn,
+            self.context.workspace(),
             &self.collection_name,
             Some(&self.sample_name),
             &PathBuf::from(&filename),
@@ -2284,6 +2327,7 @@ impl SequenceGraph {
         let conn = self.context.graph().conn();
         gfa_export(
             conn,
+            self.context.workspace(),
             &self.collection_name,
             &PathBuf::from(&filename),
             &self.sample_name,
@@ -2299,8 +2343,15 @@ impl SequenceGraph {
             File::create(&filename)
                 .map_err(|e| Error::Other(format!("Failed to create file '{filename}': {e}")))?,
         );
-        genbank_export(conn, &self.collection_name, &self.sample_name, writer, None)
-            .map_err(|e| Error::Other(format!("GenBank export failed: {e}")))
+        genbank_export(
+            conn,
+            self.context.workspace(),
+            &self.collection_name,
+            &self.sample_name,
+            writer,
+            None,
+        )
+        .map_err(|e| Error::Other(format!("GenBank export failed: {e}")))
     }
 
     fn build_index(&self, sequence_kind: String, k: i32) -> std::result::Result<(), Error> {
@@ -2314,9 +2365,10 @@ impl SequenceGraph {
             .join("search_index");
         fs::create_dir_all(&index_dir)
             .map_err(|e| Error::Other(format!("Failed to create index dir: {e}")))?;
-        let graph =
-            BlockGroup::get_graph(conn, &self.id, None).map_err(|e| Error::Other(e.to_string()))?;
-        let matcher = GenGraphMatcher::new_with_sequence_kind(conn, graph, kind);
+        let graph = BlockGroup::get_graph(conn, self.context.workspace(), &self.id, None)
+            .map_err(|e| Error::Other(e.to_string()))?;
+        let matcher =
+            GenGraphMatcher::new_with_sequence_kind(conn, self.context.workspace(), graph, kind);
         let index = SeedIndex::build(&matcher, k as usize, normalized);
         let path = index_dir.join(format!("{}.bin", self.id));
         let bytes = index
@@ -2328,9 +2380,10 @@ impl SequenceGraph {
     fn search(&self, query: String, sequence_kind: String) -> std::result::Result<List, Error> {
         let kind = parse_sequence_kind_r(&sequence_kind).map_err(Error::Other)?;
         let conn = self.context.graph().conn();
-        let graph =
-            BlockGroup::get_graph(conn, &self.id, None).map_err(|e| Error::Other(e.to_string()))?;
-        let matcher = GenGraphMatcher::new_with_sequence_kind(conn, graph, kind);
+        let graph = BlockGroup::get_graph(conn, self.context.workspace(), &self.id, None)
+            .map_err(|e| Error::Other(e.to_string()))?;
+        let matcher =
+            GenGraphMatcher::new_with_sequence_kind(conn, self.context.workspace(), graph, kind);
         let index_dir = self
             .context
             .workspace()
@@ -2373,7 +2426,8 @@ impl SequenceGraph {
     ) -> std::result::Result<String, Error> {
         let conn = self.context.graph().conn();
         let nid = hash_id_from_string(&node_id).map_err(Error::Other)?;
-        let sequences = Node::get_sequences_by_node_ids(conn, &[nid], None);
+        let sequences =
+            Node::get_sequences_by_node_ids(conn, self.context.workspace(), &[nid], None);
         let seq = sequences
             .get(&nid)
             .ok_or_else(|| Error::Other(format!("Node with id {nid} not found")))?;
@@ -2462,8 +2516,8 @@ impl SequenceGraph {
 
     fn to_dict(&self) -> std::result::Result<List, Error> {
         let conn = self.context.graph().conn();
-        let graph =
-            BlockGroup::get_graph(conn, &self.id, None).map_err(|e| Error::Other(e.to_string()))?;
+        let graph = BlockGroup::get_graph(conn, self.context.workspace(), &self.id, None)
+            .map_err(|e| Error::Other(e.to_string()))?;
 
         let nodes = graph
             .nodes()
@@ -2517,6 +2571,7 @@ impl SequenceGraph {
         let conn = self.context.graph().conn();
         list_annotation_records(
             conn,
+            self.context.workspace(),
             &self.id,
             &self.collection_name,
             &self.sample_name,
@@ -2600,11 +2655,11 @@ impl SequenceGraph {
             let label = self.name.clone();
             if let Some(start) = start {
                 run_translation_operation(&self.context, &label, || {
-                    translate_from_path(conn, &bg_id, start, tr_params)
+                    translate_from_path(conn, self.context.workspace(), &bg_id, start, tr_params)
                 })?
             } else {
                 run_translation_operation(&self.context, &label, || {
-                    translate_block_group(conn, &bg_id, tr_params)
+                    translate_block_group(conn, self.context.workspace(), &bg_id, tr_params)
                 })?
             }
         } else if let Some(name) = robj_scalar_string(&region) {
@@ -2615,7 +2670,13 @@ impl SequenceGraph {
             if path.is_some() {
                 let coordinate = start.unwrap_or(0);
                 run_translation_operation(&self.context, &name, || {
-                    translate_from_path(conn, &bg_id, coordinate, tr_params)
+                    translate_from_path(
+                        conn,
+                        self.context.workspace(),
+                        &bg_id,
+                        coordinate,
+                        tr_params,
+                    )
                 })?
             } else {
                 let annotation = Annotation::query_with_lineage(
@@ -2635,7 +2696,13 @@ impl SequenceGraph {
                 })?;
 
                 run_translation_operation(&self.context, &name, || {
-                    translate_annotation(conn, &annotation, Some(&bg_id), tr_params)
+                    translate_annotation(
+                        conn,
+                        self.context.workspace(),
+                        &annotation,
+                        Some(&bg_id),
+                        tr_params,
+                    )
                 })?
             }
         } else if let Some(id) = gen_annotation_record_id(&region)? {
@@ -2643,7 +2710,13 @@ impl SequenceGraph {
                 .ok_or_else(|| Error::Other(format!("Annotation with id '{id}' not found")))?;
             let label = annotation.name.clone();
             run_translation_operation(&self.context, &label, || {
-                translate_annotation(conn, &annotation, Some(&bg_id), tr_params)
+                translate_annotation(
+                    conn,
+                    self.context.workspace(),
+                    &annotation,
+                    Some(&bg_id),
+                    tr_params,
+                )
             })?
         } else {
             return Err(Error::Other(

--- a/src/commands/export/fasta.rs
+++ b/src/commands/export/fasta.rs
@@ -38,6 +38,7 @@ pub fn execute(cli_context: &CliContext, cmd: Command) -> Result<()> {
         .unwrap_or_else(|| get_default_collection(config_conn));
     export_fasta(
         conn,
+        context.workspace(),
         name,
         Some(cmd.sample.as_str()),
         &PathBuf::from(cmd.path),

--- a/src/commands/export/genbank.rs
+++ b/src/commands/export/genbank.rs
@@ -39,6 +39,7 @@ pub fn execute(cli_context: &CliContext, cmd: Command) -> Result<()> {
     let file = File::create(PathBuf::from(cmd.path))?;
     export_genbank(
         conn,
+        context.workspace(),
         name,
         cmd.sample.as_str(),
         file,

--- a/src/commands/export/gfa.rs
+++ b/src/commands/export/gfa.rs
@@ -41,6 +41,7 @@ pub fn execute(cli_context: &CliContext, cmd: Command) -> Result<()> {
         .unwrap_or_else(|| get_default_collection(config_conn));
     export_gfa(
         conn,
+        context.workspace(),
         name,
         &PathBuf::from(cmd.path),
         cmd.sample.as_str(),

--- a/src/commands/graph_operations/derive_chunks.rs
+++ b/src/commands/graph_operations/derive_chunks.rs
@@ -187,7 +187,7 @@ mod tests {
             .map(|bg| {
                 BlockGroup::get_current_path(conn, &bg.id, None)
                     .unwrap()
-                    .sequence(conn, None)
+                    .sequence(conn, context.workspace(), None)
                     .unwrap()
             })
             .collect()

--- a/src/commands/graph_operations/derive_translation.rs
+++ b/src/commands/graph_operations/derive_translation.rs
@@ -81,9 +81,21 @@ pub fn derive_translation_operation(
         Some(annotation)
             if resolved.start == resolved.anchor_start && resolved.end == resolved.anchor_end =>
         {
-            translate_annotation(graph_conn, annotation, Some(&bg_id), tr_params)
+            translate_annotation(
+                graph_conn,
+                db_context.workspace(),
+                annotation,
+                Some(&bg_id),
+                tr_params,
+            )
         }
-        _ => translate_from_path(graph_conn, &bg_id, resolved.start, tr_params),
+        _ => translate_from_path(
+            graph_conn,
+            db_context.workspace(),
+            &bg_id,
+            resolved.start,
+            tr_params,
+        ),
     };
     let protein_bg = match protein_result {
         Ok(protein_bg) => protein_bg,

--- a/src/commands/graph_operations/make_stitch.rs
+++ b/src/commands/graph_operations/make_stitch.rs
@@ -156,7 +156,7 @@ mod tests {
         let stitched_sequence =
             BlockGroup::get_current_path(graph_conn, &stitched_block_group_id, None)
                 .unwrap()
-                .sequence(graph_conn, None)
+                .sequence(graph_conn, context.workspace(), None)
                 .unwrap();
         assert_eq!(stitched_sequence, "ATCGATCGATCGATCGATCGGGAACACACAGAGA");
     }

--- a/src/diffs/gfa.rs
+++ b/src/diffs/gfa.rs
@@ -5,7 +5,7 @@ use std::{
     path::PathBuf,
 };
 
-use gen_core::{NodeIntervalBlock, range::Range};
+use gen_core::{NodeIntervalBlock, Workspace, range::Range};
 use gen_models::{
     block_group::{BlockGroup, BlockGroupError},
     db::GraphConnection,
@@ -30,6 +30,7 @@ pub enum GfaDiffError {
 
 pub fn gfa_sample_diff(
     conn: &GraphConnection,
+    workspace: &Workspace,
     collection_name: &str,
     filename: &PathBuf,
     from_sample_name: &str,
@@ -136,7 +137,7 @@ pub fn gfa_sample_diff(
         }
 
         if let Some(source_path) = source_path_result {
-            let source_sequence = source_path.sequence(conn, None)?;
+            let source_sequence = source_path.sequence(conn, workspace, None)?;
 
             let source_len = source_sequence.len() as i64;
             if last_source_position < source_len {
@@ -159,7 +160,7 @@ pub fn gfa_sample_diff(
         }
 
         if let Some(target_path) = target_path_result {
-            let target_sequence = target_path.sequence(conn, None)?;
+            let target_sequence = target_path.sequence(conn, workspace, None)?;
 
             let target_len = target_sequence.len() as i64;
             if last_target_position < target_len {
@@ -402,6 +403,7 @@ mod tests {
         let gfa_path = temp_dir.path().join("parent-child-diff.gfa");
         gfa_sample_diff(
             conn,
+            context.workspace(),
             collection_name,
             &gfa_path,
             Sample::DEFAULT_NAME,
@@ -419,8 +421,13 @@ mod tests {
         let new_child_block_group = Collection::get_block_groups(conn, "test collection 2", None)
             .pop()
             .unwrap();
-        let all_child_sequences =
-            BlockGroup::get_all_sequences(conn, &new_child_block_group.id, false).unwrap();
+        let all_child_sequences = BlockGroup::get_all_sequences(
+            conn,
+            crate::test_helpers::test_workspace(),
+            &new_child_block_group.id,
+            false,
+        )
+        .unwrap();
 
         // We've replaced the middle AAAA with CCCC, so expect that as the child sequence
         assert_eq!(
@@ -487,6 +494,7 @@ mod tests {
         let gfa_path = temp_dir.path().join("parent-grandchild-diff.gfa");
         gfa_sample_diff(
             conn,
+            context.workspace(),
             collection_name,
             &gfa_path,
             Sample::DEFAULT_NAME,
@@ -504,8 +512,13 @@ mod tests {
             Collection::get_block_groups(conn, "test collection 3", None)
                 .pop()
                 .unwrap();
-        let all_grandchild_sequences =
-            BlockGroup::get_all_sequences(conn, &new_grandchild_block_group.id, false).unwrap();
+        let all_grandchild_sequences = BlockGroup::get_all_sequences(
+            conn,
+            crate::test_helpers::test_workspace(),
+            &new_grandchild_block_group.id,
+            false,
+        )
+        .unwrap();
 
         // We've replaced the middle AAAA with CCCC and the middle TTTT with GGGG, so four possible sequences
         assert_eq!(
@@ -522,7 +535,15 @@ mod tests {
         );
 
         let gfa_path = temp_dir.path().join("child-grandchild-diff.gfa");
-        gfa_sample_diff(conn, collection_name, &gfa_path, "child", "grandchild").unwrap();
+        gfa_sample_diff(
+            conn,
+            context.workspace(),
+            collection_name,
+            &gfa_path,
+            "child",
+            "grandchild",
+        )
+        .unwrap();
 
         let _ = import_gfa(
             &context,
@@ -535,8 +556,13 @@ mod tests {
             Collection::get_block_groups(conn, "test collection 4", None)
                 .pop()
                 .unwrap();
-        let all_grandchild_sequences =
-            BlockGroup::get_all_sequences(conn, &new_grandchild_block_group.id, false).unwrap();
+        let all_grandchild_sequences = BlockGroup::get_all_sequences(
+            conn,
+            crate::test_helpers::test_workspace(),
+            &new_grandchild_block_group.id,
+            false,
+        )
+        .unwrap();
 
         assert_eq!(
             all_grandchild_sequences,
@@ -625,6 +651,7 @@ mod tests {
         let gfa_path = temp_dir.path().join("diff-against-nothing.gfa");
         gfa_sample_diff(
             conn,
+            context.workspace(),
             collection_name,
             &gfa_path,
             Sample::DEFAULT_NAME,
@@ -642,8 +669,13 @@ mod tests {
         let new_block_group = Collection::get_block_groups(conn, "test collection 2", None)
             .pop()
             .unwrap();
-        let all_sequences =
-            BlockGroup::get_all_sequences(conn, &new_block_group.id, false).unwrap();
+        let all_sequences = BlockGroup::get_all_sequences(
+            conn,
+            crate::test_helpers::test_workspace(),
+            &new_block_group.id,
+            false,
+        )
+        .unwrap();
 
         assert_eq!(
             all_sequences,
@@ -732,6 +764,7 @@ mod tests {
         let gfa_path = temp_dir.path().join("self-diff.gfa");
         gfa_sample_diff(
             conn,
+            context.workspace(),
             collection_name,
             &gfa_path,
             "test sample",
@@ -749,8 +782,13 @@ mod tests {
         let new_block_group = Collection::get_block_groups(conn, "test collection 2", None)
             .pop()
             .unwrap();
-        let all_sequences =
-            BlockGroup::get_all_sequences(conn, &new_block_group.id, false).unwrap();
+        let all_sequences = BlockGroup::get_all_sequences(
+            conn,
+            crate::test_helpers::test_workspace(),
+            &new_block_group.id,
+            false,
+        )
+        .unwrap();
 
         assert_eq!(
             all_sequences,
@@ -903,7 +941,15 @@ mod tests {
 
         let temp_dir = tempdir().unwrap();
         let gfa_path = temp_dir.path().join("unrelated-diff.gfa");
-        gfa_sample_diff(conn, collection_name, &gfa_path, "sample1", "sample2").unwrap();
+        gfa_sample_diff(
+            conn,
+            context.workspace(),
+            collection_name,
+            &gfa_path,
+            "sample1",
+            "sample2",
+        )
+        .unwrap();
 
         let _ = import_gfa(
             &context,
@@ -915,8 +961,13 @@ mod tests {
         let new_block_group = Collection::get_block_groups(conn, "test collection 3", None)
             .pop()
             .unwrap();
-        let all_sequences =
-            BlockGroup::get_all_sequences(conn, &new_block_group.id, false).unwrap();
+        let all_sequences = BlockGroup::get_all_sequences(
+            conn,
+            crate::test_helpers::test_workspace(),
+            &new_block_group.id,
+            false,
+        )
+        .unwrap();
 
         assert_eq!(
             all_sequences,
@@ -1070,7 +1121,15 @@ mod tests {
 
         let temp_dir = tempdir().unwrap();
         let gfa_path = temp_dir.path().join("unrelated-diff.gfa");
-        gfa_sample_diff(conn, collection_name, &gfa_path, "sample1", "sample2").unwrap();
+        gfa_sample_diff(
+            conn,
+            context.workspace(),
+            collection_name,
+            &gfa_path,
+            "sample1",
+            "sample2",
+        )
+        .unwrap();
 
         let _ = import_gfa(
             &context,
@@ -1082,8 +1141,13 @@ mod tests {
         let new_block_group = Collection::get_block_groups(conn, "test collection 3", None)
             .pop()
             .unwrap();
-        let all_sequences =
-            BlockGroup::get_all_sequences(conn, &new_block_group.id, false).unwrap();
+        let all_sequences = BlockGroup::get_all_sequences(
+            conn,
+            crate::test_helpers::test_workspace(),
+            &new_block_group.id,
+            false,
+        )
+        .unwrap();
 
         assert_eq!(
             all_sequences,
@@ -1208,6 +1272,7 @@ mod tests {
         let gfa_path = temp_dir.path().join("parent-child-diff.gfa");
         gfa_sample_diff(
             conn,
+            context.workspace(),
             collection_name,
             &gfa_path,
             Sample::DEFAULT_NAME,
@@ -1225,8 +1290,13 @@ mod tests {
         let new_child_block_group = Collection::get_block_groups(conn, "test collection 2", None)
             .pop()
             .unwrap();
-        let all_child_sequences =
-            BlockGroup::get_all_sequences(conn, &new_child_block_group.id, false).unwrap();
+        let all_child_sequences = BlockGroup::get_all_sequences(
+            conn,
+            crate::test_helpers::test_workspace(),
+            &new_child_block_group.id,
+            false,
+        )
+        .unwrap();
 
         // We've replaced [2, 6) of AAAA with CCCC
         assert_eq!(
@@ -1293,6 +1363,7 @@ mod tests {
         let gfa_path = temp_dir.path().join("parent-grandchild-diff.gfa");
         gfa_sample_diff(
             conn,
+            context.workspace(),
             collection_name,
             &gfa_path,
             Sample::DEFAULT_NAME,
@@ -1311,8 +1382,13 @@ mod tests {
             Collection::get_block_groups(conn, "test collection 3", None)
                 .pop()
                 .unwrap();
-        let all_grandchild_sequences =
-            BlockGroup::get_all_sequences(conn, &new_grandchild_block_group.id, false).unwrap();
+        let all_grandchild_sequences = BlockGroup::get_all_sequences(
+            conn,
+            crate::test_helpers::test_workspace(),
+            &new_grandchild_block_group.id,
+            false,
+        )
+        .unwrap();
 
         // Original is AAAAAAAAAAAAAAAA
         // Grandchild is AACCGGGGAAAAAA
@@ -1326,7 +1402,15 @@ mod tests {
         );
 
         let gfa_path = temp_dir.path().join("child-grandchild-diff.gfa");
-        gfa_sample_diff(conn, collection_name, &gfa_path, "child", "grandchild").unwrap();
+        gfa_sample_diff(
+            conn,
+            context.workspace(),
+            collection_name,
+            &gfa_path,
+            "child",
+            "grandchild",
+        )
+        .unwrap();
 
         let _ = import_gfa(
             &context,
@@ -1339,8 +1423,13 @@ mod tests {
             Collection::get_block_groups(conn, "test collection 4", None)
                 .pop()
                 .unwrap();
-        let all_grandchild_sequences =
-            BlockGroup::get_all_sequences(conn, &new_grandchild_block_group.id, false).unwrap();
+        let all_grandchild_sequences = BlockGroup::get_all_sequences(
+            conn,
+            crate::test_helpers::test_workspace(),
+            &new_grandchild_block_group.id,
+            false,
+        )
+        .unwrap();
 
         // Child is      AACCCCAAAAAAAAAA
         // Grandchild is AACCGGGGAAAAAA

--- a/src/exports/fasta.rs
+++ b/src/exports/fasta.rs
@@ -1,5 +1,6 @@
 use std::{fs::File, path::PathBuf};
 
+use gen_core::Workspace;
 use gen_models::{
     block_group::{BlockGroup, BlockGroupError},
     collection::Collection,
@@ -22,6 +23,7 @@ pub enum FastaExportError {
 
 pub fn export_fasta(
     conn: &GraphConnection,
+    workspace: &Workspace,
     collection_name: &str,
     sample_name: Option<&str>,
     filename: &PathBuf,
@@ -40,8 +42,9 @@ pub fn export_fasta(
         let path = BlockGroup::get_current_path(conn, &block_group.id, history_ref)?;
 
         let definition = fasta::record::Definition::new(block_group.name, None);
-        let sequence =
-            fasta::record::Sequence::from(path.sequence(conn, history_ref)?.into_bytes());
+        let sequence = fasta::record::Sequence::from(
+            path.sequence(conn, workspace, history_ref)?.into_bytes(),
+        );
         let record = fasta::Record::new(definition, sequence);
 
         writer.write_record(&record)?;
@@ -84,7 +87,15 @@ mod tests {
         .unwrap();
         let tmp_dir = tempfile::tempdir().unwrap().keep();
         let filename = tmp_dir.join("out.fa");
-        export_fasta(conn, &collection, None, &filename, None).unwrap();
+        export_fasta(
+            conn,
+            context.workspace(),
+            &collection,
+            None,
+            &filename,
+            None,
+        )
+        .unwrap();
 
         let mut fasta_reader = fasta::io::reader::Builder
             .build_from_path(filename)
@@ -140,7 +151,15 @@ mod tests {
 
         let tmp_dir = tempfile::tempdir().unwrap().keep();
         let filename = tmp_dir.join("out.fa");
-        export_fasta(conn, &collection, Some("child sample"), &filename, None).unwrap();
+        export_fasta(
+            conn,
+            context.workspace(),
+            &collection,
+            Some("child sample"),
+            &filename,
+            None,
+        )
+        .unwrap();
 
         let mut fasta_reader = fasta::io::reader::Builder
             .build_from_path(filename)

--- a/src/exports/genbank.rs
+++ b/src/exports/genbank.rs
@@ -11,7 +11,7 @@ use std::{
 
 use gb_io::{self, seq::Location};
 use gen_annotations::projection::{AnnotationSegment, project_annotation_segments};
-use gen_core::{Strand, is_terminal, path::PathBlock, range::Range};
+use gen_core::{Strand, Workspace, is_terminal, path::PathBlock, range::Range};
 use gen_graph::{GenGraph, GraphEdge, GraphNode, all_simple_paths};
 use gen_models::{
     accession::{Accession, AccessionSpan, NewAccession},
@@ -254,6 +254,7 @@ fn get_path_nodes(graph: &GenGraph, path_blocks: &[PathBlock]) -> Vec<GraphNode>
 
 pub fn export_genbank(
     conn: &GraphConnection,
+    workspace: &Workspace,
     collection_name: &str,
     sample_name: &str,
     writer: impl Write,
@@ -280,13 +281,13 @@ pub fn export_genbank(
     for block_group in block_groups.iter() {
         let path = BlockGroup::get_current_path(conn, &block_group.id, history_ref)?;
         let path_blocks = path
-            .blocks(conn, history_ref)?
+            .coordinate_blocks(conn, history_ref)
             .into_iter()
             .filter(|block| !is_terminal(block.node_id))
             .collect::<Vec<_>>();
         let mut seq = gb_io::seq::Seq::empty();
         seq.name = Some(block_group.name.clone());
-        seq.seq = path.sequence(conn, history_ref)?.into_bytes();
+        seq.seq = path.sequence(conn, workspace, history_ref)?.into_bytes();
         export_annotations(
             conn,
             &path,
@@ -297,7 +298,7 @@ pub fn export_genbank(
         )?;
 
         // Identify the node traversal corresponding to our path.
-        let graph = BlockGroup::get_graph(conn, &block_group.id, history_ref)?;
+        let graph = BlockGroup::get_graph(conn, workspace, &block_group.id, history_ref)?;
         let path_nodes = get_path_nodes(&graph, &path_blocks);
         let path_node_set: HashSet<&GraphNode> = HashSet::from_iter(&path_nodes);
         let mut node_it = path_nodes.iter().peekable();
@@ -331,7 +332,12 @@ pub fn export_genbank(
 
                     let mut sequence = String::new();
                     for sub_node in sub_path.iter() {
-                        let seqs = Node::get_sequences_by_node_ids(conn, &[sub_node.node_id], None);
+                        let seqs = Node::get_sequences_by_node_ids(
+                            conn,
+                            workspace,
+                            &[sub_node.node_id],
+                            None,
+                        );
                         let seq = &seqs[&sub_node.node_id];
                         sequence.push_str(
                             &seq.get_sequence(sub_node.sequence_start, sub_node.sequence_end)?,
@@ -543,8 +549,7 @@ mod tests {
         sample_name: &str,
     ) {
         let blocks = path
-            .blocks(conn, None)
-            .unwrap()
+            .coordinate_blocks(conn, None)
             .into_iter()
             .filter(|block| !is_terminal(block.node_id))
             .collect::<Vec<_>>();
@@ -615,7 +620,15 @@ mod tests {
         )
         .unwrap();
         let mut output = Vec::new();
-        export_genbank(conn, "", Sample::DEFAULT_NAME, &mut output, None).unwrap();
+        export_genbank(
+            conn,
+            context.workspace(),
+            "",
+            Sample::DEFAULT_NAME,
+            &mut output,
+            None,
+        )
+        .unwrap();
         compare_genbanks(&path, &output);
     }
 
@@ -644,7 +657,15 @@ mod tests {
         )
         .unwrap();
         let mut output = Vec::new();
-        export_genbank(conn, "", Sample::DEFAULT_NAME, &mut output, None).unwrap();
+        export_genbank(
+            conn,
+            context.workspace(),
+            "",
+            Sample::DEFAULT_NAME,
+            &mut output,
+            None,
+        )
+        .unwrap();
         compare_genbanks(&path, &output);
     }
 
@@ -673,7 +694,15 @@ mod tests {
         )
         .unwrap();
         let mut output = Vec::new();
-        export_genbank(conn, "", Sample::DEFAULT_NAME, &mut output, None).unwrap();
+        export_genbank(
+            conn,
+            context.workspace(),
+            "",
+            Sample::DEFAULT_NAME,
+            &mut output,
+            None,
+        )
+        .unwrap();
         compare_genbanks(&path, &output);
     }
 
@@ -702,7 +731,15 @@ mod tests {
         .unwrap();
 
         let mut output = Vec::new();
-        export_genbank(conn, "fixtures", "puc19-export", &mut output, None).unwrap();
+        export_genbank(
+            conn,
+            context.workspace(),
+            "fixtures",
+            "puc19-export",
+            &mut output,
+            None,
+        )
+        .unwrap();
 
         let parsed = reader::parse_slice(&output).unwrap();
         let features = &parsed[0].features;
@@ -830,7 +867,7 @@ mod tests {
         );
 
         let mut output = Vec::new();
-        export_genbank(conn, "test", "test", &mut output, None).unwrap();
+        export_genbank(conn, context.workspace(), "test", "test", &mut output, None).unwrap();
 
         let parsed = reader::parse_slice(&output).unwrap();
         let features = &parsed[0].features;
@@ -957,7 +994,7 @@ mod tests {
         .unwrap();
 
         let mut output = Vec::new();
-        export_genbank(conn, "test", "test", &mut output, None).unwrap();
+        export_genbank(conn, context.workspace(), "test", "test", &mut output, None).unwrap();
 
         let exported_text = String::from_utf8(output).unwrap();
         assert!(
@@ -995,6 +1032,7 @@ mod tests {
         let mut historical_output = Vec::new();
         export_genbank(
             conn,
+            context.workspace(),
             "test",
             "test",
             &mut historical_output,
@@ -1009,8 +1047,15 @@ mod tests {
             .collect::<HashSet<_>>();
 
         let mut current_output = Vec::new();
-        export_genbank(conn, "test", "test", &mut current_output, None)
-            .expect("should export current GenBank");
+        export_genbank(
+            conn,
+            context.workspace(),
+            "test",
+            "test",
+            &mut current_output,
+            None,
+        )
+        .expect("should export current GenBank");
         let current_labels = reader::parse_slice(&current_output)
             .expect("should parse current GenBank")
             .into_iter()

--- a/src/exports/gfa.rs
+++ b/src/exports/gfa.rs
@@ -5,7 +5,7 @@ use std::{
     path::PathBuf,
 };
 
-use gen_core::{HashId, is_terminal, strand::Strand};
+use gen_core::{HashId, Workspace, is_terminal, strand::Strand};
 use gen_graph::{GenGraph, project_path};
 use gen_models::{
     block_group::BlockGroup,
@@ -49,6 +49,7 @@ pub enum GfaExportError {
 
 pub fn export_gfa(
     conn: &GraphConnection,
+    workspace: &Workspace,
     collection_name: &str,
     filename: &PathBuf,
     sample_name: &str,
@@ -73,9 +74,14 @@ pub fn export_gfa(
     for block_group in sample_block_groups {
         let block_group_edges =
             BlockGroupEdge::edges_for_block_group(conn, &block_group.id, history_ref);
-        for mut block in
-            Edge::blocks_from_edges(conn, &block_group.id, &block_group_edges, history_ref)
-                .map_err(|source| GfaExportError::Edge { source })?
+        for mut block in Edge::blocks_from_edges(
+            conn,
+            workspace,
+            &block_group.id,
+            &block_group_edges,
+            history_ref,
+        )
+        .map_err(|source| GfaExportError::Edge { source })?
         {
             if seen_blocks.insert((block.node_id, block.start, block.end)) {
                 block.id = blocks.len() as i64;
@@ -249,12 +255,7 @@ fn get_paths(
         };
         let sample_name = block_group.sample_name;
 
-        let path_blocks =
-            path.blocks(conn, None)
-                .map_err(|source| GfaExportError::PathForName {
-                    path_name: path.name.clone(),
-                    source,
-                })?;
+        let path_blocks = path.coordinate_blocks(conn, None);
         let projected_path = project_path(graph, &path_blocks);
 
         if !projected_path.is_empty() {
@@ -502,7 +503,13 @@ mod tests {
         )
         .unwrap();
 
-        let all_sequences = BlockGroup::get_all_sequences(conn, &block_group.id, false).unwrap();
+        let all_sequences = BlockGroup::get_all_sequences(
+            conn,
+            crate::test_helpers::test_workspace(),
+            &block_group.id,
+            false,
+        )
+        .unwrap();
 
         let temp_dir = tempdir().expect("Couldn't get handle to temp directory");
         let mut gfa_path = PathBuf::from(temp_dir.path());
@@ -510,6 +517,7 @@ mod tests {
 
         export_gfa(
             conn,
+            context.workspace(),
             collection_name,
             &gfa_path,
             Sample::DEFAULT_NAME,
@@ -528,13 +536,22 @@ mod tests {
         let block_group2 = Collection::get_block_groups(conn, "test collection 2", None)
             .pop()
             .unwrap();
-        let all_sequences2 = BlockGroup::get_all_sequences(conn, &block_group2.id, false).unwrap();
+        let all_sequences2 = BlockGroup::get_all_sequences(
+            conn,
+            crate::test_helpers::test_workspace(),
+            &block_group2.id,
+            false,
+        )
+        .unwrap();
 
         assert_eq!(all_sequences, all_sequences2);
 
         let paths = Path::query_for_collection(conn, "test collection 2");
         assert_eq!(paths.len(), 1);
-        assert_eq!(paths[0].sequence(conn, None).unwrap(), "AAAATTTTGGGGCCCC");
+        assert_eq!(
+            paths[0].sequence(conn, context.workspace(), None).unwrap(),
+            "AAAATTTTGGGGCCCC"
+        );
     }
 
     #[test]
@@ -593,9 +610,15 @@ mod tests {
         .unwrap();
 
         let block_group = get_sample_bg(conn, collection, "deleted");
-        let graph = BlockGroup::get_graph(conn, &block_group.id, None).unwrap();
+        let graph = BlockGroup::get_graph(
+            conn,
+            crate::test_helpers::test_workspace(),
+            &block_group.id,
+            None,
+        )
+        .unwrap();
         let node_ids = graph.nodes().map(|node| node.node_id).collect::<Vec<_>>();
-        let sequences = Node::get_sequences_by_node_ids(conn, &node_ids, None);
+        let sequences = Node::get_sequences_by_node_ids(conn, context.workspace(), &node_ids, None);
         let rendered_sequence = |node: GraphNode| {
             sequences[&node.node_id]
                 .get_sequence(node.sequence_start, node.sequence_end)
@@ -632,7 +655,16 @@ mod tests {
         );
         let temp_dir = tempdir().expect("should create a temporary directory");
         let gfa_path = temp_dir.path().join("front-deletion.gfa");
-        export_gfa(conn, collection, &gfa_path, "deleted", None, None).unwrap();
+        export_gfa(
+            conn,
+            context.workspace(),
+            collection,
+            &gfa_path,
+            "deleted",
+            None,
+            None,
+        )
+        .unwrap();
         let gfa_lines = fs::read_to_string(&gfa_path)
             .expect("should read the exported GFA")
             .lines()
@@ -680,7 +712,15 @@ mod tests {
         let temp_dir = tempdir().expect("Couldn't get handle to temp directory");
         let gfa_path = PathBuf::from(temp_dir.path()).join("missing.gfa");
 
-        let result = export_gfa(conn, "missing", &gfa_path, Sample::DEFAULT_NAME, None, None);
+        let result = export_gfa(
+            conn,
+            context.workspace(),
+            "missing",
+            &gfa_path,
+            Sample::DEFAULT_NAME,
+            None,
+            None,
+        );
 
         assert!(matches!(
             result,
@@ -697,12 +737,27 @@ mod tests {
         let conn = context.graph().conn();
 
         let (bg_id, _path) = setup_block_group(conn);
-        let all_sequences = BlockGroup::get_all_sequences(conn, &bg_id, false).unwrap();
+        let all_sequences = BlockGroup::get_all_sequences(
+            conn,
+            crate::test_helpers::test_workspace(),
+            &bg_id,
+            false,
+        )
+        .unwrap();
 
         let temp_dir = tempdir().expect("Couldn't get handle to temp directory");
         let gfa_path = PathBuf::from(temp_dir.path()).join("split.gfa");
 
-        export_gfa(conn, "test", &gfa_path, "test", 5, None).unwrap();
+        export_gfa(
+            conn,
+            context.workspace(),
+            "test",
+            &gfa_path,
+            "test",
+            5,
+            None,
+        )
+        .unwrap();
 
         let _ = import_gfa(
             &context,
@@ -714,11 +769,23 @@ mod tests {
         let block_group2 = Collection::get_block_groups(conn, "test collection 2", None)
             .pop()
             .unwrap();
-        let all_sequences2 = BlockGroup::get_all_sequences(conn, &block_group2.id, false).unwrap();
+        let all_sequences2 = BlockGroup::get_all_sequences(
+            conn,
+            crate::test_helpers::test_workspace(),
+            &block_group2.id,
+            false,
+        )
+        .unwrap();
 
         assert_eq!(all_sequences, all_sequences2);
 
-        let graph = BlockGroup::get_graph(conn, &block_group2.id, None).unwrap();
+        let graph = BlockGroup::get_graph(
+            conn,
+            crate::test_helpers::test_workspace(),
+            &block_group2.id,
+            None,
+        )
+        .unwrap();
         let graph_nodes = graph
             .nodes()
             .filter_map(|node| {
@@ -729,7 +796,8 @@ mod tests {
                 }
             })
             .collect::<Vec<_>>();
-        let node_sequences = Node::get_sequences_by_node_ids(conn, &graph_nodes, None);
+        let node_sequences =
+            Node::get_sequences_by_node_ids(conn, context.workspace(), &graph_nodes, None);
         assert!(node_sequences.len() > 1);
         for sequence in node_sequences.values() {
             assert!(
@@ -751,7 +819,13 @@ mod tests {
         let _ = import_gfa(&context, &gfa_path, &collection_name, Sample::DEFAULT_NAME);
 
         let block_group_id = BlockGroup::get_id(&collection_name, Sample::DEFAULT_NAME, "", None);
-        let all_sequences = BlockGroup::get_all_sequences(conn, &block_group_id, false).unwrap();
+        let all_sequences = BlockGroup::get_all_sequences(
+            conn,
+            crate::test_helpers::test_workspace(),
+            &block_group_id,
+            false,
+        )
+        .unwrap();
 
         let temp_dir = tempdir().expect("Couldn't get handle to temp directory");
         let mut gfa_path = PathBuf::from(temp_dir.path());
@@ -759,6 +833,7 @@ mod tests {
 
         export_gfa(
             conn,
+            context.workspace(),
             &collection_name,
             &gfa_path,
             Sample::DEFAULT_NAME,
@@ -776,7 +851,13 @@ mod tests {
         let block_group2 = Collection::get_block_groups(conn, "test collection 2", None)
             .pop()
             .unwrap();
-        let all_sequences2 = BlockGroup::get_all_sequences(conn, &block_group2.id, false).unwrap();
+        let all_sequences2 = BlockGroup::get_all_sequences(
+            conn,
+            crate::test_helpers::test_workspace(),
+            &block_group2.id,
+            false,
+        )
+        .unwrap();
 
         assert_eq!(all_sequences, all_sequences2);
     }
@@ -792,7 +873,13 @@ mod tests {
         let _ = import_gfa(&context, &gfa_path, &collection_name, Sample::DEFAULT_NAME);
 
         let block_group_id = BlockGroup::get_id(&collection_name, Sample::DEFAULT_NAME, "", None);
-        let all_sequences = BlockGroup::get_all_sequences(conn, &block_group_id, false).unwrap();
+        let all_sequences = BlockGroup::get_all_sequences(
+            conn,
+            crate::test_helpers::test_workspace(),
+            &block_group_id,
+            false,
+        )
+        .unwrap();
 
         let temp_dir = tempdir().expect("Couldn't get handle to temp directory");
         let mut gfa_path = PathBuf::from(temp_dir.path());
@@ -800,6 +887,7 @@ mod tests {
 
         export_gfa(
             conn,
+            context.workspace(),
             &collection_name,
             &gfa_path,
             Sample::DEFAULT_NAME,
@@ -817,7 +905,13 @@ mod tests {
         let block_group2 = Collection::get_block_groups(conn, "anderson promoters 2", None)
             .pop()
             .unwrap();
-        let all_sequences2 = BlockGroup::get_all_sequences(conn, &block_group2.id, false).unwrap();
+        let all_sequences2 = BlockGroup::get_all_sequences(
+            conn,
+            crate::test_helpers::test_workspace(),
+            &block_group2.id,
+            false,
+        )
+        .unwrap();
 
         assert_eq!(all_sequences, all_sequences2);
     }
@@ -833,7 +927,13 @@ mod tests {
         let _ = import_gfa(&context, &gfa_path, &collection_name, Sample::DEFAULT_NAME);
 
         let block_group_id = BlockGroup::get_id(&collection_name, Sample::DEFAULT_NAME, "", None);
-        let all_sequences = BlockGroup::get_all_sequences(conn, &block_group_id, false).unwrap();
+        let all_sequences = BlockGroup::get_all_sequences(
+            conn,
+            crate::test_helpers::test_workspace(),
+            &block_group_id,
+            false,
+        )
+        .unwrap();
 
         let temp_dir = tempdir().expect("Couldn't get handle to temp directory");
         let mut gfa_path = PathBuf::from(temp_dir.path());
@@ -841,6 +941,7 @@ mod tests {
 
         export_gfa(
             conn,
+            context.workspace(),
             &collection_name,
             &gfa_path,
             Sample::DEFAULT_NAME,
@@ -858,7 +959,13 @@ mod tests {
         let block_group2 = Collection::get_block_groups(conn, "test collection 2", None)
             .pop()
             .unwrap();
-        let all_sequences2 = BlockGroup::get_all_sequences(conn, &block_group2.id, false).unwrap();
+        let all_sequences2 = BlockGroup::get_all_sequences(
+            conn,
+            crate::test_helpers::test_workspace(),
+            &block_group2.id,
+            false,
+        )
+        .unwrap();
 
         assert_eq!(all_sequences, all_sequences2);
     }
@@ -897,7 +1004,7 @@ mod tests {
             phased: 0,
             preserve_edge: true,
         };
-        BlockGroup::insert_change(conn, &change).unwrap();
+        BlockGroup::insert_change(conn, crate::test_helpers::test_workspace(), &change).unwrap();
 
         let augmented_edges = BlockGroupEdge::edges_for_block_group(conn, &block_group_id, None);
         let mut node_ids = HashSet::new();
@@ -938,7 +1045,16 @@ mod tests {
         let temp_dir = tempdir().expect("Couldn't get handle to temp directory");
         let mut gfa_path = PathBuf::from(temp_dir.path());
         gfa_path.push("intermediate.gfa");
-        export_gfa(conn, "test", &gfa_path, "test", None, None).unwrap();
+        export_gfa(
+            conn,
+            context.workspace(),
+            "test",
+            &gfa_path,
+            "test",
+            None,
+            None,
+        )
+        .unwrap();
         let _ = import_gfa(
             &context,
             &gfa_path,

--- a/src/graphs/graph_search.rs
+++ b/src/graphs/graph_search.rs
@@ -3,7 +3,7 @@ use std::{
     path::Path,
 };
 
-use gen_core::{HashId, PATH_END_NODE_ID, PATH_START_NODE_ID, Strand};
+use gen_core::{HashId, PATH_END_NODE_ID, PATH_START_NODE_ID, Strand, Workspace};
 use gen_graph::{GenGraph, GraphNode, GraphNodeSlice};
 use gen_models::{
     db::GraphConnection, locus::GraphLocus, node::Node, sequence::reverse_complement,
@@ -148,24 +148,24 @@ impl GenGraphMatcher {
     ///
     /// Batch-loads all full node sequences up front. No further database access
     /// occurs during matching.
-    pub fn new(conn: &GraphConnection, graph: GenGraph) -> Self {
-        Self::new_with_sequence_kind(conn, graph, SequenceKind::Dna)
+    pub fn new(conn: &GraphConnection, workspace: &Workspace, graph: GenGraph) -> Self {
+        Self::new_with_sequence_kind(conn, workspace, graph, SequenceKind::Dna)
     }
 
     /// Build a single-stranded DNA matcher from a database connection and graph.
     ///
     /// Batch-loads all full node sequences up front. No further database access
     /// occurs during matching.
-    pub fn new_ssdna(conn: &GraphConnection, graph: GenGraph) -> Self {
-        Self::new_with_sequence_kind(conn, graph, SequenceKind::SsDna)
+    pub fn new_ssdna(conn: &GraphConnection, workspace: &Workspace, graph: GenGraph) -> Self {
+        Self::new_with_sequence_kind(conn, workspace, graph, SequenceKind::SsDna)
     }
 
     /// Build a protein matcher from a database connection and graph.
     ///
     /// Batch-loads all full node sequences up front. No further database access
     /// occurs during matching.
-    pub fn new_protein(conn: &GraphConnection, graph: GenGraph) -> Self {
-        Self::new_with_sequence_kind(conn, graph, SequenceKind::Protein)
+    pub fn new_protein(conn: &GraphConnection, workspace: &Workspace, graph: GenGraph) -> Self {
+        Self::new_with_sequence_kind(conn, workspace, graph, SequenceKind::Protein)
     }
 
     /// Build a matcher from a database connection, graph, and sequence kind.
@@ -174,6 +174,7 @@ impl GenGraphMatcher {
     /// occurs during matching.
     pub fn new_with_sequence_kind(
         conn: &GraphConnection,
+        workspace: &Workspace,
         graph: GenGraph,
         sequence_kind: SequenceKind,
     ) -> Self {
@@ -185,7 +186,7 @@ impl GenGraphMatcher {
         };
 
         let mut node_sequences: HashMap<HashId, Vec<u8>> =
-            Node::get_sequences_by_node_ids(conn, &node_ids, None)
+            Node::get_sequences_by_node_ids(conn, workspace, &node_ids, None)
                 .into_iter()
                 .map(|(node_id, seq)| {
                     (
@@ -784,8 +785,14 @@ mod tests {
         let conn = ctx.graph().conn();
         Collection::create(conn, "test").unwrap();
         let (block_group_id, _path) = setup_block_group(conn);
-        let graph = BlockGroup::get_graph(conn, &block_group_id, None).unwrap();
-        GenGraphMatcher::new(conn, graph)
+        let graph = BlockGroup::get_graph(
+            conn,
+            crate::test_helpers::test_workspace(),
+            &block_group_id,
+            None,
+        )
+        .unwrap();
+        GenGraphMatcher::new(conn, ctx.workspace(), graph)
     }
 
     fn build_ssdna_matcher() -> GenGraphMatcher {
@@ -793,8 +800,14 @@ mod tests {
         let conn = ctx.graph().conn();
         let _ = Collection::create(conn, "test");
         let (block_group_id, _path) = setup_block_group(conn);
-        let graph = BlockGroup::get_graph(conn, &block_group_id, None).unwrap();
-        GenGraphMatcher::new_ssdna(conn, graph)
+        let graph = BlockGroup::get_graph(
+            conn,
+            crate::test_helpers::test_workspace(),
+            &block_group_id,
+            None,
+        )
+        .unwrap();
+        GenGraphMatcher::new_ssdna(conn, ctx.workspace(), graph)
     }
 
     fn test_protein_matcher() -> GenGraphMatcher {
@@ -802,8 +815,14 @@ mod tests {
         let conn = ctx.graph().conn();
         Collection::create(conn, "test").unwrap();
         let (block_group_id, _path) = setup_block_group(conn);
-        let graph = BlockGroup::get_graph(conn, &block_group_id, None).unwrap();
-        GenGraphMatcher::new_protein(conn, graph)
+        let graph = BlockGroup::get_graph(
+            conn,
+            crate::test_helpers::test_workspace(),
+            &block_group_id,
+            None,
+        )
+        .unwrap();
+        GenGraphMatcher::new_protein(conn, ctx.workspace(), graph)
     }
 
     fn test_exact_matcher() -> GenGraphMatcher {
@@ -811,8 +830,14 @@ mod tests {
         let conn = ctx.graph().conn();
         Collection::create(conn, "test").unwrap();
         let (block_group_id, _path) = setup_block_group(conn);
-        let graph = BlockGroup::get_graph(conn, &block_group_id, None).unwrap();
-        GenGraphMatcher::new_with_sequence_kind(conn, graph, SequenceKind::Exact)
+        let graph = BlockGroup::get_graph(
+            conn,
+            crate::test_helpers::test_workspace(),
+            &block_group_id,
+            None,
+        )
+        .unwrap();
+        GenGraphMatcher::new_with_sequence_kind(conn, ctx.workspace(), graph, SequenceKind::Exact)
     }
 
     #[test]

--- a/src/graphs/operators.rs
+++ b/src/graphs/operators.rs
@@ -1,9 +1,11 @@
 use core::ops::Range;
 use std::collections::HashMap;
 
-use gen_core::{HashId, PATH_END_NODE_ID, PATH_START_NODE_ID, Strand, is_end_node, is_start_node};
+use gen_core::{
+    HashId, PATH_END_NODE_ID, PATH_START_NODE_ID, Strand, Workspace, is_end_node, is_start_node,
+};
 use gen_models::{
-    block_group::{BlockGroup, NewBlockGroup},
+    block_group::{BlockGroup, NewBlockGroup, SubgraphBoundary},
     block_group_edge::{AugmentedEdge, BlockGroupEdge, BlockGroupEdgeData},
     db::{DbContext, GraphConnection},
     edge::Edge,
@@ -169,11 +171,16 @@ pub fn derive_chunks(
 
         BlockGroup::derive_subgraph(
             conn,
+            context.workspace(),
             &parent_block_group_id,
-            &start_block,
-            &end_block,
-            start_node_coordinate,
-            end_node_coordinate,
+            SubgraphBoundary {
+                block: &start_block,
+                sequence_coordinate: start_node_coordinate,
+            },
+            SubgraphBoundary {
+                block: &end_block,
+                sequence_coordinate: end_node_coordinate,
+            },
             &child_block_group_id,
             create_block_group,
         )?;
@@ -460,16 +467,17 @@ fn create_stitched_block_group(
         new_region_name,
     )?;
 
-    validate_stitched_block_group_is_acyclic(conn, &child_block_group.id)?;
+    validate_stitched_block_group_is_acyclic(conn, context.workspace(), &child_block_group.id)?;
 
     Ok(())
 }
 
 fn validate_stitched_block_group_is_acyclic(
     conn: &GraphConnection,
+    workspace: &Workspace,
     block_group_id: &HashId,
 ) -> Result<(), GraphOperationError> {
-    let graph = BlockGroup::get_graph(conn, block_group_id, None)?;
+    let graph = BlockGroup::get_graph(conn, workspace, block_group_id, None)?;
     if is_cyclic_directed(&graph) {
         return Err(GraphOperationError::StitchedGraphCycle(format!(
             "block group {block_group_id} is cyclic"
@@ -652,11 +660,19 @@ mod tests {
             .new_path_with(conn, 16, 24, &edge_into_insert, &edge_out_of_insert)
             .unwrap();
         assert_eq!(
-            insert_path.sequence(conn, None).unwrap(),
+            insert_path
+                .sequence(conn, context.workspace(), None)
+                .unwrap(),
             "AAAAAAAAAATTTTTTAAAAAAAACCCCCCGGGGGGGGGG"
         );
 
-        let all_sequences = BlockGroup::get_all_sequences(conn, &block_group1_id, false).unwrap();
+        let all_sequences = BlockGroup::get_all_sequences(
+            conn,
+            crate::test_helpers::test_workspace(),
+            &block_group1_id,
+            false,
+        )
+        .unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec![
@@ -681,14 +697,23 @@ mod tests {
         let block_groups = Sample::get_block_groups(conn, "test", Sample::DEFAULT_NAME, None);
         let block_group2 = block_groups.iter().find(|x| x.name == "chr1").unwrap();
 
-        let all_sequences2 = BlockGroup::get_all_sequences(conn, &block_group2.id, false).unwrap();
+        let all_sequences2 = BlockGroup::get_all_sequences(
+            conn,
+            crate::test_helpers::test_workspace(),
+            &block_group2.id,
+            false,
+        )
+        .unwrap();
         assert_eq!(
             all_sequences2,
             HashSet::from_iter(vec!["TTTTTCCCCC".to_string(), "TAAAAAAAAC".to_string(),])
         );
 
         let new_path = BlockGroup::get_current_path(conn, &block_group2.id, None).unwrap();
-        assert_eq!(new_path.sequence(conn, None).unwrap(), "TAAAAAAAAC");
+        assert_eq!(
+            new_path.sequence(conn, context.workspace(), None).unwrap(),
+            "TAAAAAAAAC"
+        );
     }
 
     #[test]
@@ -737,8 +762,13 @@ mod tests {
         let original_block_groups =
             Sample::get_block_groups(conn, collection, Sample::DEFAULT_NAME, None);
         let original_block_group_id = &original_block_groups[0].id;
-        let all_original_sequences =
-            BlockGroup::get_all_sequences(conn, original_block_group_id, false).unwrap();
+        let all_original_sequences = BlockGroup::get_all_sequences(
+            conn,
+            crate::test_helpers::test_workspace(),
+            original_block_group_id,
+            false,
+        )
+        .unwrap();
         assert_eq!(
             all_original_sequences,
             HashSet::from_iter(vec!["ATCGATCGATCGATCGATCGGGAACACACAGAGA".to_string(),])
@@ -746,8 +776,13 @@ mod tests {
 
         let grandchild_block_groups = Sample::get_block_groups(conn, collection, "test2", None);
         let grandchild_block_group_id = &grandchild_block_groups[0].id;
-        let all_grandchild_sequences =
-            BlockGroup::get_all_sequences(conn, grandchild_block_group_id, false).unwrap();
+        let all_grandchild_sequences = BlockGroup::get_all_sequences(
+            conn,
+            crate::test_helpers::test_workspace(),
+            grandchild_block_group_id,
+            false,
+        )
+        .unwrap();
         assert_eq!(
             all_grandchild_sequences,
             HashSet::from_iter(vec![
@@ -779,17 +814,32 @@ mod tests {
         let block_groups = Sample::get_block_groups(conn, collection, "test3", None);
         let block_group2 = block_groups.iter().find(|x| x.name == "m123.2").unwrap();
 
-        let all_sequences2 = BlockGroup::get_all_sequences(conn, &block_group2.id, false).unwrap();
+        let all_sequences2 = BlockGroup::get_all_sequences(
+            conn,
+            crate::test_helpers::test_workspace(),
+            &block_group2.id,
+            false,
+        )
+        .unwrap();
         assert_eq!(
             all_sequences2,
             HashSet::from_iter(vec!["TCAATCG".to_string(), "TCGATCG".to_string(),])
         );
 
         let path2 = BlockGroup::get_current_path(conn, &block_group2.id, None).unwrap();
-        assert_eq!(path2.sequence(conn, None).unwrap(), "TCAATCG");
+        assert_eq!(
+            path2.sequence(conn, context.workspace(), None).unwrap(),
+            "TCAATCG"
+        );
 
         let block_group3 = block_groups.iter().find(|x| x.name == "m123.3").unwrap();
-        let all_sequences3 = BlockGroup::get_all_sequences(conn, &block_group3.id, false).unwrap();
+        let all_sequences3 = BlockGroup::get_all_sequences(
+            conn,
+            crate::test_helpers::test_workspace(),
+            &block_group3.id,
+            false,
+        )
+        .unwrap();
         assert_eq!(
             all_sequences3,
             HashSet::from_iter(vec![
@@ -799,7 +849,10 @@ mod tests {
         );
 
         let path3 = BlockGroup::get_current_path(conn, &block_group3.id, None).unwrap();
-        assert_eq!(path3.sequence(conn, None).unwrap(), "ATCGATCAAGGAACACA");
+        assert_eq!(
+            path3.sequence(conn, context.workspace(), None).unwrap(),
+            "ATCGATCAAGGAACACA"
+        );
     }
 
     #[test]
@@ -848,8 +901,13 @@ mod tests {
         let original_block_groups =
             Sample::get_block_groups(conn, collection, Sample::DEFAULT_NAME, None);
         let original_block_group_id = &original_block_groups[0].id;
-        let all_original_sequences =
-            BlockGroup::get_all_sequences(conn, original_block_group_id, false).unwrap();
+        let all_original_sequences = BlockGroup::get_all_sequences(
+            conn,
+            crate::test_helpers::test_workspace(),
+            original_block_group_id,
+            false,
+        )
+        .unwrap();
         assert_eq!(
             all_original_sequences,
             HashSet::from_iter(vec!["ATCGATCGATCGATCGATCGGGAACACACAGAGA".to_string(),])
@@ -857,8 +915,13 @@ mod tests {
 
         let grandchild_block_groups = Sample::get_block_groups(conn, collection, "test2", None);
         let grandchild_block_group_id = &grandchild_block_groups[0].id;
-        let all_grandchild_sequences =
-            BlockGroup::get_all_sequences(conn, grandchild_block_group_id, false).unwrap();
+        let all_grandchild_sequences = BlockGroup::get_all_sequences(
+            conn,
+            crate::test_helpers::test_workspace(),
+            grandchild_block_group_id,
+            false,
+        )
+        .unwrap();
         assert_eq!(
             all_grandchild_sequences,
             HashSet::from_iter(vec![
@@ -890,17 +953,32 @@ mod tests {
         let block_groups = Sample::get_block_groups(conn, collection, "test3", None);
         let block_group2 = block_groups.iter().find(|x| x.name == "m123.2").unwrap();
 
-        let all_sequences2 = BlockGroup::get_all_sequences(conn, &block_group2.id, false).unwrap();
+        let all_sequences2 = BlockGroup::get_all_sequences(
+            conn,
+            crate::test_helpers::test_workspace(),
+            &block_group2.id,
+            false,
+        )
+        .unwrap();
         assert_eq!(
             all_sequences2,
             HashSet::from_iter(vec!["TCAATCG".to_string(), "TCGATCG".to_string(),])
         );
 
         let path2 = BlockGroup::get_current_path(conn, &block_group2.id, None).unwrap();
-        assert_eq!(path2.sequence(conn, None).unwrap(), "TCAATCG");
+        assert_eq!(
+            path2.sequence(conn, context.workspace(), None).unwrap(),
+            "TCAATCG"
+        );
 
         let block_group3 = block_groups.iter().find(|x| x.name == "m123.3").unwrap();
-        let all_sequences3 = BlockGroup::get_all_sequences(conn, &block_group3.id, false).unwrap();
+        let all_sequences3 = BlockGroup::get_all_sequences(
+            conn,
+            crate::test_helpers::test_workspace(),
+            &block_group3.id,
+            false,
+        )
+        .unwrap();
         assert_eq!(
             all_sequences3,
             HashSet::from_iter(vec![
@@ -910,7 +988,10 @@ mod tests {
         );
 
         let path3 = BlockGroup::get_current_path(conn, &block_group3.id, None).unwrap();
-        assert_eq!(path3.sequence(conn, None).unwrap(), "ATCGATCAAGGAACACA");
+        assert_eq!(
+            path3.sequence(conn, context.workspace(), None).unwrap(),
+            "ATCGATCAAGGAACACA"
+        );
 
         // Stitch the two main chunks back together in same order
         make_stitch(
@@ -929,7 +1010,13 @@ mod tests {
             .find(|x| x.name == "m123.stitched")
             .unwrap();
 
-        let all_sequences4 = BlockGroup::get_all_sequences(conn, &block_group4.id, false).unwrap();
+        let all_sequences4 = BlockGroup::get_all_sequences(
+            conn,
+            crate::test_helpers::test_workspace(),
+            &block_group4.id,
+            false,
+        )
+        .unwrap();
         assert_eq!(
             all_sequences4,
             HashSet::from_iter(vec![
@@ -943,7 +1030,7 @@ mod tests {
         let path4 = BlockGroup::get_current_path(conn, &block_group4.id, None).unwrap();
         // path2 + path3 concatenated
         assert_eq!(
-            path4.sequence(conn, None).unwrap(),
+            path4.sequence(conn, context.workspace(), None).unwrap(),
             "TCAATCGATCGATCAAGGAACACA"
         );
 
@@ -964,7 +1051,13 @@ mod tests {
             .find(|x| x.name == "m123.reverse-stitched")
             .unwrap();
 
-        let all_sequences5 = BlockGroup::get_all_sequences(conn, &block_group5.id, false).unwrap();
+        let all_sequences5 = BlockGroup::get_all_sequences(
+            conn,
+            crate::test_helpers::test_workspace(),
+            &block_group5.id,
+            false,
+        )
+        .unwrap();
         assert_eq!(
             all_sequences5,
             HashSet::from_iter(vec![
@@ -978,7 +1071,7 @@ mod tests {
         let path5 = BlockGroup::get_current_path(conn, &block_group5.id, None).unwrap();
         // path3 + path2 concatenated
         assert_eq!(
-            path5.sequence(conn, None).unwrap(),
+            path5.sequence(conn, context.workspace(), None).unwrap(),
             "ATCGATCAAGGAACACATCAATCG"
         );
     }

--- a/src/graphs/translation.rs
+++ b/src/graphs/translation.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet, VecDeque};
 
 use gen_annotations::projection;
 use gen_core::{
-    HashId, NodeIntervalBlock, PATH_END_NODE_ID, PATH_START_NODE_ID, Strand, is_terminal,
+    HashId, NodeIntervalBlock, PATH_END_NODE_ID, PATH_START_NODE_ID, Strand, Workspace, is_terminal,
 };
 use gen_graph::{GraphNode, all_intermediate_edges};
 use gen_models::{
@@ -570,6 +570,12 @@ struct TranslationSubgraph {
     exit_nodes: Vec<HashId>,
 }
 
+struct TranslationTarget<'a> {
+    sample_name: &'a str,
+    block_group_name: &'a str,
+    label_hash: HashId,
+}
+
 /// Translate the full sequence graph: the whole sub-DAG between the graph start
 /// and end nodes, with every parallel branch represented. Each walk ends at the
 /// first in-frame stop codon, which is emitted as a `*` residue and then bounded
@@ -578,12 +584,13 @@ struct TranslationSubgraph {
 /// terminates would explode the protein graph.
 pub fn translate_block_group(
     conn: &GraphConnection,
+    workspace: &Workspace,
     block_group_id: &HashId,
     params: TranslationParams<'_>,
 ) -> Result<BlockGroup, TranslationError> {
     let block_group = BlockGroup::get_by_id(conn, block_group_id, None)
         .map_err(|e| TranslationError::BlockGroupError(e.to_string()))?;
-    let subgraph = extract_full_graph(conn, block_group_id)?;
+    let subgraph = extract_full_graph(conn, workspace, block_group_id)?;
     let strand = params.strand.unwrap_or(Strand::Forward);
     let label = HashId::convert_str(&format!("translate-full:{block_group_id}"));
     let block_group_name = params
@@ -592,12 +599,15 @@ pub fn translate_block_group(
         .unwrap_or_else(|| format!("{} (protein)", block_group.name));
     translate_from(
         conn,
+        workspace,
         subgraph,
         strand,
         params,
-        &block_group.sample_name,
-        &block_group_name,
-        label,
+        TranslationTarget {
+            sample_name: &block_group.sample_name,
+            block_group_name: &block_group_name,
+            label_hash: label,
+        },
     )
 }
 
@@ -605,9 +615,10 @@ pub fn translate_block_group(
 /// terminals) as an in-memory sub-DAG. No database writes.
 fn extract_full_graph(
     conn: &GraphConnection,
+    workspace: &Workspace,
     block_group_id: &HashId,
 ) -> Result<TranslationSubgraph, TranslationError> {
-    let gen_graph = BlockGroup::get_graph(conn, block_group_id, None)
+    let gen_graph = BlockGroup::get_graph(conn, workspace, block_group_id, None)
         .map_err(|e| TranslationError::BlockGroupError(e.to_string()))?;
     let start_node = gen_graph
         .nodes()
@@ -690,11 +701,12 @@ fn extract_full_graph(
 /// nothing past the entry point is ever consulted.
 fn extract_from_entry(
     conn: &GraphConnection,
+    workspace: &Workspace,
     block_group_id: &HashId,
     entry_node_id: HashId,
     entry_coord: i64,
 ) -> Result<TranslationSubgraph, TranslationError> {
-    let gen_graph = BlockGroup::get_graph(conn, block_group_id, None)
+    let gen_graph = BlockGroup::get_graph(conn, workspace, block_group_id, None)
         .map_err(|e| TranslationError::BlockGroupError(e.to_string()))?;
 
     let entry_node = gen_graph
@@ -798,6 +810,7 @@ fn extract_from_entry(
 /// first in-frame stop codon, the same as every other translation entry point.
 pub fn translate_annotation(
     conn: &GraphConnection,
+    workspace: &Workspace,
     annotation: &Annotation,
     block_group_id: Option<&HashId>,
     params: TranslationParams<'_>,
@@ -829,6 +842,7 @@ pub fn translate_annotation(
 
     let subgraph = extract_from_entry(
         conn,
+        workspace,
         block_group_id,
         segments[0].node_id,
         segments[0].range.start,
@@ -839,12 +853,15 @@ pub fn translate_annotation(
         .unwrap_or_else(|| format!("{} (protein)", annotation.name));
     translate_from(
         conn,
+        workspace,
         subgraph,
         strand,
         params,
-        &block_group.sample_name,
-        &block_group_name,
-        annotation.id,
+        TranslationTarget {
+            sample_name: &block_group.sample_name,
+            block_group_name: &block_group_name,
+            label_hash: annotation.id,
+        },
     )
 }
 
@@ -854,6 +871,7 @@ pub fn translate_annotation(
 /// the same entry-point pipeline `translate_annotation` uses.
 pub fn translate_from_path(
     conn: &GraphConnection,
+    workspace: &Workspace,
     block_group_id: &HashId,
     coordinate: i64,
     params: TranslationParams<'_>,
@@ -876,7 +894,13 @@ pub fn translate_from_path(
     let entry_seq = entry_block.sequence_start + (coordinate - entry_block.start);
     let strand = params.strand.unwrap_or(entry_block.strand);
 
-    let subgraph = extract_from_entry(conn, block_group_id, entry_block.node_id, entry_seq)?;
+    let subgraph = extract_from_entry(
+        conn,
+        workspace,
+        block_group_id,
+        entry_block.node_id,
+        entry_seq,
+    )?;
     let block_group_name = params
         .name
         .map(str::to_string)
@@ -884,12 +908,15 @@ pub fn translate_from_path(
     let label = HashId::convert_str(&format!("translate-from:{block_group_id}:{coordinate}"));
     translate_from(
         conn,
+        workspace,
         subgraph,
         strand,
         params,
-        &block_group.sample_name,
-        &block_group_name,
-        label,
+        TranslationTarget {
+            sample_name: &block_group.sample_name,
+            block_group_name: &block_group_name,
+            label_hash: label,
+        },
     )
 }
 
@@ -912,13 +939,17 @@ pub fn translate_from_path(
 /// predecessor, e.g. where a junction or two variant paths reconverge).
 fn translate_from(
     conn: &GraphConnection,
+    workspace: &Workspace,
     subgraph: TranslationSubgraph,
     strand: Strand,
     params: TranslationParams<'_>,
-    sample_name: &str,
-    block_group_name: &str,
-    label_hash: HashId,
+    target: TranslationTarget<'_>,
 ) -> Result<BlockGroup, TranslationError> {
+    let TranslationTarget {
+        sample_name,
+        block_group_name,
+        label_hash,
+    } = target;
     let TranslationSubgraph {
         graph: subgraph,
         node_ranges,
@@ -936,7 +967,7 @@ fn translate_from(
             .filter_map(|(nid, _, _)| if seen.insert(*nid) { Some(*nid) } else { None })
             .collect()
     };
-    let sequences_by_node = Node::get_sequences_by_node_ids(conn, &real_node_ids, None);
+    let sequences_by_node = Node::get_sequences_by_node_ids(conn, workspace, &real_node_ids, None);
 
     let mut dna_by_node: HashMap<HashId, String> = HashMap::new();
     for virtual_node_id in subgraph.nodes() {
@@ -1417,7 +1448,7 @@ mod tests {
         CodonTable, TranslationError, TranslationParams, translate_annotation,
         translate_block_group, translate_from_path,
     };
-    use crate::test_helpers::{create_bg, get_connection};
+    use crate::test_helpers::{create_bg, get_connection, test_workspace};
 
     #[test]
     fn standard_met() {
@@ -1834,7 +1865,8 @@ ncbieaa  "FFLLSSSSYY**CC*WLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG"
         }
         node_ids.retain(|id| *id != PATH_START_NODE_ID && *id != PATH_END_NODE_ID);
         let node_ids_vec: Vec<HashId> = node_ids.into_iter().collect();
-        let sequences_by_node = Node::get_sequences_by_node_ids(conn, &node_ids_vec, None);
+        let sequences_by_node =
+            Node::get_sequences_by_node_ids(conn, test_workspace(), &node_ids_vec, None);
         sequences_by_node
             .values()
             .filter(|seq| {
@@ -1846,8 +1878,13 @@ ncbieaa  "FFLLSSSSYY**CC*WLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG"
 
     /// Whether PATH_END is reachable from PATH_START in the protein graph.
     fn start_reaches_end(conn: &GraphConnection, block_group_id: &HashId) -> bool {
-        let graph =
-            BlockGroup::get_graph(conn, block_group_id, None).expect("should load protein graph");
+        let graph = BlockGroup::get_graph(
+            conn,
+            crate::test_helpers::test_workspace(),
+            block_group_id,
+            None,
+        )
+        .expect("should load protein graph");
         let start = graph.nodes().find(|n| n.node_id == PATH_START_NODE_ID);
         let end = graph.nodes().find(|n| n.node_id == PATH_END_NODE_ID);
         match (start, end) {
@@ -1861,10 +1898,22 @@ ncbieaa  "FFLLSSSSYY**CC*WLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG"
         // ATG→M, GAA→E, TGA→* : single node, frame 0
         let (conn, annotation, block_group_id) = setup_linear_gene(&["ATGGAATGA"]);
         let params = TranslationParams::new("test");
-        let protein =
-            translate_annotation(&conn, &annotation, Some(&block_group_id), params).unwrap();
+        let protein = translate_annotation(
+            &conn,
+            test_workspace(),
+            &annotation,
+            Some(&block_group_id),
+            params,
+        )
+        .unwrap();
         assert_eq!(
-            BlockGroup::get_all_sequences(&conn, &protein.id, true).unwrap(),
+            BlockGroup::get_all_sequences(
+                &conn,
+                crate::test_helpers::test_workspace(),
+                &protein.id,
+                true
+            )
+            .unwrap(),
             HashSet::from(["ME*".to_string()])
         );
     }
@@ -1873,8 +1922,14 @@ ncbieaa  "FFLLSSSSYY**CC*WLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG"
     fn translate_default_name_is_source_name_protein_suffixed() {
         let (conn, annotation, block_group_id) = setup_linear_gene(&["ATGGAATGA"]);
         let params = TranslationParams::new("test");
-        let protein =
-            translate_annotation(&conn, &annotation, Some(&block_group_id), params).unwrap();
+        let protein = translate_annotation(
+            &conn,
+            test_workspace(),
+            &annotation,
+            Some(&block_group_id),
+            params,
+        )
+        .unwrap();
         assert_eq!(protein.name, "test-gene (protein)");
     }
 
@@ -1882,8 +1937,14 @@ ncbieaa  "FFLLSSSSYY**CC*WLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG"
     fn translate_explicit_name_overrides_default() {
         let (conn, annotation, block_group_id) = setup_linear_gene(&["ATGGAATGA"]);
         let params = TranslationParams::new("test").name("custom-protein-name");
-        let protein =
-            translate_annotation(&conn, &annotation, Some(&block_group_id), params).unwrap();
+        let protein = translate_annotation(
+            &conn,
+            test_workspace(),
+            &annotation,
+            Some(&block_group_id),
+            params,
+        )
+        .unwrap();
         assert_eq!(protein.name, "custom-protein-name");
     }
 
@@ -1891,13 +1952,26 @@ ncbieaa  "FFLLSSSSYY**CC*WLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG"
     fn translate_duplicate_name_in_sample_errors() {
         let (conn, annotation, block_group_id) = setup_linear_gene(&["ATGGAATGA"]);
         let params = TranslationParams::new("test");
-        translate_annotation(&conn, &annotation, Some(&block_group_id), params).unwrap();
+        translate_annotation(
+            &conn,
+            test_workspace(),
+            &annotation,
+            Some(&block_group_id),
+            params,
+        )
+        .unwrap();
 
         // Same collection, same sample (it's always the source sample now), same
         // default name: the second translation must error instead of silently
         // merging new protein edges into the first run's sequence graph.
         let params = TranslationParams::new("test");
-        let result = translate_annotation(&conn, &annotation, Some(&block_group_id), params);
+        let result = translate_annotation(
+            &conn,
+            test_workspace(),
+            &annotation,
+            Some(&block_group_id),
+            params,
+        );
         assert!(matches!(
             result,
             Err(TranslationError::DuplicateBlockGroup(name)) if name == "test-gene (protein)"
@@ -1909,10 +1983,22 @@ ncbieaa  "FFLLSSSSYY**CC*WLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG"
         // initial_frame=1 → head_skip=2, reads "GGAATG" → G,M; tail "A" dropped
         let (conn, annotation, block_group_id) = setup_linear_gene(&["ATGGAATGA"]);
         let params = TranslationParams::new("test").initial_frame(1).unwrap();
-        let protein =
-            translate_annotation(&conn, &annotation, Some(&block_group_id), params).unwrap();
+        let protein = translate_annotation(
+            &conn,
+            test_workspace(),
+            &annotation,
+            Some(&block_group_id),
+            params,
+        )
+        .unwrap();
         assert_eq!(
-            BlockGroup::get_all_sequences(&conn, &protein.id, true).unwrap(),
+            BlockGroup::get_all_sequences(
+                &conn,
+                crate::test_helpers::test_workspace(),
+                &protein.id,
+                true
+            )
+            .unwrap(),
             HashSet::from(["GM".to_string()])
         );
     }
@@ -1923,10 +2009,22 @@ ncbieaa  "FFLLSSSSYY**CC*WLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG"
         // Node B = "AATGA": junction G+"AA"="GAA"→E; B[2..]="TGA"→*
         let (conn, annotation, block_group_id) = setup_linear_gene(&["ATGG", "AATGA"]);
         let params = TranslationParams::new("test");
-        let protein =
-            translate_annotation(&conn, &annotation, Some(&block_group_id), params).unwrap();
+        let protein = translate_annotation(
+            &conn,
+            test_workspace(),
+            &annotation,
+            Some(&block_group_id),
+            params,
+        )
+        .unwrap();
         assert_eq!(
-            BlockGroup::get_all_sequences(&conn, &protein.id, true).unwrap(),
+            BlockGroup::get_all_sequences(
+                &conn,
+                crate::test_helpers::test_workspace(),
+                &protein.id,
+                true
+            )
+            .unwrap(),
             HashSet::from(["ME*".to_string()])
         );
     }
@@ -1937,10 +2035,22 @@ ncbieaa  "FFLLSSSSYY**CC*WLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG"
         // Junction ATG=M (B fully consumed); node C: GAA→E, TGA→* → "E*"
         let (conn, annotation, block_group_id) = setup_linear_gene(&["AT", "G", "GAATGA"]);
         let params = TranslationParams::new("test");
-        let protein =
-            translate_annotation(&conn, &annotation, Some(&block_group_id), params).unwrap();
+        let protein = translate_annotation(
+            &conn,
+            test_workspace(),
+            &annotation,
+            Some(&block_group_id),
+            params,
+        )
+        .unwrap();
         assert_eq!(
-            BlockGroup::get_all_sequences(&conn, &protein.id, true).unwrap(),
+            BlockGroup::get_all_sequences(
+                &conn,
+                crate::test_helpers::test_workspace(),
+                &protein.id,
+                true
+            )
+            .unwrap(),
             HashSet::from(["ME*".to_string()])
         );
     }
@@ -1951,10 +2061,22 @@ ncbieaa  "FFLLSSSSYY**CC*WLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG"
         // Multi-hop junction "T"+"G"+"G" = TGG = W; node C → "E*"
         let (conn, annotation, block_group_id) = setup_linear_gene(&["T", "G", "GGAATGA"]);
         let params = TranslationParams::new("test");
-        let protein =
-            translate_annotation(&conn, &annotation, Some(&block_group_id), params).unwrap();
+        let protein = translate_annotation(
+            &conn,
+            test_workspace(),
+            &annotation,
+            Some(&block_group_id),
+            params,
+        )
+        .unwrap();
         assert_eq!(
-            BlockGroup::get_all_sequences(&conn, &protein.id, true).unwrap(),
+            BlockGroup::get_all_sequences(
+                &conn,
+                crate::test_helpers::test_workspace(),
+                &protein.id,
+                true
+            )
+            .unwrap(),
             HashSet::from(["WE*".to_string()])
         );
     }
@@ -1964,10 +2086,22 @@ ncbieaa  "FFLLSSSSYY**CC*WLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG"
         // Table 4: TGA → W (Trp), not stop
         let (conn, annotation, block_group_id) = setup_linear_gene(&["ATGTGA"]);
         let params = TranslationParams::new("test").codon_table(CodonTable::ncbi(4).unwrap());
-        let protein =
-            translate_annotation(&conn, &annotation, Some(&block_group_id), params).unwrap();
+        let protein = translate_annotation(
+            &conn,
+            test_workspace(),
+            &annotation,
+            Some(&block_group_id),
+            params,
+        )
+        .unwrap();
         assert_eq!(
-            BlockGroup::get_all_sequences(&conn, &protein.id, true).unwrap(),
+            BlockGroup::get_all_sequences(
+                &conn,
+                crate::test_helpers::test_workspace(),
+                &protein.id,
+                true
+            )
+            .unwrap(),
             HashSet::from(["MW".to_string()])
         );
     }
@@ -2014,7 +2148,13 @@ ncbieaa  "FFLLSSSSYY**CC*WLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG"
         let params = TranslationParams::new("test");
         // Strand is resolved before subgraph extraction, so a valid block-group id is
         // required even though this case errors out first.
-        let result = translate_annotation(&conn, &annotation, Some(&block_group.id), params);
+        let result = translate_annotation(
+            &conn,
+            test_workspace(),
+            &annotation,
+            Some(&block_group.id),
+            params,
+        );
         assert!(
             matches!(result, Err(TranslationError::AmbiguousStrand)),
             "expected AmbiguousStrand, got {:?}",
@@ -2055,11 +2195,23 @@ ncbieaa  "FFLLSSSSYY**CC*WLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG"
         );
 
         let params = TranslationParams::new("test");
-        let protein =
-            translate_annotation(&conn, &annotation, Some(&block_group.id), params).unwrap();
+        let protein = translate_annotation(
+            &conn,
+            test_workspace(),
+            &annotation,
+            Some(&block_group.id),
+            params,
+        )
+        .unwrap();
 
         assert_eq!(
-            BlockGroup::get_all_sequences(&conn, &protein.id, true).unwrap(),
+            BlockGroup::get_all_sequences(
+                &conn,
+                crate::test_helpers::test_workspace(),
+                &protein.id,
+                true
+            )
+            .unwrap(),
             HashSet::from([expected.to_string()]),
             "reverse-strand protein should read N → C left to right"
         );
@@ -2077,8 +2229,14 @@ ncbieaa  "FFLLSSSSYY**CC*WLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG"
     fn non_synonymous_snp_creates_variant_protein_path() {
         let (conn, annotation, block_group_id) = setup_variant_gene("ATG", "GAA", "CAA", "TGA");
         let params = TranslationParams::new("test");
-        let protein =
-            translate_annotation(&conn, &annotation, Some(&block_group_id), params).unwrap();
+        let protein = translate_annotation(
+            &conn,
+            test_workspace(),
+            &annotation,
+            Some(&block_group_id),
+            params,
+        )
+        .unwrap();
 
         // Both amino acids must appear as protein nodes.
         assert_eq!(
@@ -2118,8 +2276,14 @@ ncbieaa  "FFLLSSSSYY**CC*WLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG"
     fn synonymous_snp_collapses_to_single_protein_node() {
         let (conn, annotation, block_group_id) = setup_variant_gene("ATG", "GAA", "GAG", "TGA");
         let params = TranslationParams::new("test");
-        let protein =
-            translate_annotation(&conn, &annotation, Some(&block_group_id), params).unwrap();
+        let protein = translate_annotation(
+            &conn,
+            test_workspace(),
+            &annotation,
+            Some(&block_group_id),
+            params,
+        )
+        .unwrap();
 
         // Synonymous collapse: exactly one protein node with sequence "E".
         assert_eq!(
@@ -2150,8 +2314,14 @@ ncbieaa  "FFLLSSSSYY**CC*WLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG"
     fn synonymous_junction_snp_collapses_junction_node() {
         let (conn, annotation, block_group_id) = setup_variant_gene("ATGG", "AA", "AG", "TAA");
         let params = TranslationParams::new("test");
-        let protein =
-            translate_annotation(&conn, &annotation, Some(&block_group_id), params).unwrap();
+        let protein = translate_annotation(
+            &conn,
+            test_workspace(),
+            &annotation,
+            Some(&block_group_id),
+            params,
+        )
+        .unwrap();
 
         // Exactly one junction node coding for E.
         assert_eq!(
@@ -2174,7 +2344,8 @@ ncbieaa  "FFLLSSSSYY**CC*WLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG"
     fn full_block_group_keeps_parallel_columns() {
         let (conn, block_group_id) = setup_parallel_columns();
         let params = TranslationParams::new("test");
-        let protein = translate_block_group(&conn, &block_group_id, params).unwrap();
+        let protein =
+            translate_block_group(&conn, test_workspace(), &block_group_id, params).unwrap();
 
         for amino_acid in ["G", "A", "D", "F"] {
             assert_eq!(
@@ -2193,8 +2364,14 @@ ncbieaa  "FFLLSSSSYY**CC*WLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG"
     fn variant_bubble_protein_graph_is_connected() {
         let (conn, annotation, block_group_id) = setup_real_bubble();
         let params = TranslationParams::new("test");
-        let protein =
-            translate_annotation(&conn, &annotation, Some(&block_group_id), params).unwrap();
+        let protein = translate_annotation(
+            &conn,
+            test_workspace(),
+            &annotation,
+            Some(&block_group_id),
+            params,
+        )
+        .unwrap();
 
         // Both the wild-type (E) and variant (A) junction residues must appear.
         assert_eq!(
@@ -2217,8 +2394,13 @@ ncbieaa  "FFLLSSSSYY**CC*WLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG"
             start_reaches_end(&conn, &protein.id),
             "protein graph has no PATH_START → PATH_END path (disconnected)"
         );
-        let protein_graph =
-            BlockGroup::get_graph(&conn, &protein.id, None).expect("should load protein graph");
+        let protein_graph = BlockGroup::get_graph(
+            &conn,
+            crate::test_helpers::test_workspace(),
+            &protein.id,
+            None,
+        )
+        .expect("should load protein graph");
         assert_eq!(
             connected_components(&protein_graph),
             1,
@@ -2233,10 +2415,22 @@ ncbieaa  "FFLLSSSSYY**CC*WLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG"
         // A = "ATGT": ATG→M, tail "T" (1 byte). B = "AAGG": junction "T"+"AA" = "TAA" = stop.
         let (conn, annotation, block_group_id) = setup_linear_gene(&["ATGT", "AAGG"]);
         let params = TranslationParams::new("test");
-        let protein =
-            translate_annotation(&conn, &annotation, Some(&block_group_id), params).unwrap();
+        let protein = translate_annotation(
+            &conn,
+            test_workspace(),
+            &annotation,
+            Some(&block_group_id),
+            params,
+        )
+        .unwrap();
         assert_eq!(
-            BlockGroup::get_all_sequences(&conn, &protein.id, true).unwrap(),
+            BlockGroup::get_all_sequences(
+                &conn,
+                crate::test_helpers::test_workspace(),
+                &protein.id,
+                true
+            )
+            .unwrap(),
             HashSet::from(["M*".to_string()])
         );
     }
@@ -2291,13 +2485,20 @@ ncbieaa  "FFLLSSSSYY**CC*WLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG"
 
         let protein = translate_annotation(
             &conn,
+            test_workspace(),
             &annotation,
             Some(&child_bg.id),
             TranslationParams::new("test"),
         )
         .unwrap();
         assert_eq!(
-            BlockGroup::get_all_sequences(&conn, &protein.id, true).unwrap(),
+            BlockGroup::get_all_sequences(
+                &conn,
+                crate::test_helpers::test_workspace(),
+                &protein.id,
+                true
+            )
+            .unwrap(),
             HashSet::from(["ME*".to_string()]),
             "translation should only follow the annotation's own entry node"
         );
@@ -2310,10 +2511,22 @@ ncbieaa  "FFLLSSSSYY**CC*WLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG"
         // TAA is a stop in the standard table; the rest of the node is never read.
         let (conn, annotation, block_group_id) = setup_linear_gene(&["TAAGGGCCC"]);
         let params = TranslationParams::new("test");
-        let protein =
-            translate_annotation(&conn, &annotation, Some(&block_group_id), params).unwrap();
+        let protein = translate_annotation(
+            &conn,
+            test_workspace(),
+            &annotation,
+            Some(&block_group_id),
+            params,
+        )
+        .unwrap();
         assert_eq!(
-            BlockGroup::get_all_sequences(&conn, &protein.id, true).unwrap(),
+            BlockGroup::get_all_sequences(
+                &conn,
+                crate::test_helpers::test_workspace(),
+                &protein.id,
+                true
+            )
+            .unwrap(),
             HashSet::from(["*".to_string()])
         );
     }
@@ -2331,10 +2544,22 @@ ncbieaa  "FFLLSSSSYY**CC*WLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG"
         let (conn, annotation, block_group_id) =
             setup_variant_gene("ATG", "CCC", "CC", "GTAGGGTAA");
         let params = TranslationParams::new("test");
-        let protein =
-            translate_annotation(&conn, &annotation, Some(&block_group_id), params).unwrap();
+        let protein = translate_annotation(
+            &conn,
+            test_workspace(),
+            &annotation,
+            Some(&block_group_id),
+            params,
+        )
+        .unwrap();
         assert_eq!(
-            BlockGroup::get_all_sequences(&conn, &protein.id, true).unwrap(),
+            BlockGroup::get_all_sequences(
+                &conn,
+                crate::test_helpers::test_workspace(),
+                &protein.id,
+                true
+            )
+            .unwrap(),
             HashSet::from(["MP*".to_string(), "MPVG*".to_string()]),
             "frameshift deletion should truncate the variant protein at the premature stop"
         );
@@ -2352,10 +2577,22 @@ ncbieaa  "FFLLSSSSYY**CC*WLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG"
         let (conn, annotation, block_group_id) =
             setup_variant_gene("ATG", "AAA", "AA", "TGACTAAGG");
         let params = TranslationParams::new("test");
-        let protein =
-            translate_annotation(&conn, &annotation, Some(&block_group_id), params).unwrap();
+        let protein = translate_annotation(
+            &conn,
+            test_workspace(),
+            &annotation,
+            Some(&block_group_id),
+            params,
+        )
+        .unwrap();
         assert_eq!(
-            BlockGroup::get_all_sequences(&conn, &protein.id, true).unwrap(),
+            BlockGroup::get_all_sequences(
+                &conn,
+                crate::test_helpers::test_workspace(),
+                &protein.id,
+                true
+            )
+            .unwrap(),
             HashSet::from(["MK*".to_string(), "MND*".to_string()]),
             "frameshift deletion should read through the wild-type stop to a later one"
         );
@@ -2410,7 +2647,8 @@ ncbieaa  "FFLLSSSSYY**CC*WLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG"
     fn junction_codons_with_same_amino_acid_deduplicate() {
         let (conn, block_group_id) = setup_junction_fanout();
         let params = TranslationParams::new("test");
-        let protein = translate_block_group(&conn, &block_group_id, params).unwrap();
+        let protein =
+            translate_block_group(&conn, test_workspace(), &block_group_id, params).unwrap();
 
         assert_eq!(
             count_protein_nodes_with_aa(&conn, &protein.id, "K"),
@@ -2469,7 +2707,8 @@ ncbieaa  "FFLLSSSSYY**CC*WLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG"
     fn many_to_one_junction_convergence_deduplicates() {
         let (conn, block_group_id) = setup_many_to_one_junction();
         let params = TranslationParams::new("test");
-        let protein = translate_block_group(&conn, &block_group_id, params).unwrap();
+        let protein =
+            translate_block_group(&conn, test_workspace(), &block_group_id, params).unwrap();
 
         assert_eq!(
             count_protein_nodes_with_aa(&conn, &protein.id, "K"),
@@ -2533,6 +2772,7 @@ ncbieaa  "FFLLSSSSYY**CC*WLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG"
 
         let parent_protein = translate_annotation(
             &conn,
+            test_workspace(),
             &annotation,
             Some(&parent_bg.id),
             TranslationParams::new("test"),
@@ -2540,6 +2780,7 @@ ncbieaa  "FFLLSSSSYY**CC*WLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG"
         .unwrap();
         let child_protein = translate_annotation(
             &conn,
+            test_workspace(),
             &annotation,
             Some(&child_bg.id),
             TranslationParams::new("test"),
@@ -2547,12 +2788,30 @@ ncbieaa  "FFLLSSSSYY**CC*WLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG"
         .unwrap();
 
         assert_eq!(
-            BlockGroup::get_all_sequences(&conn, &parent_protein.id, true).unwrap(),
+            BlockGroup::get_all_sequences(
+                &conn,
+                crate::test_helpers::test_workspace(),
+                &parent_protein.id,
+                true
+            )
+            .unwrap(),
             HashSet::from(["ME*".to_string()])
         );
         assert_eq!(
-            BlockGroup::get_all_sequences(&conn, &child_protein.id, true).unwrap(),
-            BlockGroup::get_all_sequences(&conn, &parent_protein.id, true).unwrap(),
+            BlockGroup::get_all_sequences(
+                &conn,
+                crate::test_helpers::test_workspace(),
+                &child_protein.id,
+                true
+            )
+            .unwrap(),
+            BlockGroup::get_all_sequences(
+                &conn,
+                crate::test_helpers::test_workspace(),
+                &parent_protein.id,
+                true
+            )
+            .unwrap(),
             "upstream deletion changed the annotated protein",
         );
     }
@@ -2615,6 +2874,7 @@ ncbieaa  "FFLLSSSSYY**CC*WLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG"
 
         let parent_protein = translate_annotation(
             &conn,
+            test_workspace(),
             &annotation,
             Some(&parent_bg.id),
             TranslationParams::new("test"),
@@ -2622,6 +2882,7 @@ ncbieaa  "FFLLSSSSYY**CC*WLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG"
         .unwrap();
         let child_protein = translate_annotation(
             &conn,
+            test_workspace(),
             &annotation,
             Some(&child_bg.id),
             TranslationParams::new("test"),
@@ -2629,16 +2890,40 @@ ncbieaa  "FFLLSSSSYY**CC*WLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG"
         .unwrap();
 
         assert_eq!(
-            BlockGroup::get_all_sequences(&conn, &parent_protein.id, true).unwrap(),
+            BlockGroup::get_all_sequences(
+                &conn,
+                crate::test_helpers::test_workspace(),
+                &parent_protein.id,
+                true
+            )
+            .unwrap(),
             HashSet::from(["ME*".to_string()])
         );
         assert_eq!(
-            BlockGroup::get_all_sequences(&conn, &child_protein.id, true).unwrap(),
+            BlockGroup::get_all_sequences(
+                &conn,
+                crate::test_helpers::test_workspace(),
+                &child_protein.id,
+                true
+            )
+            .unwrap(),
             HashSet::from(["MQ*".to_string()])
         );
         assert_ne!(
-            BlockGroup::get_all_sequences(&conn, &child_protein.id, true).unwrap(),
-            BlockGroup::get_all_sequences(&conn, &parent_protein.id, true).unwrap(),
+            BlockGroup::get_all_sequences(
+                &conn,
+                crate::test_helpers::test_workspace(),
+                &child_protein.id,
+                true
+            )
+            .unwrap(),
+            BlockGroup::get_all_sequences(
+                &conn,
+                crate::test_helpers::test_workspace(),
+                &parent_protein.id,
+                true
+            )
+            .unwrap(),
             "point mutation inside the CDS did not change the protein",
         );
     }
@@ -2697,6 +2982,7 @@ ncbieaa  "FFLLSSSSYY**CC*WLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG"
 
         let protein = translate_annotation(
             &conn,
+            test_workspace(),
             &annotation,
             Some(&child_bg.id),
             TranslationParams::new("test"),
@@ -2704,7 +2990,13 @@ ncbieaa  "FFLLSSSSYY**CC*WLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG"
         .unwrap();
 
         assert_eq!(
-            BlockGroup::get_all_sequences(&conn, &protein.id, true).unwrap(),
+            BlockGroup::get_all_sequences(
+                &conn,
+                crate::test_helpers::test_workspace(),
+                &protein.id,
+                true
+            )
+            .unwrap(),
             HashSet::from(["ME*".to_string()]),
             "translation should only follow the annotation's own entry node"
         );
@@ -2762,6 +3054,7 @@ ncbieaa  "FFLLSSSSYY**CC*WLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG"
 
         let protein = translate_annotation(
             &conn,
+            test_workspace(),
             &annotation,
             Some(&child_bg.id),
             TranslationParams::new("test"),
@@ -2769,7 +3062,13 @@ ncbieaa  "FFLLSSSSYY**CC*WLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG"
         .unwrap();
 
         assert_eq!(
-            BlockGroup::get_all_sequences(&conn, &protein.id, true).unwrap(),
+            BlockGroup::get_all_sequences(
+                &conn,
+                crate::test_helpers::test_workspace(),
+                &protein.id,
+                true
+            )
+            .unwrap(),
             HashSet::from(["ME*".to_string(), "MEW".to_string()]),
             "last-base variant was dropped from the extracted subgraph",
         );
@@ -2818,11 +3117,23 @@ ncbieaa  "FFLLSSSSYY**CC*WLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG"
         );
         Path::create(&conn, "probe", &block_group.id, &[e_start_a, e_a_end]).unwrap();
 
-        let from_path =
-            translate_from_path(&conn, &block_group.id, 0, TranslationParams::new("test")).unwrap();
+        let from_path = translate_from_path(
+            &conn,
+            test_workspace(),
+            &block_group.id,
+            0,
+            TranslationParams::new("test"),
+        )
+        .unwrap();
 
         assert_eq!(
-            BlockGroup::get_all_sequences(&conn, &from_path.id, true).unwrap(),
+            BlockGroup::get_all_sequences(
+                &conn,
+                crate::test_helpers::test_workspace(),
+                &from_path.id,
+                true
+            )
+            .unwrap(),
             HashSet::from(["*".to_string()]),
             "translate_from_path(0) should only translate the literal entry node (A), \
              not the unrelated D/P/Z branch reachable from PATH_START"
@@ -2841,10 +3152,17 @@ ncbieaa  "FFLLSSSSYY**CC*WLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG"
         let (conn, block_group_id, _, _) =
             setup_reverse_variant_gene(REV_PREFIX, "GAA", "CAA", REV_SUFFIX);
         let params = TranslationParams::new("test").strand(Strand::Reverse);
-        let protein = translate_block_group(&conn, &block_group_id, params).unwrap();
+        let protein =
+            translate_block_group(&conn, test_workspace(), &block_group_id, params).unwrap();
 
         assert_eq!(
-            BlockGroup::get_all_sequences(&conn, &protein.id, true).unwrap(),
+            BlockGroup::get_all_sequences(
+                &conn,
+                crate::test_helpers::test_workspace(),
+                &protein.id,
+                true
+            )
+            .unwrap(),
             HashSet::from(["MKPEGF*".to_string(), "MKPQGF*".to_string()])
         );
     }
@@ -2866,11 +3184,23 @@ ncbieaa  "FFLLSSSSYY**CC*WLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG"
         );
 
         let params = TranslationParams::new("test");
-        let protein =
-            translate_annotation(&conn, &annotation, Some(&block_group_id), params).unwrap();
+        let protein = translate_annotation(
+            &conn,
+            test_workspace(),
+            &annotation,
+            Some(&block_group_id),
+            params,
+        )
+        .unwrap();
 
         assert_eq!(
-            BlockGroup::get_all_sequences(&conn, &protein.id, true).unwrap(),
+            BlockGroup::get_all_sequences(
+                &conn,
+                crate::test_helpers::test_workspace(),
+                &protein.id,
+                true
+            )
+            .unwrap(),
             HashSet::from(["MKPEGF*".to_string(), "MKPQGF*".to_string()])
         );
     }
@@ -2884,10 +3214,17 @@ ncbieaa  "FFLLSSSSYY**CC*WLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG"
         let (conn, block_group_id, _, _) =
             setup_reverse_variant_gene(REV_PREFIX, "GAA", "CAA", REV_SUFFIX);
         let params = TranslationParams::new("test").strand(Strand::Reverse);
-        let protein = translate_from_path(&conn, &block_group_id, 0, params).unwrap();
+        let protein =
+            translate_from_path(&conn, test_workspace(), &block_group_id, 0, params).unwrap();
 
         assert_eq!(
-            BlockGroup::get_all_sequences(&conn, &protein.id, true).unwrap(),
+            BlockGroup::get_all_sequences(
+                &conn,
+                crate::test_helpers::test_workspace(),
+                &protein.id,
+                true
+            )
+            .unwrap(),
             HashSet::from(["MKPEGF*".to_string(), "MKPQGF*".to_string()])
         );
     }

--- a/src/imports/fasta.rs
+++ b/src/imports/fasta.rs
@@ -243,13 +243,14 @@ mod tests {
 
         let block_group_id = BlockGroup::get_id("test", Sample::DEFAULT_NAME, "m123", None);
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &block_group_id, false).unwrap(),
+            BlockGroup::get_all_sequences(conn, context.workspace(), &block_group_id, false)
+                .unwrap(),
             HashSet::from_iter(vec!["ATCGATCGATCGATCGATCGGGAACACACAGAGA".to_string()])
         );
 
         let path = Path::all(conn)[0].clone();
         assert_eq!(
-            path.sequence(conn, None).unwrap(),
+            path.sequence(conn, context.workspace(), None).unwrap(),
             "ATCGATCGATCGATCGATCGGGAACACACAGAGA".to_string()
         );
     }
@@ -272,7 +273,8 @@ mod tests {
         .unwrap();
         let block_group_id = BlockGroup::get_id("test", Sample::DEFAULT_NAME, "m123", None);
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &block_group_id, false).unwrap(),
+            BlockGroup::get_all_sequences(conn, context.workspace(), &block_group_id, false)
+                .unwrap(),
             HashSet::from_iter(vec!["ATCGATCGATCGATCGATCGGGAACACACAGAGA".to_string()])
         );
     }
@@ -319,7 +321,8 @@ mod tests {
         .unwrap();
         let block_group_id = BlockGroup::get_id("test", Sample::DEFAULT_NAME, "m123", None);
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &block_group_id, false).unwrap(),
+            BlockGroup::get_all_sequences(conn, context.workspace(), &block_group_id, false)
+                .unwrap(),
             HashSet::from_iter(vec!["ATCGATCGATCGATCGATCGGGAACACACAGAGA".to_string()])
         );
     }
@@ -342,13 +345,14 @@ mod tests {
         .unwrap();
         let block_group_id = BlockGroup::get_id("test", "new-sample", "m123", None);
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &block_group_id, false).unwrap(),
+            BlockGroup::get_all_sequences(conn, context.workspace(), &block_group_id, false)
+                .unwrap(),
             HashSet::from_iter(vec!["ATCGATCGATCGATCGATCGGGAACACACAGAGA".to_string()])
         );
 
         let path = Path::all(conn)[0].clone();
         assert_eq!(
-            path.sequence(conn, None).unwrap(),
+            path.sequence(conn, context.workspace(), None).unwrap(),
             "ATCGATCGATCGATCGATCGGGAACACACAGAGA".to_string()
         );
         assert_eq!(
@@ -375,13 +379,14 @@ mod tests {
         .unwrap();
         let block_group_id = BlockGroup::get_id("test", Sample::DEFAULT_NAME, "m123", None);
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &block_group_id, false).unwrap(),
+            BlockGroup::get_all_sequences(conn, context.workspace(), &block_group_id, false)
+                .unwrap(),
             HashSet::from_iter(vec!["ATCGATCGATCGATCGATCGGGAACACACAGAGA".to_string()])
         );
 
         let path = Path::all(conn)[0].clone();
         assert_eq!(
-            path.sequence(conn, None).unwrap(),
+            path.sequence(conn, context.workspace(), None).unwrap(),
             "ATCGATCGATCGATCGATCGGGAACACACAGAGA".to_string()
         );
     }

--- a/src/imports/genbank.rs
+++ b/src/imports/genbank.rs
@@ -630,7 +630,7 @@ where
                             None,
                         ),
                     };
-                    BlockGroup::insert_change(conn, &change).unwrap();
+                    BlockGroup::insert_change(conn, context.workspace(), &change).unwrap();
                     applied_changes.push((edit, change_node_id));
                 }
 
@@ -1199,7 +1199,13 @@ mod tests {
             let f = reader::parse_file(&path).unwrap();
             let seq = str::from_utf8(&f[0].seq).unwrap().to_string();
             let block_group_id = BlockGroup::get_id("", Sample::DEFAULT_NAME, "insertion", None);
-            let seqs = BlockGroup::get_all_sequences(conn, &block_group_id, false).unwrap();
+            let seqs = BlockGroup::get_all_sequences(
+                conn,
+                crate::test_helpers::test_workspace(),
+                &block_group_id,
+                false,
+            )
+            .unwrap();
             assert_eq!(
                 seqs,
                 HashSet::from_iter([
@@ -1247,7 +1253,13 @@ mod tests {
         GATGCCATTGGGATATATCAACGGTGGTATATCCAGTGATTTTTTTCTCCAT",
             );
             let block_group_id = BlockGroup::get_id("", Sample::DEFAULT_NAME, "deletion", None);
-            let seqs = BlockGroup::get_all_sequences(conn, &block_group_id, false).unwrap();
+            let seqs = BlockGroup::get_all_sequences(
+                conn,
+                crate::test_helpers::test_workspace(),
+                &block_group_id,
+                false,
+            )
+            .unwrap();
             assert_eq!(
                 seqs,
                 HashSet::from_iter([
@@ -1296,6 +1308,7 @@ mod tests {
             );
             let seqs = BlockGroup::get_all_sequences(
                 conn,
+                crate::test_helpers::test_workspace(),
                 &BlockGroup::get_id("", Sample::DEFAULT_NAME, "deletion_and_insertion", None),
                 false,
             )
@@ -1350,6 +1363,7 @@ mod tests {
             );
             let seqs = BlockGroup::get_all_sequences(
                 conn,
+                crate::test_helpers::test_workspace(),
                 &BlockGroup::get_id("", Sample::DEFAULT_NAME, "substitution", None),
                 false,
             )
@@ -1389,6 +1403,7 @@ mod tests {
             let mod_seq = str::from_utf8(&f[0].seq).unwrap().to_string();
             let sequences: HashSet<String> = BlockGroup::get_all_sequences(
                 conn,
+                crate::test_helpers::test_workspace(),
                 &BlockGroup::get_id("", Sample::DEFAULT_NAME, "insertion", None),
                 false,
             )

--- a/src/imports/gfa.rs
+++ b/src/imports/gfa.rs
@@ -370,7 +370,7 @@ pub fn import_gfa(
     let bar = progress_bar.add(get_progress_bar(None));
     bar.set_message("Breaking cycles");
     let message_bar = progress_bar.add(get_message_bar());
-    let graph = BlockGroup::get_graph(conn, &block_group.id, None)?;
+    let graph = BlockGroup::get_graph(conn, context.workspace(), &block_group.id, None)?;
     let mut undirected_graph: UnGraphMap<GraphNode, GraphEdge> = UnGraphMap::new();
     for node in graph.nodes() {
         undirected_graph.add_node(node);
@@ -527,7 +527,7 @@ mod tests {
         )[0]
         .clone();
 
-        let result = path.sequence(conn, None);
+        let result = path.sequence(conn, context.workspace(), None);
         assert_eq!(result.unwrap(), "ATCGATCGATCGATCGATCGGGAACACACAGAGA");
 
         let node_count = Node::query(conn, "select * from nodes", rusqlite::params!()).len() as i64;
@@ -558,7 +558,13 @@ mod tests {
         let _ = import_gfa(&context, &gfa_path, &collection_name, Sample::DEFAULT_NAME);
 
         let block_group_id = BlockGroup::get_id(&collection_name, Sample::DEFAULT_NAME, "", None);
-        let all_sequences = BlockGroup::get_all_sequences(conn, &block_group_id, false).unwrap();
+        let all_sequences = BlockGroup::get_all_sequences(
+            conn,
+            crate::test_helpers::test_workspace(),
+            &block_group_id,
+            false,
+        )
+        .unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec!["AAAATTTTGGGGCCCC".to_string()])
@@ -585,7 +591,7 @@ mod tests {
         )[0]
         .clone();
 
-        let result = path.sequence(conn, None);
+        let result = path.sequence(conn, context.workspace(), None);
         assert_eq!(result.unwrap(), "ACCTACAAATTCAAAC");
 
         let node_count = Node::query(conn, "select * from nodes", rusqlite::params!()).len() as i64;
@@ -609,7 +615,7 @@ mod tests {
         )[0]
         .clone();
 
-        let result = path.sequence(conn, None);
+        let result = path.sequence(conn, context.workspace(), None);
         assert_eq!(result.unwrap(), "TATGCCAGCTGCGAATA");
 
         let node_count = Node::query(conn, "select * from nodes", rusqlite::params!()).len() as i64;
@@ -636,7 +642,7 @@ mod tests {
         )[0]
         .clone();
 
-        let result = path.sequence(conn, None);
+        let result = path.sequence(conn, context.workspace(), None);
         let big_part = "TGCTAGCTACTAGTGAAAGAGGAGAAATACTAGATGGCTTCCTCCGAAGACGTTATCAAAGAGTTCATGCGTTTCAAAGTTCGTATGGAAGGTTCCGTTAACGGTCACGAGTTCGAAATCGAAGGTGAAGGTGAAGGTCGTCCGTACGAAGGTACCCAGACCGCTAAACTGAAAGTTACCAAAGGTGGTCCGCTGCCGTTCGCTTGGGACATCCTGTCCCCGCAGTTCCAGTACGGTTCCAAAGCTTACGTTAAACACCCGGCTGACATCCCGGACTACCTGAAACTGTCCTTCCCGGAAGGTTTCAAATGGGAACGTGTTATGAACTTCGAAGACGGTGGTGTTGTTACCGTTACCCAGGACTCCTCCCTGCAAGACGGTGAGTTCATCTACAAAGTTAAACTGCGTGGTACCAACTTCCCGTCCGACGGTCCGGTTATGCAGAAAAAAACCATGGGTTGGGAAGCTTCCACCGAACGTATGTACCCGGAAGACGGTGCTCTGAAAGGTGAAATCAAAATGCGTCTGAAACTGAAAGACGGTGGTCACTACGACGCTGAAGTTAAAACCACCTACATGGCTAAAAAACCGGTTCAGCTGCCGGGTGCTTACAAAACCGACATCAAACTGGACATCACCTCCCACAACGAAGACTACACCATCGTTGAACAGTACGAACGTGCTGAAGGTCGTCACTCCACCGGTGCTTAATAACGCTGATAGTGCTAGTGTAGATCGCTACTAGAGCCAGGCATCAAATAAAACGAAAGGCTCAGTCGAAAGACTGGGCCTTTCGTTTTATCTGTTGTTTGTCGGTGAACGCTCTCTACTAGAGTCACACTGGCTCACCTTCGGGTGGGCCTTTCTGCGTTTATATACTAGAAGCGGCCGCTGCAGGCTTCCTCGCTCACTGACTCGCTGCGCTCGGTCGTTCGGCTGCGGCGAGCGGTATCAGCTCACTCAAAGGCGGTAATACGGTTATCCACAGAATCAGGGGATAACGCAGGAAAGAACATGTGAGCAAAAGGCCAGCAAAAGGCCAGGAACCGTAAAAAGGCCGCGTTGCTGGCGTTTTTCCATAGGCTCCGCCCCCCTGACGAGCATCACAAAAATCGACGCTCAAGTCAGAGGTGGCGAAACCCGACAGGACTATAAAGATACCAGGCGTTTCCCCCTGGAAGCTCCCTCGTGCGCTCTCCTGTTCCGACCCTGCCGCTTACCGGATACCTGTCCGCCTTTCTCCCTTCGGGAAGCGTGGCGCTTTCTCATAGCTCACGCTGTAGGTATCTCAGTTCGGTGTAGGTCGTTCGCTCCAAGCTGGGCTGTGTGCACGAACCCCCCGTTCAGCCCGACCGCTGCGCCTTATCCGGTAACTATCGTCTTGAGTCCAACCCGGTAAGACACGACTTATCGCCACTGGCAGCAGCCACTGGTAACAGGATTAGCAGAGCGAGGTATGTAGGCGGTGCTACAGAGTTCTTGAAGTGGTGGCCTAACTACGGCTACACTAGAAGGACAGTATTTGGTATCTGCGCTCTGCTGAAGCCAGTTACCTTCGGAAAAAGAGTTGGTAGCTCTTGATCCGGCAAACAAACCACCGCTGGTAGCGGTGGTTTTTTTGTTTGCAAGCAGCAGATTACGCGCAGAAAAAAAGGATCTCAAGAAGATCCTTTGATCTTTTCTACGGGGTCTGACGCTCAGTGGAACGAAAACTCACGTTAAGGGATTTTGGTCATGAGATTATCAAAAAGGATCTTCACCTAGATCCTTTTAAATTAAAAATGAAGTTTTAAATCAATCTAAAGTATATATGAGTAAACTTGGTCTGACAGTTACCAATGCTTAATCAGTGAGGCACCTATCTCAGCGATCTGTCTATTTCGTTCATCCATAGTTGCCTGACTCCCCGTCGTGTAGATAACTACGATACGGGAGGGCTTACCATCTGGCCCCAGTGCTGCAATGATACCGCGAGACCCACGCTCACCGGCTCCAGATTTATCAGCAATAAACCAGCCAGCCGGAAGGGCCGAGCGCAGAAGTGGTCCTGCAACTTTATCCGCCTCCATCCAGTCTATTAATTGTTGCCGGGAAGCTAGAGTAAGTAGTTCGCCAGTTAATAGTTTGCGCAACGTTGTTGCCATTGCTACAGGCATCGTGGTGTCACGCTCGTCGTTTGGTATGGCTTCATTCAGCTCCGGTTCCCAACGATCAAGGCGAGTTACATGATCCCCCATGTTGTGCAAAAAAGCGGTTAGCTCCTTCGGTCCTCCGATCGTTGTCAGAAGTAAGTTGGCCGCAGTGTTATCACTCATGGTTATGGCAGCACTGCATAATTCTCTTACTGTCATGCCATCCGTAAGATGCTTTTCTGTGACTGGTGAGTACTCAACCAAGTCATTCTGAGAATAGTGTATGCGGCGACCGAGTTGCTCTTGCCCGGCGTCAATACGGGATAATACCGCGCCACATAGCAGAACTTTAAAAGTGCTCATCATTGGAAAACGTTCTTCGGGGCGAAAACTCTCAAGGATCTTACCGCTGTTGAGATCCAGTTCGATGTAACCCACTCGTGCACCCAACTGATCTTCAGCATCTTTTACTTTCACCAGCGTTTCTGGGTGAGCAAAAACAGGAAGGCAAAATGCCGCAAAAAAGGGAATAAGGGCGACACGGAAATGTTGAATACTCATACTCTTCCTTTTTCAATATTATTGAAGCATTTATCAGGGTTATTGTCTCATGAGCGGATACATATTTGAATGTATTTAGAAAAATAAACAAATAGGGGTTCCGCGCACATTTCCCCGAAAAGTGCCACCTGACGTCTAAGAAACCATTATTATCATGACATTAACCTATAAAAATAGGCGTATCACGAGGCAGAATTTCAGATAAAAAAAATCCTTAGCTTTCGCTAAGGATGATTTCTGGAATTCGCGGCCGCATCTAGAG";
         let expected_sequence_parts = vec![
             "T",
@@ -711,7 +717,13 @@ mod tests {
                 }
             }
         }
-        let all_sequences = BlockGroup::get_all_sequences(conn, &block_group_id, false).unwrap();
+        let all_sequences = BlockGroup::get_all_sequences(
+            conn,
+            crate::test_helpers::test_workspace(),
+            &block_group_id,
+            false,
+        )
+        .unwrap();
         assert_eq!(all_sequences.len(), 1024);
         assert_eq!(all_sequences, expected_sequences);
 
@@ -736,10 +748,16 @@ mod tests {
         )[0]
         .clone();
 
-        let result = path.sequence(conn, None);
+        let result = path.sequence(conn, context.workspace(), None);
         assert_eq!(result.unwrap(), "AA");
 
-        let all_sequences = BlockGroup::get_all_sequences(conn, &block_group_id, false).unwrap();
+        let all_sequences = BlockGroup::get_all_sequences(
+            conn,
+            crate::test_helpers::test_workspace(),
+            &block_group_id,
+            false,
+        )
+        .unwrap();
         assert_eq!(all_sequences, HashSet::from_iter(vec!["AA".to_string()]));
 
         let node_count = Node::query(conn, "select * from nodes", rusqlite::params!()).len() as i64;
@@ -757,7 +775,13 @@ mod tests {
 
         let block_group_id = BlockGroup::get_id(&collection_name, Sample::DEFAULT_NAME, "", None);
 
-        let all_sequences = BlockGroup::get_all_sequences(conn, &block_group_id, false).unwrap();
+        let all_sequences = BlockGroup::get_all_sequences(
+            conn,
+            crate::test_helpers::test_workspace(),
+            &block_group_id,
+            false,
+        )
+        .unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec!["AAACCCTTTGGGACTCTA".to_string()])
@@ -777,7 +801,13 @@ mod tests {
 
         let block_group_id = BlockGroup::get_id(&collection_name, Sample::DEFAULT_NAME, "", None);
 
-        let all_sequences = BlockGroup::get_all_sequences(conn, &block_group_id, false).unwrap();
+        let all_sequences = BlockGroup::get_all_sequences(
+            conn,
+            crate::test_helpers::test_workspace(),
+            &block_group_id,
+            false,
+        )
+        .unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec!["TTTGGGACTCTAAAACCC".to_string()])

--- a/src/imports/library.rs
+++ b/src/imports/library.rs
@@ -184,12 +184,20 @@ mod tests {
             }
         }
 
-        let actual_sequences = BlockGroup::get_all_sequences(conn, &block_group.id, false).unwrap();
+        let actual_sequences = BlockGroup::get_all_sequences(
+            conn,
+            crate::test_helpers::test_workspace(),
+            &block_group.id,
+            false,
+        )
+        .unwrap();
         assert_eq!(actual_sequences, expected_sequences);
 
         let current_path = BlockGroup::get_current_path(conn, &block_group.id, None).unwrap();
         assert_eq!(
-            current_path.sequence(conn, None).unwrap(),
+            current_path
+                .sequence(conn, context.workspace(), None)
+                .unwrap(),
             "TCTAGAGAAAGAGGGGACAAACTAGATGCGTAAAGGAGAAGAACTTTAA"
         );
 
@@ -224,7 +232,13 @@ mod tests {
         let block_groups = Sample::get_block_groups(conn, collection, Sample::DEFAULT_NAME, None);
         let block_group = &block_groups[0];
 
-        let all_sequences = BlockGroup::get_all_sequences(conn, &block_group.id, false).unwrap();
+        let all_sequences = BlockGroup::get_all_sequences(
+            conn,
+            crate::test_helpers::test_workspace(),
+            &block_group.id,
+            false,
+        )
+        .unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec![
@@ -271,7 +285,13 @@ mod tests {
                 expected_sequences.push(part1.to_string() + part2);
             }
         }
-        let all_sequences = BlockGroup::get_all_sequences(conn, &block_group.id, false).unwrap();
+        let all_sequences = BlockGroup::get_all_sequences(
+            conn,
+            crate::test_helpers::test_workspace(),
+            &block_group.id,
+            false,
+        )
+        .unwrap();
         assert_eq!(
             all_sequences,
             expected_sequences

--- a/src/imports/sequences.rs
+++ b/src/imports/sequences.rs
@@ -285,7 +285,13 @@ mod tests {
 
         let block_group_id = BlockGroup::get_id("test", Sample::DEFAULT_NAME, "chr1", None);
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &block_group_id, false).unwrap(),
+            BlockGroup::get_all_sequences(
+                conn,
+                crate::test_helpers::test_workspace(),
+                &block_group_id,
+                false
+            )
+            .unwrap(),
             HashSet::from_iter(vec!["ATCG".to_string()])
         );
 
@@ -322,7 +328,13 @@ mod tests {
 
         let block_group_id = BlockGroup::get_id("test", Sample::DEFAULT_NAME, "region-a", None);
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &block_group_id, false).unwrap(),
+            BlockGroup::get_all_sequences(
+                conn,
+                crate::test_helpers::test_workspace(),
+                &block_group_id,
+                false
+            )
+            .unwrap(),
             HashSet::from_iter(vec!["TCGA".to_string()])
         );
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -300,6 +300,7 @@ fn call_cli() -> Result<(), Box<dyn std::error::Error>> {
                         )?;
                         match show_inline_block_group_widget(
                             graph_conn,
+                            db_context.workspace(),
                             bg.id,
                             vec![current_path],
                             clamp_inline_view_height(height),
@@ -358,7 +359,7 @@ fn call_cli() -> Result<(), Box<dyn std::error::Error>> {
             if diff.operations.is_empty() {
                 println!("No differences found between {source_ref} and {target_ref}.");
             } else {
-                view_diff(graph_conn, &diff)?;
+                view_diff(graph_conn, db_context.workspace(), &diff)?;
             }
             Ok(())
         }
@@ -379,6 +380,7 @@ fn call_cli() -> Result<(), Box<dyn std::error::Error>> {
                 let mut bed_file = File::open(bed)?;
                 Ok(translate::bed::translate_bed(
                     graph_conn,
+                    db_context.workspace(),
                     collection_name,
                     sample.as_str(),
                     None,
@@ -391,6 +393,7 @@ fn call_cli() -> Result<(), Box<dyn std::error::Error>> {
                 let mut gff_file = BufReader::new(File::open(gff)?);
                 Ok(translate::gff::translate_gff(
                     graph_conn,
+                    db_context.workspace(),
                     collection_name,
                     sample.as_str(),
                     None,
@@ -705,8 +708,9 @@ fn call_cli() -> Result<(), Box<dyn std::error::Error>> {
                 .ensure_search_index()
                 .map_err(|_| "No .gen directory found. Run 'gen init' first.")?;
             for bg in block_groups {
-                let graph = BlockGroup::get_graph(graph_conn, &bg.id, None)?;
-                let matcher = GenGraphMatcher::new(graph_conn, graph);
+                let graph =
+                    BlockGroup::get_graph(graph_conn, db_context.workspace(), &bg.id, None)?;
+                let matcher = GenGraphMatcher::new(graph_conn, db_context.workspace(), graph);
                 let index = SeedIndex::build(&matcher, kmer_size, true);
                 let path = index_dir.join(format!("{}.bin", bg.id));
                 index.save_to_path(&path).map_err(|e| anyhow!("{e}"))?;
@@ -757,8 +761,9 @@ fn call_cli() -> Result<(), Box<dyn std::error::Error>> {
             let query_bytes = query.as_bytes();
             println!("sample\tgraph\tblocks\toffset");
             for bg in block_groups {
-                let graph = BlockGroup::get_graph(graph_conn, &bg.id, None)?;
-                let matcher = GenGraphMatcher::new(graph_conn, graph);
+                let graph =
+                    BlockGroup::get_graph(graph_conn, db_context.workspace(), &bg.id, None)?;
+                let matcher = GenGraphMatcher::new(graph_conn, db_context.workspace(), graph);
                 let matches = index_dir
                     .as_ref()
                     .and_then(|dir| {
@@ -870,7 +875,8 @@ fn call_cli() -> Result<(), Box<dyn std::error::Error>> {
                 })?;
             let path =
                 BlockGroup::get_current_path(graph_conn, &block_group.id, history_ref.as_deref())?;
-            let sequence = path.sequence(graph_conn, history_ref.as_deref())?;
+            let sequence =
+                path.sequence(graph_conn, db_context.workspace(), history_ref.as_deref())?;
             if end_coordinate == -1 {
                 end_coordinate = sequence.len() as i64;
             }
@@ -892,6 +898,7 @@ fn call_cli() -> Result<(), Box<dyn std::error::Error>> {
             });
             gfa_sample_diff(
                 graph_conn,
+                db_context.workspace(),
                 collection_name,
                 &PathBuf::from(gfa),
                 sample1.as_str(),

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Debug, fs, io::Write, ops::Add};
+use std::{fmt::Debug, fs, io::Write, ops::Add, sync::OnceLock};
 
 use gen_core::{
     HashId, PATH_END_NODE_ID, PATH_START_NODE_ID, Strand, config::Workspace,
@@ -46,6 +46,16 @@ pub fn create_bg(
 use intervaltree::IntervalTree;
 use rusqlite::Connection;
 use tempfile::tempdir;
+
+pub fn test_workspace() -> &'static Workspace {
+    static WORKSPACE: OnceLock<Workspace> = OnceLock::new();
+
+    WORKSPACE.get_or_init(|| {
+        let workspace = Workspace::new(tempdir().expect("should create test directory").keep());
+        workspace.ensure_gen_dir();
+        workspace
+    })
+}
 
 pub fn get_connection<'a>(
     db_path: impl Into<Option<&'a str>>,

--- a/src/updates.rs
+++ b/src/updates.rs
@@ -1,4 +1,4 @@
-use gen_core::{HashId, NO_CHROMOSOME_INDEX, PathBlock};
+use gen_core::{HashId, NO_CHROMOSOME_INDEX, PathBlock, Workspace};
 use gen_models::{
     block_group::{BlockGroup, BlockGroupChange},
     db::GraphConnection,
@@ -81,6 +81,7 @@ impl InsertChangeData {
 
 pub(crate) fn insert_update_change(
     conn: &GraphConnection,
+    workspace: &Workspace,
     region: ResolvedGenRegion,
     data: InsertChangeData,
 ) -> Result<(), BlockGroupError> {
@@ -92,5 +93,5 @@ pub(crate) fn insert_update_change(
         phased: data.phased,
         preserve_edge: data.preserve_edge,
     };
-    BlockGroup::insert_change(conn, &change)
+    BlockGroup::insert_change(conn, workspace, &change)
 }

--- a/src/updates/fasta.rs
+++ b/src/updates/fasta.rs
@@ -119,6 +119,7 @@ pub fn update_with_fasta(
 
                 insert_fasta_change(
                     conn,
+                    context.workspace(),
                     &resolved_region,
                     state.block_group_id,
                     state.path.as_ref(),
@@ -158,6 +159,7 @@ pub fn update_with_fasta(
 
                 insert_fasta_change(
                     conn,
+                    context.workspace(),
                     &resolved_region,
                     state.block_group_id,
                     state.path.as_ref(),
@@ -223,6 +225,7 @@ pub fn update_with_fasta(
 
 fn insert_fasta_change(
     conn: &gen_models::db::GraphConnection,
+    workspace: &gen_core::Workspace,
     region: &ResolvedGenRegion,
     target_block_group_id: HashId,
     path: Option<&gen_models::path::Path>,
@@ -230,7 +233,7 @@ fn insert_fasta_change(
 ) -> Result<(), FastaError> {
     let source = target_update_region(conn, region, target_block_group_id, path)?;
     let data = InsertChangeData::new(block);
-    insert_update_change(conn, source, data)?;
+    insert_update_change(conn, workspace, source, data)?;
     Ok(())
 }
 
@@ -313,7 +316,13 @@ mod tests {
         );
         assert_eq!(block_groups.len(), 1);
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &block_groups[0].id, false).unwrap(),
+            BlockGroup::get_all_sequences(
+                conn,
+                crate::test_helpers::test_workspace(),
+                &block_groups[0].id,
+                false
+            )
+            .unwrap(),
             HashSet::from_iter(expected_sequences),
         );
     }
@@ -363,11 +372,15 @@ mod tests {
         let child_path = BlockGroup::get_current_path(conn, &child_blockgroup, None).unwrap();
         let other_path = BlockGroup::get_current_path(conn, &other_blockgroup, None).unwrap();
         assert_eq!(
-            child_path.sequence(conn, None).unwrap(),
+            child_path
+                .sequence(conn, context.workspace(), None)
+                .unwrap(),
             "ATAAAAAAAATCGATCGATCGATCGGGAACACACAGAGA"
         );
         assert_eq!(
-            other_path.sequence(conn, None).unwrap(),
+            other_path
+                .sequence(conn, context.workspace(), None)
+                .unwrap(),
             "ATCGATCGATCGATCGATCGGGAACACACAGAGA"
         );
     }
@@ -422,7 +435,13 @@ mod tests {
         );
         assert_eq!(block_groups.len(), 1);
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &block_groups[0].id, false).unwrap(),
+            BlockGroup::get_all_sequences(
+                conn,
+                crate::test_helpers::test_workspace(),
+                &block_groups[0].id,
+                false
+            )
+            .unwrap(),
             HashSet::from_iter(expected_sequences),
         );
     }
@@ -489,7 +508,13 @@ mod tests {
         );
         assert_eq!(block_groups.len(), 1);
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &block_groups[0].id, false).unwrap(),
+            BlockGroup::get_all_sequences(
+                conn,
+                crate::test_helpers::test_workspace(),
+                &block_groups[0].id,
+                false
+            )
+            .unwrap(),
             HashSet::from_iter(expected_sequences),
         );
     }
@@ -556,7 +581,13 @@ mod tests {
         );
         assert_eq!(block_groups.len(), 1);
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &block_groups[0].id, false).unwrap(),
+            BlockGroup::get_all_sequences(
+                conn,
+                crate::test_helpers::test_workspace(),
+                &block_groups[0].id,
+                false
+            )
+            .unwrap(),
             HashSet::from_iter(expected_sequences),
         );
     }
@@ -629,7 +660,13 @@ mod tests {
         );
         assert_eq!(block_groups.len(), 1);
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &block_groups[0].id, false).unwrap(),
+            BlockGroup::get_all_sequences(
+                conn,
+                crate::test_helpers::test_workspace(),
+                &block_groups[0].id,
+                false
+            )
+            .unwrap(),
             HashSet::from_iter(expected_sequences),
         );
     }
@@ -696,7 +733,13 @@ mod tests {
         );
         assert_eq!(block_groups.len(), 1);
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &block_groups[0].id, false).unwrap(),
+            BlockGroup::get_all_sequences(
+                conn,
+                crate::test_helpers::test_workspace(),
+                &block_groups[0].id,
+                false
+            )
+            .unwrap(),
             HashSet::from_iter(expected_sequences),
         );
     }
@@ -761,7 +804,13 @@ mod tests {
         );
         assert_eq!(block_groups.len(), 1);
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &block_groups[0].id, false).unwrap(),
+            BlockGroup::get_all_sequences(
+                conn,
+                crate::test_helpers::test_workspace(),
+                &block_groups[0].id,
+                false
+            )
+            .unwrap(),
             HashSet::from_iter(expected_sequences),
         );
     }
@@ -805,7 +854,13 @@ mod tests {
         assert!(result.is_ok(), "{result:?}");
         let block_group = get_sample_bg(conn, &collection, "derived");
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &block_group.id, false).unwrap(),
+            BlockGroup::get_all_sequences(
+                conn,
+                crate::test_helpers::test_workspace(),
+                &block_group.id,
+                false
+            )
+            .unwrap(),
             HashSet::from_iter([
                 "ATCGATCGATCGATCGATCGGGAACACACAGAGA".to_string(),
                 "ATAAACGATCGATCGGGAACACACAGAGA".to_string(),
@@ -859,13 +914,21 @@ mod tests {
         );
         assert_eq!(block_groups.len(), 1);
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &block_groups[0].id, false).unwrap(),
+            BlockGroup::get_all_sequences(
+                conn,
+                crate::test_helpers::test_workspace(),
+                &block_groups[0].id,
+                false
+            )
+            .unwrap(),
             HashSet::from_iter(expected_sequences),
         );
 
         let latest_path = BlockGroup::get_current_path(conn, &block_groups[0].id, None).unwrap();
         assert_eq!(
-            latest_path.sequence(conn, None).unwrap(),
+            latest_path
+                .sequence(conn, context.workspace(), None)
+                .unwrap(),
             "ATTCGATCGATCGATCGGGAACACACAGAGA"
         );
     }
@@ -919,7 +982,13 @@ mod tests {
         );
         assert_eq!(block_groups.len(), 1);
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &block_groups[0].id, false).unwrap(),
+            BlockGroup::get_all_sequences(
+                conn,
+                crate::test_helpers::test_workspace(),
+                &block_groups[0].id,
+                false
+            )
+            .unwrap(),
             HashSet::from_iter(expected_sequences),
         );
     }
@@ -973,7 +1042,13 @@ mod tests {
         );
         assert_eq!(block_groups.len(), 1);
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &block_groups[0].id, false).unwrap(),
+            BlockGroup::get_all_sequences(
+                conn,
+                crate::test_helpers::test_workspace(),
+                &block_groups[0].id,
+                false
+            )
+            .unwrap(),
             HashSet::from_iter(expected_sequences),
         );
     }

--- a/src/updates/gaf.rs
+++ b/src/updates/gaf.rs
@@ -500,7 +500,14 @@ mod tests {
         let _ = import_gfa(&context, &gfa_path, &collection, "");
         let gaf_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("fixtures/chr22_het.gaf");
         update_with_gaf(&context, gaf_path, csv_path, "test", "child", None).unwrap();
-        let graph = Sample::get_graph(conn, "test", "child", None).unwrap();
+        let graph = Sample::get_graph(
+            conn,
+            crate::test_helpers::test_workspace(),
+            "test",
+            "child",
+            None,
+        )
+        .unwrap();
 
         let query = Node::query(
             conn,
@@ -565,7 +572,14 @@ mod tests {
         let _ = import_gfa(&context, &gfa_path, &collection, "");
         let gaf_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("fixtures/chr22_het.gaf");
         update_with_gaf(&context, gaf_path, csv_path, "test", "child", None).unwrap();
-        let graph = Sample::get_graph(conn, "test", "child", None).unwrap();
+        let graph = Sample::get_graph(
+            conn,
+            crate::test_helpers::test_workspace(),
+            "test",
+            "child",
+            None,
+        )
+        .unwrap();
 
         // we should end up with a new edge putting our insert to the beginning of the graph, which is node 3.
         let query = Node::query(

--- a/src/updates/genbank.rs
+++ b/src/updates/genbank.rs
@@ -214,7 +214,7 @@ where
                             preserve_edge: true,
                         },
                     };
-                    BlockGroup::insert_change(conn, &change).unwrap();
+                    BlockGroup::insert_change(conn, context.workspace(), &change).unwrap();
                 }
             }
             Err(e) => return Err(GenBankError::ParseError(format!("Failed to parse {e}"))),
@@ -379,12 +379,16 @@ mod tests {
             let f = reader::parse_file(&path).unwrap();
             let mod_seq = str::from_utf8(&f[0].seq).unwrap().to_string();
             let block_group_id = BlockGroup::get_id("", Sample::DEFAULT_NAME, "insertion", None);
-            let sequences: HashSet<String> =
-                BlockGroup::get_all_sequences(conn, &block_group_id, false)
-                    .unwrap()
-                    .iter()
-                    .map(|s| s.to_lowercase())
-                    .collect();
+            let sequences: HashSet<String> = BlockGroup::get_all_sequences(
+                conn,
+                crate::test_helpers::test_workspace(),
+                &block_group_id,
+                false,
+            )
+            .unwrap()
+            .iter()
+            .map(|s| s.to_lowercase())
+            .collect();
             let unchanged_seq = get_unmodified_sequence();
             assert!(sequences.contains(&mod_seq));
             assert!(sequences.contains(&unchanged_seq));
@@ -432,12 +436,16 @@ mod tests {
 
             let f = reader::parse_file(&path).unwrap();
             let block_group_id = BlockGroup::get_id("", Sample::DEFAULT_NAME, "insertion", None);
-            let sequences: HashSet<String> =
-                BlockGroup::get_all_sequences(conn, &block_group_id, false)
-                    .unwrap()
-                    .iter()
-                    .map(|s| s.to_lowercase())
-                    .collect();
+            let sequences: HashSet<String> = BlockGroup::get_all_sequences(
+                conn,
+                crate::test_helpers::test_workspace(),
+                &block_group_id,
+                false,
+            )
+            .unwrap()
+            .iter()
+            .map(|s| s.to_lowercase())
+            .collect();
             let unchanged_seq = get_unmodified_sequence();
             assert!(sequences.contains(&unchanged_seq));
             let mod_seq = str::from_utf8(&f[0].seq).unwrap().to_string();
@@ -446,12 +454,16 @@ mod tests {
             // we have a new blockgroup called deletion that uses the same base sequence but
             // has a deletion in it.
             let block_group_id = BlockGroup::get_id("", Sample::DEFAULT_NAME, "deletion", None);
-            let sequences: HashSet<String> =
-                BlockGroup::get_all_sequences(conn, &block_group_id, false)
-                    .unwrap()
-                    .iter()
-                    .map(|s| s.to_lowercase())
-                    .collect();
+            let sequences: HashSet<String> = BlockGroup::get_all_sequences(
+                conn,
+                crate::test_helpers::test_workspace(),
+                &block_group_id,
+                false,
+            )
+            .unwrap()
+            .iter()
+            .map(|s| s.to_lowercase())
+            .collect();
             let mod_seq = str::from_utf8(&f[1].seq).unwrap().to_string();
             assert!(sequences.contains(&unchanged_seq));
             assert!(sequences.contains(&mod_seq));

--- a/src/updates/gfa.rs
+++ b/src/updates/gfa.rs
@@ -93,7 +93,7 @@ pub fn update_with_gfa(
             .collect::<Vec<String>>()
             .join("");
         for existing_path in existing_paths.iter() {
-            if existing_path.sequence(conn, None)? == path_sequence {
+            if existing_path.sequence(conn, context.workspace(), None)? == path_sequence {
                 existing_path_ids_by_new_path_name.insert(path.name.clone(), existing_path.id);
             }
         }
@@ -120,7 +120,7 @@ pub fn update_with_gfa(
             .collect::<Vec<String>>()
             .join("");
         for existing_path in existing_paths.iter() {
-            if existing_path.sequence(conn, None)? == walk_sequence {
+            if existing_path.sequence(conn, context.workspace(), None)? == walk_sequence {
                 existing_path_ids_by_new_path_name.insert(walk_name.clone(), existing_path.id);
             }
         }
@@ -546,7 +546,13 @@ mod tests {
         );
         assert_eq!(block_groups.len(), 1);
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &block_groups[0].id, false).unwrap(),
+            BlockGroup::get_all_sequences(
+                conn,
+                crate::test_helpers::test_workspace(),
+                &block_groups[0].id,
+                false
+            )
+            .unwrap(),
             HashSet::from_iter(expected_sequences),
         );
     }
@@ -596,7 +602,13 @@ mod tests {
         );
         assert_eq!(block_groups.len(), 1);
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &block_groups[0].id, false).unwrap(),
+            BlockGroup::get_all_sequences(
+                conn,
+                crate::test_helpers::test_workspace(),
+                &block_groups[0].id,
+                false
+            )
+            .unwrap(),
             HashSet::from_iter(expected_sequences),
         );
     }

--- a/src/updates/library.rs
+++ b/src/updates/library.rs
@@ -202,6 +202,7 @@ fn update_graph_with_library(
             ResolvedRegionKind::Annotation | ResolvedRegionKind::Accession => {
                 update_graph_native_library(
                     conn,
+                    context.workspace(),
                     new_sample_name,
                     &target_region,
                     &target_block_group,
@@ -311,7 +312,7 @@ fn update_path_library(
     )?;
 
     let resolved_with_positions = resolved_region
-        .find_graph_positions(conn, 0, 0)
+        .find_graph_positions(conn, context.workspace(), 0, 0)
         .map_err(UpdateWithLibraryError::from)?;
     let splice_point = &resolved_with_positions.start_anchors.unwrap()[0];
     let location_accession = create_location_accession(conn, target_block_group.id, splice_point)?;
@@ -383,13 +384,14 @@ fn update_path_library(
 
 fn update_graph_native_library(
     conn: &gen_models::db::GraphConnection,
+    workspace: &gen_core::Workspace,
     new_sample_name: &str,
     resolved_region: &ResolvedGenRegion,
     target_block_group: &BlockGroup,
     parts_list: Vec<Vec<SequencePart>>,
 ) -> Result<(), UpdateWithLibraryError> {
     let resolved = resolved_region
-        .find_graph_positions(conn, 0, 0)
+        .find_graph_positions(conn, workspace, 0, 0)
         .map_err(UpdateWithLibraryError::from)?;
     let start_positions = resolved.start_anchors.as_ref().unwrap();
     let end_positions = resolved.end_anchors.as_ref().unwrap();
@@ -552,7 +554,13 @@ mod tests {
         let block_groups = Sample::get_block_groups(conn, "test", "new sample", None);
         let block_group = &block_groups[0];
 
-        let all_sequences = BlockGroup::get_all_sequences(conn, &block_group.id, false).unwrap();
+        let all_sequences = BlockGroup::get_all_sequences(
+            conn,
+            crate::test_helpers::test_workspace(),
+            &block_group.id,
+            false,
+        )
+        .unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec![
@@ -610,7 +618,13 @@ mod tests {
         let block_groups = Sample::get_block_groups(conn, "test", "new sample", None);
         let block_group = &block_groups[0];
 
-        let all_sequences = BlockGroup::get_all_sequences(conn, &block_group.id, false).unwrap();
+        let all_sequences = BlockGroup::get_all_sequences(
+            conn,
+            crate::test_helpers::test_workspace(),
+            &block_group.id,
+            false,
+        )
+        .unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec![
@@ -623,7 +637,7 @@ mod tests {
 
         let path = BlockGroup::get_current_path(conn, &block_group.id, None).unwrap();
         assert_eq!(
-            path.sequence(conn, None).unwrap(),
+            path.sequence(conn, context.workspace(), None).unwrap(),
             "ATCGATCGATCGATCGATCGGGAACACACAGAGA".to_string()
         );
         assert_eq!(
@@ -677,7 +691,13 @@ mod tests {
 
         let block_group = crate::test_helpers::get_sample_bg(conn, &collection, "derived");
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &block_group.id, false).unwrap(),
+            BlockGroup::get_all_sequences(
+                conn,
+                crate::test_helpers::test_workspace(),
+                &block_group.id,
+                false
+            )
+            .unwrap(),
             HashSet::from_iter(vec![
                 "ATCGATCGATCGATCGATCGGGAACACACAGAGA".to_string(),
                 "ATAAAACGATCGATCGGGAACACACAGAGA".to_string(),
@@ -727,7 +747,13 @@ mod tests {
 
         let block_group = crate::test_helpers::get_sample_bg(conn, &collection, "derived");
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &block_group.id, false).unwrap(),
+            BlockGroup::get_all_sequences(
+                conn,
+                crate::test_helpers::test_workspace(),
+                &block_group.id,
+                false
+            )
+            .unwrap(),
             HashSet::from_iter(vec![
                 "ATCGATCGATCGATCGATCGGGAACACACAGAGA".to_string(),
                 "ATCGAAAAAGGAACACACAGAGA".to_string(),
@@ -784,7 +810,13 @@ mod tests {
                 expected_sequences.push(seq);
             }
         }
-        let all_sequences = BlockGroup::get_all_sequences(conn, &block_group.id, false).unwrap();
+        let all_sequences = BlockGroup::get_all_sequences(
+            conn,
+            crate::test_helpers::test_workspace(),
+            &block_group.id,
+            false,
+        )
+        .unwrap();
         assert_eq!(
             all_sequences,
             expected_sequences
@@ -834,7 +866,13 @@ mod tests {
         let block_groups = Sample::get_block_groups(conn, "test", "new sample", None);
         let block_group = &block_groups[0];
 
-        let all_sequences = BlockGroup::get_all_sequences(conn, &block_group.id, false).unwrap();
+        let all_sequences = BlockGroup::get_all_sequences(
+            conn,
+            crate::test_helpers::test_workspace(),
+            &block_group.id,
+            false,
+        )
+        .unwrap();
         assert_eq!(
             all_sequences,
             HashSet::from_iter(vec![
@@ -893,7 +931,13 @@ mod tests {
                 expected_sequences.push(seq);
             }
         }
-        let all_sequences = BlockGroup::get_all_sequences(conn, &block_group.id, false).unwrap();
+        let all_sequences = BlockGroup::get_all_sequences(
+            conn,
+            crate::test_helpers::test_workspace(),
+            &block_group.id,
+            false,
+        )
+        .unwrap();
         assert_eq!(
             all_sequences,
             expected_sequences

--- a/src/updates/sequence.rs
+++ b/src/updates/sequence.rs
@@ -83,6 +83,7 @@ pub fn update_with_sequence(
 
             insert_sequence_change(
                 conn,
+                context.workspace(),
                 &resolved_region,
                 target_block_group,
                 &path,
@@ -118,6 +119,7 @@ pub fn update_with_sequence(
 
             insert_sequence_change(
                 conn,
+                context.workspace(),
                 &resolved_region,
                 target_block_group,
                 &path,
@@ -170,6 +172,7 @@ pub fn update_with_sequence(
 
 fn insert_sequence_change(
     conn: &gen_models::db::GraphConnection,
+    workspace: &gen_core::Workspace,
     region: &ResolvedGenRegion,
     target_block_group: &BlockGroup,
     path: &gen_models::path::Path,
@@ -177,7 +180,7 @@ fn insert_sequence_change(
 ) -> Result<(), SequenceUpdateError> {
     let source = target_update_region(conn, region, target_block_group.id, Some(path))?;
     let data = InsertChangeData::new(block);
-    insert_update_change(conn, source, data)?;
+    insert_update_change(conn, workspace, source, data)?;
     Ok(())
 }
 
@@ -249,10 +252,16 @@ mod tests {
             preserve_edge: true,
         };
 
-        BlockGroup::insert_change(&conn, &change).unwrap();
+        BlockGroup::insert_change(&conn, crate::test_helpers::test_workspace(), &change).unwrap();
 
         assert_eq!(
-            BlockGroup::get_all_sequences(&conn, &block_group_id, false).unwrap(),
+            BlockGroup::get_all_sequences(
+                &conn,
+                crate::test_helpers::test_workspace(),
+                &block_group_id,
+                false
+            )
+            .unwrap(),
             HashSet::from_iter([
                 "AAAAAAAAAATTTTTTTTTTCCCCCCCCCCGGGGGGGGGG".to_string(),
                 "AAAAAAAAAATTTTTNNNNCCCCCGGGGGGGGGG".to_string(),
@@ -283,10 +292,16 @@ mod tests {
             preserve_edge: true,
         };
 
-        BlockGroup::insert_change(&conn, &change).unwrap();
+        BlockGroup::insert_change(&conn, crate::test_helpers::test_workspace(), &change).unwrap();
 
         assert_eq!(
-            BlockGroup::get_all_sequences(&conn, &block_group_id, false).unwrap(),
+            BlockGroup::get_all_sequences(
+                &conn,
+                crate::test_helpers::test_workspace(),
+                &block_group_id,
+                false
+            )
+            .unwrap(),
             HashSet::from_iter([
                 "AAAAAAAAAATTTTTTTTTTCCCCCCCCCCGGGGGGGGGG".to_string(),
                 "AAAAANNNNGGGGG".to_string(),
@@ -343,7 +358,13 @@ mod tests {
         );
         let block_group = get_sample_bg(conn, &collection, "derived");
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &block_group.id, false).unwrap(),
+            BlockGroup::get_all_sequences(
+                conn,
+                crate::test_helpers::test_workspace(),
+                &block_group.id,
+                false
+            )
+            .unwrap(),
             HashSet::from_iter([
                 "ATCGATCGATCGATCGATCGGGAACACACAGAGA".to_string(),
                 "ATAAACGATCGATCGGGAACACACAGAGA".to_string(),
@@ -403,7 +424,13 @@ mod tests {
         );
         assert_eq!(block_groups.len(), 1);
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &block_groups[0].id, false).unwrap(),
+            BlockGroup::get_all_sequences(
+                conn,
+                crate::test_helpers::test_workspace(),
+                &block_groups[0].id,
+                false
+            )
+            .unwrap(),
             HashSet::from_iter(expected_sequences),
         );
         assert_eq!(
@@ -454,11 +481,15 @@ mod tests {
         let child_path = BlockGroup::get_current_path(conn, &child_blockgroup, None).unwrap();
         let other_path = BlockGroup::get_current_path(conn, &other_blockgroup, None).unwrap();
         assert_eq!(
-            child_path.sequence(conn, None).unwrap(),
+            child_path
+                .sequence(conn, context.workspace(), None)
+                .unwrap(),
             "ATAAAAAAAATCGATCGATCGATCGGGAACACACAGAGA"
         );
         assert_eq!(
-            other_path.sequence(conn, None).unwrap(),
+            other_path
+                .sequence(conn, context.workspace(), None)
+                .unwrap(),
             "ATCGATCGATCGATCGATCGGGAACACACAGAGA"
         );
     }
@@ -516,7 +547,13 @@ mod tests {
         );
         assert_eq!(block_groups.len(), 1);
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &block_groups[0].id, false).unwrap(),
+            BlockGroup::get_all_sequences(
+                conn,
+                crate::test_helpers::test_workspace(),
+                &block_groups[0].id,
+                false
+            )
+            .unwrap(),
             HashSet::from_iter(expected_sequences),
         );
     }
@@ -574,7 +611,13 @@ mod tests {
         );
         assert_eq!(block_groups.len(), 1);
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &block_groups[0].id, false).unwrap(),
+            BlockGroup::get_all_sequences(
+                conn,
+                crate::test_helpers::test_workspace(),
+                &block_groups[0].id,
+                false
+            )
+            .unwrap(),
             HashSet::from_iter(expected_sequences),
         );
     }
@@ -638,7 +681,13 @@ mod tests {
         );
         assert_eq!(block_groups.len(), 1);
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &block_groups[0].id, false).unwrap(),
+            BlockGroup::get_all_sequences(
+                conn,
+                crate::test_helpers::test_workspace(),
+                &block_groups[0].id,
+                false
+            )
+            .unwrap(),
             HashSet::from_iter(expected_sequences),
         );
     }
@@ -696,7 +745,13 @@ mod tests {
         );
         assert_eq!(block_groups.len(), 1);
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &block_groups[0].id, false).unwrap(),
+            BlockGroup::get_all_sequences(
+                conn,
+                crate::test_helpers::test_workspace(),
+                &block_groups[0].id,
+                false
+            )
+            .unwrap(),
             HashSet::from_iter(expected_sequences),
         );
     }
@@ -754,7 +809,13 @@ mod tests {
         );
         assert_eq!(block_groups.len(), 1);
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &block_groups[0].id, false).unwrap(),
+            BlockGroup::get_all_sequences(
+                conn,
+                crate::test_helpers::test_workspace(),
+                &block_groups[0].id,
+                false
+            )
+            .unwrap(),
             HashSet::from_iter(expected_sequences),
         );
     }
@@ -801,13 +862,21 @@ mod tests {
         );
         assert_eq!(block_groups.len(), 1);
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &block_groups[0].id, false).unwrap(),
+            BlockGroup::get_all_sequences(
+                conn,
+                crate::test_helpers::test_workspace(),
+                &block_groups[0].id,
+                false
+            )
+            .unwrap(),
             HashSet::from_iter(expected_sequences),
         );
 
         let latest_path = BlockGroup::get_current_path(conn, &block_groups[0].id, None).unwrap();
         assert_eq!(
-            latest_path.sequence(conn, None).unwrap(),
+            latest_path
+                .sequence(conn, context.workspace(), None)
+                .unwrap(),
             "ATTCGATCGATCGATCGGGAACACACAGAGA"
         );
     }
@@ -865,9 +934,15 @@ mod tests {
         .unwrap();
 
         let block_group = get_sample_bg(conn, &collection, "deleted");
-        let graph = BlockGroup::get_graph(conn, &block_group.id, None).unwrap();
+        let graph = BlockGroup::get_graph(
+            conn,
+            crate::test_helpers::test_workspace(),
+            &block_group.id,
+            None,
+        )
+        .unwrap();
         let node_ids = graph.nodes().map(|node| node.node_id).collect::<Vec<_>>();
-        let sequences = Node::get_sequences_by_node_ids(conn, &node_ids, None);
+        let sequences = Node::get_sequences_by_node_ids(conn, context.workspace(), &node_ids, None);
         let rendered_sequence = |node: GraphNode| {
             sequences[&node.node_id]
                 .get_sequence(node.sequence_start, node.sequence_end)
@@ -909,9 +984,15 @@ mod tests {
         .unwrap();
 
         let block_group = get_sample_bg(conn, &collection, "deleted2");
-        let graph = BlockGroup::get_graph(conn, &block_group.id, None).unwrap();
+        let graph = BlockGroup::get_graph(
+            conn,
+            crate::test_helpers::test_workspace(),
+            &block_group.id,
+            None,
+        )
+        .unwrap();
         let node_ids = graph.nodes().map(|node| node.node_id).collect::<Vec<_>>();
-        let sequences = Node::get_sequences_by_node_ids(conn, &node_ids, None);
+        let sequences = Node::get_sequences_by_node_ids(conn, context.workspace(), &node_ids, None);
         let rendered_sequence = |node: GraphNode| {
             sequences[&node.node_id]
                 .get_sequence(node.sequence_start, node.sequence_end)

--- a/src/updates/vcf.rs
+++ b/src/updates/vcf.rs
@@ -687,9 +687,16 @@ pub fn update_with_vcf(
                         }
                     })
                     .collect::<Vec<_>>();
-                BlockGroup::insert_changes(conn, &in_place_changes, Some(&mut tree_map)).unwrap();
+                BlockGroup::insert_changes(
+                    conn,
+                    context.workspace(),
+                    &in_place_changes,
+                    Some(&mut tree_map),
+                )
+                .unwrap();
             } else {
-                BlockGroup::insert_changes(conn, chunk, Some(&mut tree_map)).unwrap();
+                BlockGroup::insert_changes(conn, context.workspace(), chunk, Some(&mut tree_map))
+                    .unwrap();
             }
             bar.inc(chunk.len() as u64);
         }
@@ -781,6 +788,7 @@ mod tests {
         assert_eq!(
             BlockGroup::get_all_sequences(
                 conn,
+                crate::test_helpers::test_workspace(),
                 &get_sample_bg(conn, &collection, Sample::DEFAULT_NAME).id,
                 false,
             )
@@ -789,14 +797,24 @@ mod tests {
         );
         // `G1` genotype has no changes
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &get_sample_bg(conn, &collection, "G1").id, false)
-                .unwrap(),
+            BlockGroup::get_all_sequences(
+                conn,
+                crate::test_helpers::test_workspace(),
+                &get_sample_bg(conn, &collection, "G1").id,
+                false
+            )
+            .unwrap(),
             HashSet::from_iter(vec!["ATCGATCGATCGATCGATCGGGAACACACAGAGA".to_string()])
         );
         // `foo` is homozygous for the first variant and does not contain the second
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &get_sample_bg(conn, &collection, "foo").id, false)
-                .unwrap(),
+            BlockGroup::get_all_sequences(
+                conn,
+                crate::test_helpers::test_workspace(),
+                &get_sample_bg(conn, &collection, "foo").id,
+                false
+            )
+            .unwrap(),
             HashSet::from_iter(vec!["ATCATCGATCGATCGATCGGGAACACACAGAGA".to_string(),])
         );
 
@@ -833,6 +851,7 @@ mod tests {
         assert_eq!(
             BlockGroup::get_all_sequences(
                 conn,
+                crate::test_helpers::test_workspace(),
                 &get_sample_bg(conn, &collection, Sample::DEFAULT_NAME).id,
                 false,
             )
@@ -841,8 +860,13 @@ mod tests {
         );
         // `bar` sample has the refrence + a deletion of the C
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &get_sample_bg(conn, &collection, "bar").id, false)
-                .unwrap(),
+            BlockGroup::get_all_sequences(
+                conn,
+                crate::test_helpers::test_workspace(),
+                &get_sample_bg(conn, &collection, "bar").id,
+                false
+            )
+            .unwrap(),
             HashSet::from_iter(vec![
                 "ATCGATCGATCGATCGATCGGGAACACACAGAGA".to_string(),
                 "ATCGATCGATGATCGATCGGGAACACACAGAGA".to_string()
@@ -850,8 +874,13 @@ mod tests {
         );
         // `baz` sample has a deletion of CG and an insertion of A
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &get_sample_bg(conn, &collection, "baz").id, false)
-                .unwrap(),
+            BlockGroup::get_all_sequences(
+                conn,
+                crate::test_helpers::test_workspace(),
+                &get_sample_bg(conn, &collection, "baz").id,
+                false
+            )
+            .unwrap(),
             HashSet::from_iter(vec![
                 "ATCGATCGATATCGATCGGGAACACACAGAGA".to_string(),
                 "ATCGATCGATCAGATCGATCGGGAACACACAGAGA".to_string(),
@@ -890,6 +919,7 @@ mod tests {
         assert_eq!(
             BlockGroup::get_all_sequences(
                 conn,
+                crate::test_helpers::test_workspace(),
                 &get_sample_bg(conn, &collection, Sample::DEFAULT_NAME).id,
                 false,
             )
@@ -899,6 +929,7 @@ mod tests {
         assert_eq!(
             BlockGroup::get_all_sequences(
                 conn,
+                crate::test_helpers::test_workspace(),
                 &get_sample_bg(conn, &collection, "sample 1").id,
                 false
             )
@@ -948,6 +979,7 @@ mod tests {
         assert_eq!(
             BlockGroup::get_all_sequences(
                 conn,
+                crate::test_helpers::test_workspace(),
                 &get_sample_bg(conn, &collection, "sample 1").id,
                 false
             )
@@ -1023,6 +1055,7 @@ mod tests {
         assert_eq!(
             BlockGroup::get_all_sequences(
                 conn,
+                crate::test_helpers::test_workspace(),
                 &get_sample_bg(conn, &collection, "unknown").id,
                 false
             )
@@ -1064,8 +1097,13 @@ mod tests {
         )
         .unwrap();
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &get_sample_bg(conn, &collection, "foo").id, false)
-                .unwrap(),
+            BlockGroup::get_all_sequences(
+                conn,
+                crate::test_helpers::test_workspace(),
+                &get_sample_bg(conn, &collection, "foo").id,
+                false
+            )
+            .unwrap(),
             HashSet::from_iter(
                 ["ATCATCGATCGATCGATCGGGAACACACAGAGA",]
                     .iter()
@@ -1104,8 +1142,13 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &get_sample_bg(conn, &collection, "foo").id, true)
-                .unwrap(),
+            BlockGroup::get_all_sequences(
+                conn,
+                crate::test_helpers::test_workspace(),
+                &get_sample_bg(conn, &collection, "foo").id,
+                true
+            )
+            .unwrap(),
             HashSet::from_iter(vec![
                 "ATCGATCGATCGGATCGGGAACACACAGAGA".to_string(),
                 "ATCGATCGATCGATCATCATCGATCGGGAACACACAGAGA".to_string()
@@ -1428,6 +1471,7 @@ mod tests {
         assert_eq!(
             BlockGroup::get_all_sequences(
                 conn,
+                crate::test_helpers::test_workspace(),
                 &get_sample_bg(conn, &collection, Sample::DEFAULT_NAME).id,
                 true,
             )
@@ -1435,18 +1479,33 @@ mod tests {
             HashSet::from_iter(vec!["ATCGATCGATCGATCGATCGGGAACACACAGAGA".to_string()])
         );
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &get_sample_bg(conn, &collection, "f1").id, true)
-                .unwrap(),
+            BlockGroup::get_all_sequences(
+                conn,
+                crate::test_helpers::test_workspace(),
+                &get_sample_bg(conn, &collection, "f1").id,
+                true
+            )
+            .unwrap(),
             HashSet::from_iter(vec!["ATCTCGATCGATCGCGGGAACACACAGAGA".to_string()])
         );
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &get_sample_bg(conn, &collection, "f2").id, true)
-                .unwrap(),
+            BlockGroup::get_all_sequences(
+                conn,
+                crate::test_helpers::test_workspace(),
+                &get_sample_bg(conn, &collection, "f2").id,
+                true
+            )
+            .unwrap(),
             HashSet::from_iter(vec!["ATCTGGATCGATCGCGGAATCAGAACACACAGGA".to_string()])
         );
         assert_eq!(
-            BlockGroup::get_all_sequences(conn, &get_sample_bg(conn, &collection, "f3").id, true)
-                .unwrap(),
+            BlockGroup::get_all_sequences(
+                conn,
+                crate::test_helpers::test_workspace(),
+                &get_sample_bg(conn, &collection, "f3").id,
+                true
+            )
+            .unwrap(),
             HashSet::from_iter(vec!["ATCGGGATCGATCGCTCAGAACACACAGGA".to_string()])
         );
     }
@@ -1492,6 +1551,7 @@ mod tests {
 
         let child_sequences = BlockGroup::get_all_sequences(
             conn,
+            crate::test_helpers::test_workspace(),
             &get_sample_bg(conn, &collection, "child").id,
             true,
         )
@@ -1548,6 +1608,7 @@ mod tests {
 
         let child_sequences = BlockGroup::get_all_sequences(
             conn,
+            crate::test_helpers::test_workspace(),
             &get_sample_bg(conn, &collection, "child").id,
             true,
         )

--- a/src/views/annotations.rs
+++ b/src/views/annotations.rs
@@ -44,6 +44,7 @@ use crate::views::{
 
 pub struct AnnotationGroupTrackRequest<'a> {
     pub conn: &'a GraphConnection,
+    pub workspace: &'a Workspace,
     pub history_ref: Option<&'a str>,
     pub current_block_group: &'a BlockGroup,
     pub entry: &'a AnnotationGroupEntry,
@@ -56,6 +57,7 @@ pub fn load_annotations_for_group(
 ) -> Result<Vec<AnnotationSpan>, AnnotationError> {
     load_group_annotations(
         request.conn,
+        request.workspace,
         request.current_block_group,
         request.entry,
         request.node_ids,
@@ -157,6 +159,7 @@ fn spans_whole_block_group(segments: &[AnnotationSegment], graph: &GenGraph) -> 
 
 fn load_group_annotations(
     conn: &GraphConnection,
+    workspace: &Workspace,
     current_block_group: &BlockGroup,
     entry: &AnnotationGroupEntry,
     node_ids: &HashSet<HashId>,
@@ -177,7 +180,7 @@ fn load_group_annotations(
     // a combinatorial library). Clip them onto the block group's full graph so an
     // annotation still covers every surviving fragment of its original range, on every
     // branch, with a gap wherever an edit spliced in unrelated sequence.
-    let graph = BlockGroup::get_graph(conn, &current_block_group.id, history_ref)
+    let graph = BlockGroup::get_graph(conn, workspace, &current_block_group.id, history_ref)
         .unwrap_or_else(|_| GenGraph::new());
     Ok(annotations
         .into_iter()
@@ -769,6 +772,7 @@ pub fn load_annotation_file_track(
     match request.entry.file_addition.file_type {
         FileTypes::Gff3 => translate_gff(
             request.conn,
+            request.workspace,
             request.collection_name,
             request.sample_name,
             request.history_ref,
@@ -777,6 +781,7 @@ pub fn load_annotation_file_track(
         )?,
         FileTypes::Bed => translate_bed(
             request.conn,
+            request.workspace,
             request.collection_name,
             request.sample_name,
             request.history_ref,
@@ -1051,7 +1056,8 @@ mod tests {
 
         let block_groups = Sample::get_block_groups(conn, "fixtures", "puc19-sample", None);
         let block_group = &block_groups[0];
-        let graph = BlockGroup::get_graph(conn, &block_group.id, None).unwrap();
+        let graph =
+            BlockGroup::get_graph(conn, context.workspace(), &block_group.id, None).unwrap();
         let node_ids: HashSet<HashId> = graph.nodes().map(|n| n.node_id).collect();
 
         let groups =
@@ -1066,6 +1072,7 @@ mod tests {
 
         let spans = load_annotations_for_group(&AnnotationGroupTrackRequest {
             conn,
+            workspace: context.workspace(),
             history_ref: None,
             current_block_group: block_group,
             entry: &entry,
@@ -1128,7 +1135,8 @@ mod tests {
         let block_groups = Sample::get_block_groups(conn, collection, Sample::DEFAULT_NAME, None);
         let block_group = &block_groups[0];
 
-        let graph = BlockGroup::get_graph(conn, &block_group.id, None).unwrap();
+        let graph =
+            BlockGroup::get_graph(conn, context.workspace(), &block_group.id, None).unwrap();
         let node_ids: HashSet<HashId> = graph.nodes().map(|n| n.node_id).collect();
 
         let entry = AnnotationGroupEntry {
@@ -1141,6 +1149,7 @@ mod tests {
 
         let spans = load_annotations_for_group(&AnnotationGroupTrackRequest {
             conn,
+            workspace: context.workspace(),
             history_ref: None,
             current_block_group: block_group,
             entry: &entry,
@@ -1222,7 +1231,9 @@ mod tests {
             entry.source_block_group_id, selected_block_group.id,
             "the entry source should differ from the currently selected block group"
         );
-        let selected_graph = BlockGroup::get_graph(conn, &selected_block_group.id, None).unwrap();
+        let selected_graph =
+            BlockGroup::get_graph(conn, context.workspace(), &selected_block_group.id, None)
+                .unwrap();
         let node_ids = selected_graph
             .nodes()
             .map(|node| node.node_id)
@@ -1230,6 +1241,7 @@ mod tests {
 
         let spans = load_annotations_for_group(&AnnotationGroupTrackRequest {
             conn,
+            workspace: context.workspace(),
             history_ref: None,
             current_block_group: &selected_block_group,
             entry: &entry,

--- a/src/views/block_group.rs
+++ b/src/views/block_group.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use crossterm::event::{self, KeyCode, KeyEventKind, MouseButton, MouseEventKind};
-use gen_core::{HashId, PATH_START_NODE_ID};
+use gen_core::{HashId, PATH_START_NODE_ID, Workspace};
 use gen_graph::{GenGraph, GraphNode};
 use gen_models::{block_group::BlockGroup, db::GraphConnection, node::Node, traits::Query};
 use gen_tui::{
@@ -80,9 +80,7 @@ fn get_block_group_path_nodes(
     )
     .map_err(|e| format!("Failed to query path: {}", e))?;
 
-    let path_blocks = path
-        .blocks(conn, None)
-        .map_err(|err| format!("Failed to load path blocks: {err}"))?;
+    let path_blocks = path.coordinate_blocks(conn, None);
 
     let path_nodes = project_path_overlay_nodes(graph, &path_blocks);
     if path_nodes.is_empty() {
@@ -162,22 +160,30 @@ pub(crate) fn expand_query_window(window: (i64, i64)) -> (i64, i64) {
     (window.0.saturating_sub(span), window.1.saturating_add(span))
 }
 
+struct AnnotationViewportRequest<'a> {
+    conn: &'a GraphConnection,
+    workspace: &'a Workspace,
+    history_ref: Option<&'a str>,
+    block_group: &'a BlockGroup,
+    node_ids: &'a HashSet<HashId>,
+}
+
 fn load_annotation_groups_for_viewport(
-    conn: &GraphConnection,
-    history_ref: Option<&str>,
-    block_group: &BlockGroup,
-    node_ids: &HashSet<HashId>,
+    request: AnnotationViewportRequest<'_>,
     explorer_state: &mut CollectionExplorerState,
     overlays: &mut Vec<GraphOverlay>,
     messages: &mut crate::views::messages::MessageBuffer,
 ) {
-    for entry in load_annotation_group_entries(conn, block_group, history_ref) {
+    for entry in
+        load_annotation_group_entries(request.conn, request.block_group, request.history_ref)
+    {
         let spans = match load_annotations_for_group(&AnnotationGroupTrackRequest {
-            conn,
-            history_ref,
-            current_block_group: block_group,
+            conn: request.conn,
+            workspace: request.workspace,
+            history_ref: request.history_ref,
+            current_block_group: request.block_group,
             entry: &entry,
-            node_ids,
+            node_ids: request.node_ids,
         }) {
             Ok(spans) => spans,
             Err(err) => {
@@ -261,7 +267,7 @@ pub fn view_block_group(
 
         let block_group = block_group.unwrap();
         block_group_id = Some(block_group.id);
-        block_graph = BlockGroup::get_graph(conn, &block_group.id, history_ref)?;
+        block_graph = BlockGroup::get_graph(conn, workspace, &block_group.id, history_ref)?;
         explorer_state.selected_block_group_id = Some(block_group.id);
         focus_zone = FocusZone::Canvas;
     } else {
@@ -556,6 +562,7 @@ pub fn view_block_group(
                                             load_annotations_for_group(
                                                 &AnnotationGroupTrackRequest {
                                                     conn,
+                                                    workspace,
                                                     history_ref,
                                                     current_block_group: current_block_group
                                                         .as_ref()
@@ -677,6 +684,7 @@ pub fn view_block_group(
                                 let spans = match entry.map(|entry| {
                                     load_annotations_for_group(&AnnotationGroupTrackRequest {
                                         conn,
+                                        workspace,
                                         history_ref,
                                         current_block_group: bg,
                                         entry,
@@ -1067,7 +1075,7 @@ pub fn view_block_group(
                 reapply_overlays(&mut graph_controller, &mut overlays, &mut annotation_colors);
 
                 let canvas_style = Style::default().bg(current_theme()[0x00]);
-                let widget = create_gen_graph_widget(conn)
+                let widget = create_gen_graph_widget(conn, workspace)
                     .detail_level(graph_controller.get_detail_level())
                     .style(canvas_style)
                     .cursor();
@@ -1220,10 +1228,13 @@ pub fn view_block_group(
                 );
                 explorer_state.active_annotation_groups.clear();
                 load_annotation_groups_for_viewport(
-                    conn,
-                    history_ref,
-                    block_group,
-                    &node_ids,
+                    AnnotationViewportRequest {
+                        conn,
+                        workspace,
+                        history_ref,
+                        block_group,
+                        node_ids: &node_ids,
+                    },
                     &mut explorer_state,
                     &mut overlays,
                     &mut messages,
@@ -1238,7 +1249,7 @@ pub fn view_block_group(
         // for the full duration of the blocking DB work.
         if is_loading && let Some(ref new_block_group_id) = explorer_state.selected_block_group_id {
             // Create a new graph for the selected block group
-            block_graph = BlockGroup::get_graph(conn, new_block_group_id, history_ref)?;
+            block_graph = BlockGroup::get_graph(conn, workspace, new_block_group_id, history_ref)?;
             // Update the graph controller
             graph_controller = create_gen_graph_controller(block_graph.clone());
             let block_group = match BlockGroup::get_by_id(conn, new_block_group_id, history_ref) {

--- a/src/views/block_group_inline.rs
+++ b/src/views/block_group_inline.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use crossterm::event::{self, Event, KeyCode, KeyEventKind};
-use gen_core::HashId;
+use gen_core::{HashId, Workspace};
 use gen_graph::GenGraph;
 use gen_models::{block_group::BlockGroup, db::GraphConnection, path::Path};
 use gen_tui::{
@@ -41,9 +41,7 @@ fn get_path_nodes(
     path: &Path,
     graph: &GenGraph,
 ) -> std::io::Result<Vec<gen_graph::GraphNode>> {
-    let path_blocks = path
-        .blocks(conn, None)
-        .map_err(|err| Error::other(format!("Failed to load path blocks: {err}")))?;
+    let path_blocks = path.coordinate_blocks(conn, None);
 
     let path_nodes = project_path_overlay_nodes(graph, &path_blocks);
     if path_nodes.is_empty() {
@@ -113,6 +111,7 @@ impl EventSource for TickEventSource {
 pub struct InlineGenGraphState<'a> {
     controller: GraphController<GenGraph, GenGraphNodeSizer>,
     conn: &'a GraphConnection,
+    workspace: &'a Workspace,
     paths: Vec<Vec<gen_graph::GraphNode>>,
     block_group_id: Option<HashId>,
     history_ref: Option<&'a str>,
@@ -126,6 +125,7 @@ impl<'a> InlineGenGraphState<'a> {
     pub fn new(
         graph: &GenGraph,
         conn: &'a GraphConnection,
+        workspace: &'a Workspace,
         block_group_id: Option<HashId>,
         history_ref: Option<&'a str>,
     ) -> Self {
@@ -136,6 +136,7 @@ impl<'a> InlineGenGraphState<'a> {
         Self {
             controller: graph_controller,
             conn,
+            workspace,
             paths: Vec::new(),
             block_group_id,
             history_ref,
@@ -165,6 +166,7 @@ impl<'a> InlineGenGraphState<'a> {
         for entry in load_annotation_group_entries(conn, &block_group, self.history_ref) {
             let Ok(entry_spans) = load_annotations_for_group(&AnnotationGroupTrackRequest {
                 conn,
+                workspace: self.workspace,
                 history_ref: self.history_ref,
                 current_block_group: &block_group,
                 entry: &entry,
@@ -203,11 +205,12 @@ impl<'a> InlineGenGraphState<'a> {
 ///
 pub fn show_inline_gen_graph_widget(
     conn: &GraphConnection,
+    workspace: &Workspace,
     graph: &GenGraph,
     paths: Vec<Path>,
     height: u16,
 ) -> Result<bool> {
-    show_inline_widget(conn, graph, paths, height, None, None)
+    show_inline_widget(conn, workspace, graph, paths, height, None, None)
 }
 
 /// Display an inline widget for a `BlockGroup`'s graph, with annotations loaded.
@@ -215,14 +218,17 @@ pub fn show_inline_gen_graph_widget(
 /// See [`show_inline_gen_graph_widget`] for controls and return value.
 pub fn show_inline_block_group_widget(
     conn: &GraphConnection,
+    workspace: &Workspace,
     block_group_id: HashId,
     paths: Vec<Path>,
     height: u16,
     history_ref: Option<&str>,
 ) -> Result<bool> {
-    let graph = BlockGroup::get_graph(conn, &block_group_id, history_ref).map_err(Error::other)?;
+    let graph = BlockGroup::get_graph(conn, workspace, &block_group_id, history_ref)
+        .map_err(Error::other)?;
     show_inline_widget(
         conn,
+        workspace,
         &graph,
         paths,
         height,
@@ -233,6 +239,7 @@ pub fn show_inline_block_group_widget(
 
 fn show_inline_widget(
     conn: &GraphConnection,
+    workspace: &Workspace,
     graph: &GenGraph,
     paths: Vec<Path>,
     height: u16,
@@ -247,7 +254,8 @@ fn show_inline_widget(
 
     match terminal_result {
         Ok(mut terminal) => {
-            let mut state = InlineGenGraphState::new(graph, conn, block_group_id, history_ref);
+            let mut state =
+                InlineGenGraphState::new(graph, conn, workspace, block_group_id, history_ref);
             for path in paths {
                 state.add_path(&path, conn)?;
             }
@@ -394,7 +402,7 @@ fn render_inline(frame: &mut Frame, state: &mut InlineGenGraphState) {
 
     // Create the GenGraph widget with current level of detail
     let detail_level = state.controller.get_detail_level();
-    let widget = create_gen_graph_widget(state.conn)
+    let widget = create_gen_graph_widget(state.conn, state.workspace)
         .detail_level(detail_level)
         .cursor();
 
@@ -429,7 +437,7 @@ fn render_final(frame: &mut Frame, state: &mut InlineGenGraphState) {
 
     // Create the GenGraph widget with current level of detail
     let detail_level = state.controller.get_detail_level();
-    let widget = create_gen_graph_widget(state.conn).detail_level(detail_level);
+    let widget = create_gen_graph_widget(state.conn, state.workspace).detail_level(detail_level);
 
     // Render the graph widget
     frame.render_stateful_widget(
@@ -484,11 +492,12 @@ mod tests {
     use petgraph::graphmap::DiGraphMap;
 
     use super::*;
-    use crate::{graph::GraphNode, test_helpers::get_connection};
+    use crate::{graph::GraphNode, test_helpers::setup_gen};
 
     #[test]
     fn test_inline_state_creation() {
-        let conn = get_connection(None).expect("Failed to get test database connection");
+        let context = setup_gen();
+        let conn = context.graph().conn();
         let mut graph = DiGraphMap::new();
 
         // Add a simple test node
@@ -499,7 +508,7 @@ mod tests {
         };
         graph.add_node(node);
 
-        let state = InlineGenGraphState::new(&graph, &conn, None, None);
+        let state = InlineGenGraphState::new(&graph, conn, context.workspace(), None, None);
         assert_eq!(state.controller.get_detail_level(), VisualDetail::Truncated);
     }
 }

--- a/src/views/diff.rs
+++ b/src/views/diff.rs
@@ -69,7 +69,11 @@ enum DiffPanel {
     Graph,
 }
 
-pub fn view_diff(conn: &GraphConnection, diff: &OperationDiff) -> Result<(), io::Error> {
+pub fn view_diff(
+    conn: &GraphConnection,
+    workspace: &gen_core::Workspace,
+    diff: &OperationDiff,
+) -> Result<(), io::Error> {
     let samples = collect_samples(&diff.diff_graph);
 
     if samples.is_empty() {
@@ -160,7 +164,7 @@ pub fn view_diff(conn: &GraphConnection, diff: &OperationDiff) -> Result<(), io:
             f.render_widget(graph_block, main[1]);
 
             let canvas_style = Style::default().bg(current_theme()[0x00]);
-            let widget = create_gen_graph_widget(conn)
+            let widget = create_gen_graph_widget(conn, workspace)
                 .detail_level(graph_controller.get_detail_level())
                 .style(canvas_style)
                 .cursor();

--- a/src/views/gen_graph_widget.rs
+++ b/src/views/gen_graph_widget.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet, VecDeque};
 
 use gen_core::{
     INDETERMINATE_CHROMOSOME_INDEX, NO_CHROMOSOME_INDEX, PRESERVE_EDIT_SITE_CHROMOSOME_INDEX,
-    is_end_node, is_start_node,
+    Workspace, is_end_node, is_start_node,
 };
 use gen_graph::{GenGraph, GraphEdge, GraphNode, GraphNodeSlice};
 use gen_models::{db::GraphConnection, locus::GraphLocus, node::Node, sequence::SequenceError};
@@ -96,14 +96,16 @@ impl NodeSizer<GenGraph> for GenGraphNodeSizer {
 /// and genomic sequence visualization with caching.
 pub struct GenGraphNodeRenderer<'a> {
     conn: &'a GraphConnection,
+    workspace: &'a Workspace,
     cache: HashMap<GraphNode, String>,
 }
 
 impl<'a> GenGraphNodeRenderer<'a> {
     /// Create a new GenGraph node renderer with database connection
-    pub fn new(conn: &'a GraphConnection) -> Self {
+    pub fn new(conn: &'a GraphConnection, workspace: &'a Workspace) -> Self {
         Self {
             conn,
+            workspace,
             cache: HashMap::new(),
         }
     }
@@ -126,7 +128,8 @@ impl<'a> GenGraphNodeRenderer<'a> {
             node_key.sequence_start,
             node_key.sequence_end,
         );
-        let sequences = Node::get_sequences_by_node_ids(self.conn, &[db_node_id], None);
+        let sequences =
+            Node::get_sequences_by_node_ids(self.conn, self.workspace, &[db_node_id], None);
         let sequence = match sequences.get(&db_node_id) {
             Some(seq) => seq.get_sequence(start, end)?,
             None => "?".repeat((end - start).max(0) as usize),
@@ -245,10 +248,11 @@ pub fn inner_truncation(s: &str, target_length: u32) -> String {
 ///
 /// # Returns
 /// A configured GraphWidget ready to visualize GenGraph data
-pub fn create_gen_graph_widget(
-    conn: &GraphConnection,
-) -> GraphWidget<'_, GenGraph, GenGraphNodeSizer, GenGraphNodeRenderer<'_>> {
-    let renderer = GenGraphNodeRenderer::new(conn);
+pub fn create_gen_graph_widget<'a>(
+    conn: &'a GraphConnection,
+    workspace: &'a Workspace,
+) -> GraphWidget<'a, GenGraph, GenGraphNodeSizer, GenGraphNodeRenderer<'a>> {
+    let renderer = GenGraphNodeRenderer::new(conn, workspace);
     GraphWidget::with_renderer(renderer)
 }
 
@@ -965,7 +969,7 @@ mod tests {
         viewport_state.viewport_bounds = Rect::new(0, 0, 5, 5);
         let mut buffer = Buffer::empty(viewport_state.viewport_bounds);
         let mut world_buffer = WorldBuffer::new(&mut buffer, &viewport_state);
-        let mut renderer = GenGraphNodeRenderer::new(context.graph().conn());
+        let mut renderer = GenGraphNodeRenderer::new(context.graph().conn(), context.workspace());
 
         renderer.render_node(
             &mut world_buffer,
@@ -994,7 +998,7 @@ mod tests {
         let mut world_buffer = WorldBuffer::new(&mut buffer, &viewport_state);
         let position = WorldPos::ZERO;
         world_buffer.set_char_styled(position, '━', Style::default().fg(Color::Yellow));
-        let mut renderer = GenGraphNodeRenderer::new(context.graph().conn());
+        let mut renderer = GenGraphNodeRenderer::new(context.graph().conn(), context.workspace());
 
         renderer.render_node(
             &mut world_buffer,
@@ -1108,7 +1112,14 @@ mod tests {
         )
         .unwrap();
 
-        let gen_graph = Sample::get_graph(conn, collection, "SAMPLE1", None).unwrap();
+        let gen_graph = Sample::get_graph(
+            conn,
+            crate::test_helpers::test_workspace(),
+            collection,
+            "SAMPLE1",
+            None,
+        )
+        .unwrap();
         let mut controller = create_gen_graph_controller(gen_graph);
 
         let mut terminal = create_test_terminal(120, 30);
@@ -1118,11 +1129,8 @@ mod tests {
                 controller.viewport_state.viewport_bounds = area;
                 controller.ensure_camera_coverage().unwrap();
                 controller.rebuild_viewport_graph().unwrap();
-                GraphWidget::with_renderer(GenGraphNodeRenderer::new(conn)).render(
-                    area,
-                    f.buffer_mut(),
-                    &mut controller,
-                );
+                GraphWidget::with_renderer(GenGraphNodeRenderer::new(conn, context.workspace()))
+                    .render(area, f.buffer_mut(), &mut controller);
             })
             .unwrap();
 
@@ -1156,7 +1164,14 @@ mod tests {
         )
         .unwrap();
 
-        let gen_graph = Sample::get_graph(conn, collection, Sample::DEFAULT_NAME, None).unwrap();
+        let gen_graph = Sample::get_graph(
+            conn,
+            crate::test_helpers::test_workspace(),
+            collection,
+            Sample::DEFAULT_NAME,
+            None,
+        )
+        .unwrap();
         let mut controller = create_gen_graph_controller(gen_graph);
 
         let block = controller

--- a/src/views/operations.rs
+++ b/src/views/operations.rs
@@ -486,7 +486,7 @@ pub fn view_operations(
                 graph_controller.update_animations(frame_delta);
 
                 let canvas_style = Style::default().bg(current_theme()[0x00]);
-                let widget = create_gen_graph_widget(conn)
+                let widget = create_gen_graph_widget(conn, context.workspace())
                     .detail_level(graph_controller.get_detail_level())
                     .style(canvas_style)
                     .cursor();

--- a/src/views/patch.rs
+++ b/src/views/patch.rs
@@ -122,7 +122,11 @@ where
     R: Read + Seek,
 {
     let prepared = prepare_patch_view(source_context, reader)?;
-    view_diff(prepared.context.graph().conn(), &prepared.diff)?;
+    view_diff(
+        prepared.context.graph().conn(),
+        prepared.context.workspace(),
+        &prepared.diff,
+    )?;
     Ok(())
 }
 

--- a/src/views/testing/connectivity_test.rs
+++ b/src/views/testing/connectivity_test.rs
@@ -40,8 +40,14 @@ mod tests {
         import_gfa(&context, &gfa_path, collection_name, Sample::DEFAULT_NAME)
             .expect("GFA import failed");
 
-        let gen_graph =
-            Sample::get_graph(conn, collection_name, Sample::DEFAULT_NAME, None).unwrap();
+        let gen_graph = Sample::get_graph(
+            conn,
+            crate::test_helpers::test_workspace(),
+            collection_name,
+            Sample::DEFAULT_NAME,
+            None,
+        )
+        .unwrap();
 
         // Test with small partitions to force inter-partition edges
         let config = GraphConfig {

--- a/src/views/testing/keyboard_navigation_test.rs
+++ b/src/views/testing/keyboard_navigation_test.rs
@@ -45,8 +45,14 @@ mod tests {
         import_gfa(&context, &gfa_path, collection_name, Sample::DEFAULT_NAME)
             .expect("GFA import failed");
 
-        let gen_graph =
-            Sample::get_graph(conn, collection_name, Sample::DEFAULT_NAME, None).unwrap();
+        let gen_graph = Sample::get_graph(
+            conn,
+            crate::test_helpers::test_workspace(),
+            collection_name,
+            Sample::DEFAULT_NAME,
+            None,
+        )
+        .unwrap();
 
         let config = GraphConfig {
             partition: PartitionConfig {
@@ -317,8 +323,14 @@ mod tests {
         import_gfa(&context, &gfa_path, collection_name, Sample::DEFAULT_NAME)
             .expect("GFA import failed");
 
-        let gen_graph =
-            Sample::get_graph(conn, collection_name, Sample::DEFAULT_NAME, None).unwrap();
+        let gen_graph = Sample::get_graph(
+            conn,
+            crate::test_helpers::test_workspace(),
+            collection_name,
+            Sample::DEFAULT_NAME,
+            None,
+        )
+        .unwrap();
 
         // Configure with large partition for stability
         let config = GraphConfig {
@@ -388,8 +400,14 @@ mod tests {
         import_gfa(&context, &gfa_path, collection_name, Sample::DEFAULT_NAME)
             .expect("GFA import failed");
 
-        let gen_graph =
-            Sample::get_graph(conn, collection_name, Sample::DEFAULT_NAME, None).unwrap();
+        let gen_graph = Sample::get_graph(
+            conn,
+            crate::test_helpers::test_workspace(),
+            collection_name,
+            Sample::DEFAULT_NAME,
+            None,
+        )
+        .unwrap();
 
         // Configure with large partition for stability
         let config = GraphConfig {

--- a/tests/history_cli_tests.rs
+++ b/tests/history_cli_tests.rs
@@ -107,7 +107,7 @@ mod diff_views {
 
     use super::{
         DiffChangeKind, DiffRange, DoltHistoryStore, HashSet, HistoryStore, Node, Path, PathBuf,
-        assert_success, collect_operation_diff, fs, get_connection, run_gen, tempdir,
+        Workspace, assert_success, collect_operation_diff, fs, get_connection, run_gen, tempdir,
     };
 
     fn maybe_export_diff_graph_debug(graph: &gen_diff::graph::DiffGenGraph, export_path: &Path) {
@@ -187,6 +187,7 @@ mod diff_views {
     #[test]
     fn test_view_diff_reports_vcf_added_and_removed_nodes_from_deltas() {
         let repo_dir = tempdir().expect("should create temp repo directory");
+        let workspace = Workspace::new(repo_dir.path());
         let fixtures_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("fixtures");
         let fasta_path = fixtures_dir.join("simple.fa");
         let vcf_path = fixtures_dir.join("simple.vcf");
@@ -288,6 +289,7 @@ mod diff_views {
             .expect("lineage-derived sample should retain parent block group id");
         let parent_graph = gen_models::block_group::BlockGroup::get_graph(
             &graph_conn,
+            &workspace,
             &parent_block_group_id,
             None,
         )
@@ -339,8 +341,9 @@ mod diff_views {
             .collect::<HashSet<_>>()
             .into_iter()
             .collect::<Vec<_>>();
+        let workspace = gen_core::Workspace::new(repo_dir.path());
         let sequences_by_node_id =
-            Node::get_sequences_by_node_ids(&graph_conn, &diff_node_ids, None);
+            Node::get_sequences_by_node_ids(&graph_conn, &workspace, &diff_node_ids, None);
         let removed_sequences = unknown_diff
             .graph
             .nodes()


### PR DESCRIPTION
Cosmetic change where workspace is passed to all sequence creation. This is so on-disk operations can scope the workspace to find the correct file in a later PR