### PR TITLE
Back shallow sequences with AssetRefs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1845,6 +1845,7 @@ dependencies = [
  "capnp",
  "chrono",
  "fallible-streaming-iterator",
+ "flate2",
  "gen-capnp-schemas",
  "gen-core",
  "gen-graph",

--- a/gen-capnp-schemas/gen-models.capnp
+++ b/gen-capnp-schemas/gen-models.capnp
@@ -27,9 +27,9 @@ struct Sequence {
   sequenceType @1 :Text;
   sequence @2 :Text;
   name @3 :Text;
-  filePath @4 :Text;
-  length @5 :Int64;
-  externalSequence @6 :Bool;
+  length @4 :Int64;
+  externalSequence @5 :Bool;
+  assetRefId @6 :List(UInt8);
 }
 
 struct Node {

--- a/gen-models/Cargo.toml
+++ b/gen-models/Cargo.toml
@@ -24,6 +24,7 @@ capnp = { version = "0.24" }
 include_dir = "0.7.4"
 chrono = "0.4.40"
 fallible-streaming-iterator = "0.1.9"
+flate2 = "1.1.0"
 intervaltree = "0.2.7"
 itertools = "0.14.0"
 noodles = { version = "0.101.0", features = ["async", "bed", "bgzf", "core", "fasta", "gff", "gtf", "tabix", "vcf"] }

--- a/gen-models/migrations/core/01-initial/up.sql
+++ b/gen-models/migrations/core/01-initial/up.sql
@@ -12,8 +12,9 @@ CREATE TABLE sequences (
   sequence_type TEXT NOT NULL,
   sequence TEXT NOT NULL,
   name TEXT NOT NULL,
-  file_path TEXT NOT NULL,
-  length INTEGER NOT NULL
+  asset_ref_id BLOB,
+  length INTEGER NOT NULL,
+  FOREIGN KEY(asset_ref_id) REFERENCES gen_asset_refs(id)
 ) STRICT;
 
 CREATE TABLE nodes (
@@ -300,6 +301,6 @@ INSERT INTO reference_aliases (reference_name, refseq_accession_id, genbank_acce
 INSERT INTO reference_aliases (reference_name, refseq_accession_id, genbank_accession_id, ucsc_id, ensembl_id) values ('Domestic cat', 'NC_018741.3', 'CM001396.3', 'chrX', 'X');
 INSERT INTO reference_aliases (reference_name, refseq_accession_id, genbank_accession_id, ucsc_id, ensembl_id) values ('Domestic cat', 'NC_001700.1', '', 'chrM', 'MT');
 
-INSERT INTO sequences (hash, sequence_type, sequence, name, file_path, "length") values (X'84d6adbd5395281933fe41e877d3a7f02a3b1990a65be1901b2c91fc685e083b', "OTHER", "start-node-yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy", "", "", 64), (X'1c7dfc64977b0838af0762d7333dcb64c175b15e65a70099ec38f46bf1a15ea3', "OTHER", "end-node-zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz", "", "", 64);
+INSERT INTO sequences (hash, sequence_type, sequence, name, asset_ref_id, "length") values (X'84d6adbd5395281933fe41e877d3a7f02a3b1990a65be1901b2c91fc685e083b', "OTHER", "start-node-yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy", "", NULL, 64), (X'1c7dfc64977b0838af0762d7333dcb64c175b15e65a70099ec38f46bf1a15ea3', "OTHER", "end-node-zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz", "", NULL, 64);
 INSERT INTO nodes (id, sequence_hash) values (X'84d6adbd5395281933fe41e877d3a7f0', X'84d6adbd5395281933fe41e877d3a7f02a3b1990a65be1901b2c91fc685e083b');
 INSERT INTO nodes (id, sequence_hash) values (X'1c7dfc64977b0838af0762d7333dcb64', X'1c7dfc64977b0838af0762d7333dcb64c175b15e65a70099ec38f46bf1a15ea3');

--- a/gen-models/src/annotations.rs
+++ b/gen-models/src/annotations.rs
@@ -20,10 +20,7 @@ use crate::{
     file_types::FileTypes,
     gen_models_capnp::{annotation, annotation_group, annotation_group_sample},
     history::{HistoryStore, dolt::DoltHistoryStore},
-    operations::{
-        FileAddition, OperationAssetRecord, OperationFile, OperationInfo, OperationSummary,
-        track_operation_assets,
-    },
+    operations::{FileAddition, OperationFile, OperationInfo, OperationSummary, track_asset_refs},
     traits::Query,
 };
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
@@ -831,23 +828,28 @@ pub fn add_annotation_file(
     let summary = message
         .map(str::to_string)
         .unwrap_or_else(|| format!("Add annotation file {path}"));
-    let mut tracked_assets = vec![OperationAssetRecord {
-        file_addition: &file_addition,
-        role: AssetRole::Annotation,
-        logical_path: Some(&annotation_logical_path),
+    let created_on = chrono::Utc::now()
+        .timestamp_nanos_opt()
+        .expect("should create annotation asset timestamp");
+    let mut tracked_assets = vec![AssetRef::from_file_addition(
+        &file_addition,
+        AssetRole::Annotation,
+        Some(&annotation_logical_path),
         name,
-        upstream_asset_ref_id: None,
-    }];
+        None,
+        created_on,
+    )];
     if let Some((index_file_addition, index_logical_path, index_name)) = prepared_index.as_ref() {
-        tracked_assets.push(OperationAssetRecord {
-            file_addition: index_file_addition,
-            role: AssetRole::AnnotationIndex,
-            logical_path: Some(index_logical_path),
-            name: index_name.as_deref(),
-            upstream_asset_ref_id: Some(&annotation_asset_ref_id),
-        });
+        tracked_assets.push(AssetRef::from_file_addition(
+            index_file_addition,
+            AssetRole::AnnotationIndex,
+            Some(index_logical_path),
+            index_name.as_deref(),
+            Some(&annotation_asset_ref_id),
+            created_on,
+        ));
     }
-    track_operation_assets(
+    track_asset_refs(
         graph_conn,
         Some(&log_id),
         &OperationKind::AnnotationFile,

--- a/gen-models/src/assets.rs
+++ b/gen-models/src/assets.rs
@@ -276,6 +276,55 @@ impl Query for OperationAsset {
 }
 
 impl AssetRef {
+    /// Return the versioned store path for an asset.
+    ///
+    /// Logical paths describe the materialized workspace view and can point at a newer version.
+    /// Sequence readers use this path so they cannot follow repository metadata outside the
+    /// repository or silently switch to another asset version.
+    pub fn versioned_store_path(
+        &self,
+        workspace: &Workspace,
+    ) -> Result<PathBuf, FileAdditionError> {
+        let checksum = self.checksum.ok_or_else(|| {
+            FileAdditionError::ChecksumError(format!(
+                "asset {} has no checksum for repository lookup",
+                self.id
+            ))
+        })?;
+        let repo_root = LocalAssetUri::canonicalize_or_normalize(&workspace.repo_root()?);
+        let asset_path = workspace
+            .asset_dir()?
+            .join(<dyn AssetUri>::from_uri(&self.uri).hashed_filename(&checksum));
+        if !asset_path.exists() {
+            return Err(FileAdditionError::FileNotFound(
+                asset_path.display().to_string(),
+            ));
+        }
+        let resolved_path = LocalAssetUri::canonicalize_or_normalize(&asset_path);
+        if !resolved_path.starts_with(&repo_root) {
+            return Err(FileAdditionError::PathOutsideRepo {
+                path: resolved_path,
+                repo_root,
+            });
+        }
+        Ok(resolved_path)
+    }
+
+    /// Opens the asset identified by this reference.
+    ///
+    /// Local references resolve through the repository's content-addressed asset store. Remote
+    /// references retain their URI and are opened lazily through the configured storage backend.
+    pub fn reader(&self, workspace: &Workspace) -> Result<blocking::StdReader, FileAdditionError> {
+        if LocalAssetUri::is_local_path_or_file_uri(&self.uri) {
+            let asset_path = self.versioned_store_path(workspace)?;
+            return OpenDalLocation::from_absolute_path(&asset_path)
+                .map_err(opendal_file_addition_error)?
+                .reader();
+        }
+
+        <dyn AssetUri>::from_uri(&self.uri).reader(workspace)
+    }
+
     pub fn id_hash(
         uri: &str,
         file_type: &str,
@@ -299,6 +348,37 @@ impl AssetRef {
             identity.push_str(&upstream_asset_ref_id.to_string());
         }
         HashId(calculate_hash(&identity))
+    }
+
+    pub(crate) fn from_file_addition(
+        file_addition: &FileAddition,
+        role: AssetRole,
+        logical_path: Option<&str>,
+        name: Option<&str>,
+        upstream_asset_ref_id: Option<&HashId>,
+        created_on: i64,
+    ) -> Self {
+        let file_type = file_addition.file_type.as_str();
+        Self {
+            id: Self::id_hash(
+                &file_addition.asset_uri,
+                file_type,
+                file_addition.checksum.as_ref(),
+                &role,
+                logical_path,
+                name,
+                upstream_asset_ref_id,
+            ),
+            uri: file_addition.asset_uri.clone(),
+            file_type: file_type.to_string(),
+            checksum: file_addition.checksum,
+            size: None,
+            role,
+            logical_path: logical_path.map(str::to_string),
+            name: name.map(str::to_string),
+            created_on,
+            upstream_asset_ref_id: upstream_asset_ref_id.copied(),
+        }
     }
 
     pub fn create(conn: &GraphConnection, asset_ref: &AssetRef) -> rusqlite::Result<()> {

--- a/gen-models/src/node.rs
+++ b/gen-models/src/node.rs
@@ -98,7 +98,7 @@ impl Node {
 
     pub fn get_sequences_by_node_ids(
         conn: &GraphConnection,
-        _workspace: &Workspace,
+        workspace: &Workspace,
         node_ids: &[HashId],
         history_ref: Option<&str>,
     ) -> HashMap<HashId, Sequence> {
@@ -108,8 +108,9 @@ impl Node {
             .map(|node| (node.id, node.sequence_hash))
             .collect::<HashMap<HashId, Sha256Hash>>();
         let sequences_by_hash: HashMap<Sha256Hash, Sequence> = HashMap::from_iter(
-            <Sequence as Query>::query_by_ids(
+            Sequence::query_by_ids(
                 conn,
+                workspace,
                 &sequence_hashes_by_node_id
                     .values()
                     .cloned()

--- a/gen-models/src/operations.rs
+++ b/gen-models/src/operations.rs
@@ -93,6 +93,43 @@ impl OperationFile {
         self
     }
 
+    /// Construct the AssetRef from an OperationFile
+    pub fn prepare_asset_ref(
+        &self,
+        workspace: &Workspace,
+        created_on: i64,
+    ) -> Result<AssetRef, FileAdditionError> {
+        let file_addition = FileAddition::prepare(
+            workspace,
+            &self.file_path,
+            self.file_type,
+            self.checksum_override,
+        )?;
+        let logical_path =
+            Self::storage_file_path(workspace, &self.file_path, file_addition.checksum.as_ref())?;
+        let file_type = file_addition.file_type.as_str();
+        Ok(AssetRef {
+            id: AssetRef::id_hash(
+                &file_addition.asset_uri,
+                file_type,
+                file_addition.checksum.as_ref(),
+                &AssetRole::Input,
+                Some(&logical_path),
+                Some(&self.filename),
+                None,
+            ),
+            uri: file_addition.asset_uri,
+            file_type: file_type.to_string(),
+            checksum: file_addition.checksum,
+            size: None,
+            role: AssetRole::Input,
+            logical_path: Some(logical_path),
+            name: Some(self.filename.clone()),
+            created_on,
+            upstream_asset_ref_id: None,
+        })
+    }
+
     /// Resolves the path stored in operation metadata without materializing remote assets.
     ///
     /// Local inputs use their content-addressed repository path and therefore require a checksum;
@@ -153,23 +190,13 @@ pub fn commit_operation_summary(
         return Err(OperationError::NoChanges);
     }
 
-    let prepared_files = operation_info
+    let created_on = chrono::Utc::now()
+        .timestamp_nanos_opt()
+        .expect("should create operation asset timestamp");
+    let prepared_assets = operation_info
         .files
         .iter()
-        .map(|operation_file| {
-            let file_addition = FileAddition::prepare(
-                workspace,
-                &operation_file.file_path,
-                operation_file.file_type,
-                operation_file.checksum_override,
-            )?;
-            let logical_path = OperationFile::storage_file_path(
-                workspace,
-                &operation_file.file_path,
-                file_addition.checksum.as_ref(),
-            )?;
-            Ok((file_addition, logical_path))
-        })
+        .map(|operation_file| operation_file.prepare_asset_ref(workspace, created_on))
         .collect::<Result<Vec<_>, _>>()
         .map_err(|err| match err {
             FileAdditionError::ConfigError(config_error) => {
@@ -177,50 +204,29 @@ pub fn commit_operation_summary(
             }
             other => OperationError::SQLError(other.to_string()),
         })?;
-    let tracked_assets = prepared_files
-        .iter()
-        .zip(operation_info.files.iter())
-        .map(
-            |((file_addition, logical_path), operation_file)| OperationAssetRecord {
-                file_addition,
-                role: AssetRole::Input,
-                logical_path: Some(logical_path.as_str()),
-                name: Some(operation_file.filename.as_str()),
-                upstream_asset_ref_id: None,
-            },
-        )
-        .collect::<Vec<_>>();
     let operation_kind = OperationKind::Other(operation_info.description.clone());
-    track_operation_assets(
+    track_asset_refs(
         graph_conn,
         None,
         &operation_kind,
         &operation_summary.summary,
-        &tracked_assets,
+        &prepared_assets,
     )?;
 
     let commit_result = history_store.commit_all(&operation_summary.summary);
     commit_result.map_err(OperationError::from)
 }
 
-pub(crate) struct OperationAssetRecord<'a> {
-    pub file_addition: &'a FileAddition,
-    pub role: AssetRole,
-    pub logical_path: Option<&'a str>,
-    pub name: Option<&'a str>,
-    pub upstream_asset_ref_id: Option<&'a HashId>,
-}
-
 #[cfg_attr(
     feature = "profiling",
     tracing::instrument(skip(graph_conn, log_id, assets))
 )]
-pub(crate) fn track_operation_assets(
+pub(crate) fn track_asset_refs(
     graph_conn: &crate::db::GraphConnection,
     log_id: Option<&HashId>,
     operation_kind: &OperationKind,
     command: &str,
-    assets: &[OperationAssetRecord<'_>],
+    assets: &[AssetRef],
 ) -> Result<(), rusqlite::Error> {
     let created_on = chrono::Utc::now()
         .timestamp_nanos_opt()
@@ -228,44 +234,24 @@ pub(crate) fn track_operation_assets(
     let log_id = log_id
         .copied()
         .unwrap_or_else(|| OperationLog::id_hash(operation_kind, command, created_on));
-    let operation_log = OperationLog {
-        id: log_id,
-        operation_kind: operation_kind.clone(),
-        command: command.to_string(),
-        created_on,
-    };
-    OperationLog::create(graph_conn, &operation_log)?;
-
-    for asset in assets {
-        let file_type = asset.file_addition.file_type.as_str();
-        let asset_ref_id = AssetRef::id_hash(
-            &asset.file_addition.asset_uri,
-            file_type,
-            asset.file_addition.checksum.as_ref(),
-            &asset.role,
-            asset.logical_path,
-            asset.name,
-            asset.upstream_asset_ref_id,
-        );
-        let asset_ref = AssetRef {
-            id: asset_ref_id,
-            uri: asset.file_addition.asset_uri.clone(),
-            file_type: file_type.to_string(),
-            checksum: asset.file_addition.checksum,
-            size: None,
-            role: asset.role.clone(),
-            logical_path: asset.logical_path.map(str::to_string),
-            name: asset.name.map(str::to_string),
+    OperationLog::create(
+        graph_conn,
+        &OperationLog {
+            id: log_id,
+            operation_kind: operation_kind.clone(),
+            command: command.to_string(),
             created_on,
-            upstream_asset_ref_id: asset.upstream_asset_ref_id.copied(),
-        };
-        AssetRef::create(graph_conn, &asset_ref)?;
+        },
+    )?;
+
+    for asset_ref in assets {
+        AssetRef::create(graph_conn, asset_ref)?;
         OperationAsset::create(
             graph_conn,
             &OperationAsset {
                 log_id,
-                asset_ref_id,
-                role: asset.role.clone(),
+                asset_ref_id: asset_ref.id,
+                role: asset_ref.role.clone(),
             },
         )?;
     }
@@ -335,24 +321,28 @@ pub fn add_files_operation(
             format!("Add {} files", files.len())
         }
     });
-    let tracked_assets = unique_file_additions
+    let created_on = chrono::Utc::now()
+        .timestamp_nanos_opt()
+        .expect("should create operation asset timestamp");
+    let asset_refs = unique_file_additions
         .iter()
-        .map(
-            |(file_addition, filename, file_path)| OperationAssetRecord {
+        .map(|(file_addition, filename, file_path)| {
+            AssetRef::from_file_addition(
                 file_addition,
-                role: AssetRole::Input,
-                logical_path: Some(file_path.as_str()),
-                name: Some(filename.as_str()),
-                upstream_asset_ref_id: None,
-            },
-        )
+                AssetRole::Input,
+                Some(file_path),
+                Some(filename),
+                None,
+                created_on,
+            )
+        })
         .collect::<Vec<_>>();
-    track_operation_assets(
+    track_asset_refs(
         graph_conn,
         Some(&log_id),
         &OperationKind::AddFile,
         &summary,
-        &tracked_assets,
+        &asset_refs,
     )?;
     let history_store = DoltHistoryStore::new_with_config(graph_conn, context.config().conn());
     if history_store.status()?.is_empty() {

--- a/gen-models/src/sequence.rs
+++ b/gen-models/src/sequence.rs
@@ -842,6 +842,8 @@ mod tests {
             None,
         )
         .remove(0);
+        // Overwrite temp_file_path with a garbage sequence, showing that sequence access uses the versioned file
+        // and not any local materialized file.
         fs::write(
             &temp_file_path,
             ">m123\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n",

--- a/gen-models/src/sequence.rs
+++ b/gen-models/src/sequence.rs
@@ -1,47 +1,79 @@
-use std::{collections::HashMap, fs, str, sync};
+use core::hash::{Hash, Hasher};
+use std::{io::BufReader, ops::Range, rc::Rc, str, sync};
 
-use cached::proc_macro::cached;
-use gen_core::{HashId, Sha256Hash, traits::Capnp};
-use noodles::{
-    bgzf::{self, gzi},
-    core::Region,
-    fasta::{self, fai, io::indexed_reader::Builder as IndexBuilder},
-};
-use rusqlite::{Row, params};
+use flate2::read::MultiGzDecoder;
+use gen_core::{HashId, Sha256Hash, Workspace, traits::Capnp};
+use noodles::{bgzf, fasta};
+use rusqlite::{Row, ToSql, params, types::Value};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use thiserror::Error;
 
-use crate::{db::GraphConnection, gen_models_capnp::sequence, traits::*};
+use crate::{
+    assets::{AssetRef, AssetUri, LocalAssetUri},
+    db::GraphConnection,
+    gen_models_capnp::sequence,
+    traits::Query,
+};
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Sequence {
     pub hash: Sha256Hash,
     pub sequence_type: String,
     sequence: String,
-    // these 2 fields are only relevant when the sequence is stored externally
+    // These fields are only relevant when the sequence is stored externally.
     pub name: String,
-    pub file_path: String,
+    pub asset_ref_id: Option<HashId>,
     pub length: i64,
-    // indicates whether the sequence is stored externally, a quick flag instead of having to
-    // check sequence or file_path and do the logic in function calls.
+    // Indicates whether the sequence is stored externally, a quick flag instead of checking the
+    // sequence and asset reference in each caller.
     pub external_sequence: bool,
+    #[serde(skip)]
+    asset_ref: Option<AssetRef>,
+    #[serde(skip)]
+    workspace: Option<Workspace>,
+    #[serde(skip)]
+    asset_resolution_error: Option<String>,
+}
+
+impl PartialEq for Sequence {
+    fn eq(&self, other: &Self) -> bool {
+        self.hash == other.hash
+            && self.sequence_type == other.sequence_type
+            && self.sequence == other.sequence
+            && self.name == other.name
+            && self.asset_ref_id == other.asset_ref_id
+            && self.length == other.length
+            && self.external_sequence == other.external_sequence
+    }
+}
+
+impl Eq for Sequence {}
+
+impl Hash for Sequence {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.hash.hash(state);
+        self.sequence_type.hash(state);
+        self.sequence.hash(state);
+        self.name.hash(state);
+        self.asset_ref_id.hash(state);
+        self.length.hash(state);
+        self.external_sequence.hash(state);
+    }
 }
 
 #[derive(Debug, Error, PartialEq)]
 pub enum SequenceError {
     #[error("Database error: {0}")]
     DatabaseError(#[from] rusqlite::Error),
-    #[error("Sequence or file_path must be set.")]
+    #[error("Sequence or asset_ref_id must be set.")]
     NoSequence(),
-    #[error("A filepath must have an accompanying sequence name.")]
-    FilepathMissingSequenceName(),
+    #[error("An asset reference must have an accompanying sequence name.")]
+    AssetMissingSequenceName(),
     #[error("Sequence length must be specified.")]
     MissingSequenceLength(),
     #[error("Sequence cache lock poisoned: {0}")]
     CachePoisoned(String),
-    #[error("Invalid indexed sequence region '{name}': {reason}")]
-    InvalidRegion { name: String, reason: String },
     #[error("Sequence I/O error: {0}")]
     Io(String),
     #[error("Invalid UTF-8 while reading sequence data: {0}")]
@@ -50,6 +82,8 @@ pub enum SequenceError {
     IdMissing { file_path: String, name: String },
     #[error("Sequence bounds out of range: start={start}, end={end}, length={length}")]
     BoundsError { start: i64, end: i64, length: i64 },
+    #[error("Unable to resolve sequence asset: {0}")]
+    AssetResolution(String),
 }
 
 impl<'a> Capnp<'a> for Sequence {
@@ -61,9 +95,11 @@ impl<'a> Capnp<'a> for Sequence {
         builder.set_sequence_type(&self.sequence_type);
         builder.set_sequence(&self.sequence);
         builder.set_name(&self.name);
-        builder.set_file_path(&self.file_path);
         builder.set_length(self.length);
         builder.set_external_sequence(self.external_sequence);
+        if let Some(asset_ref_id) = self.asset_ref_id {
+            builder.set_asset_ref_id(&asset_ref_id.0).unwrap();
+        }
     }
 
     fn read_capnp(reader: Self::Reader) -> Self {
@@ -77,18 +113,26 @@ impl<'a> Capnp<'a> for Sequence {
         let sequence_type = reader.get_sequence_type().unwrap().to_string().unwrap();
         let sequence = reader.get_sequence().unwrap().to_string().unwrap();
         let name = reader.get_name().unwrap().to_string().unwrap();
-        let file_path = reader.get_file_path().unwrap().to_string().unwrap();
         let length = reader.get_length();
-        let external_sequence = reader.get_external_sequence();
+        let asset_ref_id = reader.get_asset_ref_id().ok().and_then(|value| {
+            value
+                .as_slice()
+                .and_then(|bytes| bytes.try_into().ok())
+                .map(HashId)
+        });
+        let external_sequence = asset_ref_id.is_some();
 
         Sequence {
             hash,
             sequence_type,
             sequence,
             name,
-            file_path,
+            asset_ref_id,
             length,
             external_sequence,
+            asset_ref: None,
+            workspace: None,
+            asset_resolution_error: None,
         }
     }
 }
@@ -98,7 +142,7 @@ pub struct NewSequence<'a> {
     sequence_type: Option<&'a str>,
     sequence: Option<&'a str>,
     name: Option<&'a str>,
-    file_path: Option<&'a str>,
+    asset_ref_id: Option<&'a HashId>,
     length: Option<i64>,
     shallow: bool,
 }
@@ -109,7 +153,7 @@ impl<'a> From<&'a Sequence> for NewSequence<'a> {
             .sequence_type(&value.sequence_type)
             .sequence(&value.sequence)
             .name(&value.name)
-            .file_path(&value.file_path)
+            .asset_ref_id(value.asset_ref_id.as_ref())
             .length(value.length)
     }
 }
@@ -143,9 +187,9 @@ impl<'a> NewSequence<'a> {
         self
     }
 
-    pub fn file_path(mut self, path: &'a str) -> Self {
-        if !path.is_empty() {
-            self.file_path = Some(path);
+    pub fn asset_ref_id(mut self, asset_ref_id: Option<&'a HashId>) -> Self {
+        if asset_ref_id.is_some() {
+            self.asset_ref_id = asset_ref_id;
             self.shallow = true;
         }
         self
@@ -172,27 +216,28 @@ impl<'a> NewSequence<'a> {
             hasher.update("");
         }
         hasher.update(";");
-        if let Some(v) = self.file_path {
-            hasher.update(v);
+        if let Some(value) = self.asset_ref_id {
+            hasher.update(value.0);
         } else {
             hasher.update("");
         }
         hasher.update(";");
-
         Sha256Hash(hasher.finalize().into())
     }
 
     pub fn build(self) -> Sequence {
-        let file_path = self.file_path.unwrap_or("").to_string();
-        let external_sequence = !file_path.is_empty();
+        let external_sequence = self.asset_ref_id.is_some();
         Sequence {
             hash: self.hash(),
             sequence_type: self.sequence_type.unwrap().to_string(),
             sequence: self.sequence.unwrap_or("").to_string(),
             name: self.name.unwrap_or("").to_string(),
-            file_path,
+            asset_ref_id: self.asset_ref_id.copied(),
             length: self.length.unwrap(),
             external_sequence,
+            asset_ref: None,
+            workspace: None,
+            asset_resolution_error: None,
         }
     }
 
@@ -202,11 +247,11 @@ impl<'a> NewSequence<'a> {
     )]
     pub fn save(self, conn: &GraphConnection) -> Result<Sequence, SequenceError> {
         let mut length = 0;
-        if self.sequence.is_none() && self.file_path.is_none() {
+        if self.sequence.is_none() && self.asset_ref_id.is_none() {
             return Err(SequenceError::NoSequence());
         }
-        if self.file_path.is_some() && self.name.is_none() {
-            return Err(SequenceError::FilepathMissingSequenceName());
+        if self.asset_ref_id.is_some() && self.name.is_none() {
+            return Err(SequenceError::AssetMissingSequenceName());
         }
         if self.length.is_none() {
             if let Some(v) = self.sequence {
@@ -224,7 +269,7 @@ impl<'a> NewSequence<'a> {
         ) {
             Ok(_) => {}
             Err(rusqlite::Error::QueryReturnedNoRows) => {
-                let mut stmt = conn.prepare("INSERT INTO sequences (hash, sequence_type, sequence, name, file_path, length) VALUES (?1, ?2, ?3, ?4, ?5, ?6);")?;
+                let mut stmt = conn.prepare("INSERT INTO sequences (hash, sequence_type, sequence, name, asset_ref_id, length) VALUES (?1, ?2, ?3, ?4, ?5, ?6);")?;
                 match stmt.execute(params![
                     hash,
                     self.sequence_type.unwrap().to_string(),
@@ -234,7 +279,7 @@ impl<'a> NewSequence<'a> {
                         self.sequence.unwrap()
                     },
                     self.name.unwrap_or(""),
-                    self.file_path.unwrap_or(""),
+                    self.asset_ref_id,
                     self.length.unwrap_or(length)
                 ]) {
                     Ok(_) => {}
@@ -249,29 +294,20 @@ impl<'a> NewSequence<'a> {
             sequence_type: self.sequence_type.unwrap().to_string(),
             sequence: self.sequence.unwrap_or("").to_string(),
             name: self.name.unwrap_or("").to_string(),
-            file_path: self.file_path.unwrap_or("").to_string(),
+            asset_ref_id: self.asset_ref_id.copied(),
             length: self.length.unwrap_or(length),
-            external_sequence: !self.file_path.unwrap_or("").is_empty(),
+            external_sequence: self.asset_ref_id.is_some(),
+            asset_ref: None,
+            workspace: None,
+            asset_resolution_error: None,
         })
     }
 }
 
-#[cached(key = "String", convert = r#"{ format!("{}", path) }"#)]
-fn fasta_index(path: &str) -> Option<fai::Index> {
-    let index_path = format!("{path}.fai");
-    if fs::metadata(&index_path).is_ok() {
-        return Some(fai::fs::read(&index_path).unwrap());
-    }
-    None
-}
-
-#[cached(key = "String", convert = r#"{ format!("{}", path) }"#)]
-fn fasta_gzi_index(path: &str) -> Option<gzi::Index> {
-    let index_path = format!("{path}.gzi");
-    if fs::metadata(&index_path).is_ok() {
-        return Some(gzi::fs::read(&index_path).unwrap());
-    }
-    None
+fn asset_extension(asset_ref: &AssetRef) -> Option<String> {
+    <dyn AssetUri>::from_uri(&asset_ref.uri)
+        .suffix()
+        .and_then(|suffix| suffix.rsplit('.').next().map(str::to_string))
 }
 
 fn validate_sequence_bounds(
@@ -330,27 +366,31 @@ fn sequence_slice(
     })
 }
 
+type SequenceCache = sync::RwLock<Option<((HashId, String), Option<String>)>>;
+
 pub fn cached_sequence(
-    file_path: &str,
+    workspace: &Workspace,
+    sequence_asset: &AssetRef,
     name: &str,
-    start: i64,
-    end: i64,
+    range: Range<i64>,
     circular: bool,
 ) -> Result<String, SequenceError> {
-    static SEQUENCE_CACHE: sync::LazyLock<sync::RwLock<HashMap<String, Option<String>>>> =
-        sync::LazyLock::new(|| sync::RwLock::new(HashMap::new()));
-    let key = format!("{file_path}-{name}");
+    static SEQUENCE_CACHE: sync::LazyLock<SequenceCache> =
+        sync::LazyLock::new(|| sync::RwLock::new(None));
+    let cache_key = (sequence_asset.id, name.to_string());
 
     {
         let cache = SEQUENCE_CACHE
             .read()
             .map_err(|err| SequenceError::CachePoisoned(err.to_string()))?;
-        if let Some(cached_sequence) = cache.get(&key) {
+        if let Some((cached_key, cached_sequence)) = cache.as_ref()
+            && cached_key == &cache_key
+        {
             if let Some(sequence) = cached_sequence {
-                return sequence_slice(sequence, start, end, circular);
+                return sequence_slice(sequence, range.start, range.end, circular);
             }
             return Err(SequenceError::IdMissing {
-                file_path: file_path.to_string(),
+                file_path: sequence_asset.uri.clone(),
                 name: name.to_string(),
             });
         }
@@ -361,78 +401,41 @@ pub fn cached_sequence(
         .map_err(|err| SequenceError::CachePoisoned(err.to_string()))?;
 
     let mut sequence: Option<String> = None;
-    if let Some(index) = fasta_index(file_path) {
-        let region = name
-            .parse::<Region>()
-            .map_err(|err| SequenceError::InvalidRegion {
-                name: name.to_string(),
-                reason: err.to_string(),
-            })?;
-        let builder = IndexBuilder::default().set_index(index);
-        if let Some(gzi_index) = fasta_gzi_index(file_path) {
-            let bgzf_reader = bgzf::io::indexed_reader::Builder::default()
-                .set_index(gzi_index)
-                .build_from_path(file_path)
-                .map_err(|err| SequenceError::Io(err.to_string()))?;
-            let mut reader = builder
-                .build_from_reader(bgzf_reader)
-                .map_err(|err| SequenceError::Io(err.to_string()))?;
+    let sequence_extension = asset_extension(sequence_asset);
+    let sequence_reader = sequence_asset
+        .reader(workspace)
+        .map_err(|err| SequenceError::Io(err.to_string()))?;
+    let reader_stream: Box<dyn std::io::BufRead> = match sequence_extension.as_deref() {
+        Some("gz") => Box::new(BufReader::new(MultiGzDecoder::new(sequence_reader))),
+        Some("bgz") => Box::new(bgzf::io::Reader::new(sequence_reader)),
+        _ => Box::new(sequence_reader),
+    };
+    let mut reader = fasta::io::reader::Builder
+        .build_from_reader(reader_stream)
+        .map_err(|err| SequenceError::Io(err.to_string()))?;
+    for result in reader.records() {
+        let record = result.map_err(|err| SequenceError::Io(err.to_string()))?;
+        if String::from_utf8(record.name().to_vec())
+            .map_err(|err| SequenceError::Utf8(err.to_string()))?
+            == name
+        {
             sequence = Some(
-                str::from_utf8(
-                    reader
-                        .query(&region)
-                        .map_err(|err| SequenceError::Io(err.to_string()))?
-                        .sequence()
-                        .as_ref(),
-                )
-                .map_err(|err| SequenceError::Utf8(err.to_string()))?
-                .to_string(),
-            )
-        } else {
-            let mut reader = builder
-                .build_from_path(file_path)
-                .map_err(|err| SequenceError::Io(err.to_string()))?;
-            sequence = Some(
-                str::from_utf8(
-                    reader
-                        .query(&region)
-                        .map_err(|err| SequenceError::Io(err.to_string()))?
-                        .sequence()
-                        .as_ref(),
-                )
-                .map_err(|err| SequenceError::Utf8(err.to_string()))?
-                .to_string(),
+                str::from_utf8(record.sequence().as_ref())
+                    .map_err(|err| SequenceError::Utf8(err.to_string()))?
+                    .to_string(),
             );
-        }
-    } else {
-        let mut reader = fasta::io::reader::Builder
-            .build_from_path(file_path)
-            .map_err(|err| SequenceError::Io(err.to_string()))?;
-        for result in reader.records() {
-            let record = result.map_err(|err| SequenceError::Io(err.to_string()))?;
-            if String::from_utf8(record.name().to_vec())
-                .map_err(|err| SequenceError::Utf8(err.to_string()))?
-                == name
-            {
-                sequence = Some(
-                    str::from_utf8(record.sequence().as_ref())
-                        .map_err(|err| SequenceError::Utf8(err.to_string()))?
-                        .to_string(),
-                );
-                break;
-            }
+            break;
         }
     }
-    // this is a LRU cache setup, we just keep the last sequence we fetched so we don't end up loading
-    // plant genomes into memory.
-    cache.clear();
-    cache.insert(key.clone(), sequence);
+    // This is an LRU cache setup; keep only the last sequence fetched so loading multiple plant
+    // genomes does not retain every genome in memory.
+    *cache = Some((cache_key, sequence));
     // we do this to avoid a clone of potentially large data.
-    if let Some(seq) = &cache[&key] {
-        return sequence_slice(seq, start, end, circular);
+    if let Some((_, Some(seq))) = cache.as_ref() {
+        return sequence_slice(seq, range.start, range.end, circular);
     }
     Err(SequenceError::IdMissing {
-        file_path: file_path.to_string(),
+        file_path: sequence_asset.uri.clone(),
         name: name.to_string(),
     })
 }
@@ -449,6 +452,77 @@ impl Sequence {
             .any(|part| part.eq_ignore_ascii_case("circular"))
     }
 
+    pub fn query_by_ids<T>(
+        conn: &GraphConnection,
+        workspace: &Workspace,
+        ids: &[T],
+        history_ref: Option<&str>,
+    ) -> Vec<Self>
+    where
+        T: Clone,
+        rusqlite::types::Value: From<T>,
+    {
+        let sequence_table = <Self as Query>::table_name_with_history_ref(history_ref);
+        let asset_table = AssetRef::table_name_with_history_ref(history_ref);
+        let query = format!(
+            "WITH arr AS (
+                SELECT value, rowid AS pos FROM rarray(:ids)
+             )
+             SELECT sequences.*, asset_refs.*
+             FROM {sequence_table} AS sequences
+             LEFT JOIN {asset_table} AS asset_refs
+               ON sequences.asset_ref_id = asset_refs.id
+             JOIN arr ON sequences.hash = arr.value
+             ORDER BY arr.pos;"
+        );
+        let values: Vec<Value> = ids.iter().map(|id| Value::from(id.clone())).collect();
+        let id_values = Rc::new(values);
+        let mut query_params: Vec<(&str, &dyn ToSql)> = vec![(":ids", &id_values)];
+        if let Some(history_ref) = history_ref.as_ref() {
+            query_params.push((":history_ref", history_ref));
+        }
+        let mut statement = conn.prepare(&query).unwrap();
+        statement
+            .query_map(&query_params[..], |row| {
+                Ok(Self::process_joined_row(row, workspace))
+            })
+            .unwrap()
+            .map(|row| row.unwrap())
+            .collect()
+    }
+
+    fn process_joined_row(row: &Row, workspace: &Workspace) -> Self {
+        let mut sequence = <Self as Query>::process_row(row);
+        if let Some(asset_ref_id) = sequence.asset_ref_id {
+            let Some(joined_asset_ref_id): Option<HashId> = row.get(6).unwrap() else {
+                sequence.asset_resolution_error =
+                    Some(format!("asset reference {asset_ref_id} does not exist"));
+                return sequence;
+            };
+            let asset_ref = AssetRef {
+                id: joined_asset_ref_id,
+                uri: row.get(7).unwrap(),
+                file_type: row.get(8).unwrap(),
+                checksum: row.get(9).unwrap(),
+                size: row.get(10).unwrap(),
+                role: row.get(11).unwrap(),
+                logical_path: row.get(12).unwrap(),
+                name: row.get(13).unwrap(),
+                created_on: row.get(14).unwrap(),
+                upstream_asset_ref_id: row.get(15).unwrap(),
+            };
+            if LocalAssetUri::is_local_path_or_file_uri(&asset_ref.uri)
+                && let Err(error) = asset_ref.versioned_store_path(workspace)
+            {
+                sequence.asset_resolution_error = Some(error.to_string());
+                return sequence;
+            }
+            sequence.asset_ref = Some(asset_ref);
+            sequence.workspace = Some(workspace.clone());
+        }
+        sequence
+    }
+
     pub fn get_sequence(
         &self,
         start: impl Into<Option<i64>>,
@@ -461,7 +535,26 @@ impl Sequence {
         let start = start.unwrap_or(0);
         let end = end.unwrap_or(self.length);
         if self.external_sequence {
-            return cached_sequence(&self.file_path, &self.name, start, end, self.is_circular());
+            if let Some(error) = self.asset_resolution_error.as_ref() {
+                return Err(SequenceError::AssetResolution(error.clone()));
+            }
+            let asset_ref = self.asset_ref.as_ref().ok_or_else(|| {
+                SequenceError::AssetResolution(
+                    "sequence asset was loaded without repository context".to_string(),
+                )
+            })?;
+            let workspace = self.workspace.as_ref().ok_or_else(|| {
+                SequenceError::AssetResolution(
+                    "sequence asset was loaded without repository context".to_string(),
+                )
+            })?;
+            return cached_sequence(
+                workspace,
+                asset_ref,
+                &self.name,
+                start..end,
+                self.is_circular(),
+            );
         }
         if start == 0 && end == self.length {
             return Ok(self.sequence.clone());
@@ -476,12 +569,29 @@ impl Sequence {
         stmt.execute(params![hash]).unwrap();
     }
 
-    pub fn query_by_blockgroup(conn: &GraphConnection, block_group_id: &HashId) -> Vec<Sequence> {
-        Sequence::query(
-            conn,
-            "select sequences.* from block_group_edges bge left join edges on bge.edge_id = edges.id left join nodes on (edges.source_node_id = nodes.id or edges.target_node_id = nodes.id) left join sequences on (nodes.sequence_hash = sequences.hash) where bge.block_group_id = ?1;",
-            params![block_group_id],
-        )
+    pub fn query_by_blockgroup(
+        conn: &GraphConnection,
+        workspace: &Workspace,
+        block_group_id: &HashId,
+    ) -> Vec<Sequence> {
+        let asset_table = AssetRef::table_name_with_history_ref(None);
+        let query = format!(
+            "SELECT sequences.*, asset_refs.*
+             FROM block_group_edges bge
+             LEFT JOIN edges ON bge.edge_id = edges.id
+             LEFT JOIN nodes ON (edges.source_node_id = nodes.id OR edges.target_node_id = nodes.id)
+             LEFT JOIN sequences ON (nodes.sequence_hash = sequences.hash)
+             LEFT JOIN {asset_table} AS asset_refs ON sequences.asset_ref_id = asset_refs.id
+             WHERE bge.block_group_id = ?1;"
+        );
+        let mut statement = conn.prepare(&query).unwrap();
+        statement
+            .query_map(params![block_group_id], |row| {
+                Ok(Self::process_joined_row(row, workspace))
+            })
+            .unwrap()
+            .map(|row| row.unwrap())
+            .collect()
     }
 }
 
@@ -492,11 +602,7 @@ impl Query for Sequence {
     const TABLE_NAME: &'static str = "sequences";
 
     fn process_row(row: &Row) -> Self::Model {
-        let file_path: String = row.get(4).unwrap();
-        let mut external_sequence = false;
-        if !file_path.is_empty() {
-            external_sequence = true;
-        }
+        let asset_ref_id: Option<HashId> = row.get(4).unwrap();
         let hash: Sha256Hash = row.get(0).unwrap();
         let sequence = row.get(2).unwrap();
         Sequence {
@@ -504,9 +610,12 @@ impl Query for Sequence {
             sequence_type: row.get(1).unwrap(),
             sequence,
             name: row.get(3).unwrap(),
-            file_path,
+            asset_ref_id,
             length: row.get(5).unwrap(),
-            external_sequence,
+            external_sequence: asset_ref_id.is_some(),
+            asset_ref: None,
+            workspace: None,
+            asset_resolution_error: None,
         }
     }
 }
@@ -538,15 +647,30 @@ pub fn reverse_complement(seq: &[u8]) -> Vec<u8> {
 
 #[cfg(test)]
 mod tests {
-    // Note this useful idiom: importing names from outer (for mod tests) scope.
-    #[allow(unused_imports)]
-    use std::time;
-    use std::{fs::OpenOptions, io::Write};
+    use std::{fs, io::Write as _, time::Instant};
 
-    use rand::RngExt;
+    use gen_core::traits::Capnp as _;
+    use rand::RngExt as _;
+    use sha2::Digest as _;
 
-    use super::*;
-    use crate::test_helpers::get_connection;
+    use super::{Sequence, SequenceError};
+    use crate::{
+        assets::{AssetRef, AssetRole},
+        gen_models_capnp::sequence,
+        operations::OperationFile,
+        test_helpers::{get_connection, setup_gen_on_disk},
+        traits::Query,
+    };
+
+    fn prepare_asset(context: &crate::db::DbContext, path: &str) -> AssetRef {
+        let operation_file = OperationFile::new(path);
+        let asset_ref = operation_file
+            .prepare_asset_ref(context.workspace(), 1)
+            .expect("should retain test asset");
+        AssetRef::create(context.graph().conn(), &asset_ref)
+            .expect("should create test asset reference");
+        asset_ref
+    }
 
     #[test]
     fn test_builder() {
@@ -556,14 +680,19 @@ mod tests {
             .build();
         assert_eq!(sequence.length, 4);
         assert_eq!(sequence.sequence, "ATCG");
+        assert_eq!(
+            sequence.hash.to_string(),
+            "4ab41cf208e5a797ed0052a3fc5f87bed18f94fc1fc7fdd6ed3199b4e1c34ace"
+        );
     }
 
     #[test]
-    fn test_builder_with_from_disk() {
+    fn test_builder_with_asset_ref() {
+        let asset_ref_id = gen_core::HashId::convert_str("asset");
         let sequence = Sequence::new()
             .sequence_type("DNA")
             .name("chr1")
-            .file_path("/foo/bar")
+            .asset_ref_id(Some(&asset_ref_id))
             .length(50)
             .build();
         assert_eq!(sequence.length, 50);
@@ -610,18 +739,25 @@ mod tests {
 
     #[test]
     fn test_create_sequence_on_disk() {
-        let conn = &get_connection(None).unwrap();
+        let context = setup_gen_on_disk();
+        let fasta_path = context
+            .workspace()
+            .repo_root()
+            .unwrap()
+            .join("reference.fa");
+        fs::write(&fasta_path, ">chr1\nAACCGGTTAA\n").unwrap();
+        let asset_ref = prepare_asset(&context, fasta_path.to_str().unwrap());
         let sequence = Sequence::new()
             .sequence_type("DNA")
             .name("chr1")
-            .file_path("/some/path.fa")
+            .asset_ref_id(Some(&asset_ref.id))
             .length(10)
-            .save(conn)
+            .save(context.graph().conn())
             .unwrap();
         assert_eq!(sequence.sequence_type, "DNA");
         assert_eq!(&sequence.sequence, "");
         assert_eq!(sequence.name, "chr1");
-        assert_eq!(sequence.file_path, "/some/path.fa");
+        assert_eq!(sequence.asset_ref_id, Some(asset_ref.id));
         assert_eq!(sequence.length, 10);
         assert!(sequence.external_sequence);
     }
@@ -684,21 +820,33 @@ mod tests {
 
     #[test]
     fn test_get_sequence_from_disk() {
-        let conn = &get_connection(None).unwrap();
-        let temp_dir = tempfile::tempdir().unwrap();
-        let temp_file_path = temp_dir.path().join("simple.fa");
+        let context = setup_gen_on_disk();
+        let temp_file_path = context.workspace().repo_root().unwrap().join("simple.fa");
         fs::write(
             &temp_file_path,
             ">m123\nATCGATCGATCGATCGATCGGGAACACACAGAGA\n",
         )
         .unwrap();
-        let seq = Sequence::new()
+        let asset_ref = prepare_asset(&context, temp_file_path.to_str().unwrap());
+        let sequence = Sequence::new()
             .sequence_type("DNA")
             .name("m123")
-            .file_path(temp_file_path.to_str().unwrap())
+            .asset_ref_id(Some(&asset_ref.id))
             .length(34)
-            .save(conn)
+            .save(context.graph().conn())
             .unwrap();
+        let seq = Sequence::query_by_ids(
+            context.graph().conn(),
+            context.workspace(),
+            &[sequence.hash],
+            None,
+        )
+        .remove(0);
+        fs::write(
+            &temp_file_path,
+            ">m123\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n",
+        )
+        .unwrap();
         assert_eq!(
             seq.get_sequence(None, None).unwrap(),
             "ATCGATCGATCGATCGATCGGGAACACACAGAGA"
@@ -712,19 +860,94 @@ mod tests {
         assert_eq!(seq.get_sequence(None, 5).unwrap(), "ATCGA");
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn test_on_disk_sequence_rejects_asset_outside_repository() {
+        use std::os::unix::fs::symlink;
+
+        let context = setup_gen_on_disk();
+        let outside_directory = tempfile::tempdir().unwrap();
+        let outside_path = outside_directory.path().join("secret.fa");
+        let contents = b">secret\nPRIVATE\n";
+        fs::write(&outside_path, contents).unwrap();
+        let checksum = gen_core::Sha256Hash(sha2::Sha256::digest(contents).into());
+        let uri = format!("file://{}", outside_path.display());
+        let asset_ref = AssetRef {
+            id: AssetRef::id_hash(
+                &uri,
+                "fasta",
+                Some(&checksum),
+                &AssetRole::Input,
+                outside_path.to_str(),
+                Some("secret.fa"),
+                None,
+            ),
+            uri,
+            file_type: "fasta".to_string(),
+            checksum: Some(checksum),
+            size: None,
+            role: AssetRole::Input,
+            logical_path: Some(outside_path.to_string_lossy().to_string()),
+            name: Some("secret.fa".to_string()),
+            created_on: 1,
+            upstream_asset_ref_id: None,
+        };
+        AssetRef::create(context.graph().conn(), &asset_ref).unwrap();
+        let asset_filename =
+            <dyn crate::assets::AssetUri>::from_uri(&asset_ref.uri).hashed_filename(&checksum);
+        symlink(
+            &outside_path,
+            context
+                .workspace()
+                .asset_dir()
+                .unwrap()
+                .join(asset_filename),
+        )
+        .unwrap();
+        let unresolved_sequence = Sequence::new()
+            .sequence_type("DNA")
+            .name("secret")
+            .asset_ref_id(Some(&asset_ref.id))
+            .length(7)
+            .save(context.graph().conn())
+            .unwrap();
+        let sequence = Sequence::query_by_ids(
+            context.graph().conn(),
+            context.workspace(),
+            &[unresolved_sequence.hash],
+            None,
+        )
+        .remove(0);
+
+        let error = sequence
+            .get_sequence(None, None)
+            .expect_err("should not read an asset outside the repository");
+        assert!(
+            matches!(&error, SequenceError::AssetResolution(reason) if reason.contains("not within repo root")),
+            "should report the repository boundary: {error}"
+        );
+    }
+
     #[test]
     fn test_get_sequence_from_disk_circular() {
-        let conn = &get_connection(None).unwrap();
-        let temp_dir = tempfile::tempdir().unwrap();
-        let temp_file_path = temp_dir.path().join("simple.fa");
+        let context = setup_gen_on_disk();
+        let temp_file_path = context.workspace().repo_root().unwrap().join("simple.fa");
         fs::write(&temp_file_path, ">m123\nAAACCCTTT\n").unwrap();
-        let seq = Sequence::new()
+        let asset_ref = prepare_asset(&context, temp_file_path.to_str().unwrap());
+        let sequence = Sequence::new()
             .sequence_type("circular")
             .name("m123")
-            .file_path(temp_file_path.to_str().unwrap())
+            .asset_ref_id(Some(&asset_ref.id))
             .length(9)
-            .save(conn)
+            .save(context.graph().conn())
             .unwrap();
+        let seq = Sequence::query_by_ids(
+            context.graph().conn(),
+            context.workspace(),
+            &[sequence.hash],
+            None,
+        )
+        .remove(0);
         assert_eq!(seq.get_sequence(4, 2).unwrap(), "CCTTTAA");
         assert_eq!(
             seq.get_sequence(0, 10),
@@ -737,16 +960,10 @@ mod tests {
     }
 
     #[test]
-    // #[cfg(feature = "benchmark")]
     fn test_cached_sequence_performance() {
-        let conn = &get_connection(None).unwrap();
-        let temp_dir = tempfile::tempdir().unwrap();
-        let temp_file_path = temp_dir.path().join("large.fa");
-        let mut file = OpenOptions::new()
-            .append(true)
-            .create(true)
-            .open(&temp_file_path)
-            .unwrap();
+        let context = setup_gen_on_disk();
+        let fasta_path = context.workspace().repo_root().unwrap().join("large.fa");
+        let mut file = fs::File::create(&fasta_path).unwrap();
         writeln!(file, ">chr22").unwrap();
         for _ in 1..3_000_000 {
             writeln!(
@@ -755,26 +972,31 @@ mod tests {
             )
             .unwrap();
         }
-        // write index
-        let index_path = temp_dir.path().join("large.fa.fai");
-        fs::write(&index_path, "chr22	203999932	7	68	69\n").unwrap();
+        let asset_ref = prepare_asset(&context, fasta_path.to_str().unwrap());
         let sequence = Sequence::new()
             .sequence_type("DNA")
-            .file_path(temp_file_path.to_str().unwrap())
             .name("chr22")
+            .asset_ref_id(Some(&asset_ref.id))
             .length(203_999_932)
-            .save(conn)
+            .save(context.graph().conn())
             .unwrap();
-        let s = time::Instant::now();
-        for _ in 1..1_000_000 {
-            let start = rand::rng().random_range(1..200_000_000);
+        let sequence = Sequence::query_by_ids(
+            context.graph().conn(),
+            context.workspace(),
+            &[sequence.hash],
+            None,
+        )
+        .remove(0);
 
+        let start_time = Instant::now();
+        for _ in 1..1_000_000 {
+            let start = rand::rng().random_range(1_i64..200_000_000_i64);
             sequence.get_sequence(start, start + 20).unwrap();
         }
-        let elapsed = s.elapsed().as_secs();
+        let elapsed = start_time.elapsed().as_secs();
         assert!(
             elapsed < 5,
-            "Cached sequence benchmark failed: {elapsed}s elapsed"
+            "cached sequence benchmark failed: {elapsed}s elapsed"
         );
     }
 
@@ -783,13 +1005,16 @@ mod tests {
         use capnp::message::TypedBuilder;
 
         let sequence = Sequence {
-            hash: Sha256Hash::convert_str("test_hash"),
+            hash: gen_core::Sha256Hash::convert_str("test_hash"),
             sequence_type: "DNA".to_string(),
             sequence: "ATCG".to_string(),
             name: "test_seq".to_string(),
-            file_path: "/path/to/file".to_string(),
+            asset_ref_id: Some(gen_core::HashId::convert_str("asset")),
             length: 4,
-            external_sequence: false,
+            external_sequence: true,
+            asset_ref: None,
+            workspace: None,
+            asset_resolution_error: None,
         };
 
         let mut message = TypedBuilder::<sequence::Owned>::new_default();

--- a/gen-python/Cargo.lock
+++ b/gen-python/Cargo.lock
@@ -1490,6 +1490,7 @@ dependencies = [
  "capnp",
  "chrono",
  "fallible-streaming-iterator",
+ "flate2",
  "gen-capnp-schemas",
  "gen-core",
  "gen-graph",

--- a/src/imports/fasta.rs
+++ b/src/imports/fasta.rs
@@ -41,8 +41,7 @@ pub fn import_fasta(
 ) -> Result<OperationSummary, FastaError> {
     let conn = context.graph().conn();
     let progress_bar = get_handler();
-    let mut operation_files =
-        vec![OperationFile::new(fasta.to_string()).set_file_type(FileTypes::Fasta)];
+    let mut operation_file = OperationFile::new(fasta.to_string()).set_file_type(FileTypes::Fasta);
     let mut sequence_asset_ref_id = None;
     let mut checksum_handle = None;
     let input: Box<dyn Read> = if shallow {
@@ -54,9 +53,9 @@ pub fn import_fasta(
         )
         .expect("should fit sequence asset timestamp in i64");
         let sequence_asset_ref =
-            operation_files[0].prepare_asset_ref(context.workspace(), created_on)?;
+            operation_file.prepare_asset_ref(context.workspace(), created_on)?;
         if let Some(checksum) = sequence_asset_ref.checksum {
-            operation_files[0] = operation_files[0].clone().set_checksum_override(checksum);
+            operation_file = operation_file.set_checksum_override(checksum);
         }
         AssetRef::create(conn, &sequence_asset_ref)
             .map_err(gen_models::errors::FileAdditionError::DatabaseError)?;
@@ -198,15 +197,13 @@ pub fn import_fasta(
                 "FASTA reader did not reach EOF before checksum was requested",
             )
         })?;
-        operation_files[0] = operation_files[0]
-            .clone()
-            .set_checksum_override(checksum_override);
+        operation_file = operation_file.set_checksum_override(checksum_override);
     }
 
     let bar = add_saving_operation_bar(&progress_bar);
     let operation_summary = OperationSummary::new(
         OperationInfo {
-            files: operation_files,
+            files: vec![operation_file],
             description: "fasta_addition".to_string(),
         },
         summary_str,

--- a/src/imports/fasta.rs
+++ b/src/imports/fasta.rs
@@ -1,14 +1,14 @@
 use std::{
     collections::HashMap,
-    io::{BufRead, BufReader},
-    path::PathBuf,
+    io::{BufRead, BufReader, Read},
     str,
+    time::{SystemTime, UNIX_EPOCH},
 };
 
 use flate2::read::MultiGzDecoder;
 use gen_core::{HashId, PATH_END_NODE_ID, PATH_START_NODE_ID, Strand};
 use gen_models::{
-    assets::{AssetUri, ChecksummedReader},
+    assets::{AssetRef, AssetUri, ChecksummedReader},
     block_group::{BlockGroup, NewBlockGroup},
     block_group_edge::{BlockGroupEdge, BlockGroupEdgeData},
     collection::Collection,
@@ -41,16 +41,41 @@ pub fn import_fasta(
 ) -> Result<OperationSummary, FastaError> {
     let conn = context.graph().conn();
     let progress_bar = get_handler();
-    let path = PathBuf::from(fasta);
+    let mut operation_files =
+        vec![OperationFile::new(fasta.to_string()).set_file_type(FileTypes::Fasta)];
+    let mut sequence_asset_ref_id = None;
+    let mut checksum_handle = None;
+    let input: Box<dyn Read> = if shallow {
+        let created_on = i64::try_from(
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("should create sequence asset timestamp")
+                .as_nanos(),
+        )
+        .expect("should fit sequence asset timestamp in i64");
+        let sequence_asset_ref =
+            operation_files[0].prepare_asset_ref(context.workspace(), created_on)?;
+        if let Some(checksum) = sequence_asset_ref.checksum {
+            operation_files[0] = operation_files[0].clone().set_checksum_override(checksum);
+        }
+        AssetRef::create(conn, &sequence_asset_ref)
+            .map_err(gen_models::errors::FileAdditionError::DatabaseError)?;
+        sequence_asset_ref_id = Some(sequence_asset_ref.id);
+        Box::new(sequence_asset_ref.reader(context.workspace())?)
+    } else {
+        let asset_uri = <dyn AssetUri>::new(context.workspace(), fasta);
+        let file = ChecksummedReader::new(asset_uri.reader(context.workspace())?);
+        checksum_handle = Some(file.checksum_handle());
+        Box::new(file)
+    };
 
-    let asset_uri = <dyn AssetUri>::new(context.workspace(), fasta);
-    let file = ChecksummedReader::new(asset_uri.reader(context.workspace())?);
-    let checksum_handle = file.checksum_handle();
-
-    let reader_stream: Box<dyn BufRead> = match path.extension().and_then(|ext| ext.to_str()) {
-        Some("gz") => Box::new(BufReader::new(MultiGzDecoder::new(file))),
-        Some("bgz") => Box::new(bgzf::io::Reader::new(file)),
-        _ => Box::new(BufReader::new(file)),
+    let fasta_extension = <dyn AssetUri>::from_uri(fasta)
+        .suffix()
+        .and_then(|suffix| suffix.rsplit('.').next().map(str::to_string));
+    let reader_stream: Box<dyn BufRead> = match fasta_extension.as_deref() {
+        Some("gz") => Box::new(BufReader::new(MultiGzDecoder::new(input))),
+        Some("bgz") => Box::new(bgzf::io::Reader::new(input)),
+        _ => Box::new(BufReader::new(input)),
     };
     let mut reader = fasta::io::reader::Builder.build_from_reader(reader_stream)?;
 
@@ -89,7 +114,7 @@ pub fn import_fasta(
             Sequence::new()
                 .sequence_type("DNA")
                 .name(&name)
-                .file_path(fasta)
+                .asset_ref_id(sequence_asset_ref_id.as_ref())
                 .length(sequence_length)
                 .save(conn)?
         } else {
@@ -166,21 +191,22 @@ pub fn import_fasta(
         summary_str.push_str(&format!(" {path_name}: {change_count} changes.\n"));
     }
 
-    let checksum_override = checksum_handle.checksum().ok_or_else(|| {
-        std::io::Error::new(
-            std::io::ErrorKind::UnexpectedEof,
-            "FASTA reader did not reach EOF before checksum was requested",
-        )
-    })?;
+    if let Some(checksum_handle) = checksum_handle {
+        let checksum_override = checksum_handle.checksum().ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "FASTA reader did not reach EOF before checksum was requested",
+            )
+        })?;
+        operation_files[0] = operation_files[0]
+            .clone()
+            .set_checksum_override(checksum_override);
+    }
 
     let bar = add_saving_operation_bar(&progress_bar);
     let operation_summary = OperationSummary::new(
         OperationInfo {
-            files: vec![
-                OperationFile::new(fasta.to_string())
-                    .set_file_type(FileTypes::Fasta)
-                    .set_checksum_override(checksum_override),
-            ],
+            files: operation_files,
             description: "fasta_addition".to_string(),
         },
         summary_str,
@@ -192,7 +218,19 @@ pub fn import_fasta(
 #[cfg(test)]
 mod tests {
     // Note this useful idiom: importing names from outer (for mod tests) scope.
-    use std::{collections::HashSet, path::PathBuf};
+    use std::{
+        collections::HashSet,
+        fs,
+        io::Write as _,
+        net::TcpListener,
+        path::PathBuf,
+        sync::{
+            Arc,
+            atomic::{AtomicBool, Ordering},
+        },
+        thread,
+        time::Duration,
+    };
 
     use gen_models::{
         assets::{AssetRef, OperationKind, OperationLog},
@@ -203,7 +241,76 @@ mod tests {
     };
 
     use super::*;
-    use crate::test_helpers::setup_gen;
+    use crate::test_helpers::{setup_gen, setup_gen_on_disk};
+
+    struct TestHttpServer {
+        address: String,
+        stop: Arc<AtomicBool>,
+        handle: Option<thread::JoinHandle<()>>,
+    }
+
+    impl TestHttpServer {
+        fn new(contents: Vec<u8>) -> Self {
+            let listener =
+                TcpListener::bind(("127.0.0.1", 0)).expect("should bind remote FASTA server");
+            listener
+                .set_nonblocking(true)
+                .expect("should configure remote FASTA server");
+            let address = listener
+                .local_addr()
+                .expect("should read remote FASTA server address")
+                .to_string();
+            let stop = Arc::new(AtomicBool::new(false));
+            let server_stop = Arc::clone(&stop);
+            let handle = thread::spawn(move || {
+                while !server_stop.load(Ordering::Relaxed) {
+                    let Ok((mut stream, _)) = listener.accept() else {
+                        thread::sleep(Duration::from_millis(2));
+                        continue;
+                    };
+                    let mut request_bytes = [0_u8; 4096];
+                    let length = stream
+                        .read(&mut request_bytes)
+                        .expect("should read remote FASTA request");
+                    let request = String::from_utf8_lossy(&request_bytes[..length]);
+                    let method = request
+                        .lines()
+                        .next()
+                        .and_then(|line| line.split_whitespace().next())
+                        .unwrap_or_default();
+                    write!(
+                        stream,
+                        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                        contents.len()
+                    )
+                    .expect("should write remote FASTA response headers");
+                    if method != "HEAD" {
+                        stream
+                            .write_all(&contents)
+                            .expect("should write remote FASTA response body");
+                    }
+                }
+            });
+            Self {
+                address,
+                stop,
+                handle: Some(handle),
+            }
+        }
+
+        fn url(&self) -> String {
+            format!("http://{}/reference.fa", self.address)
+        }
+    }
+
+    impl Drop for TestHttpServer {
+        fn drop(&mut self) {
+            self.stop.store(true, Ordering::Relaxed);
+            if let Some(handle) = self.handle.take() {
+                handle.join().expect("should stop remote FASTA server");
+            }
+        }
+    }
 
     #[test]
     fn test_add_fasta() {
@@ -295,7 +402,7 @@ mod tests {
         )
         .unwrap();
         let block_group_id = BlockGroup::get_id("test", Sample::DEFAULT_NAME, "chr22", None);
-        let sequences = Sequence::query_by_blockgroup(conn, &block_group_id);
+        let sequences = Sequence::query_by_blockgroup(conn, context.workspace(), &block_group_id);
         let dna = sequences
             .iter()
             .filter(|s| s.sequence_type == "DNA")
@@ -363,31 +470,109 @@ mod tests {
 
     #[test]
     fn test_add_fasta_shallow() {
-        let context = setup_gen();
+        let context = setup_gen_on_disk();
         let conn = context.graph().conn();
+        let fixture_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("fixtures/simple.fa");
+        let fasta_path = context
+            .workspace()
+            .repo_root()
+            .expect("should have repository root")
+            .join("shallow.fa");
+        fs::copy(&fixture_path, &fasta_path).expect("should copy shallow FASTA fixture");
 
-        let mut fasta_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        fasta_path.push("fixtures/simple.fa");
-
-        import_fasta(
+        let operation_summary = import_fasta(
             &context,
-            &fasta_path.to_str().unwrap().to_string(),
+            &fasta_path.to_string_lossy().to_string(),
             "test",
             Sample::DEFAULT_NAME,
             true,
         )
-        .unwrap();
+        .expect("should import shallow FASTA");
+        commit_operation_summary(&context, &operation_summary)
+            .expect("should commit shallow FASTA import");
+        fs::remove_file(&fasta_path).expect("should remove logical FASTA path");
+
         let block_group_id = BlockGroup::get_id("test", Sample::DEFAULT_NAME, "m123", None);
         assert_eq!(
             BlockGroup::get_all_sequences(conn, context.workspace(), &block_group_id, false)
-                .unwrap(),
+                .expect("should load shallow sequence from immutable asset"),
             HashSet::from_iter(vec!["ATCGATCGATCGATCGATCGGGAACACACAGAGA".to_string()])
+        );
+        let sequence = Sequence::query_by_blockgroup(conn, context.workspace(), &block_group_id)
+            .into_iter()
+            .find(|sequence| sequence.asset_ref_id.is_some())
+            .expect("should persist the shallow sequence AssetRef pointer");
+        let asset_ref = AssetRef::get_by_id(
+            conn,
+            &sequence
+                .asset_ref_id
+                .expect("should have sequence AssetRef"),
+            None,
+        )
+        .expect("should persist sequence AssetRef");
+        assert!(
+            asset_ref
+                .versioned_store_path(context.workspace())
+                .expect("should resolve immutable sequence asset")
+                .is_file(),
+            "immutable sequence asset should remain after logical file removal"
         );
 
         let path = Path::all(conn)[0].clone();
         assert_eq!(
-            path.sequence(conn, context.workspace(), None).unwrap(),
-            "ATCGATCGATCGATCGATCGGGAACACACAGAGA".to_string()
+            path.sequence(conn, context.workspace(), None)
+                .expect("should read path through immutable sequence asset"),
+            "ATCGATCGATCGATCGATCGGGAACACACAGAGA"
+        );
+    }
+
+    #[test]
+    fn test_add_remote_fasta_shallow_uses_remote_asset() {
+        let server = TestHttpServer::new(b">m123\nATCGATCGATCGATCGATCGGGAACACACAGAGA\n".to_vec());
+        let context = setup_gen_on_disk();
+        let conn = context.graph().conn();
+        let fasta = server.url();
+
+        let operation_summary = import_fasta(&context, &fasta, "test", Sample::DEFAULT_NAME, true)
+            .expect("should import shallow remote FASTA");
+        commit_operation_summary(&context, &operation_summary)
+            .expect("should commit shallow remote FASTA import");
+
+        let sequence_asset = AssetRef::all(conn)
+            .into_iter()
+            .find(|asset_ref| asset_ref.uri == fasta)
+            .expect("should persist remote sequence AssetRef");
+        assert_eq!(
+            sequence_asset.checksum, None,
+            "remote shallow asset should not require a retained local checksum"
+        );
+        assert!(
+            context
+                .workspace()
+                .asset_dir()
+                .expect("should have asset directory")
+                .read_dir()
+                .expect("should read asset directory")
+                .next()
+                .is_none(),
+            "remote shallow import should not retain a local asset"
+        );
+
+        let block_group_id = BlockGroup::get_id("test", Sample::DEFAULT_NAME, "m123", None);
+        assert_eq!(
+            BlockGroup::get_all_sequences(conn, context.workspace(), &block_group_id, false)
+                .expect("should stream shallow sequence from remote AssetRef"),
+            HashSet::from_iter(vec!["ATCGATCGATCGATCGATCGGGAACACACAGAGA".to_string()])
+        );
+        let sequence = Sequence::query_by_blockgroup(conn, context.workspace(), &block_group_id)
+            .into_iter()
+            .find(|sequence| sequence.asset_ref_id == Some(sequence_asset.id))
+            .expect("should resolve shallow sequence through remote AssetRef");
+        assert_eq!(
+            sequence
+                .get_sequence(2, 8)
+                .expect("should read remote sequence slice"),
+            "CGATCG"
         );
     }
 


### PR DESCRIPTION
Currently we use a direct filepath for Sequence files to store their files on-disk instead of in the database. This changes it to leverage the AssetRef model to store a pointer to on-disk sequence files. This centralizes our file fetching and lets us leverage that for associated files such as indices without adding a bunch of extra columns to this model. It also ensures whatever security mesasures we have around AssetRefs are kept by Sequence so you can't pass `/etc/some_secret_stuff` as a filepath.

There's a bunch of kind of code churn resulting from splitting the fasta index work into a subsequent PR. I marked these parts so you can gloss over them.

Failing test resolves w/ the next Pr that fixes fasta indices