### PR TITLE
Gfa edge index update

### DIFF
--- a/gen-models/migrations/core/01-initial/up.sql
+++ b/gen-models/migrations/core/01-initial/up.sql
@@ -91,7 +91,10 @@ CREATE TABLE edges (
   FOREIGN KEY(source_node_id) REFERENCES nodes(id),
   FOREIGN KEY(target_node_id) REFERENCES nodes(id)
 ) STRICT;
-CREATE UNIQUE INDEX edge_uidx ON edges(source_node_id, source_coordinate, source_strand, target_node_id, target_coordinate, target_strand);
+-- Edge IDs are deterministic hashes of the complete endpoint tuple, so the primary key is the
+-- canonical identity constraint without a second copy of every endpoint in a unique index.
+CREATE INDEX edge_source_idx ON edges(source_node_id, source_coordinate);
+CREATE INDEX edge_target_node_idx ON edges(target_node_id);
 
 CREATE TABLE path_edges (
   id BLOB PRIMARY KEY NOT NULL,

--- a/gen-models/src/edge.rs
+++ b/gen-models/src/edge.rs
@@ -2051,6 +2051,44 @@ mod tests {
     }
 
     #[test]
+    fn test_duplicate_edge_creation_is_idempotent_by_primary_key() {
+        let conn = get_connection(None).expect("should create graph connection");
+        let edge = EdgeData {
+            source_node_id: PATH_START_NODE_ID,
+            source_coordinate: -1,
+            source_strand: Strand::Forward,
+            target_node_id: PATH_END_NODE_ID,
+            target_coordinate: 0,
+            target_strand: Strand::Forward,
+        };
+
+        let first = Edge::create(
+            &conn,
+            edge.source_node_id,
+            edge.source_coordinate,
+            edge.source_strand,
+            edge.target_node_id,
+            edge.target_coordinate,
+            edge.target_strand,
+        )
+        .expect("should create edge");
+        let duplicate = Edge::create(
+            &conn,
+            edge.source_node_id,
+            edge.source_coordinate,
+            edge.source_strand,
+            edge.target_node_id,
+            edge.target_coordinate,
+            edge.target_strand,
+        )
+        .expect("should treat the duplicate edge as existing");
+
+        assert_eq!(first.id, edge.id_hash());
+        assert_eq!(duplicate.id, first.id);
+        assert_eq!(Edge::all(&conn).len(), 1);
+    }
+
+    #[test]
     fn test_blocks_from_edges() {
         let conn = get_connection(None).unwrap();
         let (block_group_id, path) = setup_block_group(&conn);


### PR DESCRIPTION
Updates the edge index to reduce disk usage. The primary key serves the same point as the index we have. Its replaced with 2 indices that are used by lookups.