### PR TITLE
Fasta sequence indexes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,6 +168,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "asyncband"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94a214ba60d6231afd0e805e3c27c45a1626d9debaa5a5061c45a1ea1b2f1ed0"
+dependencies = [
+ "hashbrown 0.17.1",
+ "slab",
+]
+
+[[package]]
 name = "atomic"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,7 +205,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
- "untrusted 0.7.1",
  "zeroize",
 ]
 
@@ -242,6 +251,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "base64ct"
@@ -301,6 +316,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -633,7 +657,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
 ]
 
@@ -691,6 +715,12 @@ checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cobs"
@@ -786,6 +816,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "const-random"
@@ -888,6 +924,16 @@ name = "crc-catalog"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
+name = "crc-fast"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e75b2483e97a5a7da73ac68a05b629f9c53cff58d8ed1c77866079e18b00dba5"
+dependencies = [
+ "digest 0.10.7",
+ "spin 0.10.1",
+]
 
 [[package]]
 name = "crc32c"
@@ -1007,6 +1053,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "csscolorparser"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1039,19 +1094,22 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.6.3"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "424e0138278faeb2b401f174ad17e715c829512d74f3d1e81eb43365c2e0590e"
+checksum = "914a755b7c2d4af2bdcff7ce1739e2db9a1b81a9b07123d8015786ae03c0980d"
 dependencies = [
- "ctor-proc-macro",
- "dtor",
+ "link-section",
+ "linktime-proc-macro",
 ]
 
 [[package]]
-name = "ctor-proc-macro"
-version = "0.0.7"
+name = "ctutils"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
 
 [[package]]
 name = "darling"
@@ -1138,6 +1196,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2"
 
 [[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "deltae"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1149,7 +1238,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -1202,10 +1291,22 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -1267,21 +1368,6 @@ checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
 ]
-
-[[package]]
-name = "dtor"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "404d02eeb088a82cfd873006cb713fe411306c7d182c344905e101fb1167d301"
-dependencies = [
- "dtor-proc-macro",
-]
-
-[[package]]
-name = "dtor-proc-macro"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
 
 [[package]]
 name = "duct"
@@ -1704,7 +1790,7 @@ name = "gen"
 version = "0.2.1"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.22.1",
  "capnp",
  "cargo-deny",
  "cargo-llvm-cov",
@@ -1737,7 +1823,7 @@ dependencies = [
  "intervaltree",
  "itertools",
  "log",
- "md-5",
+ "md-5 0.10.6",
  "more-asserts",
  "noodles",
  "once_cell",
@@ -1754,7 +1840,7 @@ dependencies = [
  "rusqdoltlite_migration",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tempfile",
  "thiserror 2.0.18",
  "tracing",
@@ -1803,7 +1889,7 @@ dependencies = [
  "rand 0.10.1",
  "rusqdoltlite",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "tempfile",
  "thiserror 1.0.69",
  "uuid",
@@ -1862,7 +1948,7 @@ dependencies = [
  "rusqdoltlite_migration",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -2096,7 +2182,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2163,6 +2258,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2204,7 +2308,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -2509,10 +2613,12 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.24"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
 dependencies = [
+ "defmt",
+ "jiff-core",
  "jiff-static",
  "jiff-tzdb-platform",
  "js-sys",
@@ -2521,15 +2627,25 @@ dependencies = [
  "portable-atomic-util",
  "serde_core",
  "wasm-bindgen",
- "windows-sys 0.61.2",
+ "windows-link",
+]
+
+[[package]]
+name = "jiff-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
+dependencies = [
+ "defmt",
 ]
 
 [[package]]
 name = "jiff-static"
-version = "0.2.24"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
 dependencies = [
+ "jiff-core",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -2619,23 +2735,6 @@ dependencies = [
  "futures-util",
  "once_cell",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "jsonwebtoken"
-version = "10.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
-dependencies = [
- "aws-lc-rs",
- "base64",
- "getrandom 0.2.17",
- "js-sys",
- "pem",
- "serde",
- "serde_json",
- "signature",
- "simple_asn1",
 ]
 
 [[package]]
@@ -2810,6 +2909,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "link-section"
+version = "0.19.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39c29a617ce3df32c08497bdc1ab6e2376e0b17948ac166a2fbe5977c5954cd9"
+
+[[package]]
+name = "linktime-proc-macro"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e57c38c1e860fd37c604281cdfb1dd2216977fd76a50f85ba2f388ef3219616"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2838,9 +2949,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru"
@@ -2895,16 +3006,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
-name = "mea"
-version = "0.6.3"
+name = "md-5"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6747f54621d156e1b47eb6b25f39a941b9fc347f98f67d25d8881ff99e8ed832"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
- "slab",
+ "cfg-if",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3151,7 +3263,7 @@ dependencies = [
  "flate2",
  "futures",
  "indexmap",
- "md-5",
+ "md-5 0.10.6",
  "noodles-bam",
  "noodles-core",
  "noodles-fasta",
@@ -3303,16 +3415,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
-dependencies = [
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-bigint-dig"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3455,12 +3557,13 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "opendal"
-version = "0.56.0"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b31d3d8e99a85d83b73ec26647f5607b80578ed9375810b6e44ffa3590a236"
+checksum = "33dbff14cc9bb085224256d6a81289d2f3202e85b06f408d42534b42162a4231"
 dependencies = [
  "ctor",
  "opendal-core",
+ "opendal-http-transport-reqwest",
  "opendal-layer-concurrent-limit",
  "opendal-layer-logging",
  "opendal-layer-retry",
@@ -3474,24 +3577,22 @@ dependencies = [
 
 [[package]]
 name = "opendal-core"
-version = "0.56.0"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1849dd2687e173e776d3af5fce1ba3ae47b9dd37a09d1c4deba850ef45fe00ca"
+checksum = "48dbcef97d3eb7591db2c18d5cae95c836bcce07359b98d98dd6f4e861eb77b7"
 dependencies = [
  "anyhow",
- "base64",
+ "asyncband",
+ "base64 0.23.1",
  "bytes",
  "futures",
  "http",
- "http-body",
  "jiff",
  "log",
- "md-5",
- "mea",
+ "md-5 0.11.0",
  "percent-encoding",
- "quick-xml 0.38.4",
+ "quick-xml 0.41.0",
  "reqsign-core",
- "reqwest 0.13.3",
  "serde",
  "serde_json",
  "tokio",
@@ -3501,22 +3602,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "opendal-layer-concurrent-limit"
-version = "0.56.0"
+name = "opendal-http-transport-reqwest"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "048b1b29c503263bdd80a9afe46a68cd02ea9bd361185b1feab4b151078998e9"
+checksum = "85663452ea32bbc17e8f79ab29788c846d116ec7de31451be9c787e462dcb36c"
 dependencies = [
+ "bytes",
  "futures",
  "http",
- "mea",
+ "http-body",
+ "opendal-core",
+ "reqwest 0.13.4",
+]
+
+[[package]]
+name = "opendal-layer-concurrent-limit"
+version = "0.58.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03f9e144b5228d741c3763ade8711d9b72e5fb6d998e779f2d7a09da0b5a3eba"
+dependencies = [
+ "asyncband",
+ "futures",
+ "http",
  "opendal-core",
 ]
 
 [[package]]
 name = "opendal-layer-logging"
-version = "0.56.0"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2645adc988b12eda106e2679ae529facfbbaa868ceb706f6f8125c6af15c47b"
+checksum = "c2de17c61cd32e9d8d7d8efb91795e714dbccbafbc3c4e219e1542f4d6324161"
 dependencies = [
  "log",
  "opendal-core",
@@ -3524,9 +3639,9 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-retry"
-version = "0.56.0"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eac134ffa4ddda6131a640a84a5315996424b9416c85052f8c64c1a33b70ad4"
+checksum = "e94db301964a25366090484d61e6da16d5979cc8faf02c3e12210dc74fafed38"
 dependencies = [
  "backon",
  "log",
@@ -3535,9 +3650,9 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-timeout"
-version = "0.56.0"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "619586ab7480c2e3009f6d18eabab18957bc094778fd130bcc38924970a90f4c"
+checksum = "08956ddda07465449bfd48825f4f0f25e0351278ac974eaa659895d9d74f2c80"
 dependencies = [
  "opendal-core",
  "tokio",
@@ -3545,30 +3660,30 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-azblob"
-version = "0.56.0"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7452bf3ec61cfd81ac9ad9ada17825931e9e371d44a045c6bfab9596c0a2ac3b"
+checksum = "6d278d2fb57661947d1c9fb44047e432b2782c48dc085b7abc99fe6e18c26cf8"
 dependencies = [
- "base64",
+ "base64 0.23.1",
  "bytes",
  "http",
  "log",
  "opendal-core",
  "opendal-service-azure-common",
- "quick-xml 0.38.4",
+ "quick-xml 0.41.0",
  "reqsign-azure-storage",
  "reqsign-core",
  "reqsign-file-read-tokio",
  "serde",
- "sha2",
+ "sha2 0.11.0",
  "uuid",
 ]
 
 [[package]]
 name = "opendal-service-azure-common"
-version = "0.56.0"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb0e45d6c8dcf66ce2da20e241bcb80e6e540e109a4ff20f318f6c9b4c54e0c"
+checksum = "cfcc1bfdac4f54d9018c462dd32ad9e2f68fdf584f825c811550c8ffc87894cd"
 dependencies = [
  "http",
  "opendal-core",
@@ -3576,9 +3691,9 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-fs"
-version = "0.56.0"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf0be0417abeeb0053376d816b90fceb9ca98f20dfb54ebf1f2a282729f83663"
+checksum = "c7ef1e1c45f3f89282a59073897e0d685e51385fed0aea771714789525cff996"
 dependencies = [
  "bytes",
  "log",
@@ -3590,9 +3705,9 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-gcs"
-version = "0.56.0"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a49477a10163431896d106136117f5670717f9c9e49cf6f710528800c6633a"
+checksum = "da1f2a8c975fd22fea01f0409bcb8774f1ac02ad79863a3490098203121555d3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3600,7 +3715,7 @@ dependencies = [
  "log",
  "opendal-core",
  "percent-encoding",
- "quick-xml 0.38.4",
+ "quick-xml 0.41.0",
  "reqsign-core",
  "reqsign-file-read-tokio",
  "reqsign-google",
@@ -3611,9 +3726,9 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-http"
-version = "0.56.0"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fe73e6978feec293acfb92bfa94bdb9cf1b5be3f7c3f93a4333a25455826005"
+checksum = "a2ebcbdfad4b81a1e6dde70e898396e011dfd52b5f8639b2628656f7915d6f4c"
 dependencies = [
  "http",
  "log",
@@ -3623,18 +3738,18 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-s3"
-version = "0.56.0"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dadddeb9bb50b0d30927dd914c298c4ddca47e4c1cfa7674d311f0cf9b051c8"
+checksum = "c64335f9f24ccb62ac36f1d976342b48611a75ba61979813a4f78a4ebd94de42"
 dependencies = [
- "base64",
+ "base64 0.23.1",
  "bytes",
- "crc32c",
+ "crc-fast",
  "http",
  "log",
- "md-5",
+ "md-5 0.11.0",
  "opendal-core",
- "quick-xml 0.38.4",
+ "quick-xml 0.41.0",
  "reqsign-aws-v4",
  "reqsign-core",
  "reqsign-file-read-tokio",
@@ -3723,17 +3838,17 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
- "digest",
- "hmac",
+ "digest 0.10.7",
+ "hmac 0.12.1",
 ]
 
 [[package]]
 name = "pem"
-version = "3.0.6"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+checksum = "d354a98a3d1251555de99e8fdd8afda05573c31b82f59063a7b0a29b5527f120"
 dependencies = [
- "base64",
+ "base64 0.23.1",
  "serde_core",
 ]
 
@@ -3792,7 +3907,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
  "pest",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3898,7 +4013,7 @@ dependencies = [
  "der",
  "pbkdf2",
  "scrypt",
- "sha2",
+ "sha2 0.10.9",
  "spki",
 ]
 
@@ -4087,19 +4202,18 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.38.4"
+version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
- "serde",
 ]
 
 [[package]]
 name = "quick-xml"
-version = "0.39.4"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
  "serde",
@@ -4520,38 +4634,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
-name = "reqsign-aws-v4"
-version = "3.0.0"
+name = "reqsign-aws-core"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44eaca382e94505a49f1a4849658d153aebf79d9c1a58e5dd3b10361511e9f43"
+checksum = "4d63b56638bb3cc7bd376a7cdce1ba3089777a08f47e4097888f2d784cc3f46c"
 dependencies = [
- "anyhow",
  "bytes",
  "form_urlencoded",
+ "hex",
  "http",
  "log",
  "percent-encoding",
- "quick-xml 0.39.4",
+ "quick-xml 0.41.0",
  "reqsign-core",
  "rust-ini",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sha1",
+ "sha1 0.11.0",
+]
+
+[[package]]
+name = "reqsign-aws-v4"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0c499f4ed12d04c3d4c78fe4cb01aee22c9dae22848c14db2c6313d9df9f43"
+dependencies = [
+ "bytes",
+ "http",
+ "log",
+ "quick-xml 0.41.0",
+ "reqsign-aws-core",
+ "reqsign-core",
+ "serde",
 ]
 
 [[package]]
 name = "reqsign-azure-storage"
-version = "3.0.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a321980405d596bd34aaf95c4722a3de4128a67fd19e74a81a83aa3fdf082e6"
+checksum = "e8177b4f08620ab7f2e9cab7d7ccb9da1b61c66b889fed46cc0880b0fe75eb6b"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.23.1",
  "bytes",
  "form_urlencoded",
  "http",
- "jsonwebtoken",
  "log",
  "pem",
  "percent-encoding",
@@ -4559,36 +4687,38 @@ dependencies = [
  "rsa",
  "serde",
  "serde_json",
- "sha1",
+ "sha1 0.11.0",
 ]
 
 [[package]]
 name = "reqsign-core"
-version = "3.0.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b10302cf0a7d7e7352ba211fc92c3c5bebf1286153e49cc5aa87348078a8e102"
+checksum = "f4ac1510872d9481205975d264deb39c109797e5068cc882ed9064270eaae5fa"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.23.1",
  "bytes",
- "form_urlencoded",
  "futures",
  "hex",
- "hmac",
+ "hmac 0.13.0",
  "http",
  "jiff",
  "log",
  "percent-encoding",
- "sha1",
- "sha2",
+ "rsa",
+ "serde",
+ "serde_json",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "reqsign-file-read-tokio"
-version = "3.0.0"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d89295b3d17abea31851cc8de55d843d89c52132c864963c38d41920613dc5"
+checksum = "95c3371bfc7e5c7f9627a04133af3583fd6c28715e7c83f79db38f3b384f535f"
 dependencies = [
  "anyhow",
  "reqsign-core",
@@ -4597,13 +4727,13 @@ dependencies = [
 
 [[package]]
 name = "reqsign-google"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35cc609b49c69e76ecaceb775a03f792d1ed3e7755ab3548d4534fd801e3242e"
+checksum = "f81a9d38870892443489c0abb5332edfa81d5a14c437af9caef7c194897c92c1"
 dependencies = [
+ "bytes",
  "form_urlencoded",
  "http",
- "jsonwebtoken",
  "log",
  "percent-encoding",
  "reqsign-aws-v4",
@@ -4611,7 +4741,6 @@ dependencies = [
  "rsa",
  "serde",
  "serde_json",
- "sha2",
  "tokio",
 ]
 
@@ -4621,7 +4750,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -4660,11 +4789,11 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -4706,7 +4835,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted 0.9.0",
+ "untrusted",
  "windows-sys 0.52.0",
 ]
 
@@ -4726,15 +4855,15 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "const-oid",
- "digest",
+ "const-oid 0.9.6",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
  "pkcs1",
  "pkcs8",
  "rand_core 0.6.4",
- "sha2",
+ "sha2 0.10.9",
  "signature",
  "spki",
  "subtle",
@@ -4913,7 +5042,7 @@ dependencies = [
  "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted 0.9.0",
+ "untrusted",
 ]
 
 [[package]]
@@ -5004,7 +5133,7 @@ checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
 dependencies = [
  "pbkdf2",
  "salsa20",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -5144,7 +5273,18 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -5155,7 +5295,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -5232,7 +5383,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -5263,18 +5414,6 @@ name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
-
-[[package]]
-name = "simple_asn1"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
-dependencies = [
- "num-bigint",
- "num-traits",
- "thiserror 2.0.18",
- "time",
-]
 
 [[package]]
 name = "siphasher"
@@ -5531,7 +5670,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smol_str",
  "thiserror 2.0.18",
  "toml-span",
@@ -5611,7 +5750,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.22.1",
  "bitflags 2.13.0",
  "fancy-regex",
  "filedescriptor",
@@ -5629,7 +5768,7 @@ dependencies = [
  "pest",
  "pest_derive",
  "phf",
- "sha2",
+ "sha2 0.10.9",
  "signal-hook",
  "siphasher",
  "terminfo",
@@ -5702,14 +5841,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
- "itoa",
  "libc",
  "num-conv",
  "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",
- "time-macros",
 ]
 
 [[package]]
@@ -5717,16 +5854,6 @@ name = "time-core"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
-
-[[package]]
-name = "time-macros"
-version = "0.2.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
-dependencies = [
- "num-conv",
- "time-core",
-]
 
 [[package]]
 name = "tiny-keccak"
@@ -6061,12 +6188,6 @@ checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
 name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
-
-[[package]]
-name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
@@ -6380,7 +6501,7 @@ checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
 dependencies = [
  "getrandom 0.3.4",
  "mac_address",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "uuid",
 ]
@@ -6953,12 +7074,12 @@ dependencies = [
  "displaydoc",
  "flate2",
  "getrandom 0.3.4",
- "hmac",
+ "hmac 0.12.1",
  "indexmap",
  "lzma-rs",
  "memchr",
  "pbkdf2",
- "sha1",
+ "sha1 0.10.6",
  "thiserror 2.0.18",
  "time",
  "xz2",

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -44,6 +44,14 @@ being downloaded in full when the server supports range requests. Otherwise,
 the file is streamed into the cache and reused locally. Run `gen cache-clear` to
 remove the cache. Local repository files and `.gen/assets` are not affected.
 
+# FASTA import
+
+Use `gen import fasta <path-or-uri> --shallow` to keep sequence content in an
+asset rather than the graph database. Local assets are read from their immutable
+repository copy; remote assets remain remote. Supply known FASTA indexes with a
+repeatable `--index <path-or-uri>` option. For example, a BGZF FASTA can use both
+`--index reference.fa.gz.fai` and `--index reference.fa.gz.gzi`.
+
 # View diff
 
 Compare two commits or branches with:

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -46,9 +46,9 @@ remove the cache. Local repository files and `.gen/assets` are not affected.
 
 # FASTA import
 
-Use `gen import fasta <path-or-uri> --shallow` to keep sequence content in an
-asset rather than the graph database. Local assets are read from their immutable
-repository copy; remote assets remain remote. Supply known FASTA indexes with a
+Use `gen import fasta <path-or-uri> --shallow` to keep sequence data in an
+asset rather than the gen database. Local assets are read from their
+repository copy; remote assets remain remote. Supply known FASTA indices with a
 repeatable `--index <path-or-uri>` option. For example, a BGZF FASTA can use both
 `--index reference.fa.gz.fai` and `--index reference.fa.gz.gzi`.
 

--- a/gen-models/Cargo.toml
+++ b/gen-models/Cargo.toml
@@ -28,7 +28,7 @@ flate2 = "1.1.0"
 intervaltree = "0.2.7"
 itertools = "0.14.0"
 noodles = { version = "0.101.0", features = ["async", "bed", "bgzf", "core", "fasta", "gff", "gtf", "tabix", "vcf"] }
-opendal = { version = "0.56", features = ["blocking", "services-fs", "services-http", "services-s3", "services-gcs", "services-azblob"] }
+opendal = { version = "0.58", features = ["blocking", "services-fs", "services-http", "services-s3", "services-gcs", "services-azblob"] }
 petgraph = "0.6.5"
 rusqlite = { package = "rusqdoltlite", version = "0.40.16", features = ["bundled", "array", "limits", "fallible_uint", "backup", "uuid"] }
 rusqlite_migration = { package = "rusqdoltlite_migration", version = "2.6.4" , features = ["from-directory"]}

--- a/gen-models/src/assets.rs
+++ b/gen-models/src/assets.rs
@@ -104,6 +104,7 @@ fn opendal_file_addition_error(err: opendal::Error) -> FileAdditionError {
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum AssetRole {
     Input,
+    SequenceIndex,
     Annotation,
     AnnotationIndex,
     Other(String),
@@ -113,6 +114,7 @@ impl AssetRole {
     pub fn as_str(&self) -> &str {
         match self {
             AssetRole::Input => "input",
+            AssetRole::SequenceIndex => "sequence-index",
             AssetRole::Annotation => "annotation",
             AssetRole::AnnotationIndex => "annotation-index",
             AssetRole::Other(role) => role.as_str(),
@@ -124,6 +126,7 @@ impl From<&str> for AssetRole {
     fn from(role: &str) -> Self {
         match role {
             "input" => AssetRole::Input,
+            "sequence-index" => AssetRole::SequenceIndex,
             "annotation" => AssetRole::Annotation,
             "annotation-index" => AssetRole::AnnotationIndex,
             other => AssetRole::Other(other.to_string()),
@@ -135,6 +138,7 @@ impl From<String> for AssetRole {
     fn from(role: String) -> Self {
         match role.as_str() {
             "input" => AssetRole::Input,
+            "sequence-index" => AssetRole::SequenceIndex,
             "annotation" => AssetRole::Annotation,
             "annotation-index" => AssetRole::AnnotationIndex,
             _ => AssetRole::Other(role),

--- a/gen-models/src/assets.rs
+++ b/gen-models/src/assets.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::HashMap,
     fs,
-    io::{self, Read, Write},
+    io::{self, BufReader, Read, Write},
     path::{Component, Path, PathBuf},
     string::ToString,
     sync::{Arc, LazyLock, Mutex},
@@ -318,15 +318,20 @@ impl AssetRef {
     ///
     /// Local references resolve through the repository's content-addressed asset store. Remote
     /// references retain their URI and are opened lazily through the configured storage backend.
-    pub fn reader(&self, workspace: &Workspace) -> Result<blocking::StdReader, FileAdditionError> {
-        if LocalAssetUri::is_local_path_or_file_uri(&self.uri) {
+    pub fn reader(
+        &self,
+        workspace: &Workspace,
+    ) -> Result<BufReader<blocking::StdReader>, FileAdditionError> {
+        let reader = if LocalAssetUri::is_local_path_or_file_uri(&self.uri) {
             let asset_path = self.versioned_store_path(workspace)?;
-            return OpenDalLocation::from_absolute_path(&asset_path)
+            OpenDalLocation::from_absolute_path(&asset_path)
                 .map_err(opendal_file_addition_error)?
-                .reader();
-        }
+                .reader()?
+        } else {
+            <dyn AssetUri>::from_uri(&self.uri).reader(workspace)?
+        };
 
-        <dyn AssetUri>::from_uri(&self.uri).reader(workspace)
+        Ok(BufReader::new(reader))
     }
 
     pub fn id_hash(
@@ -901,7 +906,7 @@ impl OpenDalLocation {
             .to_string();
         let operator = with_opendal_runtime(|| {
             let builder = services::Fs::default().root(&root.to_string_lossy());
-            let op = opendal::Operator::new(builder)?.finish();
+            let op = opendal::Operator::new(builder)?;
             blocking::Operator::new(op)
         })?;
 

--- a/gen-models/src/operations.rs
+++ b/gen-models/src/operations.rs
@@ -54,6 +54,8 @@ pub struct OperationFile {
     pub file_path: String,
     pub file_type: FileTypes,
     pub checksum_override: Option<Sha256Hash>,
+    pub role: AssetRole,
+    pub upstream_asset_ref_id: Option<HashId>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
@@ -80,6 +82,8 @@ impl OperationFile {
             file_path,
             file_type,
             checksum_override: None,
+            role: AssetRole::Input,
+            upstream_asset_ref_id: None,
         }
     }
 
@@ -90,6 +94,16 @@ impl OperationFile {
 
     pub fn set_checksum_override(mut self, checksum: Sha256Hash) -> Self {
         self.checksum_override = Some(checksum);
+        self
+    }
+
+    pub fn set_role(mut self, role: AssetRole) -> Self {
+        self.role = role;
+        self
+    }
+
+    pub fn set_upstream_asset_ref_id(mut self, upstream_asset_ref_id: &HashId) -> Self {
+        self.upstream_asset_ref_id = Some(*upstream_asset_ref_id);
         self
     }
 
@@ -113,20 +127,20 @@ impl OperationFile {
                 &file_addition.asset_uri,
                 file_type,
                 file_addition.checksum.as_ref(),
-                &AssetRole::Input,
+                &self.role,
                 Some(&logical_path),
                 Some(&self.filename),
-                None,
+                self.upstream_asset_ref_id.as_ref(),
             ),
             uri: file_addition.asset_uri,
             file_type: file_type.to_string(),
             checksum: file_addition.checksum,
             size: None,
-            role: AssetRole::Input,
+            role: self.role.clone(),
             logical_path: Some(logical_path),
             name: Some(self.filename.clone()),
             created_on,
-            upstream_asset_ref_id: None,
+            upstream_asset_ref_id: self.upstream_asset_ref_id,
         })
     }
 

--- a/gen-models/src/sequence.rs
+++ b/gen-models/src/sequence.rs
@@ -1,9 +1,15 @@
 use core::hash::{Hash, Hasher};
 use std::{io::BufReader, ops::Range, rc::Rc, str, sync};
 
+use cached::proc_macro::cached;
 use flate2::read::MultiGzDecoder;
 use gen_core::{HashId, Sha256Hash, Workspace, traits::Capnp};
-use noodles::{bgzf, fasta};
+use indexmap::IndexMap;
+use noodles::{
+    bgzf::{self, gzi},
+    core::Region,
+    fasta::{self, fai, io::indexed_reader::Builder as IndexBuilder},
+};
 use rusqlite::{Row, ToSql, params, types::Value};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -30,6 +36,8 @@ pub struct Sequence {
     pub external_sequence: bool,
     #[serde(skip)]
     asset_ref: Option<AssetRef>,
+    #[serde(skip)]
+    index_asset_refs: Vec<AssetRef>,
     #[serde(skip)]
     workspace: Option<Workspace>,
     #[serde(skip)]
@@ -74,6 +82,8 @@ pub enum SequenceError {
     MissingSequenceLength(),
     #[error("Sequence cache lock poisoned: {0}")]
     CachePoisoned(String),
+    #[error("Invalid indexed sequence region '{name}': {reason}")]
+    InvalidRegion { name: String, reason: String },
     #[error("Sequence I/O error: {0}")]
     Io(String),
     #[error("Invalid UTF-8 while reading sequence data: {0}")]
@@ -131,6 +141,7 @@ impl<'a> Capnp<'a> for Sequence {
             length,
             external_sequence,
             asset_ref: None,
+            index_asset_refs: Vec::new(),
             workspace: None,
             asset_resolution_error: None,
         }
@@ -236,6 +247,7 @@ impl<'a> NewSequence<'a> {
             length: self.length.unwrap(),
             external_sequence,
             asset_ref: None,
+            index_asset_refs: Vec::new(),
             workspace: None,
             asset_resolution_error: None,
         }
@@ -298,10 +310,29 @@ impl<'a> NewSequence<'a> {
             length: self.length.unwrap_or(length),
             external_sequence: self.asset_ref_id.is_some(),
             asset_ref: None,
+            index_asset_refs: Vec::new(),
             workspace: None,
             asset_resolution_error: None,
         })
     }
+}
+
+#[cached(
+    key = "String",
+    convert = r#"{ format!("{}:{}", workspace.base_dir().display(), asset_ref.id) }"#
+)]
+fn fasta_index(workspace: &Workspace, asset_ref: &AssetRef) -> Option<fai::Index> {
+    let reader = asset_ref.reader(workspace).ok()?;
+    fai::io::Reader::new(reader).read_index().ok()
+}
+
+#[cached(
+    key = "String",
+    convert = r#"{ format!("{}:{}", workspace.base_dir().display(), asset_ref.id) }"#
+)]
+fn fasta_gzi_index(workspace: &Workspace, asset_ref: &AssetRef) -> Option<gzi::Index> {
+    let reader = asset_ref.reader(workspace).ok()?;
+    gzi::io::Reader::new(reader).read_index().ok()
 }
 
 fn asset_extension(asset_ref: &AssetRef) -> Option<String> {
@@ -371,6 +402,7 @@ type SequenceCache = sync::RwLock<Option<((HashId, String), Option<String>)>>;
 pub fn cached_sequence(
     workspace: &Workspace,
     sequence_asset: &AssetRef,
+    index_assets: &[AssetRef],
     name: &str,
     range: Range<i64>,
     circular: bool,
@@ -401,30 +433,91 @@ pub fn cached_sequence(
         .map_err(|err| SequenceError::CachePoisoned(err.to_string()))?;
 
     let mut sequence: Option<String> = None;
+    let fasta_index_asset = index_assets
+        .iter()
+        .find(|asset_ref| asset_extension(asset_ref).as_deref() == Some("fai"));
+    let gzip_index_asset = index_assets
+        .iter()
+        .find(|asset_ref| asset_extension(asset_ref).as_deref() == Some("gzi"));
     let sequence_extension = asset_extension(sequence_asset);
-    let sequence_reader = sequence_asset
-        .reader(workspace)
-        .map_err(|err| SequenceError::Io(err.to_string()))?;
-    let reader_stream: Box<dyn std::io::BufRead> = match sequence_extension.as_deref() {
-        Some("gz") => Box::new(BufReader::new(MultiGzDecoder::new(sequence_reader))),
-        Some("bgz") => Box::new(bgzf::io::Reader::new(sequence_reader)),
-        _ => Box::new(sequence_reader),
-    };
-    let mut reader = fasta::io::reader::Builder
-        .build_from_reader(reader_stream)
-        .map_err(|err| SequenceError::Io(err.to_string()))?;
-    for result in reader.records() {
-        let record = result.map_err(|err| SequenceError::Io(err.to_string()))?;
-        if String::from_utf8(record.name().to_vec())
-            .map_err(|err| SequenceError::Utf8(err.to_string()))?
-            == name
+    let compressed = matches!(sequence_extension.as_deref(), Some("gz" | "bgz"));
+    if let Some(index) = fasta_index_asset.and_then(|asset_ref| fasta_index(workspace, asset_ref)) {
+        let region = name
+            .parse::<Region>()
+            .map_err(|err| SequenceError::InvalidRegion {
+                name: name.to_string(),
+                reason: err.to_string(),
+            })?;
+        let builder = IndexBuilder::default().set_index(index);
+        if let Some(gzi_index) =
+            gzip_index_asset.and_then(|asset_ref| fasta_gzi_index(workspace, asset_ref))
         {
+            let sequence_reader = sequence_asset
+                .reader(workspace)
+                .map_err(|err| SequenceError::Io(err.to_string()))?;
+            let bgzf_reader = bgzf::io::indexed_reader::Builder::default()
+                .set_index(gzi_index)
+                .build_from_reader(sequence_reader)
+                .map_err(|err| SequenceError::Io(err.to_string()))?;
+            let mut reader = builder
+                .build_from_reader(bgzf_reader)
+                .map_err(|err| SequenceError::Io(err.to_string()))?;
             sequence = Some(
-                str::from_utf8(record.sequence().as_ref())
-                    .map_err(|err| SequenceError::Utf8(err.to_string()))?
-                    .to_string(),
+                str::from_utf8(
+                    reader
+                        .query(&region)
+                        .map_err(|err| SequenceError::Io(err.to_string()))?
+                        .sequence()
+                        .as_ref(),
+                )
+                .map_err(|err| SequenceError::Utf8(err.to_string()))?
+                .to_string(),
+            )
+        } else if !compressed {
+            let sequence_reader = sequence_asset
+                .reader(workspace)
+                .map_err(|err| SequenceError::Io(err.to_string()))?;
+            let mut reader = builder
+                .build_from_reader(sequence_reader)
+                .map_err(|err| SequenceError::Io(err.to_string()))?;
+            sequence = Some(
+                str::from_utf8(
+                    reader
+                        .query(&region)
+                        .map_err(|err| SequenceError::Io(err.to_string()))?
+                        .sequence()
+                        .as_ref(),
+                )
+                .map_err(|err| SequenceError::Utf8(err.to_string()))?
+                .to_string(),
             );
-            break;
+        }
+    }
+    if sequence.is_none() {
+        let sequence_reader = sequence_asset
+            .reader(workspace)
+            .map_err(|err| SequenceError::Io(err.to_string()))?;
+        let reader_stream: Box<dyn std::io::BufRead> = match sequence_extension.as_deref() {
+            Some("gz") => Box::new(BufReader::new(MultiGzDecoder::new(sequence_reader))),
+            Some("bgz") => Box::new(bgzf::io::Reader::new(sequence_reader)),
+            _ => Box::new(sequence_reader),
+        };
+        let mut reader = fasta::io::reader::Builder
+            .build_from_reader(reader_stream)
+            .map_err(|err| SequenceError::Io(err.to_string()))?;
+        for result in reader.records() {
+            let record = result.map_err(|err| SequenceError::Io(err.to_string()))?;
+            if String::from_utf8(record.name().to_vec())
+                .map_err(|err| SequenceError::Utf8(err.to_string()))?
+                == name
+            {
+                sequence = Some(
+                    str::from_utf8(record.sequence().as_ref())
+                        .map_err(|err| SequenceError::Utf8(err.to_string()))?
+                        .to_string(),
+                );
+                break;
+            }
         }
     }
     // This is an LRU cache setup; keep only the last sequence fetched so loading multiple plant
@@ -468,10 +561,13 @@ impl Sequence {
             "WITH arr AS (
                 SELECT value, rowid AS pos FROM rarray(:ids)
              )
-             SELECT sequences.*, asset_refs.*
+             SELECT sequences.*, asset_refs.*, index_assets.*
              FROM {sequence_table} AS sequences
              LEFT JOIN {asset_table} AS asset_refs
                ON sequences.asset_ref_id = asset_refs.id
+             LEFT JOIN {asset_table} AS index_assets
+               ON asset_refs.id = index_assets.upstream_asset_ref_id
+              AND index_assets.role = 'sequence-index'
              JOIN arr ON sequences.hash = arr.value
              ORDER BY arr.pos;"
         );
@@ -482,13 +578,22 @@ impl Sequence {
             query_params.push((":history_ref", history_ref));
         }
         let mut statement = conn.prepare(&query).unwrap();
-        statement
+        let mut sequences: IndexMap<Sha256Hash, Self> = IndexMap::new();
+        for row in statement
             .query_map(&query_params[..], |row| {
                 Ok(Self::process_joined_row(row, workspace))
             })
             .unwrap()
-            .map(|row| row.unwrap())
-            .collect()
+        {
+            let sequence = row.unwrap();
+            let sequence_hash = sequence.hash;
+            if let Some(existing) = sequences.get_mut(&sequence_hash) {
+                existing.index_asset_refs.extend(sequence.index_asset_refs);
+            } else {
+                sequences.insert(sequence_hash, sequence);
+            }
+        }
+        sequences.into_values().collect()
     }
 
     fn process_joined_row(row: &Row, workspace: &Workspace) -> Self {
@@ -519,6 +624,27 @@ impl Sequence {
             }
             sequence.asset_ref = Some(asset_ref);
             sequence.workspace = Some(workspace.clone());
+
+            let index_asset_ref_id: Option<HashId> = row.get(16).unwrap();
+            if let Some(index_asset_ref_id) = index_asset_ref_id {
+                let index_asset = AssetRef {
+                    id: index_asset_ref_id,
+                    uri: row.get(17).unwrap(),
+                    file_type: row.get(18).unwrap(),
+                    checksum: row.get(19).unwrap(),
+                    size: row.get(20).unwrap(),
+                    role: row.get(21).unwrap(),
+                    logical_path: row.get(22).unwrap(),
+                    name: row.get(23).unwrap(),
+                    created_on: row.get(24).unwrap(),
+                    upstream_asset_ref_id: row.get(25).unwrap(),
+                };
+                if !LocalAssetUri::is_local_path_or_file_uri(&index_asset.uri)
+                    || index_asset.versioned_store_path(workspace).is_ok()
+                {
+                    sequence.index_asset_refs.push(index_asset);
+                }
+            }
         }
         sequence
     }
@@ -551,6 +677,7 @@ impl Sequence {
             return cached_sequence(
                 workspace,
                 asset_ref,
+                &self.index_asset_refs,
                 &self.name,
                 start..end,
                 self.is_circular(),
@@ -576,22 +703,34 @@ impl Sequence {
     ) -> Vec<Sequence> {
         let asset_table = AssetRef::table_name_with_history_ref(None);
         let query = format!(
-            "SELECT sequences.*, asset_refs.*
+            "SELECT sequences.*, asset_refs.*, index_assets.*
              FROM block_group_edges bge
              LEFT JOIN edges ON bge.edge_id = edges.id
              LEFT JOIN nodes ON (edges.source_node_id = nodes.id OR edges.target_node_id = nodes.id)
              LEFT JOIN sequences ON (nodes.sequence_hash = sequences.hash)
              LEFT JOIN {asset_table} AS asset_refs ON sequences.asset_ref_id = asset_refs.id
+             LEFT JOIN {asset_table} AS index_assets
+               ON asset_refs.id = index_assets.upstream_asset_ref_id
+              AND index_assets.role = 'sequence-index'
              WHERE bge.block_group_id = ?1;"
         );
         let mut statement = conn.prepare(&query).unwrap();
-        statement
+        let mut sequences: IndexMap<Sha256Hash, Self> = IndexMap::new();
+        for row in statement
             .query_map(params![block_group_id], |row| {
                 Ok(Self::process_joined_row(row, workspace))
             })
             .unwrap()
-            .map(|row| row.unwrap())
-            .collect()
+        {
+            let sequence = row.unwrap();
+            let sequence_hash = sequence.hash;
+            if let Some(existing) = sequences.get_mut(&sequence_hash) {
+                existing.index_asset_refs.extend(sequence.index_asset_refs);
+            } else {
+                sequences.insert(sequence_hash, sequence);
+            }
+        }
+        sequences.into_values().collect()
     }
 }
 
@@ -614,6 +753,7 @@ impl Query for Sequence {
             length: row.get(5).unwrap(),
             external_sequence: asset_ref_id.is_some(),
             asset_ref: None,
+            index_asset_refs: Vec::new(),
             workspace: None,
             asset_resolution_error: None,
         }
@@ -647,10 +787,10 @@ pub fn reverse_complement(seq: &[u8]) -> Vec<u8> {
 
 #[cfg(test)]
 mod tests {
-    use std::{fs, io::Write as _, time::Instant};
+    use std::{fs, fs::OpenOptions, io::Write, time};
 
     use gen_core::traits::Capnp as _;
-    use rand::RngExt as _;
+    use rand::RngExt;
     use sha2::Digest as _;
 
     use super::{Sequence, SequenceError};
@@ -662,13 +802,30 @@ mod tests {
         traits::Query,
     };
 
-    fn prepare_asset(context: &crate::db::DbContext, path: &str) -> AssetRef {
-        let operation_file = OperationFile::new(path);
+    fn prepare_asset(context: &crate::db::DbContext, path: &str, role: AssetRole) -> AssetRef {
+        let operation_file = OperationFile::new(path).set_role(role);
         let asset_ref = operation_file
             .prepare_asset_ref(context.workspace(), 1)
             .expect("should retain test asset");
         AssetRef::create(context.graph().conn(), &asset_ref)
             .expect("should create test asset reference");
+        asset_ref
+    }
+
+    fn prepare_derived_asset(
+        context: &crate::db::DbContext,
+        path: &str,
+        role: AssetRole,
+        upstream_asset_ref_id: &gen_core::HashId,
+    ) -> AssetRef {
+        let operation_file = OperationFile::new(path)
+            .set_role(role)
+            .set_upstream_asset_ref_id(upstream_asset_ref_id);
+        let asset_ref = operation_file
+            .prepare_asset_ref(context.workspace(), 1)
+            .expect("should retain derived test asset");
+        AssetRef::create(context.graph().conn(), &asset_ref)
+            .expect("should create derived test asset reference");
         asset_ref
     }
 
@@ -746,7 +903,7 @@ mod tests {
             .unwrap()
             .join("reference.fa");
         fs::write(&fasta_path, ">chr1\nAACCGGTTAA\n").unwrap();
-        let asset_ref = prepare_asset(&context, fasta_path.to_str().unwrap());
+        let asset_ref = prepare_asset(&context, fasta_path.to_str().unwrap(), AssetRole::Input);
         let sequence = Sequence::new()
             .sequence_type("DNA")
             .name("chr1")
@@ -827,7 +984,7 @@ mod tests {
             ">m123\nATCGATCGATCGATCGATCGGGAACACACAGAGA\n",
         )
         .unwrap();
-        let asset_ref = prepare_asset(&context, temp_file_path.to_str().unwrap());
+        let asset_ref = prepare_asset(&context, temp_file_path.to_str().unwrap(), AssetRole::Input);
         let sequence = Sequence::new()
             .sequence_type("DNA")
             .name("m123")
@@ -935,7 +1092,7 @@ mod tests {
         let context = setup_gen_on_disk();
         let temp_file_path = context.workspace().repo_root().unwrap().join("simple.fa");
         fs::write(&temp_file_path, ">m123\nAAACCCTTT\n").unwrap();
-        let asset_ref = prepare_asset(&context, temp_file_path.to_str().unwrap());
+        let asset_ref = prepare_asset(&context, temp_file_path.to_str().unwrap(), AssetRole::Input);
         let sequence = Sequence::new()
             .sequence_type("circular")
             .name("m123")
@@ -962,10 +1119,66 @@ mod tests {
     }
 
     #[test]
+    fn test_on_disk_sequence_uses_retained_index_asset() {
+        let context = setup_gen_on_disk();
+        let repo_root = context.workspace().repo_root().unwrap();
+        let fasta_path = repo_root.join("indexed.fa");
+        let index_path = repo_root.join("indexed.fa.fai");
+        fs::write(&fasta_path, ">chr1\nACGTACGT\n").unwrap();
+        fs::write(&index_path, "chr1\t8\t6\t8\t9\n").unwrap();
+        let asset_ref = prepare_asset(&context, fasta_path.to_str().unwrap(), AssetRole::Input);
+        let index_asset_ref = prepare_derived_asset(
+            &context,
+            index_path.to_str().unwrap(),
+            AssetRole::SequenceIndex,
+            &asset_ref.id,
+        );
+        let unresolved_sequence = Sequence::new()
+            .sequence_type("DNA")
+            .name("chr1")
+            .asset_ref_id(Some(&asset_ref.id))
+            .length(8)
+            .save(context.graph().conn())
+            .unwrap();
+        let sequence = Sequence::query_by_ids(
+            context.graph().conn(),
+            context.workspace(),
+            &[unresolved_sequence.hash],
+            None,
+        )
+        .remove(0);
+        fs::remove_file(&fasta_path).unwrap();
+        fs::remove_file(&index_path).unwrap();
+
+        assert_eq!(
+            sequence.get_sequence(2, 6).unwrap(),
+            "GTAC",
+            "should read the retained sequence through its index"
+        );
+        assert!(
+            sequence
+                .index_asset_refs
+                .iter()
+                .any(|asset_ref| asset_ref.id == index_asset_ref.id),
+            "resolved sequence should include its retained index AssetRef"
+        );
+        assert_eq!(
+            index_asset_ref.upstream_asset_ref_id,
+            Some(asset_ref.id),
+            "index AssetRef should link to the immutable sequence AssetRef"
+        );
+    }
+
+    #[test]
+    // #[cfg(feature = "benchmark")]
     fn test_cached_sequence_performance() {
         let context = setup_gen_on_disk();
-        let fasta_path = context.workspace().repo_root().unwrap().join("large.fa");
-        let mut file = fs::File::create(&fasta_path).unwrap();
+        let temp_file_path = context.workspace().repo_root().unwrap().join("large.fa");
+        let mut file = OpenOptions::new()
+            .append(true)
+            .create(true)
+            .open(&temp_file_path)
+            .unwrap();
         writeln!(file, ">chr22").unwrap();
         for _ in 1..3_000_000 {
             writeln!(
@@ -974,31 +1187,44 @@ mod tests {
             )
             .unwrap();
         }
-        let asset_ref = prepare_asset(&context, fasta_path.to_str().unwrap());
-        let sequence = Sequence::new()
+        // write index
+        let index_path = context
+            .workspace()
+            .repo_root()
+            .unwrap()
+            .join("large.fa.fai");
+        fs::write(&index_path, "chr22	203999932	7	68	69\n").unwrap();
+        let asset_ref = prepare_asset(&context, temp_file_path.to_str().unwrap(), AssetRole::Input);
+        prepare_derived_asset(
+            &context,
+            index_path.to_str().unwrap(),
+            AssetRole::SequenceIndex,
+            &asset_ref.id,
+        );
+        let unresolved_sequence = Sequence::new()
             .sequence_type("DNA")
-            .name("chr22")
             .asset_ref_id(Some(&asset_ref.id))
+            .name("chr22")
             .length(203_999_932)
             .save(context.graph().conn())
             .unwrap();
         let sequence = Sequence::query_by_ids(
             context.graph().conn(),
             context.workspace(),
-            &[sequence.hash],
+            &[unresolved_sequence.hash],
             None,
         )
         .remove(0);
-
-        let start_time = Instant::now();
+        let s = time::Instant::now();
         for _ in 1..1_000_000 {
-            let start = rand::rng().random_range(1_i64..200_000_000_i64);
+            let start = rand::rng().random_range(1..200_000_000);
+
             sequence.get_sequence(start, start + 20).unwrap();
         }
-        let elapsed = start_time.elapsed().as_secs();
+        let elapsed = s.elapsed().as_secs();
         assert!(
             elapsed < 5,
-            "cached sequence benchmark failed: {elapsed}s elapsed"
+            "Cached sequence benchmark failed: {elapsed}s elapsed"
         );
     }
 
@@ -1015,6 +1241,7 @@ mod tests {
             length: 4,
             external_sequence: true,
             asset_ref: None,
+            index_asset_refs: Vec::new(),
             workspace: None,
             asset_resolution_error: None,
         };

--- a/gen-python/src/python_api/repository/imports.rs
+++ b/gen-python/src/python_api/repository/imports.rs
@@ -36,18 +36,20 @@ impl PyRepository {
         run_operation_write(
             self,
             |ctx| {
-                let operation_summary = import_fasta(ctx, &filename, &collection, &sample, shallow)
-                    .map_err(|e| match e {
-                        FastaError::OperationError(OperationError::NoChanges) => {
-                            PyRuntimeError::new_err(format!(
-                                "'{}': contents already exist",
-                                filename
-                            ))
-                        }
-                        _ => {
-                            PyRuntimeError::new_err(format!("Failed to import '{}': {e}", filename))
-                        }
-                    })?;
+                let operation_summary = import_fasta(
+                    ctx,
+                    &filename,
+                    &collection,
+                    &sample,
+                    shallow,
+                    &[],
+                )
+                .map_err(|e| match e {
+                    FastaError::OperationError(OperationError::NoChanges) => {
+                        PyRuntimeError::new_err(format!("'{}': contents already exist", filename))
+                    }
+                    _ => PyRuntimeError::new_err(format!("Failed to import '{}': {e}", filename)),
+                })?;
                 Ok((
                     self.block_groups_in_sample(&collection, &sample),
                     operation_summary,
@@ -90,6 +92,7 @@ impl PyRepository {
                     &collection,
                     &reference,
                     shallow,
+                    &[],
                 )
                 .map_err(|e| match e {
                     FastaError::OperationError(OperationError::NoChanges) => {

--- a/gen-r/src/rust/src/lib.rs
+++ b/gen-r/src/rust/src/lib.rs
@@ -1151,6 +1151,7 @@ impl Repository {
             &collection_name,
             &sample,
             shallow,
+            &[],
         ) {
             Ok(operation_summary) => {
                 end_transactions(&self.context, &operation_summary).map_err(Error::Other)?;
@@ -1198,6 +1199,7 @@ impl Repository {
             &collection_name,
             &reference,
             shallow,
+            &[],
         ) {
             Ok(operation_summary) => {
                 end_transactions(&self.context, &operation_summary).map_err(Error::Other)?;

--- a/src/commands/graph_operations/derive_chunks.rs
+++ b/src/commands/graph_operations/derive_chunks.rs
@@ -173,6 +173,7 @@ mod tests {
             "test",
             Sample::DEFAULT_NAME,
             false,
+            &[],
         )
         .unwrap();
         context

--- a/src/commands/graph_operations/make_stitch.rs
+++ b/src/commands/graph_operations/make_stitch.rs
@@ -120,6 +120,7 @@ mod tests {
             "test",
             Sample::DEFAULT_NAME,
             false,
+            &[],
         )
         .unwrap();
         crate::commands::graph_operations::derive_chunks::derive_chunks_operation(

--- a/src/commands/import/fasta.rs
+++ b/src/commands/import/fasta.rs
@@ -17,9 +17,12 @@ pub struct Command {
     /// Fasta file path
     #[clap(index = 1)]
     pub path: String,
-    /// Don't store the sequence in the database, instead store the filename
+    /// Don't store the sequence in the database, instead store a reference to an asset
     #[arg(long, action)]
     shallow: bool,
+    /// Index associated with the shallow FASTA. May be specified multiple times.
+    #[arg(long, requires = "shallow")]
+    index: Vec<String>,
     /// The name of the collection to store the entry under
     #[arg(short, long)]
     name: Option<String>,
@@ -61,7 +64,14 @@ pub fn execute(cli_context: &CliContext, cmd: Command) -> Result<()> {
             },
         )?;
     }
-    match import_fasta(context, &cmd.path.clone(), name, sample_name, cmd.shallow) {
+    match import_fasta(
+        context,
+        &cmd.path.clone(),
+        name,
+        sample_name,
+        cmd.shallow,
+        &cmd.index,
+    ) {
         Ok(operation_summary) => {
             conn.execute("END TRANSACTION", [])?;
             match commit_operation(context, &operation_summary) {
@@ -85,5 +95,41 @@ pub fn execute(cli_context: &CliContext, cmd: Command) -> Result<()> {
             conn.execute("ROLLBACK TRANSACTION;", [])?;
             Err(e.into())
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use super::Command;
+
+    #[derive(Parser)]
+    struct TestCli {
+        #[command(flatten)]
+        command: Command,
+    }
+
+    #[test]
+    fn test_accepts_multiple_remote_fasta_indexes() {
+        let cli = TestCli::try_parse_from([
+            "test",
+            "https://example.test/reference.fa.bgz",
+            "--shallow",
+            "--index",
+            "https://example.test/reference.fa.bgz.fai",
+            "--index",
+            "https://example.test/reference.fa.bgz.gzi",
+        ])
+        .expect("should parse multiple shallow FASTA indexes");
+
+        assert_eq!(
+            cli.command.index,
+            [
+                "https://example.test/reference.fa.bgz.fai",
+                "https://example.test/reference.fa.bgz.gzi",
+            ],
+            "repeatable --index values should preserve every supplied URI"
+        );
     }
 }

--- a/src/exports/fasta.rs
+++ b/src/exports/fasta.rs
@@ -83,6 +83,7 @@ mod tests {
             &collection,
             Sample::DEFAULT_NAME,
             false,
+            &[],
         )
         .unwrap();
         let tmp_dir = tempfile::tempdir().unwrap().keep();
@@ -137,6 +138,7 @@ mod tests {
             &collection,
             Sample::DEFAULT_NAME,
             false,
+            &[],
         )
         .unwrap();
         let _ = update_with_fasta(

--- a/src/exports/gfa.rs
+++ b/src/exports/gfa.rs
@@ -582,6 +582,7 @@ mod tests {
             collection,
             Sample::DEFAULT_NAME,
             false,
+            &[],
         )
         .unwrap();
         add_annotation(

--- a/src/graphs/operators.rs
+++ b/src/graphs/operators.rs
@@ -734,6 +734,7 @@ mod tests {
             collection,
             Sample::DEFAULT_NAME,
             false,
+            &[],
         )
         .unwrap();
 
@@ -873,6 +874,7 @@ mod tests {
             collection,
             Sample::DEFAULT_NAME,
             false,
+            &[],
         )
         .unwrap();
 

--- a/src/imports/fasta.rs
+++ b/src/imports/fasta.rs
@@ -466,7 +466,7 @@ mod tests {
     }
 
     #[test]
-    fn test_add_fasta_shallow() {
+    fn test_add_fasta_shallow_uses_immutable_asset() {
         let context = setup_gen_on_disk();
         let conn = context.graph().conn();
         let fixture_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("fixtures/simple.fa");

--- a/src/imports/fasta.rs
+++ b/src/imports/fasta.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::HashMap,
     io::{BufRead, BufReader, Read},
+    path::Path as FsPath,
     str,
     time::{SystemTime, UNIX_EPOCH},
 };
@@ -8,7 +9,7 @@ use std::{
 use flate2::read::MultiGzDecoder;
 use gen_core::{HashId, PATH_END_NODE_ID, PATH_START_NODE_ID, Strand};
 use gen_models::{
-    assets::{AssetRef, AssetUri, ChecksummedReader},
+    assets::{AssetRef, AssetRole, AssetUri, ChecksummedReader},
     block_group::{BlockGroup, NewBlockGroup},
     block_group_edge::{BlockGroupEdge, BlockGroupEdgeData},
     collection::Collection,
@@ -38,6 +39,7 @@ pub fn import_fasta(
     collection_name: &str,
     sample: &str,
     shallow: bool,
+    indexes: &[String],
 ) -> Result<OperationSummary, FastaError> {
     let conn = context.graph().conn();
     let progress_bar = get_handler();
@@ -60,6 +62,29 @@ pub fn import_fasta(
         AssetRef::create(conn, &sequence_asset_ref)
             .map_err(gen_models::errors::FileAdditionError::DatabaseError)?;
         sequence_asset_ref_id = Some(sequence_asset_ref.id);
+
+        let mut index_locations = indexes.to_vec();
+        for index_extension in ["fai", "gzi"] {
+            let index_location = format!("{fasta}.{index_extension}");
+            if !index_locations.contains(&index_location) && FsPath::new(&index_location).is_file()
+            {
+                index_locations.push(index_location);
+            }
+        }
+        for index_location in index_locations {
+            let mut index_operation_file = OperationFile::new(index_location)
+                .set_file_type(FileTypes::None)
+                .set_role(AssetRole::SequenceIndex)
+                .set_upstream_asset_ref_id(&sequence_asset_ref.id);
+            let index_asset_ref =
+                index_operation_file.prepare_asset_ref(context.workspace(), created_on)?;
+            if let Some(checksum) = index_asset_ref.checksum {
+                index_operation_file = index_operation_file.set_checksum_override(checksum);
+            }
+            AssetRef::create(conn, &index_asset_ref)
+                .map_err(gen_models::errors::FileAdditionError::DatabaseError)?;
+            operation_files.push(index_operation_file);
+        }
         Box::new(sequence_asset_ref.reader(context.workspace())?)
     } else {
         let asset_uri = <dyn AssetUri>::new(context.workspace(), fasta);
@@ -214,15 +239,14 @@ pub fn import_fasta(
 
 #[cfg(test)]
 mod tests {
-    // Note this useful idiom: importing names from outer (for mod tests) scope.
     use std::{
-        collections::HashSet,
+        collections::{HashMap, HashSet},
         fs,
-        io::Write as _,
+        io::{Read as _, Write as _},
         net::TcpListener,
         path::PathBuf,
         sync::{
-            Arc,
+            Arc, Mutex,
             atomic::{AtomicBool, Ordering},
         },
         thread,
@@ -230,33 +254,42 @@ mod tests {
     };
 
     use gen_models::{
-        assets::{AssetRef, OperationKind, OperationLog},
+        assets::{AssetRef, AssetRole, OperationAsset, OperationKind, OperationLog},
+        block_group::BlockGroup,
         errors::OperationError,
         history::{HistoryStore, dolt::DoltHistoryStore},
+        node::Node,
         operations::commit_operation_summary,
-        traits::*,
+        path::Path,
+        sample::Sample,
+        sequence::Sequence,
+        traits::Query,
     };
+    use noodles::bgzf::gzi;
 
-    use super::*;
+    use super::import_fasta;
     use crate::test_helpers::{setup_gen, setup_gen_on_disk};
 
     struct TestHttpServer {
         address: String,
+        requests: Arc<Mutex<Vec<String>>>,
         stop: Arc<AtomicBool>,
         handle: Option<thread::JoinHandle<()>>,
     }
 
     impl TestHttpServer {
-        fn new(contents: Vec<u8>) -> Self {
+        fn new(files: HashMap<String, Vec<u8>>) -> Self {
             let listener =
-                TcpListener::bind(("127.0.0.1", 0)).expect("should bind remote FASTA server");
+                TcpListener::bind(("127.0.0.1", 0)).expect("should bind remote FASTA test server");
             listener
                 .set_nonblocking(true)
-                .expect("should configure remote FASTA server");
+                .expect("should configure remote FASTA test server");
             let address = listener
                 .local_addr()
                 .expect("should read remote FASTA server address")
                 .to_string();
+            let requests = Arc::new(Mutex::new(Vec::new()));
+            let server_requests = Arc::clone(&requests);
             let stop = Arc::new(AtomicBool::new(false));
             let server_stop = Arc::clone(&stop);
             let handle = thread::spawn(move || {
@@ -265,38 +298,103 @@ mod tests {
                         thread::sleep(Duration::from_millis(2));
                         continue;
                     };
-                    let mut request_bytes = [0_u8; 4096];
+                    let mut request_bytes = [0_u8; 8192];
                     let length = stream
                         .read(&mut request_bytes)
                         .expect("should read remote FASTA request");
-                    let request = String::from_utf8_lossy(&request_bytes[..length]);
-                    let method = request
-                        .lines()
+                    let request = String::from_utf8_lossy(&request_bytes[..length]).to_string();
+                    server_requests
+                        .lock()
+                        .expect("should lock remote FASTA request log")
+                        .push(request.clone());
+                    let mut request_lines = request.lines();
+                    let request_line = request_lines.next().unwrap_or_default();
+                    let mut request_parts = request_line.split_whitespace();
+                    let method = request_parts.next().unwrap_or_default();
+                    let path = request_parts
                         .next()
-                        .and_then(|line| line.split_whitespace().next())
+                        .unwrap_or_default()
+                        .split('?')
+                        .next()
                         .unwrap_or_default();
+                    let Some(contents) = files.get(path) else {
+                        stream
+                            .write_all(
+                                b"HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+                            )
+                            .expect("should write missing remote FASTA response");
+                        continue;
+                    };
+                    let range = request_lines.find_map(|line| {
+                        line.to_ascii_lowercase()
+                            .strip_prefix("range: bytes=")
+                            .map(str::to_string)
+                    });
+                    let (status, start, end) = if let Some(range) = range {
+                        let (start, end) = range
+                            .split_once('-')
+                            .expect("should parse remote FASTA byte range");
+                        let start = start
+                            .parse::<usize>()
+                            .expect("should parse remote FASTA range start");
+                        let end = if end.is_empty() {
+                            contents.len().saturating_sub(1)
+                        } else {
+                            end.parse::<usize>()
+                                .expect("should parse remote FASTA range end")
+                                .min(contents.len().saturating_sub(1))
+                        };
+                        ("206 Partial Content", start, end)
+                    } else {
+                        ("200 OK", 0, contents.len().saturating_sub(1))
+                    };
+                    let body = if contents.is_empty() || start > end {
+                        &[][..]
+                    } else {
+                        &contents[start..=end]
+                    };
+                    let content_range = if status.starts_with("206") {
+                        format!("Content-Range: bytes {start}-{end}/{}\r\n", contents.len())
+                    } else {
+                        String::new()
+                    };
                     write!(
                         stream,
-                        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
-                        contents.len()
+                        "HTTP/1.1 {status}\r\nContent-Length: {}\r\n{content_range}Accept-Ranges: bytes\r\nConnection: close\r\n\r\n",
+                        body.len()
                     )
                     .expect("should write remote FASTA response headers");
                     if method != "HEAD" {
                         stream
-                            .write_all(&contents)
+                            .write_all(body)
                             .expect("should write remote FASTA response body");
                     }
                 }
             });
             Self {
                 address,
+                requests,
                 stop,
                 handle: Some(handle),
             }
         }
 
-        fn url(&self) -> String {
-            format!("http://{}/reference.fa", self.address)
+        fn url(&self, path: &str) -> String {
+            format!("http://{}{path}", self.address)
+        }
+
+        fn clear_requests(&self) {
+            self.requests
+                .lock()
+                .expect("should lock remote FASTA request log")
+                .clear();
+        }
+
+        fn requests(&self) -> Vec<String> {
+            self.requests
+                .lock()
+                .expect("should lock remote FASTA request log")
+                .clone()
         }
     }
 
@@ -304,7 +402,7 @@ mod tests {
         fn drop(&mut self) {
             self.stop.store(true, Ordering::Relaxed);
             if let Some(handle) = self.handle.take() {
-                handle.join().expect("should stop remote FASTA server");
+                handle.join().expect("should stop remote FASTA test server");
             }
         }
     }
@@ -324,6 +422,7 @@ mod tests {
             "test",
             Sample::DEFAULT_NAME,
             false,
+            &[],
         )
         .unwrap();
         let commit_hash = commit_operation_summary(&context, &operation_summary).unwrap();
@@ -349,7 +448,8 @@ mod tests {
         assert_eq!(
             BlockGroup::get_all_sequences(conn, context.workspace(), &block_group_id, false)
                 .unwrap(),
-            HashSet::from_iter(vec!["ATCGATCGATCGATCGATCGGGAACACACAGAGA".to_string()])
+            HashSet::from_iter(vec!["ATCGATCGATCGATCGATCGGGAACACACAGAGA".to_string()]),
+            "shallow FASTA should read through retained sequence and index assets"
         );
 
         let path = Path::all(conn)[0].clone();
@@ -373,6 +473,7 @@ mod tests {
             "test",
             Sample::DEFAULT_NAME,
             false,
+            &[],
         )
         .unwrap();
         let block_group_id = BlockGroup::get_id("test", Sample::DEFAULT_NAME, "m123", None);
@@ -396,6 +497,7 @@ mod tests {
             "test",
             Sample::DEFAULT_NAME,
             false,
+            &[],
         )
         .unwrap();
         let block_group_id = BlockGroup::get_id("test", Sample::DEFAULT_NAME, "chr22", None);
@@ -421,6 +523,7 @@ mod tests {
             "test",
             Sample::DEFAULT_NAME,
             false,
+            &[],
         )
         .unwrap();
         let block_group_id = BlockGroup::get_id("test", Sample::DEFAULT_NAME, "m123", None);
@@ -445,6 +548,7 @@ mod tests {
             "test",
             "new-sample",
             false,
+            &[],
         )
         .unwrap();
         let block_group_id = BlockGroup::get_id("test", "new-sample", "m123", None);
@@ -466,34 +570,52 @@ mod tests {
     }
 
     #[test]
-    fn test_add_fasta_shallow_uses_immutable_asset() {
+    fn test_add_fasta_shallow() {
         let context = setup_gen_on_disk();
         let conn = context.graph().conn();
-        let fixture_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("fixtures/simple.fa");
+
         let fasta_path = context
             .workspace()
             .repo_root()
-            .expect("should have repository root")
-            .join("shallow.fa");
-        fs::copy(&fixture_path, &fasta_path).expect("should copy shallow FASTA fixture");
+            .unwrap()
+            .join("shallow.fa.bgz");
+        let index_path = context
+            .workspace()
+            .repo_root()
+            .unwrap()
+            .join("shallow.fa.bgz.fai");
+        let gzip_index_path = context
+            .workspace()
+            .repo_root()
+            .unwrap()
+            .join("shallow.fa.bgz.gzi");
+        fs::copy(
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("fixtures/fastas/bgzipped.fa.bgz"),
+            &fasta_path,
+        )
+        .unwrap();
+        fs::write(&index_path, "m123\t37\t6\t37\t38\n").unwrap();
+        gzi::fs::write(&gzip_index_path, &gzi::Index::default()).unwrap();
 
         let operation_summary = import_fasta(
             &context,
-            &fasta_path.to_string_lossy().to_string(),
+            &fasta_path.to_str().unwrap().to_string(),
             "test",
             Sample::DEFAULT_NAME,
             true,
+            &[],
         )
-        .expect("should import shallow FASTA");
-        commit_operation_summary(&context, &operation_summary)
-            .expect("should commit shallow FASTA import");
-        fs::remove_file(&fasta_path).expect("should remove logical FASTA path");
-
+        .unwrap();
+        commit_operation_summary(&context, &operation_summary).unwrap();
+        fs::remove_file(&fasta_path).unwrap();
+        fs::write(&index_path, "invalid logical-path index\n").unwrap();
+        fs::write(&gzip_index_path, "invalid logical-path gzip index\n").unwrap();
         let block_group_id = BlockGroup::get_id("test", Sample::DEFAULT_NAME, "m123", None);
         assert_eq!(
             BlockGroup::get_all_sequences(conn, context.workspace(), &block_group_id, false)
-                .expect("should load shallow sequence from immutable asset"),
-            HashSet::from_iter(vec!["ATCGATCGATCGATCGATCGGGAACACACAGAGA".to_string()])
+                .expect("should load shallow sequence from retained sequence and index assets"),
+            HashSet::from_iter(vec!["ATCGATCGATCGATCGATCGGGAACACACAGAGA".to_string()]),
+            "shallow FASTA should read through retained sequence and index assets"
         );
         let sequence = Sequence::query_by_blockgroup(conn, context.workspace(), &block_group_id)
             .into_iter()
@@ -517,59 +639,163 @@ mod tests {
 
         let path = Path::all(conn)[0].clone();
         assert_eq!(
-            path.sequence(conn, context.workspace(), None)
-                .expect("should read path through immutable sequence asset"),
-            "ATCGATCGATCGATCGATCGGGAACACACAGAGA"
+            path.sequence(conn, context.workspace(), None).unwrap(),
+            "ATCGATCGATCGATCGATCGGGAACACACAGAGA".to_string(),
+            "path sequence should use the immutable FASTA asset"
+        );
+        let sequence = Sequence::query_by_blockgroup(conn, context.workspace(), &block_group_id)
+            .into_iter()
+            .find(|sequence| sequence.asset_ref_id.is_some())
+            .expect("should store the shallow sequence asset pointer");
+        let asset_refs = AssetRef::all(conn);
+        assert!(
+            asset_refs.iter().any(|asset_ref| {
+                Some(asset_ref.id) == sequence.asset_ref_id && asset_ref.role == AssetRole::Input
+            }),
+            "shallow sequence should point to its input AssetRef"
+        );
+        let mut index_assets = asset_refs
+            .iter()
+            .filter(|asset_ref| {
+                asset_ref.upstream_asset_ref_id == sequence.asset_ref_id
+                    && asset_ref.role == AssetRole::SequenceIndex
+            })
+            .collect::<Vec<_>>();
+        index_assets.sort_by_key(|asset_ref| asset_ref.name.as_deref());
+        assert_eq!(
+            index_assets.len(),
+            2,
+            "BGZF FASTA should retain both discovered indexes"
+        );
+        assert_eq!(
+            index_assets[0].name.as_deref(),
+            Some("shallow.fa.bgz.fai"),
+            "first retained index should be the FASTA index"
+        );
+        assert_eq!(
+            index_assets[1].name.as_deref(),
+            Some("shallow.fa.bgz.gzi"),
+            "second retained index should be the gzip index"
+        );
+        let operation_assets = OperationAsset::all(conn);
+        assert!(
+            operation_assets.iter().any(|operation_asset| {
+                Some(operation_asset.asset_ref_id) == sequence.asset_ref_id
+            }),
+            "operation should track the shallow sequence asset"
+        );
+        assert!(
+            index_assets.iter().all(|index_asset| {
+                operation_assets
+                    .iter()
+                    .any(|operation_asset| operation_asset.asset_ref_id == index_asset.id)
+            }),
+            "operation should track every retained sequence index"
         );
     }
 
     #[test]
-    fn test_add_remote_fasta_shallow_uses_remote_asset() {
-        let server = TestHttpServer::new(b">m123\nATCGATCGATCGATCGATCGGGAACACACAGAGA\n".to_vec());
+    fn test_add_remote_shallow_fasta_with_multiple_remote_indexes() {
+        let fasta_contents = fs::read(
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("fixtures/fastas/bgzipped.fa.bgz"),
+        )
+        .expect("should read BGZF FASTA fixture");
+        let server = TestHttpServer::new(HashMap::from([
+            ("/reference.fa.bgz".to_string(), fasta_contents),
+            (
+                "/reference.fa.bgz.fai".to_string(),
+                b"m123\t37\t6\t37\t38\n".to_vec(),
+            ),
+            (
+                "/reference.fa.bgz.gzi".to_string(),
+                0_u64.to_le_bytes().to_vec(),
+            ),
+        ]));
         let context = setup_gen_on_disk();
         let conn = context.graph().conn();
-        let fasta = server.url();
+        let fasta = server.url("/reference.fa.bgz");
+        let indexes = [
+            server.url("/reference.fa.bgz.fai"),
+            server.url("/reference.fa.bgz.gzi"),
+        ];
 
-        let operation_summary = import_fasta(&context, &fasta, "test", Sample::DEFAULT_NAME, true)
-            .expect("should import shallow remote FASTA");
+        let operation_summary = import_fasta(
+            &context,
+            &fasta,
+            "test",
+            Sample::DEFAULT_NAME,
+            true,
+            &indexes,
+        )
+        .expect("should import a shallow remote BGZF with remote indexes");
         commit_operation_summary(&context, &operation_summary)
-            .expect("should commit shallow remote FASTA import");
+            .expect("should commit remote shallow FASTA assets");
 
         let sequence_asset = AssetRef::all(conn)
             .into_iter()
             .find(|asset_ref| asset_ref.uri == fasta)
-            .expect("should persist remote sequence AssetRef");
+            .expect("should store the remote sequence AssetRef");
         assert_eq!(
             sequence_asset.checksum, None,
-            "remote shallow asset should not require a retained local checksum"
+            "remote sequence AssetRef should remain checksumless"
+        );
+        let index_assets = AssetRef::get_derived_assets(conn, &sequence_asset.id, None);
+        assert_eq!(
+            index_assets.len(),
+            2,
+            "remote BGZF sequence should retain both index AssetRefs"
+        );
+        assert!(
+            index_assets.iter().all(|asset_ref| {
+                asset_ref.role == AssetRole::SequenceIndex && asset_ref.checksum.is_none()
+            }),
+            "remote indexes should remain checksumless sequence-index AssetRefs"
         );
         assert!(
             context
                 .workspace()
                 .asset_dir()
-                .expect("should have asset directory")
+                .unwrap()
                 .read_dir()
-                .expect("should read asset directory")
+                .unwrap()
                 .next()
                 .is_none(),
-            "remote shallow import should not retain a local asset"
+            "remote shallow import should not retain local sequence or index assets"
         );
 
+        server.clear_requests();
         let block_group_id = BlockGroup::get_id("test", Sample::DEFAULT_NAME, "m123", None);
-        assert_eq!(
-            BlockGroup::get_all_sequences(conn, context.workspace(), &block_group_id, false)
-                .expect("should stream shallow sequence from remote AssetRef"),
-            HashSet::from_iter(vec!["ATCGATCGATCGATCGATCGGGAACACACAGAGA".to_string()])
-        );
         let sequence = Sequence::query_by_blockgroup(conn, context.workspace(), &block_group_id)
             .into_iter()
             .find(|sequence| sequence.asset_ref_id == Some(sequence_asset.id))
-            .expect("should resolve shallow sequence through remote AssetRef");
+            .expect("should resolve the remote shallow sequence AssetRef");
         assert_eq!(
-            sequence
-                .get_sequence(2, 8)
-                .expect("should read remote sequence slice"),
-            "CGATCG"
+            sequence.get_sequence(2, 8).unwrap(),
+            "CGATCG",
+            "indexed remote lookup should return the requested slice"
+        );
+
+        let requests = server.requests();
+        assert!(
+            requests.iter().any(|request| {
+                request.starts_with("GET /reference.fa.bgz.fai ")
+                    || request.starts_with("HEAD /reference.fa.bgz.fai ")
+            }),
+            "indexed lookup should request the remote FASTA index"
+        );
+        assert!(
+            requests.iter().any(|request| {
+                request.starts_with("GET /reference.fa.bgz.gzi ")
+                    || request.starts_with("HEAD /reference.fa.bgz.gzi ")
+            }),
+            "indexed lookup should request the remote gzip index"
+        );
+        assert!(
+            requests.iter().any(|request| {
+                request.starts_with("GET /reference.fa.bgz ")
+                    && request.to_ascii_lowercase().contains("\r\nrange: bytes=")
+            }),
+            "indexed remote lookup should use a byte-range request"
         );
     }
 
@@ -588,6 +814,7 @@ mod tests {
             &collection,
             Sample::DEFAULT_NAME,
             false,
+            &[],
         )
         .unwrap();
         commit_operation_summary(&context, &operation_summary).unwrap();
@@ -602,6 +829,7 @@ mod tests {
             &collection,
             Sample::DEFAULT_NAME,
             false,
+            &[],
         )
         .unwrap();
         let result_error = commit_operation_summary(&context, &operation_summary).unwrap_err();

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -1047,6 +1047,7 @@ mod tests {
             "default",
             "foo",
             false,
+            &[],
         )
         .expect("should import fasta fixture");
         commit_operation_summary(&context, &operation_summary)

--- a/src/updates/fasta.rs
+++ b/src/updates/fasta.rs
@@ -281,6 +281,7 @@ mod tests {
             &collection,
             Sample::DEFAULT_NAME,
             false,
+            &[],
         )
         .unwrap();
         let operation_summary = update_with_fasta(
@@ -346,6 +347,7 @@ mod tests {
             &collection,
             Sample::DEFAULT_NAME,
             false,
+            &[],
         )
         .unwrap();
         let _ = update_with_fasta(
@@ -408,6 +410,7 @@ mod tests {
             &collection,
             Sample::DEFAULT_NAME,
             false,
+            &[],
         )
         .unwrap();
         let _ = update_with_fasta(
@@ -472,6 +475,7 @@ mod tests {
             &collection,
             Sample::DEFAULT_NAME,
             false,
+            &[],
         )
         .unwrap();
         let _ = update_with_fasta(
@@ -545,6 +549,7 @@ mod tests {
             &collection,
             Sample::DEFAULT_NAME,
             false,
+            &[],
         )
         .unwrap();
         let _ = update_with_fasta(
@@ -624,6 +629,7 @@ mod tests {
             &collection,
             Sample::DEFAULT_NAME,
             false,
+            &[],
         )
         .unwrap();
         let _ = update_with_fasta(
@@ -697,6 +703,7 @@ mod tests {
             &collection,
             Sample::DEFAULT_NAME,
             false,
+            &[],
         )
         .unwrap();
         let _ = update_with_fasta(
@@ -768,6 +775,7 @@ mod tests {
             &collection,
             Sample::DEFAULT_NAME,
             false,
+            &[],
         )
         .unwrap();
         let _ = update_with_fasta(
@@ -829,6 +837,7 @@ mod tests {
             &collection,
             "simple",
             false,
+            &[],
         )
         .unwrap();
         add_annotation(&context, &collection, "foobar", None, "simple", "m123:5-20").unwrap();
@@ -891,6 +900,7 @@ mod tests {
             &collection,
             Sample::DEFAULT_NAME,
             false,
+            &[],
         )
         .unwrap();
         let _ = update_with_fasta(
@@ -956,6 +966,7 @@ mod tests {
             &collection,
             Sample::DEFAULT_NAME,
             false,
+            &[],
         )
         .unwrap();
         let _ = update_with_fasta(
@@ -1016,6 +1027,7 @@ mod tests {
             &collection,
             Sample::DEFAULT_NAME,
             false,
+            &[],
         )
         .unwrap();
         let _ = update_with_fasta(

--- a/src/updates/gfa.rs
+++ b/src/updates/gfa.rs
@@ -518,6 +518,7 @@ mod tests {
             &collection,
             Sample::DEFAULT_NAME,
             false,
+            &[],
         )
         .unwrap();
 
@@ -574,6 +575,7 @@ mod tests {
             &collection,
             Sample::DEFAULT_NAME,
             false,
+            &[],
         )
         .unwrap();
 

--- a/src/updates/library.rs
+++ b/src/updates/library.rs
@@ -528,6 +528,7 @@ mod tests {
             &collection,
             Sample::DEFAULT_NAME,
             false,
+            &[],
         )
         .unwrap();
 
@@ -594,6 +595,7 @@ mod tests {
             &collection,
             Sample::DEFAULT_NAME,
             false,
+            &[],
         )
         .unwrap();
 
@@ -662,6 +664,7 @@ mod tests {
             &collection,
             "simple",
             false,
+            &[],
         )
         .unwrap();
         add_annotation(&context, &collection, "foobar", None, "simple", "m123:5-20").unwrap();
@@ -723,6 +726,7 @@ mod tests {
             &collection,
             "simple",
             false,
+            &[],
         )
         .unwrap();
         add_annotation(&context, &collection, "foobar", None, "simple", "m123:5-20").unwrap();
@@ -779,6 +783,7 @@ mod tests {
             &collection,
             Sample::DEFAULT_NAME,
             false,
+            &[],
         )
         .unwrap();
 
@@ -842,6 +847,7 @@ mod tests {
             &collection,
             Sample::DEFAULT_NAME,
             false,
+            &[],
         )
         .unwrap();
 
@@ -900,6 +906,7 @@ mod tests {
             &collection,
             Sample::DEFAULT_NAME,
             false,
+            &[],
         )
         .unwrap();
 
@@ -963,6 +970,7 @@ mod tests {
             &collection,
             Sample::DEFAULT_NAME,
             false,
+            &[],
         )
         .unwrap();
 

--- a/src/updates/sequence.rs
+++ b/src/updates/sequence.rs
@@ -323,6 +323,7 @@ mod tests {
             &collection,
             "simple",
             false,
+            &[],
         )
         .unwrap();
         add_annotation(&context, &collection, "foobar", None, "simple", "m123:5-20").unwrap();
@@ -392,6 +393,7 @@ mod tests {
             &collection,
             Sample::DEFAULT_NAME,
             false,
+            &[],
         )
         .unwrap();
         let operation_summary = update_with_sequence(
@@ -455,6 +457,7 @@ mod tests {
             &collection,
             Sample::DEFAULT_NAME,
             false,
+            &[],
         )
         .unwrap();
         let _ = update_with_sequence(
@@ -514,6 +517,7 @@ mod tests {
             &collection,
             Sample::DEFAULT_NAME,
             false,
+            &[],
         )
         .unwrap();
         let _ = update_with_sequence(
@@ -578,6 +582,7 @@ mod tests {
             &collection,
             Sample::DEFAULT_NAME,
             false,
+            &[],
         )
         .unwrap();
         let _ = update_with_sequence(
@@ -648,6 +653,7 @@ mod tests {
             &collection,
             Sample::DEFAULT_NAME,
             false,
+            &[],
         )
         .unwrap();
         let _ = update_with_sequence(
@@ -712,6 +718,7 @@ mod tests {
             &collection,
             Sample::DEFAULT_NAME,
             false,
+            &[],
         )
         .unwrap();
         let _ = update_with_sequence(
@@ -776,6 +783,7 @@ mod tests {
             &collection,
             Sample::DEFAULT_NAME,
             false,
+            &[],
         )
         .unwrap();
         let _ = update_with_sequence(
@@ -839,6 +847,7 @@ mod tests {
             &collection,
             Sample::DEFAULT_NAME,
             false,
+            &[],
         )
         .unwrap();
         let _ = update_with_sequence(
@@ -900,6 +909,7 @@ mod tests {
             &collection,
             Sample::DEFAULT_NAME,
             false,
+            &[],
         )
         .unwrap();
         add_annotation(

--- a/src/updates/vcf.rs
+++ b/src/updates/vcf.rs
@@ -774,6 +774,7 @@ mod tests {
             &collection,
             Sample::DEFAULT_NAME,
             false,
+            &[],
         )
         .unwrap();
         let _operation = update_with_vcf(
@@ -836,6 +837,7 @@ mod tests {
             &collection,
             Sample::DEFAULT_NAME,
             false,
+            &[],
         )
         .unwrap();
         let _operation = update_with_vcf(
@@ -904,6 +906,7 @@ mod tests {
             &collection,
             Sample::DEFAULT_NAME,
             false,
+            &[],
         )
         .unwrap();
         let _operation = update_with_vcf(
@@ -962,6 +965,7 @@ mod tests {
             &collection,
             Sample::DEFAULT_NAME,
             false,
+            &[],
         )
         .unwrap();
 
@@ -1004,6 +1008,7 @@ mod tests {
             &collection,
             Sample::DEFAULT_NAME,
             false,
+            &[],
         )
         .unwrap();
         let res = update_with_vcf(
@@ -1039,6 +1044,7 @@ mod tests {
             &collection,
             Sample::DEFAULT_NAME,
             false,
+            &[],
         )
         .unwrap();
         let _operation = update_with_vcf(
@@ -1084,6 +1090,7 @@ mod tests {
             &collection,
             Sample::DEFAULT_NAME,
             false,
+            &[],
         )
         .unwrap();
         update_with_vcf(
@@ -1127,6 +1134,7 @@ mod tests {
             &collection,
             Sample::DEFAULT_NAME,
             false,
+            &[],
         )
         .unwrap();
 
@@ -1173,6 +1181,7 @@ mod tests {
             &collection,
             Sample::DEFAULT_NAME,
             false,
+            &[],
         )
         .unwrap();
 
@@ -1220,6 +1229,7 @@ mod tests {
             &collection,
             Sample::DEFAULT_NAME,
             false,
+            &[],
         )
         .unwrap();
 
@@ -1276,6 +1286,7 @@ mod tests {
             &collection,
             Sample::DEFAULT_NAME,
             false,
+            &[],
         )
         .unwrap();
 
@@ -1315,6 +1326,7 @@ mod tests {
             &collection,
             Sample::DEFAULT_NAME,
             false,
+            &[],
         )
         .unwrap();
 
@@ -1366,6 +1378,7 @@ mod tests {
             &collection,
             Sample::DEFAULT_NAME,
             false,
+            &[],
         )
         .unwrap();
 
@@ -1432,6 +1445,7 @@ mod tests {
             &collection,
             Sample::DEFAULT_NAME,
             false,
+            &[],
         )
         .unwrap();
 
@@ -1525,6 +1539,7 @@ mod tests {
             &collection,
             "reference",
             false,
+            &[],
         )
         .unwrap();
 
@@ -1583,6 +1598,7 @@ mod tests {
             &collection,
             "parent-a",
             false,
+            &[],
         )
         .unwrap();
 
@@ -1592,6 +1608,7 @@ mod tests {
             &collection,
             "parent-b",
             false,
+            &[],
         )
         .unwrap();
 
@@ -1639,6 +1656,7 @@ mod tests {
             &collection,
             "reference",
             false,
+            &[],
         )
         .unwrap();
 

--- a/src/views/annotations.rs
+++ b/src/views/annotations.rs
@@ -1186,6 +1186,7 @@ mod tests {
             &collection,
             Sample::DEFAULT_NAME,
             false,
+            &[],
         )
         .unwrap();
         add_annotation(

--- a/src/views/gen_graph_widget.rs
+++ b/src/views/gen_graph_widget.rs
@@ -1099,6 +1099,7 @@ mod tests {
             collection,
             Sample::DEFAULT_NAME,
             false,
+            &[],
         )
         .unwrap();
         update_with_vcf(
@@ -1161,6 +1162,7 @@ mod tests {
             collection,
             Sample::DEFAULT_NAME,
             false,
+            &[],
         )
         .unwrap();
 

--- a/src/views/patch.rs
+++ b/src/views/patch.rs
@@ -208,7 +208,7 @@ mod tests {
             .join("fixtures/simple.fa")
             .to_string_lossy()
             .to_string();
-        let operation = import_fasta(context, &fixture_path, "default", sample, false)
+        let operation = import_fasta(context, &fixture_path, "default", sample, false, &[])
             .expect("should import the FASTA fixture");
         commit_operation_summary(context, &operation).expect("should commit the FASTA import");
     }


### PR DESCRIPTION
Redo of #255 

Utilized the previous asset index setup for fasta files. Resolves a handful of sequence churn from the last PR when index suppor wasn't quite there yet.

We need a follow up way to explicit add indices to asset refs for files where an index is added later.