### PR TITLE
Set up sccache on the Windows release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,6 +147,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
       - name: Install Dependencies
         run: choco install capnproto
       - name: Build


### PR DESCRIPTION
Completes a fix from the pip-cli PR series. Sscache wasn't installed properly in the windows build, it should be now. This wasn't caught by CI earlier because those builds only triggered on merge.