### PR TITLE
Sample diff command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -54,6 +54,28 @@ repeatable `--index <path-or-uri>` option. For example, a BGZF FASTA can use bot
 
 # View diff
 
+Compare one sequence graph between two samples with:
+
+```sh
+gen view <graph> --query <query> --base <base>
+```
+
+The base establishes the reference for the comparison. For example,
+`gen view m123 --query foo --base unknown` shows how `foo` differs from
+`unknown`. A sequence present only in the query is shown as an addition in
+green, while a sequence present only in the base is shown as a removal in red.
+Add `--full` to open the comparison in the full-screen viewer.
+
+To export a sample comparison as GFA, use the same endpoint names:
+
+```sh
+gen diff --query <query> --base <base> --gfa <output.gfa>
+```
+
+The older `--sample1` and `--sample2` names remain aliases for compatibility.
+
+## Revision diff
+
 Compare two commits or branches with:
 
 ```sh

--- a/gen-diff/src/graph.rs
+++ b/gen-diff/src/graph.rs
@@ -37,7 +37,7 @@
 //! A parent is selected only to make an added or removed child graph
 //! biologically meaningful. The changed rows would show a child's entire graph
 //! being removed or created. Thus, comparing to the parent shows the edits that
-//! introduced in the child. `load_block_group_stage_graphs` therefore
+//! introduced in the child. `load_block_group_comparison_graphs` therefore
 //! keeps two concepts separate:
 //!
 //! - `source_block_group` and `target_block_group` preserve actual membership
@@ -63,7 +63,7 @@
 //!
 //! # Graph-building approach
 //!
-//! Graph construction has three stages:
+//! Graph construction has three steps:
 //!
 //! 1. Load the selected endpoint edge sets and convert edge coordinates into
 //!    [`GraphNode`] sequence slices. Coordinates are slices of the backing
@@ -122,7 +122,7 @@ pub struct DiffChange {
 impl DiffChange {
     /// Creates the neutral annotation used for graph elements shared by both endpoints.
     ///
-    /// Stage builders and merge helpers use this constructor so unchanged
+    /// Input builders and merge helpers use this constructor so unchanged
     /// context has neither a change kind nor misleading operation attribution.
     pub const fn unchanged() -> Self {
         Self {
@@ -133,7 +133,7 @@ impl DiffChange {
 
     /// Creates an annotation from the change kind and attribution collected from Dolt.
     ///
-    /// Stage-graph construction uses this common constructor before the source
+    /// Input-graph construction uses this common constructor before the source
     /// and target annotations are consolidated into the rendered diff graph.
     pub const fn new(kind: DiffChangeKind, operation: Option<DoltHashId>) -> Self {
         Self { kind, operation }
@@ -265,7 +265,7 @@ pub(crate) struct BlockGroupDiffInputs<'a> {
 /// Builds the renderable diff for one block group identified by table-diff discovery.
 ///
 /// `build_dolt_operation_diff` calls this once per affected block group. It
-/// resolves normalized endpoint stage graphs, unifies them, and omits a
+/// resolves normalized endpoint input graphs, unifies them, and omits a
 /// source-and-target block group when the resulting graph has no visible
 /// changes, avoiding empty entries in command and TUI output.
 pub(crate) fn build_block_group_diff(
@@ -273,38 +273,39 @@ pub(crate) fn build_block_group_diff(
     block_group_id: HashId,
     inputs: &BlockGroupDiffInputs<'_>,
 ) -> Result<Option<BlockGroupDiff>, OperationDiffError> {
-    let Some(stage_graphs) = load_block_group_stage_graphs(graph_conn, block_group_id, inputs)?
+    let Some(comparison_graphs) =
+        load_block_group_comparison_graphs(graph_conn, block_group_id, inputs)?
     else {
         return Ok(None);
     };
-    let graph = build_unified_diff_graph(&stage_graphs, inputs.default_operation);
+    let graph = build_unified_diff_graph(&comparison_graphs, inputs.default_operation);
     if !diff_graph_has_changes(&graph)
-        && stage_graphs.source_block_group.is_some()
-        && stage_graphs.target_block_group.is_some()
+        && comparison_graphs.source_block_group.is_some()
+        && comparison_graphs.target_block_group.is_some()
     {
         return Ok(None);
     }
 
     Ok(Some(BlockGroupDiff {
         id: block_group_id,
-        source_block_group: stage_graphs.source_block_group,
-        target_block_group: stage_graphs.target_block_group,
+        source_block_group: comparison_graphs.source_block_group,
+        target_block_group: comparison_graphs.target_block_group,
         graph,
     }))
 }
 
-/// Loads comparable source and target stage graphs for one block-group diff.
+/// Loads comparable source and target input graphs for one block-group diff.
 ///
 /// `build_block_group_diff` uses this preparation step to keep endpoint
 /// membership separate from the lineage-aware graph chosen for display. It
 /// loads complete endpoint edges, filters copied child memberships, aligns
 /// sequence-slice boundaries, and attaches Dolt operation attribution because
 /// the unified builder needs matching graph units and real path membership.
-fn load_block_group_stage_graphs(
+fn load_block_group_comparison_graphs(
     graph_conn: &GraphConnection,
     block_group_id: HashId,
     inputs: &BlockGroupDiffInputs<'_>,
-) -> Result<Option<BlockGroupStageGraphs>, OperationDiffError> {
+) -> Result<Option<BlockGroupComparisonGraphs>, OperationDiffError> {
     let target_block_group =
         BlockGroup::get_by_id(graph_conn, &block_group_id, Some(inputs.target_ref)).ok();
     let source_block_group =
@@ -360,7 +361,7 @@ fn load_block_group_stage_graphs(
     //     target: A -> I -> B, plus internal edit-site marker edges
     //
     // The target endpoint tells us which path edges are real graph choices and
-    // lets the stage builder filter marker edges before rendering.
+    // lets the input builder filter marker edges before rendering.
     let source_edges = load_block_group_edges(
         graph_conn,
         source_effective_block_group_id,
@@ -378,9 +379,9 @@ fn load_block_group_stage_graphs(
         target_effective_block_group_id,
         target_effective_history_ref,
     );
-    let source_spans = stage_spans_from_edges(&source_edges);
-    let target_spans = stage_spans_from_edges(&target_edges);
-    let stage_operation_change_lookup = collect_stage_operation_change_lookup(
+    let source_spans = spans_from_edges(&source_edges);
+    let target_spans = spans_from_edges(&target_edges);
+    let operation_change_lookup = collect_input_operation_changes(
         block_group_id,
         inputs,
         &block_group_edge_changes,
@@ -388,23 +389,23 @@ fn load_block_group_stage_graphs(
         &target_spans,
     );
     let (source_nodes, target_nodes) =
-        split_stage_nodes_at_shared_boundaries(&source_spans, &target_spans);
-    let source_graph = build_stage_graph_from_nodes(
+        split_nodes_at_shared_boundaries(&source_spans, &target_spans);
+    let source_graph = build_diff_input_graph(
         source_nodes,
         &source_spans,
         &source_edges,
-        &stage_operation_change_lookup.source_node_operation_by_id,
-        &stage_operation_change_lookup.source_edge_operation_by_id,
+        &operation_change_lookup.source_node_operation_by_id,
+        &operation_change_lookup.source_edge_operation_by_id,
     );
-    let reconstructed_target_graph = build_stage_graph_from_nodes(
+    let reconstructed_target_graph = build_diff_input_graph(
         target_nodes,
         &target_spans,
         &target_edges,
-        &stage_operation_change_lookup.target_node_operation_by_id,
-        &stage_operation_change_lookup.target_edge_operation_by_id,
+        &operation_change_lookup.target_node_operation_by_id,
+        &operation_change_lookup.target_edge_operation_by_id,
     );
 
-    Ok(Some(BlockGroupStageGraphs {
+    Ok(Some(BlockGroupComparisonGraphs {
         source_block_group,
         target_block_group,
         source_graph,
@@ -414,9 +415,9 @@ fn load_block_group_stage_graphs(
 
 /// Loads all augmented path edges for an optional block group at one history ref.
 ///
-/// `load_block_group_stage_graphs` uses an empty vector for a genuinely missing
+/// `load_block_group_comparison_graphs` uses an empty vector for a genuinely missing
 /// endpoint and a complete edge set otherwise. Centralizing that choice keeps
-/// absence handling out of the span and stage-graph builders.
+/// absence handling out of the span and input-graph builders.
 fn load_block_group_edges(
     graph_conn: &GraphConnection,
     block_group_id: Option<HashId>,
@@ -429,11 +430,11 @@ fn load_block_group_edges(
 
 /// Derives the sequence slices covered by an endpoint's path edges.
 ///
-/// The stage loader uses these spans as lightweight graph nodes, pairing
+/// The input loader uses these spans as lightweight graph nodes, pairing
 /// observed entry and exit coordinates without fetching sequence text. This
 /// preserves enough endpoint membership for later normalization and rendering
 /// while keeping attribution attached to the original edges.
-fn stage_spans_from_edges(edges: &[AugmentedEdge]) -> HashSet<GraphNode> {
+fn spans_from_edges(edges: &[AugmentedEdge]) -> HashSet<GraphNode> {
     // A diff graph node only needs a backing node id and a sequence slice. Do
     // not call Edge::blocks_from_edges here: that query fetches sequence text
     // so GroupBlock::sequence can work, but the diff graph resolves sequence
@@ -486,7 +487,7 @@ fn stage_spans_from_edges(edges: &[AugmentedEdge]) -> HashSet<GraphNode> {
 
 /// Turns observed entry and exit coordinates into ordered sequence intervals.
 ///
-/// `stage_spans_from_edges` uses adjacent coordinates rather than graph-space
+/// `spans_from_edges` uses adjacent coordinates rather than graph-space
 /// positions because `GraphNode` ranges slice the backing sequence. The
 /// resulting intervals are the endpoint-local spans later split at shared
 /// source/target boundaries.
@@ -509,15 +510,15 @@ fn coordinate_spans(starts: &HashSet<i64>, ends: &HashSet<i64>) -> Vec<(i64, i64
 
 /// Normalizes endpoint nodes to the same sequence-slice boundaries.
 ///
-/// `load_block_group_stage_graphs` uses the paired result so the unified graph
+/// `load_block_group_comparison_graphs` uses the paired result so the unified graph
 /// can compare identical `GraphNode` keys. It takes the union of boundaries
 /// from both endpoints because an edit visible on only one side must still
 /// expose the corresponding slice on the other.
-fn split_stage_nodes_at_shared_boundaries(
+fn split_nodes_at_shared_boundaries(
     source_spans: &HashSet<GraphNode>,
     target_spans: &HashSet<GraphNode>,
 ) -> (HashSet<GraphNode>, HashSet<GraphNode>) {
-    let boundaries_by_node_id = collect_stage_boundaries(source_spans, target_spans);
+    let boundaries_by_node_id = collect_shared_boundaries(source_spans, target_spans);
     (
         split_spans_at_boundaries(source_spans, &boundaries_by_node_id),
         split_spans_at_boundaries(target_spans, &boundaries_by_node_id),
@@ -526,10 +527,10 @@ fn split_stage_nodes_at_shared_boundaries(
 
 /// Collects every endpoint boundary for each backing sequence node.
 ///
-/// `split_stage_nodes_at_shared_boundaries` uses this union as the shared cut
+/// `split_nodes_at_shared_boundaries` uses this union as the shared cut
 /// plan, ensuring source-only and target-only boundaries are applied
 /// symmetrically before graph elements are classified.
-fn collect_stage_boundaries(
+fn collect_shared_boundaries(
     source_spans: &HashSet<GraphNode>,
     target_spans: &HashSet<GraphNode>,
 ) -> HashMap<HashId, HashSet<i64>> {
@@ -608,7 +609,7 @@ fn split_spans_at_boundaries(
 
 /// Removes copied child-edge changes already represented by the effective source graph.
 ///
-/// `load_block_group_stage_graphs` uses this filter when a missing child
+/// `load_block_group_comparison_graphs` uses this filter when a missing child
 /// endpoint is displayed through its parent. Dolt reports the child's copied
 /// memberships as additions, but suppressing keys already in that parent keeps
 /// inherited paths from receiving false change attribution.
@@ -636,19 +637,19 @@ fn effective_edge_changes_for_source(
         .collect()
 }
 
-/// Builds endpoint-specific operation attribution for nodes and edges in one stage graph.
+/// Builds endpoint-specific operation attribution for nodes and edges in one input graph.
 ///
-/// `load_block_group_stage_graphs` passes this lookup to both stage builders.
+/// `load_block_group_comparison_graphs` passes this lookup to both input builders.
 /// It intersects Dolt changes with the block group's represented operations and
 /// endpoint membership so unrelated table rows do not color this graph.
-fn collect_stage_operation_change_lookup(
+fn collect_input_operation_changes(
     block_group_id: HashId,
     inputs: &BlockGroupDiffInputs<'_>,
     changed_edge_ids: &[BlockGroupEdgeChange],
     source_spans: &HashSet<GraphNode>,
     target_spans: &HashSet<GraphNode>,
-) -> StageOperationChangeLookup {
-    let mut change_lookup = StageOperationChangeLookup::default();
+) -> InputOperationChangeLookup {
+    let mut change_lookup = InputOperationChangeLookup::default();
     let Some(block_group_operations) = inputs.block_group_operations_by_id.get(&block_group_id)
     else {
         return change_lookup;
@@ -699,9 +700,9 @@ fn collect_stage_operation_change_lookup(
     change_lookup
 }
 
-/// Extracts non-terminal backing node IDs from a stage's sequence spans.
+/// Extracts non-terminal backing node IDs from an input's sequence spans.
 ///
-/// `collect_stage_operation_change_lookup` uses these sets to attribute a node
+/// `collect_input_operation_changes` uses these sets to attribute a node
 /// only when its membership actually changes between the two endpoint graphs.
 fn span_node_ids(spans: &HashSet<GraphNode>) -> HashSet<HashId> {
     spans
@@ -711,7 +712,7 @@ fn span_node_ids(spans: &HashSet<GraphNode>) -> HashSet<HashId> {
         .collect()
 }
 
-/// Unifies normalized endpoint stages into the connected graph rendered as a diff.
+/// Unifies normalized endpoint inputs into the connected graph rendered as a diff.
 ///
 /// `build_block_group_diff` uses this after endpoint loading, and focused graph
 /// tests exercise it directly. It unions node and edge identities, then merges
@@ -719,34 +720,44 @@ fn span_node_ids(spans: &HashSet<GraphNode>) -> HashSet<HashId> {
 /// the retained context and terminal structure are required by CLI and TUI
 /// layout while changed elements receive added, removed, or modified styling.
 pub(crate) fn build_unified_diff_graph(
-    stage_graphs: &BlockGroupStageGraphs,
+    comparison_graphs: &BlockGroupComparisonGraphs,
     default_operation: DoltHashId,
 ) -> DiffGenGraph {
-    let mut merged_nodes = stage_graphs
+    let mut merged_nodes = comparison_graphs
         .source_graph
         .node_changes
         .keys()
-        .chain(stage_graphs.reconstructed_target_graph.node_changes.keys())
+        .chain(
+            comparison_graphs
+                .reconstructed_target_graph
+                .node_changes
+                .keys(),
+        )
         .copied()
         .collect::<Vec<_>>();
     merged_nodes.sort();
     merged_nodes.dedup();
 
-    let mut merged_edge_keys = stage_graphs
+    let mut merged_edge_keys = comparison_graphs
         .source_graph
         .edge_changes
         .keys()
-        .chain(stage_graphs.reconstructed_target_graph.edge_changes.keys())
+        .chain(
+            comparison_graphs
+                .reconstructed_target_graph
+                .edge_changes
+                .keys(),
+        )
         .copied()
         .collect::<Vec<_>>();
     merged_edge_keys.sort();
     merged_edge_keys.dedup();
-    let source_edge_pairs = annotated_edge_pairs(&stage_graphs.source_graph);
-    let target_edge_pairs = annotated_edge_pairs(&stage_graphs.reconstructed_target_graph);
+    let source_edge_pairs = annotated_edge_pairs(&comparison_graphs.source_graph);
+    let target_edge_pairs = annotated_edge_pairs(&comparison_graphs.reconstructed_target_graph);
 
     let mut diff_graph = DiffGenGraph::new();
     for node in merged_nodes {
-        diff_graph.add_node(diff_graph_node(node, stage_graphs, default_operation));
+        diff_graph.add_node(diff_graph_node(node, comparison_graphs, default_operation));
     }
 
     let mut merged_edges_by_node_pair = HashMap::<(GraphNode, GraphNode), Vec<GraphEdgeKey>>::new();
@@ -759,22 +770,22 @@ pub(crate) fn build_unified_diff_graph(
     let mut merged_edge_pairs = merged_edges_by_node_pair.into_iter().collect::<Vec<_>>();
     merged_edge_pairs.sort_by_key(|((source, target), _)| (*source, *target));
     for ((source, target), edge_keys) in merged_edge_pairs {
-        let source_node = diff_graph_node(source, stage_graphs, default_operation);
-        let target_node = diff_graph_node(target, stage_graphs, default_operation);
+        let source_node = diff_graph_node(source, comparison_graphs, default_operation);
+        let target_node = diff_graph_node(target, comparison_graphs, default_operation);
         let unchanged_endpoints = source_node.change.kind == DiffChangeKind::Unchanged
             && target_node.change.kind == DiffChangeKind::Unchanged;
         let diff_edges = edge_keys
             .iter()
             .copied()
             .map(|edge_key| DiffGraphEdge {
-                edge: graph_edge_for_key(stage_graphs, edge_key),
-                change: merge_edge_stage_changes(
-                    stage_graphs
+                edge: graph_edge_for_key(comparison_graphs, edge_key),
+                change: merge_input_edge_changes(
+                    comparison_graphs
                         .source_graph
                         .edge_changes
                         .get(&edge_key)
                         .copied(),
-                    stage_graphs
+                    comparison_graphs
                         .reconstructed_target_graph
                         .edge_changes
                         .get(&edge_key)
@@ -815,18 +826,22 @@ fn diff_graph_has_changes(graph: &DiffGenGraph) -> bool {
 /// styling share the same presence and attribution rules.
 fn diff_graph_node(
     node: GraphNode,
-    stage_graphs: &BlockGroupStageGraphs,
+    comparison_graphs: &BlockGroupComparisonGraphs,
     default_operation: DoltHashId,
 ) -> DiffGraphNode {
-    let source_change = stage_graphs.source_graph.node_changes.get(&node).copied();
-    let target_change = stage_graphs
+    let source_change = comparison_graphs
+        .source_graph
+        .node_changes
+        .get(&node)
+        .copied();
+    let target_change = comparison_graphs
         .reconstructed_target_graph
         .node_changes
         .get(&node)
         .copied();
     DiffGraphNode {
         node,
-        change: merge_stage_changes(source_change, target_change, default_operation),
+        change: merge_input_changes(source_change, target_change, default_operation),
     }
 }
 
@@ -836,8 +851,8 @@ fn diff_graph_node(
 /// different edge identity. Comparing pairs as well as complete edge keys lets
 /// the renderer describe that case as modification instead of unrelated
 /// removal and addition.
-fn annotated_edge_pairs(stage_graph: &AnnotatedStageGraph) -> HashSet<(GraphNode, GraphNode)> {
-    stage_graph
+fn annotated_edge_pairs(input_graph: &DiffInputGraph) -> HashSet<(GraphNode, GraphNode)> {
+    input_graph
         .edge_changes
         .keys()
         .map(GraphEdgeKey::node_pair)
@@ -848,24 +863,27 @@ fn annotated_edge_pairs(stage_graph: &AnnotatedStageGraph) -> HashSet<(GraphNode
 ///
 /// `build_unified_diff_graph` prefers the target copy so current metadata is
 /// rendered, then falls back to the source for removed edges. The key was
-/// collected from one of those stages, so absence from both is an invariant
+/// collected from one of those inputs, so absence from both is an invariant
 /// violation.
-fn graph_edge_for_key(stage_graphs: &BlockGroupStageGraphs, edge_key: GraphEdgeKey) -> GraphEdge {
-    stage_graph_edge_for_key(&stage_graphs.reconstructed_target_graph, edge_key)
-        .or_else(|| stage_graph_edge_for_key(&stage_graphs.source_graph, edge_key))
+fn graph_edge_for_key(
+    comparison_graphs: &BlockGroupComparisonGraphs,
+    edge_key: GraphEdgeKey,
+) -> GraphEdge {
+    input_graph_edge_for_key(&comparison_graphs.reconstructed_target_graph, edge_key)
+        .or_else(|| input_graph_edge_for_key(&comparison_graphs.source_graph, edge_key))
         .expect("should contain graph edge for merged diff key")
 }
 
-/// Finds the exact edge for a key within one annotated stage graph.
+/// Finds the exact edge for a key within one annotated input graph.
 ///
 /// `graph_edge_for_key` uses this helper because `GenGraph` stores multiple
 /// edges per node pair. Matching the identity fields selects the edge whose
 /// change annotation participated in the unified key set.
-fn stage_graph_edge_for_key(
-    stage_graph: &AnnotatedStageGraph,
+fn input_graph_edge_for_key(
+    input_graph: &DiffInputGraph,
     edge_key: GraphEdgeKey,
 ) -> Option<GraphEdge> {
-    stage_graph
+    input_graph
         .graph
         .edge_weight(edge_key.source, edge_key.target)?
         .iter()
@@ -877,9 +895,9 @@ fn stage_graph_edge_for_key(
 ///
 /// Unified-node construction and the default edge path use this function.
 /// Presence on only one side determines addition or removal; elements on both
-/// sides become modified only when either stage carries change metadata, which
+/// sides become modified only when either input carries change metadata, which
 /// keeps shared layout context neutral.
-fn merge_stage_changes(
+fn merge_input_changes(
     source_change: Option<DiffChange>,
     target_change: Option<DiffChange>,
     default_operation: DoltHashId,
@@ -924,13 +942,13 @@ fn merge_stage_changes(
     }
 }
 
-/// Applies edge-specific reconciliation on top of the general stage rules.
+/// Applies edge-specific reconciliation on top of the general input rules.
 ///
 /// `build_unified_diff_graph` uses endpoint-pair membership and node status to
 /// distinguish real path changes from neutral continuation edges introduced by
 /// normalization. This prevents insertions from coloring surviving context as
 /// removed while still exposing deletions and edge replacements.
-fn merge_edge_stage_changes(
+fn merge_input_edge_changes(
     source_change: Option<DiffChange>,
     target_change: Option<DiffChange>,
     edge_has_unchanged_endpoints: bool,
@@ -958,14 +976,14 @@ fn merge_edge_stage_changes(
             merge_pair_matched_edge_change(change, default_operation)
         }
         (source_change, target_change) => {
-            merge_stage_changes(source_change, target_change, default_operation)
+            merge_input_changes(source_change, target_change, default_operation)
         }
     }
 }
 
 /// Classifies a one-sided edge as a replacement when its node pair survives.
 ///
-/// `merge_edge_stage_changes` uses this for edge-identity churn between the
+/// `merge_input_edge_changes` uses this for edge-identity churn between the
 /// same normalized endpoints. Promoting attributed changes to `Modified`
 /// avoids rendering one biological connection as an unrelated add/remove pair.
 fn merge_pair_matched_edge_change(change: DiffChange, default_operation: DoltHashId) -> DiffChange {
@@ -982,7 +1000,7 @@ fn merge_pair_matched_edge_change(change: DiffChange, default_operation: DoltHas
 
 /// Creates an attributed non-neutral change, filling missing Dolt attribution.
 ///
-/// Stage and edge merge helpers use the comparison's default operation so
+/// Input and edge merge helpers use the comparison's default operation so
 /// every colored element can be grouped by operation in downstream views.
 fn changed(
     kind: DiffChangeKind,
@@ -992,27 +1010,27 @@ fn changed(
     DiffChange::new(kind, Some(operation.unwrap_or(default_operation)))
 }
 
-/// Builds one endpoint's connected, annotated stage graph from normalized nodes.
+/// Builds one endpoint's connected, annotated input graph from normalized nodes.
 ///
-/// `load_block_group_stage_graphs` uses this for both endpoints, while graph
+/// `load_block_group_comparison_graphs` uses this for both endpoints, while graph
 /// reconstruction tests call it directly. It maps persisted edges onto exact
 /// sequence-slice boundaries, drops edit-site markers that are not path
 /// choices, adds terminal and within-span continuation topology for layout, and
 /// records operation attribution separately for later source/target merging.
-pub(crate) fn build_stage_graph_from_nodes(
-    mut stage_nodes: HashSet<GraphNode>,
+pub(crate) fn build_diff_input_graph(
+    mut input_nodes: HashSet<GraphNode>,
     continuation_spans: &HashSet<GraphNode>,
-    stage_edges: &[AugmentedEdge],
+    input_edges: &[AugmentedEdge],
     node_operations_by_id: &HashMap<HashId, DoltHashId>,
     edge_operations_by_id: &HashMap<HashId, DoltHashId>,
-) -> AnnotatedStageGraph {
+) -> DiffInputGraph {
     let mut graph = GenGraph::new();
     let mut node_changes = HashMap::new();
     let mut edge_changes = HashMap::new();
 
-    stage_nodes.insert(path_start_graph_node());
-    stage_nodes.insert(path_end_graph_node());
-    for node in &stage_nodes {
+    input_nodes.insert(path_start_graph_node());
+    input_nodes.insert(path_end_graph_node());
+    for node in &input_nodes {
         graph.add_node(*node);
         node_changes.insert(
             *node,
@@ -1024,16 +1042,16 @@ pub(crate) fn build_stage_graph_from_nodes(
         );
     }
 
-    let blocks_by_start = stage_nodes
+    let blocks_by_start = input_nodes
         .iter()
         .map(|node| ((node.node_id, node.sequence_start), *node))
         .collect::<HashMap<_, _>>();
-    let blocks_by_end = stage_nodes
+    let blocks_by_end = input_nodes
         .iter()
         .map(|node| ((node.node_id, node.sequence_end), *node))
         .collect::<HashMap<_, _>>();
 
-    for augmented_edge in stage_edges {
+    for augmented_edge in input_edges {
         // Edit-site marker edges preserve coordinates for later graph
         // operations. They are not path choices, so rendering them as diff
         // edges makes inserted/deleted sequence look unchanged.
@@ -1078,23 +1096,23 @@ pub(crate) fn build_stage_graph_from_nodes(
     }
 
     add_continuation_edges(
-        &stage_nodes,
+        &input_nodes,
         continuation_spans,
         &mut graph,
         &mut edge_changes,
     );
-    remove_unconnected_stage_nodes(&mut graph, &mut node_changes);
+    remove_unconnected_input_nodes(&mut graph, &mut node_changes);
 
-    AnnotatedStageGraph {
+    DiffInputGraph {
         graph,
         node_changes,
         edge_changes,
     }
 }
 
-/// Returns the canonical start terminal used in every stage and unified graph.
+/// Returns the canonical start terminal used in every input and unified graph.
 ///
-/// The stage builder and graph-layout tests use this shared value so endpoint
+/// The input builder and graph-layout tests use this shared value so endpoint
 /// graphs remain connected to the same synthetic path boundary.
 pub(crate) fn path_start_graph_node() -> GraphNode {
     GraphNode {
@@ -1104,9 +1122,9 @@ pub(crate) fn path_start_graph_node() -> GraphNode {
     }
 }
 
-/// Returns the canonical end terminal used in every stage and unified graph.
+/// Returns the canonical end terminal used in every input and unified graph.
 ///
-/// The stage builder and graph-layout tests use this shared value so endpoint
+/// The input builder and graph-layout tests use this shared value so endpoint
 /// graphs remain connected to the same synthetic path boundary.
 pub(crate) fn path_end_graph_node() -> GraphNode {
     GraphNode {
@@ -1118,12 +1136,12 @@ pub(crate) fn path_end_graph_node() -> GraphNode {
 
 /// Reconnects normalized slices that came from one continuous endpoint span.
 ///
-/// `build_stage_graph_from_nodes` invokes this after mapping persisted edges.
+/// `build_diff_input_graph` invokes this after mapping persisted edges.
 /// It adds neutral synthetic edges only between adjacent slices covered by the
 /// same original span, preserving renderable connectivity without bridging
 /// genuine deletions or endpoint gaps.
 fn add_continuation_edges(
-    stage_nodes: &HashSet<GraphNode>,
+    input_nodes: &HashSet<GraphNode>,
     continuation_spans: &HashSet<GraphNode>,
     graph: &mut GenGraph,
     edge_changes: &mut HashMap<GraphEdgeKey, DiffChange>,
@@ -1146,7 +1164,7 @@ fn add_continuation_edges(
         if is_terminal(span.node_id) || span.sequence_start == span.sequence_end {
             continue;
         }
-        let mut nodes = stage_nodes
+        let mut nodes = input_nodes
             .iter()
             .copied()
             .filter(|node| {
@@ -1195,11 +1213,11 @@ fn add_continuation_edges(
 
 /// Removes non-terminal slices that no mapped or continuation edge reaches.
 ///
-/// `build_stage_graph_from_nodes` uses this cleanup after edge construction.
+/// `build_diff_input_graph` uses this cleanup after edge construction.
 /// Coordinate normalization can produce candidate slices unsupported by actual
 /// endpoint topology; pruning them keeps the unified graph from displaying
 /// isolated artifacts while retaining terminal anchors.
-fn remove_unconnected_stage_nodes(
+fn remove_unconnected_input_nodes(
     graph: &mut GenGraph,
     node_changes: &mut HashMap<GraphNode, DiffChange>,
 ) {
@@ -1232,7 +1250,7 @@ pub(crate) struct GraphEdgeKey {
 impl GraphEdgeKey {
     /// Creates the stable edge identity used to union and annotate endpoint graphs.
     ///
-    /// Stage construction and continuation-edge insertion use this key instead
+    /// Input construction and continuation-edge insertion use this key instead
     /// of the full persisted record so volatile `created_on` metadata does not
     /// turn an otherwise identical connection into a structural diff.
     pub(crate) fn new(source: GraphNode, target: GraphNode, edge: GraphEdge) -> Self {
@@ -1257,7 +1275,7 @@ impl GraphEdgeKey {
 
     /// Tests whether a concrete edge has the structural identity represented by this key.
     ///
-    /// `stage_graph_edge_for_key` uses this after selecting a node pair because
+    /// `input_graph_edge_for_key` uses this after selecting a node pair because
     /// a `GenGraph` edge weight may contain multiple parallel edges.
     fn matches_edge(self, edge: GraphEdge) -> bool {
         self.edge_id == edge.edge_id
@@ -1268,21 +1286,21 @@ impl GraphEdgeKey {
     }
 }
 
-pub(crate) struct BlockGroupStageGraphs {
+pub(crate) struct BlockGroupComparisonGraphs {
     pub(crate) source_block_group: Option<BlockGroup>,
     pub(crate) target_block_group: Option<BlockGroup>,
-    pub(crate) source_graph: AnnotatedStageGraph,
-    pub(crate) reconstructed_target_graph: AnnotatedStageGraph,
+    pub(crate) source_graph: DiffInputGraph,
+    pub(crate) reconstructed_target_graph: DiffInputGraph,
 }
 
-pub(crate) struct AnnotatedStageGraph {
+pub(crate) struct DiffInputGraph {
     pub(crate) graph: GenGraph,
     pub(crate) node_changes: HashMap<GraphNode, DiffChange>,
     pub(crate) edge_changes: HashMap<GraphEdgeKey, DiffChange>,
 }
 
 #[derive(Debug, Default)]
-struct StageOperationChangeLookup {
+struct InputOperationChangeLookup {
     source_node_operation_by_id: HashMap<HashId, DoltHashId>,
     target_node_operation_by_id: HashMap<HashId, DoltHashId>,
     source_edge_operation_by_id: HashMap<HashId, DoltHashId>,
@@ -1332,7 +1350,7 @@ mod tests {
     }
 
     #[test]
-    fn test_split_stage_nodes_at_shared_boundaries_exposes_removed_slice() {
+    fn test_split_nodes_at_shared_boundaries_exposes_removed_slice() {
         let node_id = HashId::convert_str("reference-node");
         let source_spans = HashSet::from([GraphNode {
             node_id,
@@ -1353,7 +1371,7 @@ mod tests {
         ]);
 
         let (source_nodes, target_nodes) =
-            split_stage_nodes_at_shared_boundaries(&source_spans, &target_spans);
+            split_nodes_at_shared_boundaries(&source_spans, &target_spans);
         let removed_slice = GraphNode {
             node_id,
             sequence_start: 3,

--- a/gen-diff/src/graph.rs
+++ b/gen-diff/src/graph.rs
@@ -1,12 +1,12 @@
 //! Builds a connected, renderable graph describing changes between two states.
 //!
 //! This module is the graph-construction half of `gen-diff`.
-//! [`crate::operations`] first uses Dolt's table-diff functions to find affected
-//! block groups, edges, and nodes and to associate those rows with operations.
-//! It then calls `build_block_group_diff` for each affected block-group ID.
-//! The resulting [`BlockGroupDiff`] is consumed by the CLI, patch preview,
-//! GenHub, and the diff TUI to show unchanged context together with added,
-//! removed, and modified graph elements.
+//! [`crate::operations`] uses Dolt's table-diff functions to find affected block
+//! groups, edges, and nodes and associate those rows with operations. This module
+//! handles the boundary normalization, input construction, and graph unification.
+//! The resulting graph is consumed by the CLI, patch preview, GenHub, and the
+//! diff TUI to show unchanged context together with added, removed, and modified
+//! graph elements.
 //!
 //! # Source and target terminology
 //!
@@ -37,7 +37,7 @@
 //! A parent is selected only to make an added or removed child graph
 //! biologically meaningful. The changed rows would show a child's entire graph
 //! being removed or created. Thus, comparing to the parent shows the edits that
-//! introduced in the child. `load_block_group_comparison_graphs` therefore
+//! introduced in the child. `build_block_group_comparison` therefore
 //! keeps two concepts separate:
 //!
 //! - `source_block_group` and `target_block_group` preserve actual membership
@@ -78,7 +78,7 @@
 //!    [`DiffChange`]. Start/end nodes and unchanged context remain in the result
 //!    because the renderer needs a connected graph for layout.
 //!
-//! Loading both endpoint graphs makes path membership and marker filtering
+//! Loading both endpoint edge sets makes path membership and marker filtering
 //! straightforward. An alternative is to load the baseline once and apply the
 //! `block_group_edges` diff rows to reconstruct the changed graph; the copied
 //! child rows are sufficient for that and it may be preferable if endpoint
@@ -111,6 +111,20 @@ pub enum DiffChangeKind {
     Added,
     Removed,
     Modified,
+}
+
+/// Records whether an input edge came from storage or graph normalization.
+///
+/// An explicit edge represents path topology stored for a block group, so its
+/// presence is explicitly introduced. A continuation edge is created only to
+/// reconnect adjacent slices after a shared comparison boundary splits a stored
+/// span. This lets us mark these edges as not part of a diff.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum EdgeOrigin {
+    /// A real path edge loaded from the block group's stored edge membership.
+    Explicit,
+    /// A synthetic connection between slices of one originally continuous span.
+    Continuation,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
@@ -262,6 +276,42 @@ pub(crate) struct BlockGroupDiffInputs<'a> {
     pub(crate) node_changes: &'a [NodeChange],
 }
 
+/// When carrying out a diff based purely on edges.
+pub(crate) struct EdgeDiffInput<'a> {
+    edges: &'a [AugmentedEdge],
+    spans: HashSet<GraphNode>,
+    node_operations_by_id: Option<&'a HashMap<HashId, DoltHashId>>,
+    edge_operations_by_id: Option<&'a HashMap<HashId, DoltHashId>>,
+}
+
+impl<'a> EdgeDiffInput<'a> {
+    /// Creates an input whose changes have no operation attribution.
+    pub(crate) fn unattributed(edges: &'a [AugmentedEdge]) -> Self {
+        Self {
+            edges,
+            spans: spans_from_edges(edges),
+            node_operations_by_id: None,
+            edge_operations_by_id: None,
+        }
+    }
+
+    /// Attaches operation attribution after callers have used the cached spans.
+    pub(crate) fn with_attribution(
+        mut self,
+        node_operations_by_id: &'a HashMap<HashId, DoltHashId>,
+        edge_operations_by_id: &'a HashMap<HashId, DoltHashId>,
+    ) -> Self {
+        self.node_operations_by_id = Some(node_operations_by_id);
+        self.edge_operations_by_id = Some(edge_operations_by_id);
+        self
+    }
+
+    /// Returns the cached sequence spans represented by this input's edges.
+    pub(crate) fn spans(&self) -> &HashSet<GraphNode> {
+        &self.spans
+    }
+}
+
 /// Builds the renderable diff for one block group identified by table-diff discovery.
 ///
 /// `build_dolt_operation_diff` calls this once per affected block group. It
@@ -273,39 +323,36 @@ pub(crate) fn build_block_group_diff(
     block_group_id: HashId,
     inputs: &BlockGroupDiffInputs<'_>,
 ) -> Result<Option<BlockGroupDiff>, OperationDiffError> {
-    let Some(comparison_graphs) =
-        load_block_group_comparison_graphs(graph_conn, block_group_id, inputs)?
-    else {
+    let Some(comparison) = build_block_group_comparison(graph_conn, block_group_id, inputs)? else {
         return Ok(None);
     };
-    let graph = build_unified_diff_graph(&comparison_graphs, inputs.default_operation);
-    if !diff_graph_has_changes(&graph)
-        && comparison_graphs.source_block_group.is_some()
-        && comparison_graphs.target_block_group.is_some()
+    if !diff_graph_has_changes(&comparison.graph)
+        && comparison.source_block_group.is_some()
+        && comparison.target_block_group.is_some()
     {
         return Ok(None);
     }
 
     Ok(Some(BlockGroupDiff {
         id: block_group_id,
-        source_block_group: comparison_graphs.source_block_group,
-        target_block_group: comparison_graphs.target_block_group,
-        graph,
+        source_block_group: comparison.source_block_group,
+        target_block_group: comparison.target_block_group,
+        graph: comparison.graph,
     }))
 }
 
-/// Loads comparable source and target input graphs for one block-group diff.
+/// Builds a comparable graph while retaining block-group endpoint membership.
 ///
 /// `build_block_group_diff` uses this preparation step to keep endpoint
 /// membership separate from the lineage-aware graph chosen for display. It
 /// loads complete endpoint edges, filters copied child memberships, aligns
 /// sequence-slice boundaries, and attaches Dolt operation attribution because
 /// the unified builder needs matching graph units and real path membership.
-fn load_block_group_comparison_graphs(
+fn build_block_group_comparison(
     graph_conn: &GraphConnection,
     block_group_id: HashId,
     inputs: &BlockGroupDiffInputs<'_>,
-) -> Result<Option<BlockGroupComparisonGraphs>, OperationDiffError> {
+) -> Result<Option<BlockGroupComparison>, OperationDiffError> {
     let target_block_group =
         BlockGroup::get_by_id(graph_conn, &block_group_id, Some(inputs.target_ref)).ok();
     let source_block_group =
@@ -379,43 +426,37 @@ fn load_block_group_comparison_graphs(
         target_effective_block_group_id,
         target_effective_history_ref,
     );
-    let source_spans = spans_from_edges(&source_edges);
-    let target_spans = spans_from_edges(&target_edges);
+    let source_input = EdgeDiffInput::unattributed(&source_edges);
+    let target_input = EdgeDiffInput::unattributed(&target_edges);
     let operation_change_lookup = collect_input_operation_changes(
         block_group_id,
         inputs,
         &block_group_edge_changes,
-        &source_spans,
-        &target_spans,
+        source_input.spans(),
+        target_input.spans(),
     );
-    let (source_nodes, target_nodes) =
-        split_nodes_at_shared_boundaries(&source_spans, &target_spans);
-    let source_graph = build_diff_input_graph(
-        source_nodes,
-        &source_spans,
-        &source_edges,
-        &operation_change_lookup.source_node_operation_by_id,
-        &operation_change_lookup.source_edge_operation_by_id,
-    );
-    let reconstructed_target_graph = build_diff_input_graph(
-        target_nodes,
-        &target_spans,
-        &target_edges,
-        &operation_change_lookup.target_node_operation_by_id,
-        &operation_change_lookup.target_edge_operation_by_id,
+    let graph = build_diff_graph_from_edges(
+        source_input.with_attribution(
+            &operation_change_lookup.source_node_operation_by_id,
+            &operation_change_lookup.source_edge_operation_by_id,
+        ),
+        target_input.with_attribution(
+            &operation_change_lookup.target_node_operation_by_id,
+            &operation_change_lookup.target_edge_operation_by_id,
+        ),
+        Some(inputs.default_operation),
     );
 
-    Ok(Some(BlockGroupComparisonGraphs {
+    Ok(Some(BlockGroupComparison {
         source_block_group,
         target_block_group,
-        source_graph,
-        reconstructed_target_graph,
+        graph,
     }))
 }
 
 /// Loads all augmented path edges for an optional block group at one history ref.
 ///
-/// `load_block_group_comparison_graphs` uses an empty vector for a genuinely missing
+/// `build_block_group_comparison` uses an empty vector for a genuinely missing
 /// endpoint and a complete edge set otherwise. Centralizing that choice keeps
 /// absence handling out of the span and input-graph builders.
 fn load_block_group_edges(
@@ -428,12 +469,42 @@ fn load_block_group_edges(
     })
 }
 
+/// Builds a graph diff from two complete edge sets.
+///
+/// Both inputs use one shared sequence-boundary plan so their normalized
+/// `GraphNode` slices are directly comparable. Callers may attach operation
+/// attribution to either input; elements present only in the query are added,
+/// while elements present only in the base are removed.
+pub(crate) fn build_diff_graph_from_edges(
+    base: EdgeDiffInput<'_>,
+    query: EdgeDiffInput<'_>,
+    default_operation: Option<DoltHashId>,
+) -> DiffGenGraph {
+    let (base_nodes, query_nodes) = split_nodes_at_shared_boundaries(base.spans(), query.spans());
+    // This is a failback case where no operations are provided. Edge sets can be input directly
+    // to get a diff from and not have operations associated with the changes.
+    let no_operations = HashMap::new();
+    let base_graph = build_diff_input_graph(
+        base_nodes,
+        base.spans(),
+        base.edges,
+        base.node_operations_by_id.unwrap_or(&no_operations),
+        base.edge_operations_by_id.unwrap_or(&no_operations),
+    );
+    let query_graph = build_diff_input_graph(
+        query_nodes,
+        query.spans(),
+        query.edges,
+        query.node_operations_by_id.unwrap_or(&no_operations),
+        query.edge_operations_by_id.unwrap_or(&no_operations),
+    );
+    build_unified_diff_graph(&base_graph, &query_graph, default_operation)
+}
+
 /// Derives the sequence slices covered by an endpoint's path edges.
 ///
-/// The input loader uses these spans as lightweight graph nodes, pairing
-/// observed entry and exit coordinates without fetching sequence text. This
-/// preserves enough endpoint membership for later normalization and rendering
-/// while keeping attribution attached to the original edges.
+/// This methods exists because blocks_from_edges because loads sequences, which
+/// can add quite a bit of overhead.
 fn spans_from_edges(edges: &[AugmentedEdge]) -> HashSet<GraphNode> {
     // A diff graph node only needs a backing node id and a sequence slice. Do
     // not call Edge::blocks_from_edges here: that query fetches sequence text
@@ -510,10 +581,10 @@ fn coordinate_spans(starts: &HashSet<i64>, ends: &HashSet<i64>) -> Vec<(i64, i64
 
 /// Normalizes endpoint nodes to the same sequence-slice boundaries.
 ///
-/// `load_block_group_comparison_graphs` uses the paired result so the unified graph
-/// can compare identical `GraphNode` keys. It takes the union of boundaries
-/// from both endpoints because an edit visible on only one side must still
-/// expose the corresponding slice on the other.
+/// See `split_spans_at_boundaries` for a real explanation of what this does.
+/// It essentially converts nodes so they can be compared across graphs, such as
+/// the source graph having N[0:10] and target having N[0-3] -> N[6-10]. This converts
+/// it to: N[0-3], N[3-6], N[6-10] so additions/removals can be properly described
 fn split_nodes_at_shared_boundaries(
     source_spans: &HashSet<GraphNode>,
     target_spans: &HashSet<GraphNode>,
@@ -609,7 +680,7 @@ fn split_spans_at_boundaries(
 
 /// Removes copied child-edge changes already represented by the effective source graph.
 ///
-/// `load_block_group_comparison_graphs` uses this filter when a missing child
+/// `build_block_group_comparison` uses this filter when a missing child
 /// endpoint is displayed through its parent. Dolt reports the child's copied
 /// memberships as additions, but suppressing keys already in that parent keeps
 /// inherited paths from receiving false change attribution.
@@ -637,9 +708,9 @@ fn effective_edge_changes_for_source(
         .collect()
 }
 
-/// Builds endpoint-specific operation attribution for nodes and edges in one input graph.
+/// Builds endpoint-specific operation attribution for nodes and edges in each input graph.
 ///
-/// `load_block_group_comparison_graphs` passes this lookup to both input builders.
+/// `build_block_group_comparison` attaches this lookup to both edge inputs.
 /// It intersects Dolt changes with the block group's represented operations and
 /// endpoint membership so unrelated table rows do not color this graph.
 fn collect_input_operation_changes(
@@ -712,52 +783,35 @@ fn span_node_ids(spans: &HashSet<GraphNode>) -> HashSet<HashId> {
         .collect()
 }
 
-/// Unifies normalized endpoint inputs into the connected graph rendered as a diff.
+/// Unifies normalized inputs into the connected graph rendered as a diff.
 ///
-/// `build_block_group_diff` uses this after endpoint loading, and focused graph
-/// tests exercise it directly. It unions node and edge identities, then merges
-/// presence and operation annotations instead of discarding unchanged context;
-/// the retained context and terminal structure are required by CLI and TUI
-/// layout while changed elements receive added, removed, or modified styling.
+/// Combines both inputs into one graph, marking nodes and edges as added,
+/// removed, modified, or unchanged. Unchanged nodes and edges, including the
+/// start and end nodes, remain so the CLI and TUI can display changes in
+/// context.
 pub(crate) fn build_unified_diff_graph(
-    comparison_graphs: &BlockGroupComparisonGraphs,
-    default_operation: DoltHashId,
+    source_graph: &DiffInputGraph,
+    target_graph: &DiffInputGraph,
+    default_operation: Option<DoltHashId>,
 ) -> DiffGenGraph {
-    let mut merged_nodes = comparison_graphs
-        .source_graph
-        .node_changes
-        .keys()
-        .chain(
-            comparison_graphs
-                .reconstructed_target_graph
-                .node_changes
-                .keys(),
-        )
-        .copied()
-        .collect::<Vec<_>>();
-    merged_nodes.sort();
-    merged_nodes.dedup();
+    let merged_nodes = source_graph
+        .nodes()
+        .chain(target_graph.nodes())
+        .collect::<HashSet<_>>();
 
-    let mut merged_edge_keys = comparison_graphs
-        .source_graph
-        .edge_changes
-        .keys()
-        .chain(
-            comparison_graphs
-                .reconstructed_target_graph
-                .edge_changes
-                .keys(),
-        )
-        .copied()
-        .collect::<Vec<_>>();
-    merged_edge_keys.sort();
-    merged_edge_keys.dedup();
-    let source_edge_pairs = annotated_edge_pairs(&comparison_graphs.source_graph);
-    let target_edge_pairs = annotated_edge_pairs(&comparison_graphs.reconstructed_target_graph);
-
+    let merged_edge_keys = source_graph
+        .edges()
+        .map(|(edge_key, _)| edge_key)
+        .chain(target_graph.edges().map(|(edge_key, _)| edge_key))
+        .collect::<HashSet<_>>();
     let mut diff_graph = DiffGenGraph::new();
     for node in merged_nodes {
-        diff_graph.add_node(diff_graph_node(node, comparison_graphs, default_operation));
+        diff_graph.add_node(diff_graph_node(
+            node,
+            source_graph,
+            target_graph,
+            default_operation,
+        ));
     }
 
     let mut merged_edges_by_node_pair = HashMap::<(GraphNode, GraphNode), Vec<GraphEdgeKey>>::new();
@@ -770,29 +824,16 @@ pub(crate) fn build_unified_diff_graph(
     let mut merged_edge_pairs = merged_edges_by_node_pair.into_iter().collect::<Vec<_>>();
     merged_edge_pairs.sort_by_key(|((source, target), _)| (*source, *target));
     for ((source, target), edge_keys) in merged_edge_pairs {
-        let source_node = diff_graph_node(source, comparison_graphs, default_operation);
-        let target_node = diff_graph_node(target, comparison_graphs, default_operation);
-        let unchanged_endpoints = source_node.change.kind == DiffChangeKind::Unchanged
-            && target_node.change.kind == DiffChangeKind::Unchanged;
+        let source_node = diff_graph_node(source, source_graph, target_graph, default_operation);
+        let target_node = diff_graph_node(target, source_graph, target_graph, default_operation);
         let diff_edges = edge_keys
             .iter()
             .copied()
             .map(|edge_key| DiffGraphEdge {
-                edge: graph_edge_for_key(comparison_graphs, edge_key),
+                edge: graph_edge_for_key(source_graph, target_graph, edge_key),
                 change: merge_input_edge_changes(
-                    comparison_graphs
-                        .source_graph
-                        .edge_changes
-                        .get(&edge_key)
-                        .copied(),
-                    comparison_graphs
-                        .reconstructed_target_graph
-                        .edge_changes
-                        .get(&edge_key)
-                        .copied(),
-                    unchanged_endpoints,
-                    source_edge_pairs.contains(&(source, target)),
-                    target_edge_pairs.contains(&(source, target)),
+                    source_graph.edge_metadata(edge_key),
+                    target_graph.edge_metadata(edge_key),
                     default_operation,
                 ),
             })
@@ -826,37 +867,16 @@ fn diff_graph_has_changes(graph: &DiffGenGraph) -> bool {
 /// styling share the same presence and attribution rules.
 fn diff_graph_node(
     node: GraphNode,
-    comparison_graphs: &BlockGroupComparisonGraphs,
-    default_operation: DoltHashId,
+    source_graph: &DiffInputGraph,
+    target_graph: &DiffInputGraph,
+    default_operation: Option<DoltHashId>,
 ) -> DiffGraphNode {
-    let source_change = comparison_graphs
-        .source_graph
-        .node_changes
-        .get(&node)
-        .copied();
-    let target_change = comparison_graphs
-        .reconstructed_target_graph
-        .node_changes
-        .get(&node)
-        .copied();
+    let source_change = source_graph.node_change(node);
+    let target_change = target_graph.node_change(node);
     DiffGraphNode {
         node,
         change: merge_input_changes(source_change, target_change, default_operation),
     }
-}
-
-/// Collects endpoint pairs that have at least one annotated edge.
-///
-/// Edge merging uses these pairs to recognize topology that survives with a
-/// different edge identity. Comparing pairs as well as complete edge keys lets
-/// the renderer describe that case as modification instead of unrelated
-/// removal and addition.
-fn annotated_edge_pairs(input_graph: &DiffInputGraph) -> HashSet<(GraphNode, GraphNode)> {
-    input_graph
-        .edge_changes
-        .keys()
-        .map(GraphEdgeKey::node_pair)
-        .collect()
 }
 
 /// Retrieves the concrete edge represented by a merged identity key.
@@ -866,29 +886,14 @@ fn annotated_edge_pairs(input_graph: &DiffInputGraph) -> HashSet<(GraphNode, Gra
 /// collected from one of those inputs, so absence from both is an invariant
 /// violation.
 fn graph_edge_for_key(
-    comparison_graphs: &BlockGroupComparisonGraphs,
+    source_graph: &DiffInputGraph,
+    target_graph: &DiffInputGraph,
     edge_key: GraphEdgeKey,
 ) -> GraphEdge {
-    input_graph_edge_for_key(&comparison_graphs.reconstructed_target_graph, edge_key)
-        .or_else(|| input_graph_edge_for_key(&comparison_graphs.source_graph, edge_key))
+    target_graph
+        .edge(edge_key)
+        .or_else(|| source_graph.edge(edge_key))
         .expect("should contain graph edge for merged diff key")
-}
-
-/// Finds the exact edge for a key within one annotated input graph.
-///
-/// `graph_edge_for_key` uses this helper because `GenGraph` stores multiple
-/// edges per node pair. Matching the identity fields selects the edge whose
-/// change annotation participated in the unified key set.
-fn input_graph_edge_for_key(
-    input_graph: &DiffInputGraph,
-    edge_key: GraphEdgeKey,
-) -> Option<GraphEdge> {
-    input_graph
-        .graph
-        .edge_weight(edge_key.source, edge_key.target)?
-        .iter()
-        .copied()
-        .find(|edge| edge_key.matches_edge(*edge))
 }
 
 /// Reconciles source and target presence plus attribution for one graph element.
@@ -900,7 +905,7 @@ fn input_graph_edge_for_key(
 fn merge_input_changes(
     source_change: Option<DiffChange>,
     target_change: Option<DiffChange>,
-    default_operation: DoltHashId,
+    default_operation: Option<DoltHashId>,
 ) -> DiffChange {
     match (source_change, target_change) {
         (None, None) => DiffChange::unchanged(),
@@ -944,58 +949,24 @@ fn merge_input_changes(
 
 /// Applies edge-specific reconciliation on top of the general input rules.
 ///
-/// `build_unified_diff_graph` uses endpoint-pair membership and node status to
-/// distinguish real path changes from neutral continuation edges introduced by
-/// normalization. This prevents insertions from coloring surviving context as
-/// removed while still exposing deletions and edge replacements.
+/// Continuation edges reconnect slices split during normalization, so they
+/// stay unchanged. Explicit edges present in only one input are added or
+/// removed.
 fn merge_input_edge_changes(
-    source_change: Option<DiffChange>,
-    target_change: Option<DiffChange>,
-    edge_has_unchanged_endpoints: bool,
-    source_has_pair: bool,
-    target_has_pair: bool,
-    default_operation: DoltHashId,
+    source_metadata: Option<DiffInputEdgeMetadata>,
+    target_metadata: Option<DiffInputEdgeMetadata>,
+    default_operation: Option<DoltHashId>,
 ) -> DiffChange {
-    match (source_change, target_change) {
-        // Source-only continuation edges are context when both endpoint slices
-        // survive in the target. They should stay grey for insertions:
-        //
-        //   source: A -------- B
-        //   target: A -> I -> B
-        //
-        // Deletions still render red because their source-only edges touch a
-        // removed node:
-        //
-        //   source: A -> G -> B
-        //   target: A ------> B
-        (Some(_), None) if edge_has_unchanged_endpoints => DiffChange::unchanged(),
-        (None, Some(change)) if source_has_pair => {
-            merge_pair_matched_edge_change(change, default_operation)
-        }
-        (Some(change), None) if target_has_pair => {
-            merge_pair_matched_edge_change(change, default_operation)
-        }
-        (source_change, target_change) => {
-            merge_input_changes(source_change, target_change, default_operation)
-        }
+    if source_metadata
+        .into_iter()
+        .chain(target_metadata)
+        .any(|metadata| metadata.origin == EdgeOrigin::Continuation)
+    {
+        return DiffChange::unchanged();
     }
-}
-
-/// Classifies a one-sided edge as a replacement when its node pair survives.
-///
-/// `merge_input_edge_changes` uses this for edge-identity churn between the
-/// same normalized endpoints. Promoting attributed changes to `Modified`
-/// avoids rendering one biological connection as an unrelated add/remove pair.
-fn merge_pair_matched_edge_change(change: DiffChange, default_operation: DoltHashId) -> DiffChange {
-    if change.kind == DiffChangeKind::Unchanged && change.operation.is_none() {
-        DiffChange::unchanged()
-    } else {
-        changed(
-            DiffChangeKind::Modified,
-            change.operation,
-            default_operation,
-        )
-    }
+    let source_change = source_metadata.map(|metadata| metadata.change);
+    let target_change = target_metadata.map(|metadata| metadata.change);
+    merge_input_changes(source_change, target_change, default_operation)
 }
 
 /// Creates an attributed non-neutral change, filling missing Dolt attribution.
@@ -1005,18 +976,16 @@ fn merge_pair_matched_edge_change(change: DiffChange, default_operation: DoltHas
 fn changed(
     kind: DiffChangeKind,
     operation: Option<DoltHashId>,
-    default_operation: DoltHashId,
+    default_operation: Option<DoltHashId>,
 ) -> DiffChange {
-    DiffChange::new(kind, Some(operation.unwrap_or(default_operation)))
+    DiffChange::new(kind, operation.or(default_operation))
 }
 
-/// Builds one endpoint's connected, annotated input graph from normalized nodes.
+/// Builds one endpoint's connected diff input from normalized nodes.
 ///
-/// `load_block_group_comparison_graphs` uses this for both endpoints, while graph
-/// reconstruction tests call it directly. It maps persisted edges onto exact
-/// sequence-slice boundaries, drops edit-site markers that are not path
-/// choices, adds terminal and within-span continuation topology for layout, and
-/// records operation attribution separately for later source/target merging.
+/// Builds one input for the diff. It connects sequence slices using explicit
+/// edges and skips edges that are due to normalization, etc. If present, nodes
+/// and edges are attributed to an operation.
 pub(crate) fn build_diff_input_graph(
     mut input_nodes: HashSet<GraphNode>,
     continuation_spans: &HashSet<GraphNode>,
@@ -1026,7 +995,7 @@ pub(crate) fn build_diff_input_graph(
 ) -> DiffInputGraph {
     let mut graph = GenGraph::new();
     let mut node_changes = HashMap::new();
-    let mut edge_changes = HashMap::new();
+    let mut edge_metadata = HashMap::new();
 
     input_nodes.insert(path_start_graph_node());
     input_nodes.insert(path_end_graph_node());
@@ -1084,13 +1053,16 @@ pub(crate) fn build_diff_input_graph(
             } else {
                 graph.add_edge(source_node, target_node, vec![graph_edge]);
             }
-            edge_changes.insert(
+            edge_metadata.insert(
                 GraphEdgeKey::new(source_node, target_node, graph_edge),
-                edge_operations_by_id
-                    .get(&graph_edge.edge_id)
-                    .map_or_else(DiffChange::unchanged, |operation| {
-                        DiffChange::new(DiffChangeKind::Modified, Some(*operation))
-                    }),
+                DiffInputEdgeMetadata {
+                    change: edge_operations_by_id
+                        .get(&graph_edge.edge_id)
+                        .map_or_else(DiffChange::unchanged, |operation| {
+                            DiffChange::new(DiffChangeKind::Modified, Some(*operation))
+                        }),
+                    origin: EdgeOrigin::Explicit,
+                },
             );
         }
     }
@@ -1099,14 +1071,14 @@ pub(crate) fn build_diff_input_graph(
         &input_nodes,
         continuation_spans,
         &mut graph,
-        &mut edge_changes,
+        &mut edge_metadata,
     );
     remove_unconnected_input_nodes(&mut graph, &mut node_changes);
 
     DiffInputGraph {
         graph,
         node_changes,
-        edge_changes,
+        edge_metadata,
     }
 }
 
@@ -1136,7 +1108,7 @@ pub(crate) fn path_end_graph_node() -> GraphNode {
 
 /// Reconnects normalized slices that came from one continuous endpoint span.
 ///
-/// `build_diff_input_graph` invokes this after mapping persisted edges.
+/// `build_diff_input_graph` invokes this after mapping explicit edges.
 /// It adds neutral synthetic edges only between adjacent slices covered by the
 /// same original span, preserving renderable connectivity without bridging
 /// genuine deletions or endpoint gaps.
@@ -1144,7 +1116,7 @@ fn add_continuation_edges(
     input_nodes: &HashSet<GraphNode>,
     continuation_spans: &HashSet<GraphNode>,
     graph: &mut GenGraph,
-    edge_changes: &mut HashMap<GraphEdgeKey, DiffChange>,
+    edge_metadata: &mut HashMap<GraphEdgeKey, DiffInputEdgeMetadata>,
 ) {
     for span in continuation_spans {
         // Delayed block construction starts from the endpoint edges and keeps
@@ -1203,9 +1175,12 @@ fn add_continuation_edges(
             } else {
                 graph.add_edge(source_node, target_node, vec![synthetic_edge]);
             }
-            edge_changes.insert(
+            edge_metadata.insert(
                 GraphEdgeKey::new(source_node, target_node, synthetic_edge),
-                DiffChange::unchanged(),
+                DiffInputEdgeMetadata {
+                    change: DiffChange::unchanged(),
+                    origin: EdgeOrigin::Continuation,
+                },
             );
         }
     }
@@ -1251,7 +1226,7 @@ impl GraphEdgeKey {
     /// Creates the stable edge identity used to union and annotate endpoint graphs.
     ///
     /// Input construction and continuation-edge insertion use this key instead
-    /// of the full persisted record so volatile `created_on` metadata does not
+    /// of the full stored record so volatile `created_on` metadata does not
     /// turn an otherwise identical connection into a structural diff.
     pub(crate) fn new(source: GraphNode, target: GraphNode, edge: GraphEdge) -> Self {
         Self {
@@ -1265,18 +1240,10 @@ impl GraphEdgeKey {
         }
     }
 
-    /// Returns topology-only endpoints for pair-level edge matching.
-    ///
-    /// `annotated_edge_pairs` uses this projection to detect connections that
-    /// survive even when their persisted edge identities differ.
-    fn node_pair(&self) -> (GraphNode, GraphNode) {
-        (self.source, self.target)
-    }
-
     /// Tests whether a concrete edge has the structural identity represented by this key.
     ///
-    /// `input_graph_edge_for_key` uses this after selecting a node pair because
-    /// a `GenGraph` edge weight may contain multiple parallel edges.
+    /// `DiffInputGraph::edge` uses this after selecting a node pair because a
+    /// `GenGraph` edge weight may contain multiple parallel edges.
     fn matches_edge(self, edge: GraphEdge) -> bool {
         self.edge_id == edge.edge_id
             && self.source_strand == edge.source_strand
@@ -1286,17 +1253,68 @@ impl GraphEdgeKey {
     }
 }
 
-pub(crate) struct BlockGroupComparisonGraphs {
-    pub(crate) source_block_group: Option<BlockGroup>,
-    pub(crate) target_block_group: Option<BlockGroup>,
-    pub(crate) source_graph: DiffInputGraph,
-    pub(crate) reconstructed_target_graph: DiffInputGraph,
+struct BlockGroupComparison {
+    source_block_group: Option<BlockGroup>,
+    target_block_group: Option<BlockGroup>,
+    graph: DiffGenGraph,
 }
 
 pub(crate) struct DiffInputGraph {
-    pub(crate) graph: GenGraph,
-    pub(crate) node_changes: HashMap<GraphNode, DiffChange>,
-    pub(crate) edge_changes: HashMap<GraphEdgeKey, DiffChange>,
+    graph: GenGraph,
+    node_changes: HashMap<GraphNode, DiffChange>,
+    edge_metadata: HashMap<GraphEdgeKey, DiffInputEdgeMetadata>,
+}
+
+/// Keeps an edge's displayed change separate from why the input contains it.
+///
+/// Stores an input edge's change annotation and origin. During comparison,
+/// the origin tells us whether to mark a missing explicit edge as added or
+/// removed, or leave a synthetic continuation unchanged.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct DiffInputEdgeMetadata {
+    change: DiffChange,
+    origin: EdgeOrigin,
+}
+
+impl DiffInputGraph {
+    /// Iterates over the graph nodes present in this endpoint.
+    fn nodes(&self) -> impl Iterator<Item = GraphNode> + '_ {
+        self.node_changes.keys().copied()
+    }
+
+    /// Returns this endpoint's annotation for a node when it is present.
+    fn node_change(&self, node: GraphNode) -> Option<DiffChange> {
+        self.node_changes.get(&node).copied()
+    }
+
+    /// Iterates over stable edge keys and their input metadata.
+    fn edges(&self) -> impl Iterator<Item = (GraphEdgeKey, DiffInputEdgeMetadata)> + '_ {
+        self.edge_metadata
+            .iter()
+            .map(|(edge_key, metadata)| (*edge_key, *metadata))
+    }
+
+    /// Returns this endpoint's metadata for an edge when it is present.
+    fn edge_metadata(&self, edge_key: GraphEdgeKey) -> Option<DiffInputEdgeMetadata> {
+        self.edge_metadata.get(&edge_key).copied()
+    }
+
+    /// Returns the concrete graph edge represented by a stable key.
+    fn edge(&self, edge_key: GraphEdgeKey) -> Option<GraphEdge> {
+        self.graph
+            .edge_weight(edge_key.source, edge_key.target)?
+            .iter()
+            .copied()
+            .find(|edge| edge_key.matches_edge(*edge))
+    }
+}
+
+#[cfg(test)]
+impl DiffInputGraph {
+    /// Exposes input topology to reconstruction tests without exposing its maps.
+    pub(crate) const fn graph(&self) -> &GenGraph {
+        &self.graph
+    }
 }
 
 #[derive(Debug, Default)]
@@ -1309,7 +1327,211 @@ struct InputOperationChangeLookup {
 
 #[cfg(test)]
 mod tests {
+    use gen_models::edge::Edge;
+
     use super::*;
+
+    fn topology_test_edge(source: HashId, target: HashId, source_coordinate: i64) -> AugmentedEdge {
+        AugmentedEdge {
+            edge: Edge {
+                id: HashId::convert_str(&format!("{source}-{source_coordinate}-{target}")),
+                source_node_id: source,
+                source_coordinate,
+                source_strand: Strand::Forward,
+                target_node_id: target,
+                target_coordinate: 0,
+                target_strand: Strand::Forward,
+            },
+            chromosome_index: 0,
+            phased: 0,
+            created_on: 0,
+        }
+    }
+
+    #[test]
+    fn test_tracks_added_edge() {
+        // Simple graph like
+        // source -> {a,b} -> end
+        // adds a connection where a->b. Ensure we can track that new edge.
+        let node_a = HashId::convert_str("topology-a");
+        let node_b = HashId::convert_str("topology-b");
+        // Only the base includes the extra A -> B connection.
+        let query_edges = vec![
+            topology_test_edge(PATH_START_NODE_ID, node_a, 0),
+            topology_test_edge(node_a, PATH_END_NODE_ID, 10),
+            topology_test_edge(PATH_START_NODE_ID, node_b, 0),
+            topology_test_edge(node_b, PATH_END_NODE_ID, 10),
+        ];
+        let connection = topology_test_edge(node_a, node_b, 10);
+        let mut base_edges = query_edges.clone();
+        base_edges.push(connection.clone());
+        for (base, query, expected) in [
+            (&base_edges, &query_edges, DiffChangeKind::Removed),
+            (&query_edges, &base_edges, DiffChangeKind::Added),
+        ] {
+            let graph = build_diff_graph_from_edges(
+                EdgeDiffInput::unattributed(base),
+                EdgeDiffInput::unattributed(query),
+                None,
+            );
+            assert!(
+                graph
+                    .nodes()
+                    .all(|node| node.change.kind == DiffChangeKind::Unchanged)
+            );
+            let change = graph
+                .all_edges()
+                .flat_map(|(_, _, edges)| edges)
+                .find(|edge| edge.edge.edge_id == connection.edge.id)
+                .expect("should retain the differing explicit connection")
+                .change;
+            assert_eq!(
+                change.kind, expected,
+                "explicit membership must determine edge changes even when both nodes survive"
+            );
+            assert_eq!(change.operation, None);
+        }
+    }
+
+    #[test]
+    fn test_tracks_chromosome_index_changes_for_diploids() {
+        // Simple graph: source -> a -> end.
+        // One input has two source -> a edges, one per chromosome.
+        // Ensure the extra edge is Added/Removed while the shared edge stays unchanged.
+        let node = HashId::convert_str("parallel-node");
+        let query_edges = vec![
+            topology_test_edge(PATH_START_NODE_ID, node, 0),
+            topology_test_edge(node, PATH_END_NODE_ID, 10),
+        ];
+        let mut parallel = query_edges[0].clone();
+        parallel.chromosome_index = 1;
+        let mut base_edges = query_edges.clone();
+        base_edges.push(parallel);
+        for (base, query, expected) in [
+            (&base_edges, &query_edges, DiffChangeKind::Removed),
+            (&query_edges, &base_edges, DiffChangeKind::Added),
+        ] {
+            let graph = build_diff_graph_from_edges(
+                EdgeDiffInput::unattributed(base),
+                EdgeDiffInput::unattributed(query),
+                None,
+            );
+            let parallel_change = graph
+                .all_edges()
+                .flat_map(|(_, _, edges)| edges)
+                .find(|edge| edge.edge.chromosome_index == 1)
+                .expect("should retain the differing parallel edge")
+                .change;
+            assert_eq!(
+                parallel_change.kind, expected,
+                "parallel membership differences must remain visible alongside shared edges"
+            );
+            assert_eq!(parallel_change.operation, None);
+            let shared_change = graph
+                .all_edges()
+                .flat_map(|(_, _, edges)| edges)
+                .find(|edge| {
+                    edge.edge.edge_id == query_edges[0].edge.id
+                        && edge.edge.chromosome_index == query_edges[0].chromosome_index
+                })
+                .expect("should retain the shared parallel edge")
+                .change;
+            assert_eq!(shared_change.kind, DiffChangeKind::Unchanged);
+            assert_eq!(shared_change.operation, None);
+        }
+    }
+
+    #[test]
+    fn test_operation_attribution() {
+        // Simple graph: source -> {a,b} -> end.
+        // The query adds a -> b with an associated operation.
+        // Ensure the new edge is Added and retains that operation.
+        let node_a = HashId::convert_str("attributed-topology-a");
+        let node_b = HashId::convert_str("attributed-topology-b");
+        let base_edges = vec![
+            topology_test_edge(PATH_START_NODE_ID, node_a, 0),
+            topology_test_edge(node_a, PATH_END_NODE_ID, 10),
+            topology_test_edge(PATH_START_NODE_ID, node_b, 0),
+            topology_test_edge(node_b, PATH_END_NODE_ID, 10),
+        ];
+        let connection = topology_test_edge(node_a, node_b, 10);
+        let mut query_edges = base_edges.clone();
+        query_edges.push(connection.clone());
+        let operation = DoltHashId([9; 20]);
+        let edge_operations = HashMap::from([(connection.edge.id, operation)]);
+        let graph = build_diff_graph_from_edges(
+            EdgeDiffInput::unattributed(&base_edges)
+                .with_attribution(&HashMap::new(), &HashMap::new()),
+            EdgeDiffInput::unattributed(&query_edges)
+                .with_attribution(&HashMap::new(), &edge_operations),
+            None,
+        );
+        let change = graph
+            .all_edges()
+            .flat_map(|(_, _, edges)| edges)
+            .find(|edge| edge.edge.edge_id == connection.edge.id)
+            .expect("should retain the added explicit connection")
+            .change;
+        assert_eq!(change.kind, DiffChangeKind::Added);
+        assert_eq!(change.operation, Some(operation));
+    }
+
+    #[test]
+    fn test_continuation_is_neutral() {
+        // One input:   source -> a[0..10] -> end
+        // Other input: source -> {a[0..5], a[5..10]} -> end
+        // Normalization splits the continuous span and connects a[0..5] -> a[5..10].
+        // Ensure this synthetic connection stays neutral in either comparison direction.
+        let node = HashId::convert_str("continuation-node");
+        let continuous_edges = vec![
+            topology_test_edge(PATH_START_NODE_ID, node, 0),
+            topology_test_edge(node, PATH_END_NODE_ID, 10),
+        ];
+        let split_start = topology_test_edge(PATH_START_NODE_ID, node, 0);
+        let split_end = topology_test_edge(node, PATH_END_NODE_ID, 5);
+        let mut second_split_start = topology_test_edge(PATH_START_NODE_ID, node, 0);
+        second_split_start.edge.id = HashId::convert_str("continuation-second-start");
+        second_split_start.edge.target_coordinate = 5;
+        let second_split_end = topology_test_edge(node, PATH_END_NODE_ID, 10);
+        let split_edges = vec![split_start, split_end, second_split_start, second_split_end];
+        let first_slice = GraphNode {
+            node_id: node,
+            sequence_start: 0,
+            sequence_end: 5,
+        };
+        let second_slice = GraphNode {
+            node_id: node,
+            sequence_start: 5,
+            sequence_end: 10,
+        };
+
+        for (base, query) in [
+            (&continuous_edges, &split_edges),
+            (&split_edges, &continuous_edges),
+        ] {
+            let graph = build_diff_graph_from_edges(
+                EdgeDiffInput::unattributed(base),
+                EdgeDiffInput::unattributed(query),
+                None,
+            );
+            let continuation_edges = graph
+                .all_edges()
+                .find_map(|(source, target, edges)| {
+                    (source.node == first_slice && target.node == second_slice).then_some(edges)
+                })
+                .expect("should retain the normalization continuation");
+            assert!(
+                continuation_edges
+                    .iter()
+                    .all(|edge| edge.change.kind == DiffChangeKind::Unchanged)
+            );
+            assert!(
+                continuation_edges
+                    .iter()
+                    .all(|edge| edge.change.operation.is_none())
+            );
+        }
+    }
 
     fn block_group(id: i64) -> BlockGroup {
         BlockGroup {

--- a/gen-diff/src/lib.rs
+++ b/gen-diff/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod graph;
 pub mod operations;
+pub mod sample;
 #[cfg(test)]
 mod test_helpers;

--- a/gen-diff/src/operations.rs
+++ b/gen-diff/src/operations.rs
@@ -711,8 +711,8 @@ mod tests {
     };
     use crate::{
         graph::{
-            AnnotatedStageGraph, BlockGroupStageGraphs, DiffChangeKind, DiffGenGraph, GraphEdgeKey,
-            build_stage_graph_from_nodes, build_unified_diff_graph, path_end_graph_node,
+            BlockGroupComparisonGraphs, DiffChangeKind, DiffGenGraph, DiffInputGraph, GraphEdgeKey,
+            build_diff_input_graph, build_unified_diff_graph, path_end_graph_node,
             path_start_graph_node,
         },
         test_helpers::{get_config_connection, get_connection as test_get_connection},
@@ -1102,13 +1102,13 @@ mod tests {
             .map_err(OperationDiffError::from)
     }
 
-    fn build_stage_graph(
-        stage_blocks: &[GroupBlock],
-        stage_edges: &[AugmentedEdge],
+    fn build_diff_input(
+        input_blocks: &[GroupBlock],
+        input_edges: &[AugmentedEdge],
         node_operations_by_id: &HashMap<HashId, DoltHashId>,
         edge_operations_by_id: &HashMap<HashId, DoltHashId>,
-    ) -> AnnotatedStageGraph {
-        let stage_nodes = stage_blocks
+    ) -> DiffInputGraph {
+        let input_nodes = input_blocks
             .iter()
             .map(|block| GraphNode {
                 node_id: block.node_id,
@@ -1116,11 +1116,11 @@ mod tests {
                 sequence_end: block.end,
             })
             .collect::<HashSet<_>>();
-        let continuation_spans = stage_nodes.clone();
-        build_stage_graph_from_nodes(
-            stage_nodes,
+        let continuation_spans = input_nodes.clone();
+        build_diff_input_graph(
+            input_nodes,
             &continuation_spans,
-            stage_edges,
+            input_edges,
             node_operations_by_id,
             edge_operations_by_id,
         )
@@ -1432,13 +1432,13 @@ mod tests {
             Some(&target_ref),
         )
         .expect("should build target blocks");
-        let reconstructed_graph = build_stage_graph(
+        let reconstructed_graph = build_diff_input(
             &reconstructed_blocks,
             &reconstructed_edges,
             &HashMap::new(),
             &HashMap::new(),
         );
-        let target_graph = build_stage_graph(
+        let target_graph = build_diff_input(
             &target_blocks,
             &target_edges,
             &HashMap::new(),
@@ -1503,7 +1503,7 @@ mod tests {
     }
 
     #[test]
-    fn test_stage_graph_keeps_endpoint_local_node_slices() {
+    fn test_diff_input_graph_keeps_endpoint_local_node_slices() {
         let operation = DoltHashId([100; 20]);
         let node_id = HashId::convert_str("reference-node");
         let sequence = Sequence::new()
@@ -1517,24 +1517,24 @@ mod tests {
             GroupBlock::new(0, node_id, &sequence, 0, 3),
             GroupBlock::new(1, node_id, &sequence, 4, 10),
         ];
-        let stage_edges = vec![
+        let input_edges = vec![
             test_augmented_edge(start_edge_id, PATH_START_NODE_ID, 0, node_id, 0),
             test_augmented_edge(end_edge_id, node_id, 10, PATH_END_NODE_ID, 0),
         ];
-        let source_stage_graph = build_stage_graph(
+        let source_input_graph = build_diff_input(
             &source_blocks,
-            &stage_edges,
+            &input_edges,
             &HashMap::new(),
             &HashMap::new(),
         );
-        let target_stage_graph = build_stage_graph(
+        let target_input_graph = build_diff_input(
             &target_blocks,
-            &stage_edges,
+            &input_edges,
             &HashMap::new(),
             &HashMap::from([(node_id, operation)]),
         );
 
-        let source_nodes = source_stage_graph.graph.nodes().collect::<HashSet<_>>();
+        let source_nodes = source_input_graph.graph.nodes().collect::<HashSet<_>>();
         assert!(
             source_nodes.contains(&GraphNode {
                 node_id,
@@ -1551,7 +1551,7 @@ mod tests {
             }),
             "source graph should not synthesize slices from target-only boundaries"
         );
-        let target_nodes = target_stage_graph.graph.nodes().collect::<HashSet<_>>();
+        let target_nodes = target_input_graph.graph.nodes().collect::<HashSet<_>>();
         assert!(
             target_nodes.contains(&GraphNode {
                 node_id,
@@ -1567,16 +1567,16 @@ mod tests {
     }
 
     #[test]
-    fn test_stage_graph_keeps_terminal_blocks_for_endpoint_lookup() {
+    fn test_diff_input_graph_keeps_terminal_blocks_for_endpoint_lookup() {
         let node_id = HashId::convert_str("regular-node");
         let sequence = Sequence::new().sequence_type("DNA").sequence("ATC").build();
         let edge_id = HashId::convert_str("edge-to-start");
-        let stage_blocks = vec![
+        let input_blocks = vec![
             test_terminal_block(0, PATH_START_NODE_ID),
             GroupBlock::new(1, node_id, &sequence, 0, 3),
             test_terminal_block(2, PATH_END_NODE_ID),
         ];
-        let stage_edges = vec![test_augmented_edge(
+        let input_edges = vec![test_augmented_edge(
             edge_id,
             node_id,
             3,
@@ -1584,16 +1584,16 @@ mod tests {
             0,
         )];
 
-        let stage_graph = build_stage_graph(
-            &stage_blocks,
-            &stage_edges,
+        let input_graph = build_diff_input(
+            &input_blocks,
+            &input_edges,
             &HashMap::new(),
             &HashMap::new(),
         );
 
         let regular_node = test_graph_node(node_id, 0, 3);
         assert!(
-            stage_graph
+            input_graph
                 .graph
                 .edge_weight(regular_node, path_start_graph_node())
                 .is_some(),
@@ -1715,13 +1715,13 @@ mod tests {
                 0,
             ),
         ];
-        let source_graph = build_stage_graph(
+        let source_graph = build_diff_input(
             &source_blocks,
             &source_edges,
             &HashMap::new(),
             &HashMap::new(),
         );
-        let target_graph = build_stage_graph(
+        let target_graph = build_diff_input(
             &target_blocks,
             &target_edges,
             &HashMap::new(),
@@ -1736,14 +1736,14 @@ mod tests {
             parent_block_group_id: None,
             is_default: false,
         };
-        let stage_graphs = BlockGroupStageGraphs {
+        let comparison_graphs = BlockGroupComparisonGraphs {
             source_block_group: Some(block_group.clone()),
             target_block_group: Some(block_group),
             source_graph,
             reconstructed_target_graph: target_graph,
         };
 
-        let graph = build_unified_diff_graph(&stage_graphs, operation);
+        let graph = build_unified_diff_graph(&comparison_graphs, operation);
 
         assert_eq!(
             graph

--- a/gen-diff/src/operations.rs
+++ b/gen-diff/src/operations.rs
@@ -711,9 +711,8 @@ mod tests {
     };
     use crate::{
         graph::{
-            BlockGroupComparisonGraphs, DiffChangeKind, DiffGenGraph, DiffInputGraph, GraphEdgeKey,
-            build_diff_input_graph, build_unified_diff_graph, path_end_graph_node,
-            path_start_graph_node,
+            DiffChangeKind, DiffGenGraph, DiffInputGraph, GraphEdgeKey, build_diff_input_graph,
+            build_unified_diff_graph, path_end_graph_node, path_start_graph_node,
         },
         test_helpers::{get_config_connection, get_connection as test_get_connection},
     };
@@ -1446,12 +1445,12 @@ mod tests {
         );
 
         assert_eq!(
-            graph_edge_keys(&reconstructed_graph.graph),
-            graph_edge_keys(&target_graph.graph)
+            graph_edge_keys(reconstructed_graph.graph()),
+            graph_edge_keys(target_graph.graph())
         );
         assert_eq!(
-            reconstructed_graph.graph.nodes().collect::<HashSet<_>>(),
-            target_graph.graph.nodes().collect::<HashSet<_>>()
+            reconstructed_graph.graph().nodes().collect::<HashSet<_>>(),
+            target_graph.graph().nodes().collect::<HashSet<_>>()
         );
     }
 
@@ -1534,7 +1533,7 @@ mod tests {
             &HashMap::from([(node_id, operation)]),
         );
 
-        let source_nodes = source_input_graph.graph.nodes().collect::<HashSet<_>>();
+        let source_nodes = source_input_graph.graph().nodes().collect::<HashSet<_>>();
         assert!(
             source_nodes.contains(&GraphNode {
                 node_id,
@@ -1551,7 +1550,7 @@ mod tests {
             }),
             "source graph should not synthesize slices from target-only boundaries"
         );
-        let target_nodes = target_input_graph.graph.nodes().collect::<HashSet<_>>();
+        let target_nodes = target_input_graph.graph().nodes().collect::<HashSet<_>>();
         assert!(
             target_nodes.contains(&GraphNode {
                 node_id,
@@ -1594,7 +1593,7 @@ mod tests {
         let regular_node = test_graph_node(node_id, 0, 3);
         assert!(
             input_graph
-                .graph
+                .graph()
                 .edge_weight(regular_node, path_start_graph_node())
                 .is_some(),
             "terminal blocks should participate in endpoint lookup regardless of edge direction"
@@ -1603,6 +1602,10 @@ mod tests {
 
     #[test]
     fn test_unified_diff_graph_connects_deletion_and_addition_through_common_terminals() {
+        // Before: start -> prefix -> deleted -> middle ------------> suffix -> end
+        // After:  start -> prefix ------------> middle -> inserted -> suffix -> end
+        // Ensure replacing the explicit middle -> suffix edge removes it even
+        // though both endpoints survive, and adds both edges through inserted.
         let operation = DoltHashId([100; 20]);
         let prefix_node_id = HashId::convert_str("prefix");
         let deleted_node_id = HashId::convert_str("deleted");
@@ -1727,23 +1730,7 @@ mod tests {
             &HashMap::new(),
             &HashMap::new(),
         );
-        let block_group = BlockGroup {
-            id: HashId::pad_str(99),
-            collection_name: "collection".to_string(),
-            sample_name: "sample".to_string(),
-            name: "block-group".to_string(),
-            created_on: 0,
-            parent_block_group_id: None,
-            is_default: false,
-        };
-        let comparison_graphs = BlockGroupComparisonGraphs {
-            source_block_group: Some(block_group.clone()),
-            target_block_group: Some(block_group),
-            source_graph,
-            reconstructed_target_graph: target_graph,
-        };
-
-        let graph = build_unified_diff_graph(&comparison_graphs, operation);
+        let graph = build_unified_diff_graph(&source_graph, &target_graph, Some(operation));
 
         assert_eq!(
             graph
@@ -1775,6 +1762,9 @@ mod tests {
         assert_diff_edge_kind(&graph, prefix_node, deleted_node, DiffChangeKind::Removed);
         assert_diff_edge_kind(&graph, deleted_node, middle_node, DiffChangeKind::Removed);
         assert_diff_edge_kind(&graph, prefix_node, middle_node, DiffChangeKind::Added);
+        assert_diff_edge_kind(&graph, middle_node, suffix_node, DiffChangeKind::Removed);
+        assert_diff_edge_kind(&graph, middle_node, inserted_node, DiffChangeKind::Added);
+        assert_diff_edge_kind(&graph, inserted_node, suffix_node, DiffChangeKind::Added);
         assert_all_nodes_connected_to(&graph, path_start_graph_node());
         assert_diff_edge_kind(
             &graph,

--- a/gen-diff/src/sample.rs
+++ b/gen-diff/src/sample.rs
@@ -1,0 +1,59 @@
+//! Builds a graph diff between two samples.
+//!
+//! The base is the reference state and the query is compared against it. Graph
+//! elements found only in the query are additions, while elements found only
+//! in the base are removals.
+
+use gen_models::{
+    block_group::{BlockGroup, BlockGroupError},
+    block_group_edge::BlockGroupEdge,
+    db::GraphConnection,
+};
+
+use crate::graph::{DiffGenGraph, EdgeDiffInput, build_diff_graph_from_edges};
+
+/// The two sample block groups and their unified, annotated graph.
+#[derive(Clone, Debug)]
+pub struct SampleDiff {
+    /// Graph selected as the query for the comparison.
+    pub query_block_group: BlockGroup,
+    /// Graph selected as the base for the comparison.
+    pub base_block_group: BlockGroup,
+    /// Unified graph annotated relative to the base.
+    pub graph: DiffGenGraph,
+}
+
+/// Builds one graph showing the difference between matching query and base
+/// block groups.
+///
+/// The base is the comparison baseline. Query-only graph elements are added,
+/// while base-only elements are removed. The shared graph-diff builder aligns
+/// sequence boundaries before constructing either diff input, then unifies
+/// their explicitly annotated nodes and edges.
+pub fn build_sample_diff(
+    conn: &GraphConnection,
+    collection_name: &str,
+    graph_name: &str,
+    query_name: &str,
+    base_name: &str,
+    history_ref: Option<&str>,
+) -> Result<SampleDiff, BlockGroupError> {
+    let query_block_group =
+        BlockGroup::get_by_name(conn, collection_name, query_name, graph_name, history_ref)?;
+    let base_block_group =
+        BlockGroup::get_by_name(conn, collection_name, base_name, graph_name, history_ref)?;
+    let query_edges =
+        BlockGroupEdge::edges_for_block_group(conn, &query_block_group.id, history_ref);
+    let base_edges = BlockGroupEdge::edges_for_block_group(conn, &base_block_group.id, history_ref);
+    let graph = build_diff_graph_from_edges(
+        EdgeDiffInput::unattributed(&base_edges),
+        EdgeDiffInput::unattributed(&query_edges),
+        None,
+    );
+
+    Ok(SampleDiff {
+        query_block_group,
+        base_block_group,
+        graph,
+    })
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -123,8 +123,14 @@ pub enum Commands {
         #[arg(long = "ref")]
         history_ref: Option<String>,
         /// Optional sample to open directly. If omitted, choose it in the UI.
-        #[arg(short, long)]
+        #[arg(short, long, conflicts_with_all = ["query", "base"])]
         sample: Option<String>,
+        /// Query whose graph changes should be shown relative to the base
+        #[arg(long, requires = "base")]
+        query: Option<String>,
+        /// Base against which the query is compared
+        #[arg(long, requires = "query")]
+        base: Option<String>,
         /// Look for the sample in a specific collection
         #[arg(short, long)]
         collection: Option<String>,
@@ -557,6 +563,35 @@ mod tests {
         assert_eq!(
             parse_diff_revisions("main..feature", None),
             Ok(("main".into(), "feature".into(), DiffRange::TwoDot))
+        );
+    }
+
+    #[test]
+    fn test_view_accepts_query_and_base() {
+        let cli =
+            Cli::try_parse_from(["gen", "view", "m123", "--query", "foo", "--base", "unknown"])
+                .expect("should parse a sample graph diff");
+        let Some(Commands::View {
+            graph, query, base, ..
+        }) = cli.command
+        else {
+            panic!("should parse view command");
+        };
+        assert_eq!(graph.as_deref(), Some("m123"));
+        assert_eq!(query.as_deref(), Some("foo"));
+        assert_eq!(base.as_deref(), Some("unknown"));
+    }
+
+    #[test]
+    fn test_view_sample_diff_requires_both_endpoints() {
+        let error = match Cli::try_parse_from(["gen", "view", "m123", "--query", "foo"]) {
+            Ok(_) => panic!("query without base should fail"),
+            Err(error) => error,
+        };
+
+        assert!(
+            error.to_string().contains("--base"),
+            "missing endpoint error should name --base: {error}"
         );
     }
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -442,17 +442,17 @@ pub enum Commands {
         #[arg(long)]
         region: Option<String>,
     },
-    /// Output a file representing the "diff" between two samples
+    /// Output a file representing the diff between a query and base
     Diff {
         /// The name of the collection to diff
         #[arg(short, long)]
         name: Option<String>,
-        /// The name of the first sample to diff
-        #[arg(long)]
-        sample1: String,
-        /// The name of the second sample to diff
-        #[arg(long)]
-        sample2: String,
+        /// Query whose contents are compared against the base
+        #[arg(long, visible_alias = "sample1")]
+        query: String,
+        /// Base used as the comparison reference
+        #[arg(long, visible_alias = "sample2")]
+        base: String,
         /// The name of the output GFA file
         #[arg(long)]
         gfa: String,
@@ -558,6 +558,26 @@ mod tests {
             parse_diff_revisions("main..feature", None),
             Ok(("main".into(), "feature".into(), DiffRange::TwoDot))
         );
+    }
+
+    #[test]
+    fn test_gfa_diff_uses_query_and_base_names() {
+        let cli = Cli::try_parse_from([
+            "gen",
+            "diff",
+            "--query",
+            "foo",
+            "--base",
+            "unknown",
+            "--gfa",
+            "sample-diff.gfa",
+        ])
+        .expect("should parse query and base for a GFA diff");
+        let Some(Commands::Diff { query, base, .. }) = cli.command else {
+            panic!("should parse diff command");
+        };
+        assert_eq!(query, "foo");
+        assert_eq!(base, "unknown");
     }
 
     #[test]

--- a/src/diffs/gfa.rs
+++ b/src/diffs/gfa.rs
@@ -33,24 +33,24 @@ pub fn gfa_sample_diff(
     workspace: &Workspace,
     collection_name: &str,
     filename: &PathBuf,
-    from_sample_name: &str,
-    to_sample_name: &str,
+    query_name: &str,
+    base_name: &str,
 ) -> Result<(), GfaDiffError> {
     /*
     Generate a GFA file that represents the differences between two samples in a collection.
 
-    General approach: For each pair of shared block groups between the samples, get the current path
+    General approach: For each pair of shared block groups between the query and base, get the current path
     for each and call find_block_mappings on the pair of paths to get mappings between shared
     regions on the paths.  Each shared region may cover multiple nodes.  We assume the mappings will
     be in order from upstream to downstream on the sequences.  We iterate over them to produce a
-    list of ranges on each path's sequence.  For each mapping, and for each path, if there is an
+    list of ranges on each path's sequence. For each mapping, and for each path, if there is an
     unshared region before the common region, we append the range for that unshared region to the
     path's list of ranges, and then the range for the common region.  Obviously there may be an
     unshared region on each path at the very end, and if so, we append the range for that region to
     the appropriate path's list.
 
     We then convert the list of ranges for a path to a list of segments, with each range being
-    converted to a segment with the range's start coordinate, and the subsequence of the path for
+    converted to a segment with the range's start coordinate and the subsequence of the path for
     that range.  We also create links, with one link per pair of adjacent segments in the path.
     Each shared segment will have two links going in (one for each path) and two links going out.
     Each unshared segment will have one link in and one link out.
@@ -58,11 +58,10 @@ pub fn gfa_sample_diff(
     We also create a GFA path for each path, which is just a list of the segments generated for that
     path.
     */
-    let source_block_groups =
-        Sample::get_block_groups(conn, collection_name, from_sample_name, None);
-    let target_block_groups = Sample::get_block_groups(conn, collection_name, to_sample_name, None);
+    let query_block_groups = Sample::get_block_groups(conn, collection_name, query_name, None);
+    let base_block_groups = Sample::get_block_groups(conn, collection_name, base_name, None);
 
-    let source_paths_by_name = source_block_groups
+    let query_paths_by_name = query_block_groups
         .iter()
         .map(|bg| {
             Ok((
@@ -71,7 +70,7 @@ pub fn gfa_sample_diff(
             ))
         })
         .collect::<Result<HashMap<String, Path>, BlockGroupError>>()?;
-    let target_paths_by_name = target_block_groups
+    let base_paths_by_name = base_block_groups
         .iter()
         .map(|bg| {
             Ok((
@@ -85,100 +84,99 @@ pub fn gfa_sample_diff(
     let mut links = HashSet::new();
     let mut paths = vec![];
 
-    let target_path_names = target_paths_by_name
+    let base_path_names = base_paths_by_name
         .keys()
         .cloned()
         .collect::<HashSet<String>>();
-    let source_path_names = source_paths_by_name
+    let query_path_names = query_paths_by_name
         .keys()
         .cloned()
         .collect::<HashSet<String>>();
-    let path_names = source_path_names
-        .union(&target_path_names)
+    let path_names = query_path_names
+        .union(&base_path_names)
         .cloned()
         .collect::<Vec<String>>();
 
     for path_name in &path_names {
-        let source_path_result = source_paths_by_name.get(path_name);
-        let target_path_result = target_paths_by_name.get(path_name);
+        let query_path_result = query_paths_by_name.get(path_name);
+        let base_path_result = base_paths_by_name.get(path_name);
 
-        let mappings = match (source_path_result, target_path_result) {
-            (Some(source_path), Some(target_path)) => {
-                source_path.find_block_mappings(conn, target_path)?
+        let mappings = match (query_path_result, base_path_result) {
+            (Some(query_path), Some(base_path)) => {
+                query_path.find_block_mappings(conn, base_path)?
             }
             _ => vec![],
         };
 
-        let mut source_ranges = vec![];
-        let mut target_ranges = vec![];
+        let mut query_ranges = vec![];
+        let mut base_ranges = vec![];
 
-        let mut last_source_position = 0;
-        let mut last_target_position = 0;
+        let mut last_query_position = 0;
+        let mut last_base_position = 0;
         for mapping in &mappings {
-            // Iterate over the shared regions between the source and target path.  If there is an
+            // Iterate over the shared regions between the query and base path. If there is an
             // unshared region before the shared region, append the range for the unshared region.
             // Then append the range for the shared region.
-            if mapping.source_range.start > last_source_position {
-                source_ranges.push(Range {
-                    start: last_source_position,
+            if mapping.source_range.start > last_query_position {
+                query_ranges.push(Range {
+                    start: last_query_position,
                     end: mapping.source_range.start,
                 });
             }
-            source_ranges.push(mapping.source_range);
-            last_source_position = mapping.source_range.end;
-            if mapping.target_range.start > last_target_position {
-                target_ranges.push(Range {
-                    start: last_target_position,
+            query_ranges.push(mapping.source_range);
+            last_query_position = mapping.source_range.end;
+            if mapping.target_range.start > last_base_position {
+                base_ranges.push(Range {
+                    start: last_base_position,
                     end: mapping.target_range.start,
                 });
             }
-            target_ranges.push(mapping.target_range);
-            last_target_position = mapping.target_range.end;
+            base_ranges.push(mapping.target_range);
+            last_base_position = mapping.target_range.end;
         }
 
-        if let Some(source_path) = source_path_result {
-            let source_sequence = source_path.sequence(conn, workspace, None)?;
+        if let Some(query_path) = query_path_result {
+            let query_sequence = query_path.sequence(conn, workspace, None)?;
 
-            let source_len = source_sequence.len() as i64;
-            if last_source_position < source_len {
-                source_ranges.push(Range {
-                    start: last_source_position,
-                    end: source_len,
+            let query_length = query_sequence.len() as i64;
+            if last_query_position < query_length {
+                query_ranges.push(Range {
+                    start: last_query_position,
+                    end: query_length,
                 });
             }
 
-            let source_node_blocks = source_path.node_block_partition(conn, source_ranges)?;
-            let source_segments = segments_from_blocks(&source_node_blocks, &source_sequence);
-            segments.extend(source_segments.iter().cloned());
+            let query_node_blocks = query_path.node_block_partition(conn, query_ranges)?;
+            let query_segments = segments_from_blocks(&query_node_blocks, &query_sequence);
+            segments.extend(query_segments.iter().cloned());
 
-            let source_links = links_from_blocks(&source_node_blocks);
-            links.extend(source_links.iter().cloned());
+            let query_links = links_from_blocks(&query_node_blocks);
+            links.extend(query_links.iter().cloned());
 
-            let source_gfa_path =
-                path_from_segments(from_sample_name, source_path, &source_segments);
-            paths.push(source_gfa_path);
+            let query_gfa_path = path_from_segments(query_name, query_path, &query_segments);
+            paths.push(query_gfa_path);
         }
 
-        if let Some(target_path) = target_path_result {
-            let target_sequence = target_path.sequence(conn, workspace, None)?;
+        if let Some(base_path) = base_path_result {
+            let base_sequence = base_path.sequence(conn, workspace, None)?;
 
-            let target_len = target_sequence.len() as i64;
-            if last_target_position < target_len {
-                target_ranges.push(Range {
-                    start: last_target_position,
-                    end: target_len,
+            let base_length = base_sequence.len() as i64;
+            if last_base_position < base_length {
+                base_ranges.push(Range {
+                    start: last_base_position,
+                    end: base_length,
                 });
             }
 
-            let target_node_blocks = target_path.node_block_partition(conn, target_ranges)?;
-            let target_segments = segments_from_blocks(&target_node_blocks, &target_sequence);
-            segments.extend(target_segments.iter().cloned());
+            let base_node_blocks = base_path.node_block_partition(conn, base_ranges)?;
+            let base_segments = segments_from_blocks(&base_node_blocks, &base_sequence);
+            segments.extend(base_segments.iter().cloned());
 
-            let target_links = links_from_blocks(&target_node_blocks);
-            links.extend(target_links.iter().cloned());
+            let base_links = links_from_blocks(&base_node_blocks);
+            links.extend(base_links.iter().cloned());
 
-            let target_gfa_path = path_from_segments(to_sample_name, target_path, &target_segments);
-            paths.push(target_gfa_path);
+            let base_gfa_path = path_from_segments(base_name, base_path, &base_segments);
+            paths.push(base_gfa_path);
         }
     }
 

--- a/src/diffs/gfa.rs
+++ b/src/diffs/gfa.rs
@@ -33,8 +33,8 @@ pub fn gfa_sample_diff(
     workspace: &Workspace,
     collection_name: &str,
     filename: &PathBuf,
-    query_name: &str,
     base_name: &str,
+    query_name: &str,
 ) -> Result<(), GfaDiffError> {
     /*
     Generate a GFA file that represents the differences between two samples in a collection.
@@ -255,6 +255,8 @@ fn path_from_segments(sample_name: &str, path: &Path, segments: &[Segment]) -> G
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
+
     // Note this useful idiom: importing names from outer (for mod tests) scope.
     use gen_core::{HashId, NO_CHROMOSOME_INDEX, PATH_END_NODE_ID, PATH_START_NODE_ID, Strand};
     use gen_models::{
@@ -272,6 +274,164 @@ mod tests {
         imports::gfa::import_gfa,
         test_helpers::{create_bg, setup_gen},
     };
+
+    #[test]
+    fn test_gfa_diff_reference_frame() {
+        // Assert that the comparison is in the right direction. Normally GFA doesn't annotate
+        // removed/added, so the order of inputs doesn't matter as the graph has no indication
+        // of what segment something belongs to. This comes out in paths, so we assert that the
+        // paths are correct based on the input they should belong to.
+        // Only the child's path replaces the middle AA with CC:
+        //   base:  A -> AA -> A
+        //   child: A -> CC -> A
+        let context = setup_gen();
+        let conn = context.graph().conn();
+        let collection_name = "argument order";
+        Collection::create(conn, collection_name).unwrap();
+        let block_group = create_bg(conn, collection_name, Sample::DEFAULT_NAME, "sequence");
+        let sequence = Sequence::new()
+            .sequence_type("DNA")
+            .sequence("AAAA")
+            .save(conn)
+            .unwrap();
+        let node_id =
+            Node::create(conn, &sequence.hash, &HashId::convert_str("argument-order")).unwrap();
+        let entry = Edge::create(
+            conn,
+            PATH_START_NODE_ID,
+            0,
+            Strand::Forward,
+            node_id,
+            0,
+            Strand::Forward,
+        )
+        .unwrap();
+        let exit = Edge::create(
+            conn,
+            node_id,
+            4,
+            Strand::Forward,
+            PATH_END_NODE_ID,
+            0,
+            Strand::Forward,
+        )
+        .unwrap();
+        let edge_ids = [entry.id, exit.id];
+        BlockGroupEdge::bulk_create(
+            conn,
+            &edge_ids
+                .iter()
+                .map(|edge_id| BlockGroupEdgeData {
+                    block_group_id: block_group.id,
+                    edge_id: *edge_id,
+                    chromosome_index: NO_CHROMOSOME_INDEX,
+                    phased: 0,
+                })
+                .collect::<Vec<_>>(),
+        );
+        Path::create(conn, "sequence", &block_group.id, &edge_ids).unwrap();
+        Sample::get_or_create_child(
+            conn,
+            collection_name,
+            "child",
+            vec![Sample::DEFAULT_NAME.to_string()],
+        )
+        .unwrap();
+        let child_block_group =
+            BlockGroup::get_by_name(conn, collection_name, "child", "sequence", None).unwrap();
+        let child_sequence = Sequence::new()
+            .sequence_type("DNA")
+            .sequence("CC")
+            .save(conn)
+            .unwrap();
+        let child_node = Node::create(
+            conn,
+            &child_sequence.hash,
+            &HashId::convert_str("child-only-edit"),
+        )
+        .unwrap();
+        let edit_entry = Edge::create(
+            conn,
+            node_id,
+            1,
+            Strand::Forward,
+            child_node,
+            0,
+            Strand::Forward,
+        )
+        .unwrap();
+        let edit_exit = Edge::create(
+            conn,
+            child_node,
+            2,
+            Strand::Forward,
+            node_id,
+            3,
+            Strand::Forward,
+        )
+        .unwrap();
+        BlockGroupEdge::bulk_create(
+            conn,
+            &[edit_entry.id, edit_exit.id]
+                .iter()
+                .map(|edge_id| BlockGroupEdgeData {
+                    block_group_id: child_block_group.id,
+                    edge_id: *edge_id,
+                    chromosome_index: NO_CHROMOSOME_INDEX,
+                    phased: 0,
+                })
+                .collect::<Vec<_>>(),
+        );
+        let child_path = BlockGroup::get_current_path(conn, &child_block_group.id, None).unwrap();
+        child_path
+            .new_path_with(conn, 1, 3, &edit_entry, &edit_exit)
+            .unwrap();
+        let directory = tempdir().unwrap();
+        let filename = directory.path().join("diff.gfa");
+        gfa_sample_diff(
+            conn,
+            context.workspace(),
+            collection_name,
+            &filename,
+            Sample::DEFAULT_NAME,
+            "child",
+        )
+        .unwrap();
+        let output = fs::read_to_string(&filename).unwrap();
+        let segments = output
+            .lines()
+            .filter(|line| line.starts_with("S\t"))
+            .map(|line| {
+                let fields = line.split('\t').collect::<Vec<_>>();
+                (fields[1], fields[2])
+            })
+            .collect::<HashMap<_, _>>();
+        let path_sequences = output
+            .lines()
+            .filter(|line| line.starts_with("P\t"))
+            .map(|line| {
+                let fields = line.split('\t').collect::<Vec<_>>();
+                let sequence = fields[2]
+                    .split(',')
+                    .map(|segment| {
+                        let segment_id = segment
+                            .strip_suffix('+')
+                            .expect("should traverse forward in this fixture");
+                        segments[segment_id]
+                    })
+                    .collect::<String>();
+                (fields[1], sequence)
+            })
+            .collect::<HashMap<_, _>>();
+        assert_eq!(path_sequences.len(), 2);
+        assert_eq!(path_sequences["Reference.sequence"], "AAAA");
+        // Path updates give the child path a new name containing the edit site.
+        let (_, child_sequence) = path_sequences
+            .iter()
+            .find(|(name, _)| name.starts_with("Child."))
+            .expect("should export the child's updated path");
+        assert_eq!(child_sequence, "ACCA");
+    }
 
     #[test]
     fn test_gfa_diff() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -896,8 +896,8 @@ fn call_cli() -> Result<(), Box<dyn std::error::Error>> {
         }
         Some(Commands::Diff {
             name,
-            sample1,
-            sample2,
+            query,
+            base,
             gfa,
         }) => {
             let collection_name = &(match name {
@@ -909,8 +909,8 @@ fn call_cli() -> Result<(), Box<dyn std::error::Error>> {
                 db_context.workspace(),
                 collection_name,
                 &PathBuf::from(gfa),
-                sample1.as_str(),
-                sample2.as_str(),
+                query.as_str(),
+                base.as_str(),
             )?;
             Ok(())
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,14 +21,17 @@ use r#gen::{
     theme::init_theme,
     updates::gaf::transform_csv_to_fasta,
     views::{
-        block_group::view_block_group, block_group_inline::show_inline_block_group_widget,
-        diff::view_diff, operations::view_operations, patch::view_patch,
+        block_group::view_block_group,
+        block_group_inline::{show_inline_block_group_widget, show_inline_diff_graph_widget},
+        diff::{view_diff, view_diff_graph},
+        operations::view_operations,
+        patch::view_patch,
         tui_runtime::install_global_panic_hook,
     },
 };
 use gen_annotations::translate;
 use gen_core::{BranchName, CommitRef, config::Workspace, range::Range, region::Region};
-use gen_diff::operations::collect_operation_diff;
+use gen_diff::{operations::collect_operation_diff, sample::build_sample_diff};
 use gen_models::{
     annotations::{AnnotationFileChecksumOverrides, add_annotation, add_annotation_file},
     block_group::BlockGroup,
@@ -275,6 +278,8 @@ fn call_cli() -> Result<(), Box<dyn std::error::Error>> {
             graph,
             history_ref,
             sample,
+            query,
+            base,
             collection,
             position,
             full,
@@ -286,6 +291,38 @@ fn call_cli() -> Result<(), Box<dyn std::error::Error>> {
                 collection,
                 history_ref.as_deref(),
             )?;
+
+            if let (Some(query_name), Some(base_name)) = (query, base) {
+                let graph_name = graph.as_deref().ok_or_else(|| {
+                    anyhow!("a graph name is required when comparing a query against a base")
+                })?;
+                let diff = build_sample_diff(
+                    graph_conn,
+                    collection_name,
+                    graph_name,
+                    &query_name,
+                    &base_name,
+                    history_ref.as_deref(),
+                )?;
+                let title = format!("{graph_name}: query {query_name} against base {base_name}");
+                if full {
+                    view_diff_graph(graph_conn, db_context.workspace(), &diff.graph, title)?;
+                } else {
+                    match show_inline_diff_graph_widget(
+                        graph_conn,
+                        db_context.workspace(),
+                        &diff.graph,
+                        clamp_inline_view_height(height),
+                    ) {
+                        Ok(true) => {
+                            view_diff_graph(graph_conn, db_context.workspace(), &diff.graph, title)?
+                        }
+                        Ok(false) => {}
+                        Err(error) => eprintln!("Error showing inline widget: {error}"),
+                    }
+                }
+                return Ok(());
+            }
 
             if !full && let (Some(name), Some(sample_name)) = (graph.as_ref(), sample.as_ref()) {
                 // Use the inline widget by default if a graph is specified
@@ -909,8 +946,8 @@ fn call_cli() -> Result<(), Box<dyn std::error::Error>> {
                 db_context.workspace(),
                 collection_name,
                 &PathBuf::from(gfa),
-                query.as_str(),
                 base.as_str(),
+                query.as_str(),
             )?;
             Ok(())
         }

--- a/src/views/block_group_inline.rs
+++ b/src/views/block_group_inline.rs
@@ -26,6 +26,7 @@ use crate::views::{
     annotation_groups::load_annotation_group_entries,
     annotations::{AnnotationGroupTrackRequest, load_annotations_for_group},
     block_group::extract_viewport_node_ids,
+    diff_graph::{DiffGraphComponent, apply_diff_highlights, build_diff_graph_component},
     gen_graph_widget::{
         GenGraphNodeSizer, create_gen_graph_widget, draw_annotation_labels, reapply_overlays,
     },
@@ -119,6 +120,14 @@ pub struct InlineGenGraphState<'a> {
     overlays: Vec<GraphOverlay>,
     annotation_colors: AnnotationColorCache,
     annotation_groups_loaded: bool,
+    diff_component: Option<DiffGraphComponent>,
+}
+
+#[derive(Default)]
+struct InlineWidgetOptions<'a> {
+    block_group_id: Option<HashId>,
+    history_ref: Option<&'a str>,
+    diff_component: Option<DiffGraphComponent>,
 }
 
 impl<'a> InlineGenGraphState<'a> {
@@ -143,6 +152,7 @@ impl<'a> InlineGenGraphState<'a> {
             overlays: Vec::new(),
             annotation_colors: AnnotationColorCache::new(),
             annotation_groups_loaded: false,
+            diff_component: None,
         }
     }
 
@@ -210,7 +220,36 @@ pub fn show_inline_gen_graph_widget(
     paths: Vec<Path>,
     height: u16,
 ) -> Result<bool> {
-    show_inline_widget(conn, workspace, graph, paths, height, None, None)
+    show_inline_widget(
+        conn,
+        workspace,
+        graph,
+        paths,
+        height,
+        InlineWidgetOptions::default(),
+    )
+}
+
+/// Display an inline sample diff using the standard added/removed highlights.
+pub fn show_inline_diff_graph_widget(
+    conn: &GraphConnection,
+    workspace: &Workspace,
+    diff_graph: &gen_diff::graph::DiffGenGraph,
+    height: u16,
+) -> Result<bool> {
+    let component = build_diff_graph_component(diff_graph, String::new());
+    let graph = component.graph.clone();
+    show_inline_widget(
+        conn,
+        workspace,
+        &graph,
+        Vec::new(),
+        height,
+        InlineWidgetOptions {
+            diff_component: Some(component),
+            ..Default::default()
+        },
+    )
 }
 
 /// Display an inline widget for a `BlockGroup`'s graph, with annotations loaded.
@@ -232,8 +271,11 @@ pub fn show_inline_block_group_widget(
         &graph,
         paths,
         height,
-        Some(block_group_id),
-        history_ref,
+        InlineWidgetOptions {
+            block_group_id: Some(block_group_id),
+            history_ref,
+            ..Default::default()
+        },
     )
 }
 
@@ -243,8 +285,7 @@ fn show_inline_widget(
     graph: &GenGraph,
     paths: Vec<Path>,
     height: u16,
-    block_group_id: Option<HashId>,
-    history_ref: Option<&str>,
+    options: InlineWidgetOptions<'_>,
 ) -> Result<bool> {
     let terminal_result = panic::catch_unwind(|| {
         ratatui::init_with_options(TerminalOptions {
@@ -254,8 +295,14 @@ fn show_inline_widget(
 
     match terminal_result {
         Ok(mut terminal) => {
-            let mut state =
-                InlineGenGraphState::new(graph, conn, workspace, block_group_id, history_ref);
+            let mut state = InlineGenGraphState::new(
+                graph,
+                conn,
+                workspace,
+                options.block_group_id,
+                options.history_ref,
+            );
+            state.diff_component = options.diff_component;
             for path in paths {
                 state.add_path(&path, conn)?;
             }
@@ -281,6 +328,9 @@ fn show_inline_widget(
                                 &mut state.overlays,
                                 &mut state.annotation_colors,
                             );
+                            if let Some(diff_component) = &state.diff_component {
+                                apply_diff_highlights(&mut state.controller, diff_component);
+                            }
 
                             // Draw the frame
                             terminal.draw(|frame| {

--- a/src/views/diff.rs
+++ b/src/views/diff.rs
@@ -246,6 +246,58 @@ pub fn view_diff(
     Ok(())
 }
 
+/// Display one annotated graph diff without the operation/sample explorer.
+pub fn view_diff_graph(
+    conn: &GraphConnection,
+    workspace: &gen_core::Workspace,
+    diff_graph: &DiffGenGraph,
+    title: String,
+) -> Result<(), io::Error> {
+    let component = build_diff_graph_component(diff_graph, title);
+    let mut session = TuiSession::enter()?;
+    let terminal = session.terminal_mut();
+    let mut graph_controller = create_gen_graph_controller(component.graph.clone());
+    apply_diff_highlights(&mut graph_controller, &component);
+    let mut last_frame_time = Instant::now();
+
+    loop {
+        let now = Instant::now();
+        let frame_delta = now.duration_since(last_frame_time);
+        last_frame_time = now;
+
+        terminal.draw(|frame| {
+            let areas = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([Constraint::Min(1), Constraint::Length(1)])
+                .split(frame.area());
+            let graph_block = ratatui::widgets::Block::bordered().title(component.title.clone());
+            let canvas_area = graph_block.inner(areas[0]);
+            graph_controller.viewport_state.focus();
+            graph_controller.viewport_state.viewport_bounds = canvas_area;
+            graph_controller.update_animations(frame_delta);
+
+            frame.render_widget(graph_block, areas[0]);
+            let widget = create_gen_graph_widget(conn, workspace)
+                .detail_level(graph_controller.get_detail_level())
+                .style(ratatui::style::Style::default().bg(current_theme()[0x00]))
+                .cursor();
+            frame.render_stateful_widget(widget, canvas_area, &mut graph_controller);
+            render_status_bar(frame, areas[1], "*←→↑↓* pan | *+/-* zoom | *q/esc* quit");
+        })?;
+
+        if event::poll(std::time::Duration::from_millis(100))?
+            && let Event::Key(key) = event::read()?
+        {
+            if matches!(key.code, KeyCode::Esc | KeyCode::Char('q')) {
+                break;
+            }
+            let _ = graph_controller.handle_key_event(key);
+        }
+    }
+
+    Ok(())
+}
+
 fn collect_samples(graphs: &[BlockGroupDiff]) -> Vec<SampleComponent> {
     let mut grouped = BTreeMap::<(SampleStatus, String, String), Vec<DiffComponent>>::new();
     for graph_diff in graphs {

--- a/tests/sample_diff_tests.rs
+++ b/tests/sample_diff_tests.rs
@@ -1,0 +1,201 @@
+use std::{collections::HashSet, path::PathBuf};
+
+use r#gen::{
+    imports::fasta::import_fasta, test_helpers::setup_gen, updates::vcf::update_with_vcf,
+    views::diff_graph::build_diff_graph_component,
+};
+use gen_diff::{
+    graph::DiffChangeKind,
+    sample::{SampleDiff, build_sample_diff},
+};
+use gen_models::{db::DbContext, node::Node};
+use ratatui::style::Color;
+
+fn simple_vcf_sample_diff(query_name: &str, base_name: &str) -> (DbContext, SampleDiff) {
+    let context = setup_gen();
+    let collection_name = "test";
+    let fasta_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("fixtures/simple.fa");
+    let vcf_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("fixtures/simple.vcf");
+    let fasta_path = fasta_path
+        .to_str()
+        .expect("should encode simple FASTA fixture path")
+        .to_string();
+    let vcf_path = vcf_path
+        .to_str()
+        .expect("should encode simple VCF fixture path")
+        .to_string();
+
+    import_fasta(
+        &context,
+        &fasta_path,
+        collection_name,
+        "reference",
+        false,
+        &[],
+    )
+    .expect("should import simple FASTA fixture");
+    update_with_vcf(
+        &context,
+        &vcf_path,
+        collection_name,
+        String::new(),
+        None,
+        vec!["reference".to_string()],
+        false,
+    )
+    .expect("should update simple FASTA with simple VCF");
+
+    let diff = build_sample_diff(
+        context.graph().conn(),
+        collection_name,
+        "m123",
+        query_name,
+        base_name,
+        None,
+    )
+    .expect("should build sample diff");
+    (context, diff)
+}
+
+fn changed_sequences(
+    context: &DbContext,
+    diff: &SampleDiff,
+    change_kind: DiffChangeKind,
+) -> HashSet<String> {
+    let node_ids = diff
+        .graph
+        .nodes()
+        .map(|node| node.node.node_id)
+        .collect::<HashSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    let sequences_by_node_id = Node::get_sequences_by_node_ids(
+        context.graph().conn(),
+        context.workspace(),
+        &node_ids,
+        None,
+    );
+
+    diff.graph
+        .nodes()
+        .filter(|node| {
+            node.change.kind == change_kind && node.node.sequence_start < node.node.sequence_end
+        })
+        .map(|node| {
+            sequences_by_node_id[&node.node.node_id]
+                .get_sequence(node.node.sequence_start, node.node.sequence_end)
+                .expect("should read changed graph-node sequence")
+        })
+        .collect()
+}
+
+#[test]
+fn test_query_foo_base_unknown_marks_unknown_insertion_removed() {
+    let (context, diff) = simple_vcf_sample_diff("foo", "unknown");
+
+    assert_eq!(diff.query_block_group.sample_name, "foo");
+    assert_eq!(diff.base_block_group.sample_name, "unknown");
+    assert_eq!(
+        changed_sequences(&context, &diff, DiffChangeKind::Removed),
+        HashSet::from(["AGA".to_string()]),
+        "base-only insertion should be removed"
+    );
+    assert!(
+        changed_sequences(&context, &diff, DiffChangeKind::Added).is_empty(),
+        "foo should not add sequence relative to unknown"
+    );
+
+    let node_ids = diff
+        .graph
+        .nodes()
+        .map(|node| node.node.node_id)
+        .collect::<HashSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    let sequences_by_node_id = Node::get_sequences_by_node_ids(
+        context.graph().conn(),
+        context.workspace(),
+        &node_ids,
+        None,
+    );
+    let reference_node_id = sequences_by_node_id
+        .iter()
+        .find_map(|(node_id, sequence)| {
+            (sequence
+                .get_sequence(0, 34)
+                .is_ok_and(|sequence| sequence == "ATCGATCGATCGATCGATCGGGAACACACAGAGA"))
+            .then_some(*node_id)
+        })
+        .expect("should retain the simple FASTA backing node");
+    let shared_reference_slices = diff
+        .graph
+        .nodes()
+        .filter(|node| node.node.node_id == reference_node_id)
+        .map(|node| {
+            (
+                node.node.sequence_start,
+                node.node.sequence_end,
+                node.change.kind,
+            )
+        })
+        .collect::<HashSet<_>>();
+    assert!(
+        shared_reference_slices.contains(&(4, 10, DiffChangeKind::Unchanged))
+            && shared_reference_slices.contains(&(10, 34, DiffChangeKind::Unchanged)),
+        "the base-only insertion boundary should split shared query sequence: {shared_reference_slices:?}"
+    );
+
+    let neutral_query_continuation = diff.graph.all_edges().any(|(source, target, edges)| {
+        source.node.node_id == reference_node_id
+            && source.node.sequence_start == 4
+            && source.node.sequence_end == 10
+            && target.node.node_id == reference_node_id
+            && target.node.sequence_start == 10
+            && target.node.sequence_end == 34
+            && edges
+                .iter()
+                .all(|edge| edge.change.kind == DiffChangeKind::Unchanged)
+    });
+    assert!(
+        neutral_query_continuation,
+        "foo's boundary reconnection around unknown's insertion should stay neutral"
+    );
+
+    let component = build_diff_graph_component(&diff.graph, String::new());
+    assert!(
+        component
+            .highlighted_nodes
+            .iter()
+            .any(|(_, color)| *color == Color::Red),
+        "removed base-only sequence should use the existing red diff highlight"
+    );
+    assert!(
+        !component
+            .highlighted_edges
+            .iter()
+            .any(|((source, target), _)| {
+                source.node_id == reference_node_id
+                    && source.sequence_start == 4
+                    && source.sequence_end == 10
+                    && target.node_id == reference_node_id
+                    && target.sequence_start == 10
+                    && target.sequence_end == 34
+            }),
+        "boundary reconnection should not receive a diff highlight"
+    );
+}
+
+#[test]
+fn test_reversing_query_and_base_marks_unknown_insertion_added() {
+    let (context, diff) = simple_vcf_sample_diff("unknown", "foo");
+
+    assert_eq!(
+        changed_sequences(&context, &diff, DiffChangeKind::Added),
+        HashSet::from(["AGA".to_string()]),
+        "query-only insertion should be added"
+    );
+    assert!(
+        changed_sequences(&context, &diff, DiffChangeKind::Removed).is_empty(),
+        "unknown should not remove sequence relative to foo"
+    );
+}


### PR DESCRIPTION
I split out cosmetic from actual changes in this PR. https://github.com/genhub-bio/gen/pull/268/changes/bbb37f07b9e618950f57815334b53323ec767aa3 has the changes, feel free to comment there

This generalizes the graph diff builder a bit more to support diffs of a blockgroup between 2 samples.

The language of the prior version was confusing, so I also tried to make it more specific. A big one is removing the stage/staged terms, which made it appear as if there were multiple graphs or something similar. It was meant to be like git staged but it simply means the input so that was updated.

For the actual change, I used the term `base` and `query`. If you have better ones, let me know. `source` and `target` became very confusing as we have source/target nodes/edges. Base is meant to be baseline (but less letters) and query is what you want to search with. Reference and sample were similarly rejected as you can mix and match comparing against a reference or a sample.

