### PR TITLE
Support starting a new branch at a given operation

### DIFF
--- a/src/commands/checkout.rs
+++ b/src/commands/checkout.rs
@@ -68,8 +68,16 @@ pub fn execute(
         .map(|asset| (asset.id, asset))
         .collect();
     if let Some(name) = branch {
-        if !branch_exists(graph, name)? {
-            history_store.create_branch(&BranchName(name.to_string()), None)?;
+        let branch_already_exists = branch_exists(graph, name)?;
+        if branch_already_exists && hash.is_some() {
+            return Err(format!(
+                "Branch '{name}' already exists; cannot start it at a given operation. Choose a new branch name."
+            )
+            .into());
+        }
+        if !branch_already_exists {
+            let start_ref = hash.map(|hash_name| CommitRef(hash_name.to_string()));
+            history_store.create_branch(&BranchName(name.to_string()), start_ref.as_ref())?;
             println!("Created branch {name}");
         }
         println!("Checking out branch {name}");

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -199,6 +199,9 @@ pub enum Commands {
         /// The branch name
         #[clap(index = 1)]
         branch_name: Option<String>,
+        /// The operation hash to start a newly created branch at, instead of the current HEAD
+        #[clap(index = 2)]
+        start_point: Option<String>,
     },
     /// Merge branches
     #[command(arg_required_else_help(true))]

--- a/src/main.rs
+++ b/src/main.rs
@@ -453,13 +453,18 @@ fn call_cli() -> Result<(), Box<dyn std::error::Error>> {
             merge,
             set_remote,
             branch_name,
+            start_point,
         }) => {
             let history_store = DoltHistoryStore::new(graph_conn);
             if create {
                 let branch_name = branch_name
                     .clone()
                     .ok_or("Must provide a branch name to create.")?;
-                history_store.create_branch(&BranchName(branch_name.clone()), None)?;
+                let start_ref = start_point.clone().map(CommitRef);
+                history_store
+                    .create_branch(&BranchName(branch_name.clone()), start_ref.as_ref())?;
+            } else if start_point.is_some() {
+                return Err("A start point is only valid together with --create.".into());
             } else if delete {
                 history_store.delete_branch(&BranchName(
                     branch_name

--- a/tests/history_cli_tests.rs
+++ b/tests/history_cli_tests.rs
@@ -1499,6 +1499,105 @@ mod revision_views {
     }
 
     #[test]
+    fn test_checkout_branch_create_from_hash_starts_new_branch_at_operation() {
+        let repo_dir = tempdir().expect("should create temp repo directory");
+        let (_, feature_update_hash, feature_sample_name) =
+            setup_repo_with_feature_only_update(repo_dir.path());
+
+        assert_success(
+            &run_gen(
+                repo_dir.path(),
+                &["checkout", "--branch", "from-feature", &feature_update_hash],
+            ),
+            "checkout -b from a feature commit hash should succeed",
+        );
+
+        let samples = run_gen(repo_dir.path(), &["list-samples"]);
+        assert_success(&samples, "list-samples on from-feature should succeed");
+        let stdout = String::from_utf8_lossy(&samples.stdout);
+        assert!(
+            stdout.contains(&feature_sample_name),
+            "new branch should start at the given operation rather than at HEAD: {stdout}"
+        );
+    }
+
+    #[test]
+    fn test_checkout_branch_flag_errors_when_branch_already_exists_with_hash() {
+        let repo_dir = tempdir().expect("should create temp repo directory");
+        let (_, feature_update_hash, _) = setup_repo_with_feature_only_update(repo_dir.path());
+
+        let checkout = run_gen(
+            repo_dir.path(),
+            &["checkout", "--branch", "feature", &feature_update_hash],
+        );
+        assert!(
+            !checkout.status.success(),
+            "checkout -b with an existing branch name and a start hash should fail: stdout={} stderr={}",
+            String::from_utf8_lossy(&checkout.stdout),
+            String::from_utf8_lossy(&checkout.stderr)
+        );
+        let stderr = String::from_utf8_lossy(&checkout.stderr);
+        assert!(
+            stderr.contains("already exists"),
+            "checkout -b should explain that the branch already exists rather than silently reusing HEAD: {stderr}"
+        );
+    }
+
+    #[test]
+    fn test_branch_create_with_start_starts_new_branch_at_operation() {
+        let repo_dir = tempdir().expect("should create temp repo directory");
+        let (_, feature_update_hash, feature_sample_name) =
+            setup_repo_with_feature_only_update(repo_dir.path());
+
+        assert_success(
+            &run_gen(
+                repo_dir.path(),
+                &[
+                    "branch",
+                    "--create",
+                    "from-feature-branch-create",
+                    &feature_update_hash,
+                ],
+            ),
+            "branch --create with a start point should succeed",
+        );
+        assert_success(
+            &run_gen(repo_dir.path(), &["checkout", "from-feature-branch-create"]),
+            "checkout of the newly created branch should succeed",
+        );
+
+        let samples = run_gen(repo_dir.path(), &["list-samples"]);
+        assert_success(&samples, "list-samples should succeed");
+        let stdout = String::from_utf8_lossy(&samples.stdout);
+        assert!(
+            stdout.contains(&feature_sample_name),
+            "new branch should start at the given operation rather than at HEAD: {stdout}"
+        );
+    }
+
+    #[test]
+    fn test_branch_start_point_without_create_errors() {
+        let repo_dir = tempdir().expect("should create temp repo directory");
+        let (_, feature_update_hash, _) = setup_repo_with_feature_only_update(repo_dir.path());
+
+        let branch = run_gen(
+            repo_dir.path(),
+            &["branch", "--list", "feature", &feature_update_hash],
+        );
+        assert!(
+            !branch.status.success(),
+            "a start point without --create should fail: stdout={} stderr={}",
+            String::from_utf8_lossy(&branch.stdout),
+            String::from_utf8_lossy(&branch.stderr)
+        );
+        let stderr = String::from_utf8_lossy(&branch.stderr);
+        assert!(
+            stderr.contains("A start point is only valid together with --create"),
+            "should explain a start point requires --create: {stderr}"
+        );
+    }
+
+    #[test]
     fn test_list_samples_ref_reads_selected_commit_state() {
         let repo_dir = tempdir().expect("should create temp repo directory");
         let (_, feature_update_hash, feature_sample_name) =


### PR DESCRIPTION
The basic idea is to feel more like git:

|#|Before                                                                                               |After                                                                                   |Git equivalent                                            |
|-|-----------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------|----------------------------------------------------------|
|1|`gen checkout -b <name> <hash>` → creates `<name>` at current HEAD, silently ignoring `<hash>`       |`gen checkout -b <name> <hash>` → creates `<name>` starting at `<hash>`                 |`git checkout -b <new-branch> <start-point>`              |
|2|`gen checkout -b <existing-name> <hash>` → silently checks out the existing branch, ignoring `<hash>`|`gen checkout -b <existing-name> <hash>` → errors: branch already exists                |`git checkout -b <existing-branch> ...` → errors similarly|
|3|*(not possible — no way to pass a start point)*                                                      |`gen branch --create <name> <start-point>` → creates `<name>` starting at that operation|`git branch <name> <start-point>`                         |
|4|*(n/a)*                                                                                              |`gen branch <start-point>` without `--create` → errors                                  |*(no git equivalent)*                                     |
|—|`gen checkout <hash>` (no `-b`) → detached HEAD error                                                |unchanged                                                                               |git allows this; gen intentionally doesn't                |