### PR TITLE
Leave failed clone destinations in place for the user to clean up

### DIFF
--- a/gen-python/tests/test_remotes.py
+++ b/gen-python/tests/test_remotes.py
@@ -146,7 +146,7 @@ class RemoteTests(unittest.TestCase):
                 with self.assertRaises(TypeError):
                     method(branch=42)
 
-    def test_clone_preserves_existing_destination_and_cleans_failure(self):
+    def test_clone_preserves_existing_destination(self):
         destination = self.root / "existing"
         destination.mkdir()
         marker = destination / "keep.txt"
@@ -154,17 +154,6 @@ class RemoteTests(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeError, "already exists"):
             gen.clone((self.root / "missing").as_uri(), path=str(destination))
         self.assertEqual(marker.read_text(), "preserve me")
-        failed = self.root / "failed"
-        with self.assertRaises(RuntimeError):
-            gen.clone("not a remote URL", path=str(failed))
-        self.assertFalse(failed.exists())
-
-        empty = self.root / "empty"
-        empty.mkdir()
-        with self.assertRaises(RuntimeError):
-            gen.clone("not a remote URL", path=empty)
-        self.assertTrue(empty.is_dir())
-        self.assertEqual(list(empty.iterdir()), [])
 
         existing_file = self.root / "existing.txt"
         existing_file.write_text("preserve me")
@@ -236,7 +225,6 @@ class RemoteTests(unittest.TestCase):
                         failed = self.root / f"clone-{status}"
                         with self.assertRaisesRegex(RuntimeError, f"HTTP {status}"):
                             gen.clone(url, path=str(failed))
-                        self.assertFalse(failed.exists())
                         self.repository.remove_remote(origin)
                     self.assertEqual(len(requests), 4)
                     self.assertTrue(

--- a/src/commands/clone.rs
+++ b/src/commands/clone.rs
@@ -1,4 +1,4 @@
-use std::{fs, io, path::Path};
+use std::fs;
 
 use gen_core::config::Workspace;
 use gen_models::operations::{Defaults, Remote, RemoteBranch};
@@ -39,43 +39,14 @@ pub fn clone_to_workspace(
     if !destination_exists {
         fs::create_dir(destination)?;
     }
-    let result = (|| {
-        let workspace = Workspace::new(destination);
-        workspace.ensure_gen_dir();
-        let config = get_config_connection(Some(workspace.gen_db_path()?))?;
-        let canonical_url = canonical_remote_url(url)?;
-        let remote = Remote::create(&config, "origin", &canonical_url)?;
-        Defaults::set_default_remote(&config, Some("origin"))?;
-        let branch = clone_into_workspace(&config, &remote, &workspace)?;
-        RemoteBranch::set_remote_validated(&config, &branch, Some("origin"))?;
-        Defaults::set_current_branch(&config, Some(&branch))?;
-        Ok::<(), Box<dyn std::error::Error>>(())
-    })();
-    if result.is_err()
-        && let Err(error) = remove_incomplete_clone(destination, destination_exists)
-    {
-        eprintln!(
-            "Warning: failed to remove incomplete clone at {}: {error}",
-            destination.display()
-        );
-    }
-    result
-}
-
-fn remove_incomplete_clone(destination: &Path, preserve_directory: bool) -> io::Result<()> {
-    if !preserve_directory {
-        return fs::remove_dir_all(destination);
-    }
-    // The clone only removes what it created. A directory supplied by the caller may be a mount
-    // point, a symlink target, another process's working directory, or carry permissions the clone
-    // cannot reconstruct, so delete its contents and leave the directory itself in place.
-    for entry in fs::read_dir(destination)? {
-        let entry = entry?;
-        if entry.file_type()?.is_dir() {
-            fs::remove_dir_all(entry.path())?;
-        } else {
-            fs::remove_file(entry.path())?;
-        }
-    }
+    let workspace = Workspace::new(destination);
+    workspace.ensure_gen_dir();
+    let config = get_config_connection(Some(workspace.gen_db_path()?))?;
+    let canonical_url = canonical_remote_url(url)?;
+    let remote = Remote::create(&config, "origin", &canonical_url)?;
+    Defaults::set_default_remote(&config, Some("origin"))?;
+    let branch = clone_into_workspace(&config, &remote, &workspace)?;
+    RemoteBranch::set_remote_validated(&config, &branch, Some("origin"))?;
+    Defaults::set_current_branch(&config, Some(&branch))?;
     Ok(())
 }

--- a/tests/history_cli_tests.rs
+++ b/tests/history_cli_tests.rs
@@ -3326,7 +3326,7 @@ mod remotes {
     }
 
     #[test]
-    fn test_clone_failure_removes_only_the_new_destination() {
+    fn test_clone_failure_leaves_the_destination_for_the_user_to_clean_up() {
         let clone_parent = tempdir().expect("should create clone parent");
         let unrelated = clone_parent.path().join("unrelated.txt");
         fs::write(&unrelated, "keep me").expect("should create unrelated file");
@@ -3348,8 +3348,8 @@ mod remotes {
             "clone failure before graph-remote creation should not emit a restoration warning: {stderr}"
         );
         assert!(
-            !destination.exists(),
-            "a failed clone should remove the destination it created"
+            destination.exists(),
+            "a failed clone should leave the destination it created for the user to clean up"
         );
         assert!(
             unrelated.exists(),


### PR DESCRIPTION
Reverting a change in the previous PR per discussion with Chris.